### PR TITLE
Implement scope array infrastructure for nested function support

### DIFF
--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_GlobalFunctionCallsGlobalFunction
+﻿// IL code: Function_GlobalFunctionCallsGlobalFunction
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -73,8 +73,8 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> helloWorldProxy
-	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> helloWorld
+	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> helloWorldProxy
+	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> helloWorld
 
 } // end of class DispatchTable
 
@@ -84,12 +84,12 @@
 	// Methods
 	.method public static 
 		object helloWorldProxy (
-			object Function_GlobalFunctionCallsGlobalFunction
+			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x206b
-		// Header size: 1
-		// Code size: 51 (0x33)
+		// Method begins at RVA 0x206c
+		// Header size: 12
+		// Code size: 64 (0x40)
 		.maxstack 8
 
 		IL_0000: ldc.i4.2
@@ -105,20 +105,29 @@
 		IL_001e: stelem.ref
 		IL_001f: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
 		IL_0024: ldarg.0
-		IL_0025: ldfld object Scopes.Function_GlobalFunctionCallsGlobalFunction::helloWorld
-		IL_002a: ldarg.0
-		IL_002b: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
-		IL_0030: pop
-		IL_0031: ldnull
-		IL_0032: ret
+		IL_0025: ldc.i4.0
+		IL_0026: ldelem.ref
+		IL_0027: ldfld object Scopes.Function_GlobalFunctionCallsGlobalFunction::helloWorld
+		IL_002c: ldc.i4.1
+		IL_002d: newarr [System.Runtime]System.Object
+		IL_0032: dup
+		IL_0033: ldc.i4.0
+		IL_0034: ldarg.0
+		IL_0035: ldc.i4.0
+		IL_0036: ldelem.ref
+		IL_0037: stelem.ref
+		IL_0038: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_003d: pop
+		IL_003e: ldnull
+		IL_003f: ret
 	} // end of method Program::helloWorldProxy
 
 	.method public static 
 		object helloWorld (
-			object Function_GlobalFunctionCallsGlobalFunction
+			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x209f
+		// Method begins at RVA 0x20b8
 		// Header size: 1
 		// Code size: 38 (0x26)
 		.maxstack 8
@@ -142,28 +151,28 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x20c6
+		// Method begins at RVA 0x20df
 		// Header size: 1
 		// Code size: 35 (0x23)
 		.maxstack 8
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Program::helloWorldProxy(object)
-		IL_0007: newobj instance void class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::.ctor(object, native int)
-		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::helloWorldProxy
+		IL_0001: ldftn object Program::helloWorldProxy(object[])
+		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::helloWorldProxy
 		IL_0011: ldnull
-		IL_0012: ldftn object Program::helloWorld(object)
-		IL_0018: newobj instance void class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::.ctor(object, native int)
-		IL_001d: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::helloWorld
+		IL_0012: ldftn object Program::helloWorld(object[])
+		IL_0018: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_001d: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::helloWorld
 		IL_0022: ret
 	} // end of method Program::_LoadDispatchTable
 
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20ec
+		// Method begins at RVA 0x2104
 		// Header size: 12
-		// Code size: 83 (0x53)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -174,29 +183,34 @@
 		IL_0005: stloc.0
 		IL_0006: call void Program::_LoadDispatchTable()
 		IL_000b: ldloc.0
-		IL_000c: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::helloWorldProxy
+		IL_000c: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::helloWorldProxy
 		IL_0011: stfld object Scopes.Function_GlobalFunctionCallsGlobalFunction::helloWorldProxy
 		IL_0016: ldloc.0
-		IL_0017: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::helloWorld
+		IL_0017: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::helloWorld
 		IL_001c: stfld object Scopes.Function_GlobalFunctionCallsGlobalFunction::helloWorld
 		IL_0021: ldloc.0
 		IL_0022: ldfld object Scopes.Function_GlobalFunctionCallsGlobalFunction::helloWorldProxy
