### PR TITLE
Implement global variable assignment from functions

### DIFF
--- a/Js2IL.Tests/Function/ExecutionTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/Js2IL.Tests/Function/ExecutionTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -1,0 +1,4 @@
+﻿Start - counter: 0 message: Initial message
+Before change - counter: 0 message: Initial message
+After change - counter: 10 message: Modified message
+End - counter: 10 message: Modified message

--- a/Js2IL.Tests/Function/ExecutionTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/Js2IL.Tests/Function/ExecutionTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -1,0 +1,2 @@
+﻿Global message: Hello from global scope!
+Global number: 42

--- a/Js2IL.Tests/Function/ExecutionTests.cs
+++ b/Js2IL.Tests/Function/ExecutionTests.cs
@@ -23,5 +23,11 @@ namespace Js2IL.Tests.Function
 
         [Fact]
         public Task Function_GlobalFunctionWithArrayIteration() { var testName = nameof(Function_GlobalFunctionWithArrayIteration); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Function_GlobalFunctionLogsGlobalVariable() { var testName = nameof(Function_GlobalFunctionLogsGlobalVariable); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Function_GlobalFunctionChangesGlobalVariableValue() { var testName = nameof(Function_GlobalFunctionChangesGlobalVariableValue); return ExecutionTest(testName); }
     }
 }

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -1,0 +1,242 @@
+﻿// IL code: Function_GlobalFunctionChangesGlobalVariableValue
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Function_GlobalFunctionChangesGlobalVariableValue
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit changeGlobalValues
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method changeGlobalValues::.ctor
+
+	} // end of class changeGlobalValues
+
+
+	// Fields
+	.field public object counter
+	.field public object message
+	.field public object changeGlobalValues
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Function_GlobalFunctionChangesGlobalVariableValue::.ctor
+
+} // end of class Scopes.Function_GlobalFunctionChangesGlobalVariableValue
+
+.class public auto ansi abstract sealed beforefieldinit DispatchTable
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> changeGlobalValues
+
+} // end of class DispatchTable
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		object changeGlobalValues (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 149 (0x95)
+		.maxstack 8
+
+		IL_0000: ldc.i4.4
+		IL_0001: newarr [System.Runtime]System.Object
+		IL_0006: dup
+		IL_0007: ldc.i4.0
+		IL_0008: ldstr "Before change - counter:"
+		IL_000d: stelem.ref
+		IL_000e: dup
+		IL_000f: ldc.i4.1
+		IL_0010: ldarg.0
+		IL_0011: ldc.i4.0
+		IL_0012: ldelem.ref
+		IL_0013: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::counter
+		IL_0018: stelem.ref
+		IL_0019: dup
+		IL_001a: ldc.i4.2
+		IL_001b: ldstr "message:"
+		IL_0020: stelem.ref
+		IL_0021: dup
+		IL_0022: ldc.i4.3
+		IL_0023: ldarg.0
+		IL_0024: ldc.i4.0
+		IL_0025: ldelem.ref
+		IL_0026: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::message
+		IL_002b: stelem.ref
+		IL_002c: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_0031: ldarg.0
+		IL_0032: ldc.i4.0
+		IL_0033: ldelem.ref
+		IL_0034: ldarg.0
+		IL_0035: ldc.i4.0
+		IL_0036: ldelem.ref
+		IL_0037: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::counter
+		IL_003c: unbox.any [System.Runtime]System.Double
+		IL_0041: ldc.r8 10
+		IL_004a: add
+		IL_004b: box [System.Runtime]System.Double
+		IL_0050: stfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::counter
+		IL_0055: ldarg.0
+		IL_0056: ldc.i4.0
+		IL_0057: ldelem.ref
+		IL_0058: ldstr "Modified message"
+		IL_005d: stfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::message
+		IL_0062: ldc.i4.4
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldstr "After change - counter:"
+		IL_006f: stelem.ref
+		IL_0070: dup
+		IL_0071: ldc.i4.1
+		IL_0072: ldarg.0
+		IL_0073: ldc.i4.0
+		IL_0074: ldelem.ref
+		IL_0075: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::counter
+		IL_007a: stelem.ref
+		IL_007b: dup
+		IL_007c: ldc.i4.2
+		IL_007d: ldstr "message:"
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.3
+		IL_0085: ldarg.0
+		IL_0086: ldc.i4.0
+		IL_0087: ldelem.ref
+		IL_0088: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::message
+		IL_008d: stelem.ref
+		IL_008e: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_0093: ldnull
+		IL_0094: ret
+	} // end of method Program::changeGlobalValues
+
+	.method public static 
+		void _LoadDispatchTable () cil managed 
+	{
+		// Method begins at RVA 0x2105
+		// Header size: 1
+		// Code size: 18 (0x12)
+		.maxstack 8
+
+		IL_0000: ldnull
+		IL_0001: ldftn object Program::changeGlobalValues(object[])
+		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::changeGlobalValues
+		IL_0011: ret
+	} // end of method Program::_LoadDispatchTable
+
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2118
+		// Header size: 12
+		// Code size: 166 (0xa6)
+		.maxstack 8
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: newobj instance void Scopes.Function_GlobalFunctionChangesGlobalVariableValue::.ctor()
+		IL_0005: stloc.0
+		IL_0006: call void Program::_LoadDispatchTable()
+		IL_000b: ldloc.0
+		IL_000c: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::changeGlobalValues
+		IL_0011: stfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::changeGlobalValues
+		IL_0016: ldloc.0
+		IL_0017: ldc.r8 0.0
+		IL_0020: box [System.Runtime]System.Double
+		IL_0025: stfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::counter
+		IL_002a: ldloc.0
+		IL_002b: ldstr "Initial message"
+		IL_0030: stfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::message
+		IL_0035: ldc.i4.4
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldstr "Start - counter:"
+		IL_0042: stelem.ref
+		IL_0043: dup
+		IL_0044: ldc.i4.1
+		IL_0045: ldloc.0
+		IL_0046: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::counter
+		IL_004b: stelem.ref
+		IL_004c: dup
+		IL_004d: ldc.i4.2
+		IL_004e: ldstr "message:"
+		IL_0053: stelem.ref
+		IL_0054: dup
+		IL_0055: ldc.i4.3
+		IL_0056: ldloc.0
+		IL_0057: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::message
+		IL_005c: stelem.ref
+		IL_005d: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_0062: ldloc.0
+		IL_0063: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::changeGlobalValues
+		IL_0068: ldc.i4.1
+		IL_0069: newarr [System.Runtime]System.Object
+		IL_006e: dup
+		IL_006f: ldc.i4.0
+		IL_0070: ldloc.0
+		IL_0071: stelem.ref
+		IL_0072: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_0077: pop
+		IL_0078: ldc.i4.4
+		IL_0079: newarr [System.Runtime]System.Object
+		IL_007e: dup
+		IL_007f: ldc.i4.0
+		IL_0080: ldstr "End - counter:"
+		IL_0085: stelem.ref
+		IL_0086: dup
+		IL_0087: ldc.i4.1
+		IL_0088: ldloc.0
+		IL_0089: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::counter
+		IL_008e: stelem.ref
+		IL_008f: dup
+		IL_0090: ldc.i4.2
+		IL_0091: ldstr "message:"
+		IL_0096: stelem.ref
+		IL_0097: dup
+		IL_0098: ldc.i4.3
+		IL_0099: ldloc.0
+		IL_009a: ldfld object Scopes.Function_GlobalFunctionChangesGlobalVariableValue::message
+		IL_009f: stelem.ref
+		IL_00a0: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_00a5: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -1,0 +1,161 @@
+﻿// IL code: Function_GlobalFunctionLogsGlobalVariable
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Function_GlobalFunctionLogsGlobalVariable
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit logGlobalValues
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method logGlobalValues::.ctor
+
+	} // end of class logGlobalValues
+
+
+	// Fields
+	.field public object globalMessage
+	.field public object globalNumber
+	.field public object logGlobalValues
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Function_GlobalFunctionLogsGlobalVariable::.ctor
+
+} // end of class Scopes.Function_GlobalFunctionLogsGlobalVariable
+
+.class public auto ansi abstract sealed beforefieldinit DispatchTable
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field public static class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> logGlobalValues
+
+} // end of class DispatchTable
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		object logGlobalValues (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x2062
+		// Header size: 1
+		// Code size: 62 (0x3e)
+		.maxstack 8
+
+		IL_0000: ldc.i4.2
+		IL_0001: newarr [System.Runtime]System.Object
+		IL_0006: dup
+		IL_0007: ldc.i4.0
+		IL_0008: ldstr "Global message:"
+		IL_000d: stelem.ref
+		IL_000e: dup
+		IL_000f: ldc.i4.1
+		IL_0010: ldarg.0
+		IL_0011: ldc.i4.0
+		IL_0012: ldelem.ref
+		IL_0013: ldfld object Scopes.Function_GlobalFunctionLogsGlobalVariable::globalMessage
+		IL_0018: stelem.ref
+		IL_0019: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_001e: ldc.i4.2
+		IL_001f: newarr [System.Runtime]System.Object
+		IL_0024: dup
+		IL_0025: ldc.i4.0
+		IL_0026: ldstr "Global number:"
+		IL_002b: stelem.ref
+		IL_002c: dup
+		IL_002d: ldc.i4.1
+		IL_002e: ldarg.0
+		IL_002f: ldc.i4.0
+		IL_0030: ldelem.ref
+		IL_0031: ldfld object Scopes.Function_GlobalFunctionLogsGlobalVariable::globalNumber
+		IL_0036: stelem.ref
+		IL_0037: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_003c: ldnull
+		IL_003d: ret
+	} // end of method Program::logGlobalValues
+
+	.method public static 
+		void _LoadDispatchTable () cil managed 
+	{
+		// Method begins at RVA 0x20a1
+		// Header size: 1
+		// Code size: 18 (0x12)
+		.maxstack 8
+
+		IL_0000: ldnull
+		IL_0001: ldftn object Program::logGlobalValues(object[])
+		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_000c: stsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::logGlobalValues
+		IL_0011: ret
+	} // end of method Program::_LoadDispatchTable
+
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x20b4
+		// Header size: 12
+		// Code size: 76 (0x4c)
+		.maxstack 8
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: newobj instance void Scopes.Function_GlobalFunctionLogsGlobalVariable::.ctor()
+		IL_0005: stloc.0
+		IL_0006: call void Program::_LoadDispatchTable()
+		IL_000b: ldloc.0
+		IL_000c: ldsfld class [System.Runtime]System.Func`2<class [System.Runtime]System.Object[], class [System.Runtime]System.Object> DispatchTable::logGlobalValues
+		IL_0011: stfld object Scopes.Function_GlobalFunctionLogsGlobalVariable::logGlobalValues
+		IL_0016: ldloc.0
+		IL_0017: ldstr "Hello from global scope!"
+		IL_001c: stfld object Scopes.Function_GlobalFunctionLogsGlobalVariable::globalMessage
+		IL_0021: ldloc.0
+		IL_0022: ldc.r8 42
+		IL_002b: box [System.Runtime]System.Double
+		IL_0030: stfld object Scopes.Function_GlobalFunctionLogsGlobalVariable::globalNumber
+		IL_0035: ldloc.0
+		IL_0036: ldfld object Scopes.Function_GlobalFunctionLogsGlobalVariable::logGlobalValues
+		IL_003b: ldc.i4.1
+		IL_003c: newarr [System.Runtime]System.Object
+		IL_0041: dup
+		IL_0042: ldc.i4.0
+		IL_0043: ldloc.0
+		IL_0044: stelem.ref
+		IL_0045: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_004a: pop
+		IL_004b: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Function/GeneratorTests.cs
+++ b/Js2IL.Tests/Function/GeneratorTests.cs
@@ -29,5 +29,11 @@ namespace Js2IL.Tests.Function
 
     [Fact]
     public Task Function_GlobalFunctionWithArrayIteration() { var testName = nameof(Function_GlobalFunctionWithArrayIteration); return GenerateTest(testName); }
+
+    [Fact]
+    public Task Function_GlobalFunctionLogsGlobalVariable() { var testName = nameof(Function_GlobalFunctionLogsGlobalVariable); return GenerateTest(testName); }
+
+    [Fact]
+    public Task Function_GlobalFunctionChangesGlobalVariableValue() { var testName = nameof(Function_GlobalFunctionChangesGlobalVariableValue); return GenerateTest(testName); }
     }
 }

--- a/Js2IL.Tests/Function/JavaScript/Function_GlobalFunctionChangesGlobalVariableValue.js
+++ b/Js2IL.Tests/Function/JavaScript/Function_GlobalFunctionChangesGlobalVariableValue.js
@@ -1,0 +1,13 @@
+var counter = 0;
+var message = "Initial message";
+
+function changeGlobalValues() {
+    console.log("Before change - counter:", counter, "message:", message);
+    counter = counter + 10;
+    message = "Modified message";
+    console.log("After change - counter:", counter, "message:", message);
+}
+
+console.log("Start - counter:", counter, "message:", message);
+changeGlobalValues();
+console.log("End - counter:", counter, "message:", message);

--- a/Js2IL.Tests/Function/JavaScript/Function_GlobalFunctionLogsGlobalVariable.js
+++ b/Js2IL.Tests/Function/JavaScript/Function_GlobalFunctionLogsGlobalVariable.js
@@ -1,0 +1,9 @@
+var globalMessage = "Hello from global scope!";
+var globalNumber = 42;
+
+function logGlobalValues() {
+    console.log("Global message:", globalMessage);
+    console.log("Global number:", globalNumber);
+}
+
+logGlobalValues();

--- a/Js2IL.Tests/JavaScript/Function_GlobalFunctionChangesGlobalVariableValue.js
+++ b/Js2IL.Tests/JavaScript/Function_GlobalFunctionChangesGlobalVariableValue.js
@@ -1,0 +1,13 @@
+var counter = 0;
+var message = "Initial message";
+
+function changeGlobalValues() {
+    console.log("Before change - counter:", counter, "message:", message);
+    counter = counter + 10;
+    message = "Modified message";
+    console.log("After change - counter:", counter, "message:", message);
+}
+
+console.log("Start - counter:", counter, "message:", message);
+changeGlobalValues();
+console.log("End - counter:", counter, "message:", message);

--- a/Js2IL.Tests/JavaScript/Function_GlobalFunctionLogsGlobalVariable.js
+++ b/Js2IL.Tests/JavaScript/Function_GlobalFunctionLogsGlobalVariable.js
@@ -1,0 +1,9 @@
+var globalMessage = "Hello from global scope!";
+var globalNumber = 42;
+
+function logGlobalValues() {
+    console.log("Global message:", globalMessage);
+    console.log("Global number:", globalNumber);
+}
+
+logGlobalValues();

--- a/Js2IL/Services/ILGenerators/BinaryOperators.cs
+++ b/Js2IL/Services/ILGenerators/BinaryOperators.cs
@@ -53,6 +53,12 @@ namespace Js2IL.Services.ILGenerators
             {
                 _il.LoadArgument(scopeLocalIndex.Address);
             }
+            else if (scopeLocalIndex.Location == ObjectReferenceLocation.ScopeArray)
+            {
+                _il.LoadArgument(0); // Load scope array parameter
+                _il.LoadConstantI4(scopeLocalIndex.Address); // Load array index
+                _il.OpCode(ILOpCode.Ldelem_ref); // Load scope from array
+            }
             else
             {
                 _il.LoadLocal(scopeLocalIndex.Address);

--- a/Js2IL/Services/ILGenerators/ILMethodGenerator.cs
+++ b/Js2IL/Services/ILGenerators/ILMethodGenerator.cs
@@ -381,6 +381,10 @@ namespace Js2IL.Services.ILGenerators
                     // Handle CallExpression
                     GenerateCallExpression(callExpression);
                     break;
+                case Acornima.Ast.AssignmentExpression assignmentExpression:
+                    // Handle AssignmentExpression  
+                    _expressionEmitter.Emit(assignmentExpression, new TypeCoercion());
+                    break;
                 case Acornima.Ast.BinaryExpression binaryExpression:
                     // Handle BinaryExpression
                     _binaryOperators.Generate(binaryExpression);


### PR DESCRIPTION
- Add AssignmentExpression support to GenerateExpressionStatement in ILMethodGenerator.cs
- Create Function_GlobalFunctionChangesGlobalVariableValue test to verify global variable modification
- Test validates that functions can both read and modify global variables correctly
- Global counter variable modified from 0 to 10 and message changed from 'Initial message' to 'Modified message'
- Both execution and IL generation tests pass, confirming proper scope array handling for assignments