### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Restore .NET tools
+        run: dotnet tool restore
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+      - name: Publish
+        run: dotnet publish -c Release -o publish
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: js2il
+          path: publish
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 This is a experimental project that compiles javascript to dotnet il and creates a dotnet assembly that can be executed
 
 The ultimate purpose is to see how close performance can be to the v8 engine used by node though it is understand that optimizations such has shadow classes will have to addded to be at least compariable in performance features.
+
+## Building
+
+To compile the project locally, run:
+
+```
+dotnet build
+```
+
+For a release build:
+
+```
+dotnet publish -c Release
+```
+
+## Release pipeline
+
+When a tag beginning with `v` is pushed, GitHub Actions runs `.github/workflows/release.yml` to build the solution in Release mode and upload the published files as an artifact.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to publish release artifacts
- document the new pipeline and how to create a release build

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8233bdf483248ca07da50bf55b65