-		IL_0027: ldloc.0
-		IL_0028: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
-		IL_002d: pop
-		IL_002e: ldc.i4.2
-		IL_002f: newarr [System.Runtime]System.Object
-		IL_0034: dup
-		IL_0035: ldc.i4.0
-		IL_0036: ldstr "finally is now"
-		IL_003b: stelem.ref
-		IL_003c: dup
-		IL_003d: ldc.i4.1
-		IL_003e: ldc.r8 3
-		IL_0047: box [System.Runtime]System.Double
-		IL_004c: stelem.ref
-		IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_0052: ret
+		IL_0027: ldc.i4.1
+		IL_0028: newarr [System.Runtime]System.Object
+		IL_002d: dup
+		IL_002e: ldc.i4.0
+		IL_002f: ldloc.0
+		IL_0030: stelem.ref
+		IL_0031: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_0036: pop
+		IL_0037: ldc.i4.2
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: dup
+		IL_003e: ldc.i4.0
+		IL_003f: ldstr "finally is now"
+		IL_0044: stelem.ref
+		IL_0045: dup
+		IL_0046: ldc.i4.1
+		IL_0047: ldc.r8 3
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: stelem.ref
+		IL_0056: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_005b: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_GlobalFunctionWithArrayIteration
+﻿// IL code: Function_GlobalFunctionWithArrayIteration
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -78,7 +78,7 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> printArray
+	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> printArray
 
 } // end of class DispatchTable
 
@@ -88,7 +88,7 @@
 	// Methods
 	.method public static 
 		object printArray (
-			object Function_GlobalFunctionWithArrayIteration
+			object[] scopes
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
@@ -172,9 +172,9 @@
 		.maxstack 8
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Program::printArray(object)
-		IL_0007: newobj instance void class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::.ctor(object, native int)
-		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::printArray
+		IL_0001: ldftn object Program::printArray(object[])
+		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::printArray
 		IL_0011: ret
 	} // end of method Program::_LoadDispatchTable
 
@@ -183,7 +183,7 @@
 	{
 		// Method begins at RVA 0x2160
 		// Header size: 12
-		// Code size: 42 (0x2a)
+		// Code size: 51 (0x33)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -197,14 +197,19 @@
 		IL_000b: stloc.1
 		IL_000c: call void Program::_LoadDispatchTable()
 		IL_0011: ldloc.0
-		IL_0012: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::printArray
+		IL_0012: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::printArray
 		IL_0017: stfld object Scopes.Function_GlobalFunctionWithArrayIteration::printArray
 		IL_001c: ldloc.0
 		IL_001d: ldfld object Scopes.Function_GlobalFunctionWithArrayIteration::printArray
-		IL_0022: ldloc.0
-		IL_0023: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
-		IL_0028: pop
-		IL_0029: ret
+		IL_0022: ldc.i4.1
+		IL_0023: newarr [System.Runtime]System.Object
+		IL_0028: dup
+		IL_0029: ldc.i4.0
+		IL_002a: ldloc.0
+		IL_002b: stelem.ref
+		IL_002c: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_0031: pop
+		IL_0032: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
@@ -52,7 +52,7 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field public static class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object> printValue
+	.field public static class [System.Runtime]System.Func`3<class [System.Runtime]System.Object[], class [System.Runtime]System.Object, class [System.Runtime]System.Object> printValue
 
 } // end of class DispatchTable
 
@@ -62,7 +62,7 @@
 	// Methods
 	.method public static 
 		object printValue (
-			object Function_GlobalFunctionWithParameter,
+			object[] scopes,
 			object 'value'
 		) cil managed 
 	{
@@ -95,9 +95,9 @@
 		.maxstack 8
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Program::printValue(object, object)
-		IL_0007: newobj instance void class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::.ctor(object, native int)
-		IL_000c: stsfld class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::printValue
+		IL_0001: ldftn object Program::printValue(object[], object)
+		IL_0007: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_000c: stsfld class [System.Runtime]System.Func`3<class [System.Runtime]System.Object[], class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::printValue
 		IL_0011: ret
 	} // end of method Program::_LoadDispatchTable
 
@@ -106,7 +106,7 @@
 	{
 		// Method begins at RVA 0x2090
 		// Header size: 12
-		// Code size: 50 (0x32)
+		// Code size: 59 (0x3b)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -117,16 +117,21 @@
 		IL_0005: stloc.0
 		IL_0006: call void Program::_LoadDispatchTable()
 		IL_000b: ldloc.0
-		IL_000c: ldsfld class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::printValue
+		IL_000c: ldsfld class [System.Runtime]System.Func`3<class [System.Runtime]System.Object[], class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::printValue
 		IL_0011: stfld object Scopes.Function_GlobalFunctionWithParameter::printValue
 		IL_0016: ldloc.0
 		IL_0017: ldfld object Scopes.Function_GlobalFunctionWithParameter::printValue
-		IL_001c: ldloc.0
-		IL_001d: ldc.r8 42
-		IL_0026: box [System.Runtime]System.Double
-		IL_002b: callvirt instance !2 class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0, !1)
-		IL_0030: pop
-		IL_0031: ret
+		IL_001c: ldc.i4.1
+		IL_001d: newarr [System.Runtime]System.Object
+		IL_0022: dup
+		IL_0023: ldc.i4.0
+		IL_0024: ldloc.0
+		IL_0025: stelem.ref
+		IL_0026: ldc.r8 42
+		IL_002f: box [System.Runtime]System.Double
+		IL_0034: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0039: pop
+		IL_003a: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/Function/GeneratorTests.Function_HelloWorld.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_HelloWorld.verified.txt
@@ -52,7 +52,7 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> helloWorld
+	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> helloWorld
 
 } // end of class DispatchTable
 
@@ -62,7 +62,7 @@
 	// Methods
 	.method public static 
 		object helloWorld (
-			object Function_HelloWorld
+			object[] scopes
 		) cil managed 
 	{
 		// Method begins at RVA 0x2062
@@ -95,9 +95,9 @@
 		.maxstack 8
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Program::helloWorld(object)
-		IL_0007: newobj instance void class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::.ctor(object, native int)
-		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::helloWorld
+		IL_0001: ldftn object Program::helloWorld(object[])
+		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::helloWorld
 		IL_0011: ret
 	} // end of method Program::_LoadDispatchTable
 
@@ -106,7 +106,7 @@
 	{
 		// Method begins at RVA 0x209c
 		// Header size: 12
-		// Code size: 36 (0x24)
+		// Code size: 45 (0x2d)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -117,14 +117,19 @@
 		IL_0005: stloc.0
 		IL_0006: call void Program::_LoadDispatchTable()
 		IL_000b: ldloc.0
-		IL_000c: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::helloWorld
+		IL_000c: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::helloWorld
 		IL_0011: stfld object Scopes.Function_HelloWorld::helloWorld
 		IL_0016: ldloc.0
 		IL_0017: ldfld object Scopes.Function_HelloWorld::helloWorld
-		IL_001c: ldloc.0
-		IL_001d: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
-		IL_0022: pop
-		IL_0023: ret
+		IL_001c: ldc.i4.1
+		IL_001d: newarr [System.Runtime]System.Object
+		IL_0022: dup
+		IL_0023: ldc.i4.0
+		IL_0024: ldloc.0
+		IL_0025: stelem.ref
+		IL_0026: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_002b: pop
+		IL_002c: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/Function/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -53,7 +53,7 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> getStaticValue
+	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> getStaticValue
 
 } // end of class DispatchTable
 
@@ -63,7 +63,7 @@
 	// Methods
 	.method public static 
 		object getStaticValue (
-			object Function_ReturnsStaticValueAndLogs
+			object[] scopes
 		) cil managed 
 	{
 		// Method begins at RVA 0x2062
@@ -85,9 +85,9 @@
 		.maxstack 8
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Program::getStaticValue(object)
-		IL_0007: newobj instance void class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::.ctor(object, native int)
-		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::getStaticValue
+		IL_0001: ldftn object Program::getStaticValue(object[])
+		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::getStaticValue
 		IL_0011: ret
 	} // end of method Program::_LoadDispatchTable
 
@@ -96,7 +96,7 @@
 	{
 		// Method begins at RVA 0x2088
 		// Header size: 12
-		// Code size: 69 (0x45)
+		// Code size: 78 (0x4e)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -107,27 +107,32 @@
 		IL_0005: stloc.0
 		IL_0006: call void Program::_LoadDispatchTable()
 		IL_000b: ldloc.0
-		IL_000c: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object> DispatchTable::getStaticValue
+		IL_000c: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::getStaticValue
 		IL_0011: stfld object Scopes.Function_ReturnsStaticValueAndLogs::getStaticValue
 		IL_0016: ldloc.0
 		IL_0017: ldloc.0
 		IL_0018: ldfld object Scopes.Function_ReturnsStaticValueAndLogs::getStaticValue
-		IL_001d: ldloc.0
-		IL_001e: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
-		IL_0023: stfld object Scopes.Function_ReturnsStaticValueAndLogs::'value'
-		IL_0028: ldc.i4.2
-		IL_0029: newarr [System.Runtime]System.Object
-		IL_002e: dup
-		IL_002f: ldc.i4.0
-		IL_0030: ldstr "returned value is"
-		IL_0035: stelem.ref
-		IL_0036: dup
-		IL_0037: ldc.i4.1
-		IL_0038: ldloc.0
-		IL_0039: ldfld object Scopes.Function_ReturnsStaticValueAndLogs::'value'
+		IL_001d: ldc.i4.1
+		IL_001e: newarr [System.Runtime]System.Object
+		IL_0023: dup
+		IL_0024: ldc.i4.0
+		IL_0025: ldloc.0
+		IL_0026: stelem.ref
+		IL_0027: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
+		IL_002c: stfld object Scopes.Function_ReturnsStaticValueAndLogs::'value'
+		IL_0031: ldc.i4.2
+		IL_0032: newarr [System.Runtime]System.Object
+		IL_0037: dup
+		IL_0038: ldc.i4.0
+		IL_0039: ldstr "returned value is"
 		IL_003e: stelem.ref
-		IL_003f: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_0044: ret
+		IL_003f: dup
+		IL_0040: ldc.i4.1
+		IL_0041: ldloc.0
+		IL_0042: ldfld object Scopes.Function_ReturnsStaticValueAndLogs::'value'
+		IL_0047: stelem.ref
+		IL_0048: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_004d: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL/Dispatch/DispatchTableGenerator.cs
+++ b/Js2IL/Dispatch/DispatchTableGenerator.cs
@@ -118,22 +118,22 @@ namespace Js2IL.Dispatch
                 var fieldSigEncoder = new BlobEncoder(blobBuilder).FieldSignature();
                 if (paramCount == 0)
                 {
-                    // Func<object, object>
+                    // Func<object[], object>
                     var genericInst = fieldSigEncoder.GenericInstantiation(
                         _bclReferences.Func2Generic_TypeRef,
                         2,
                         false);
-                    genericInst.AddArgument().Type(_bclReferences.ObjectType, false); // scope param
+                    genericInst.AddArgument().SZArray().Type(_bclReferences.ObjectType, false);
                     genericInst.AddArgument().Type(_bclReferences.ObjectType, false); // return object
                 }
                 else if (paramCount == 1)
                 {
-                    // Func<object, object, object>
+                    // Func<object[], object, object>
                     var genericInst = fieldSigEncoder.GenericInstantiation(
                         _bclReferences.Func3Generic_TypeRef,
                         3,
                         false);
-                    genericInst.AddArgument().Type(_bclReferences.ObjectType, false); // scope param
+                    genericInst.AddArgument().SZArray().Type(_bclReferences.ObjectType, false); // js params    
                     genericInst.AddArgument().Type(_bclReferences.ObjectType, false); // js param1
                     genericInst.AddArgument().Type(_bclReferences.ObjectType, false); // return object
                 }
@@ -208,15 +208,15 @@ namespace Js2IL.Dispatch
                 il.OpCode(ILOpCode.Ldftn);
                 il.Token(function.MethodDefinitionHandle); // The handle of the static method
 
-                // 3. Create the delegate (Func<object,object> or Func<object,object,object>)
+                // 3. Create the delegate (Func<object[],object> or Func<object[],object,object>)
                 il.OpCode(ILOpCode.Newobj);
                 if (function.Declaration.Params.Count == 0)
                 {
-                    il.Token(_bclReferences.FuncObjectObject_Ctor_Ref);
+                    il.Token(_bclReferences.FuncObjectArrayObject_Ctor_Ref);
                 }
                 else if (function.Declaration.Params.Count == 1)
                 {
-                    il.Token(_bclReferences.FuncObjectObjectObject_Ctor_Ref);
+                    il.Token(_bclReferences.FuncObjectArrayObjectObject_Ctor_Ref);
                 }
                 else
                 {

--- a/Js2IL/Services/BaseClassLibraryReferences.cs
+++ b/Js2IL/Services/BaseClassLibraryReferences.cs
@@ -152,6 +152,14 @@ namespace Js2IL.Services
         public TypeSpecificationHandle FuncObjectObjectObject_TypeSpec { get; private set; }
         public MemberReferenceHandle FuncObjectObjectObject_Ctor_Ref { get; private set; }
         public MemberReferenceHandle FuncObjectObjectObject_Invoke_Ref { get; private set; }
+        
+        // Func delegates with scope array parameter (object[])
+        public TypeSpecificationHandle FuncObjectArrayObject_TypeSpec { get; private set; }
+        public MemberReferenceHandle FuncObjectArrayObject_Ctor_Ref { get; private set; }
+        public MemberReferenceHandle FuncObjectArrayObject_Invoke_Ref { get; private set; }
+        public TypeSpecificationHandle FuncObjectArrayObjectObject_TypeSpec { get; private set; }
+        public MemberReferenceHandle FuncObjectArrayObjectObject_Ctor_Ref { get; private set; }
+        public MemberReferenceHandle FuncObjectArrayObjectObject_Invoke_Ref { get; private set; }
 
         private void LoadObjectTypes(MetadataBuilder metadataBuilder)
         {
@@ -412,6 +420,84 @@ namespace Js2IL.Services
                 FuncObjectObjectObject_TypeSpec,
                 metadataBuilder.GetOrAddString("Invoke"),
                 func3InvokeSig);
+
+            // Func<object[], object> type (scope array, no additional params)
+            var funcArrayObjectBlob = new BlobBuilder();
+            var funcArrayObjectEncoder = new BlobEncoder(funcArrayObjectBlob)
+                .TypeSpecificationSignature()
+                .GenericInstantiation(Func2Generic_TypeRef, 2, isValueType: false);
+            funcArrayObjectEncoder.AddArgument().SZArray().Object();
+            funcArrayObjectEncoder.AddArgument().Object();
+            FuncObjectArrayObject_TypeSpec = metadataBuilder.AddTypeSpecification(
+                metadataBuilder.GetOrAddBlob(funcArrayObjectBlob));
+
+            var funcArrayCtorBlob = new BlobBuilder();
+            new BlobEncoder(funcArrayCtorBlob)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(2,
+                    returnType => returnType.Void(),
+                    parameters => {
+                        parameters.AddParameter().Type().Object(); // object target
+                        parameters.AddParameter().Type().IntPtr(); // native int method
+                    });
+            var funcArrayCtorSig = metadataBuilder.GetOrAddBlob(funcArrayCtorBlob);
+            FuncObjectArrayObject_Ctor_Ref = metadataBuilder.AddMemberReference(
+                FuncObjectArrayObject_TypeSpec,
+                metadataBuilder.GetOrAddString(".ctor"),
+                funcArrayCtorSig);
+
+            var funcArrayInvokeBlob = new BlobBuilder();
+            new BlobEncoder(funcArrayInvokeBlob)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(1,
+                    returnType => returnType.Type().GenericTypeParameter(1), // TResult (object)
+                    parameters => { parameters.AddParameter().Type().GenericTypeParameter(0); }); // object[] parameter
+            var funcArrayInvokeSig = metadataBuilder.GetOrAddBlob(funcArrayInvokeBlob);
+            FuncObjectArrayObject_Invoke_Ref = metadataBuilder.AddMemberReference(
+                FuncObjectArrayObject_TypeSpec,
+                metadataBuilder.GetOrAddString("Invoke"),
+                funcArrayInvokeSig);
+
+            // Func<object[], object, object> type (scope array, one additional param)
+            var funcArrayObjectObjectBlob = new BlobBuilder();
+            var funcArrayObjectObjectEncoder = new BlobEncoder(funcArrayObjectObjectBlob)
+                .TypeSpecificationSignature()
+                .GenericInstantiation(Func3Generic_TypeRef, 3, isValueType: false);
+            funcArrayObjectObjectEncoder.AddArgument().SZArray().Object();
+            funcArrayObjectObjectEncoder.AddArgument().Object();
+            funcArrayObjectObjectEncoder.AddArgument().Object();
+            FuncObjectArrayObjectObject_TypeSpec = metadataBuilder.AddTypeSpecification(
+                metadataBuilder.GetOrAddBlob(funcArrayObjectObjectBlob));
+
+            var funcArrayObjectCtorBlob = new BlobBuilder();
+            new BlobEncoder(funcArrayObjectCtorBlob)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(2,
+                    returnType => returnType.Void(),
+                    parameters => {
+                        parameters.AddParameter().Type().Object(); // object target
+                        parameters.AddParameter().Type().IntPtr(); // native int method
+                    });
+            var funcArrayObjectCtorSig = metadataBuilder.GetOrAddBlob(funcArrayObjectCtorBlob);
+            FuncObjectArrayObjectObject_Ctor_Ref = metadataBuilder.AddMemberReference(
+                FuncObjectArrayObjectObject_TypeSpec,
+                metadataBuilder.GetOrAddString(".ctor"),
+                funcArrayObjectCtorSig);
+
+            var funcArrayObjectInvokeBlob = new BlobBuilder();
+            new BlobEncoder(funcArrayObjectInvokeBlob)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(2,
+                    returnType => returnType.Type().GenericTypeParameter(2), // TResult (object)
+                    parameters => {
+                        parameters.AddParameter().Type().GenericTypeParameter(0); // object[] parameter
+                        parameters.AddParameter().Type().GenericTypeParameter(1); // T2 (object)
+                    });
+            var funcArrayObjectInvokeSig = metadataBuilder.GetOrAddBlob(funcArrayObjectInvokeBlob);
+            FuncObjectArrayObjectObject_Invoke_Ref = metadataBuilder.AddMemberReference(
+                FuncObjectArrayObjectObject_TypeSpec,
+                metadataBuilder.GetOrAddString("Invoke"),
+                funcArrayObjectInvokeSig);
         }
     }
 }

--- a/Js2IL/Services/VariableBindings/Variable.cs
+++ b/Js2IL/Services/VariableBindings/Variable.cs
@@ -29,7 +29,8 @@ namespace Js2IL.Services
     internal enum ObjectReferenceLocation
     {
         Local,
-        Parameter
+        Parameter,
+        ScopeArray
     }
 
     internal record ScopeObjectReference
@@ -77,8 +78,8 @@ namespace Js2IL.Services
 
             _scopeLocalSlots[globalVariables._leafScopeName] = new ScopeObjectReference
             {
-                Location = ObjectReferenceLocation.Parameter,
-                Address = 0
+                Location = ObjectReferenceLocation.ScopeArray,
+                Address = 0 // Index 0 in scope array for global scope
             };
         }
 


### PR DESCRIPTION
- Change function signatures from object scope to object[] scopes parameter
- Update dispatch table to use Func<object[], object> delegate types
- Add ScopeArray location type to Variable.cs for proper scope access
- Implement scope array creation and access patterns in IL generation
- Add new BaseClassLibraryReferences for scope array function delegates
- Fix delegate constructor signatures to use IntPtr instead of Pointer
- Update all test snapshots to reflect new scope array IL generation

This provides the foundation for nested functions with proper lexical scoping by allowing functions to receive multiple scope objects for closure support.