### PR TITLE
Utilities/Ecma335 TypeBuilder + integration: centralize ECMA-335 meta…

### DIFF
--- a/Js2IL/Services/ILGenerators/MainGenerator.cs
+++ b/Js2IL/Services/ILGenerators/MainGenerator.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Js2IL.SymbolTables;
+using Js2IL.Utilities.Ecma335;
 
 namespace Js2IL.Services.ILGenerators
 {
@@ -17,8 +18,8 @@ namespace Js2IL.Services.ILGenerators
         private SymbolTable _symbolTable;
 
         private Dispatch.DispatchTableGenerator _dispatchTableGenerator;
+    private readonly TypeBuilder? _programTypeBuilder;
 
-        public MethodDefinitionHandle FirstMethod { get; private set; }
 
         public MainGenerator(Variables variables, BaseClassLibraryReferences bclReferences, MetadataBuilder metadataBuilder, MethodBodyStreamEncoder methodBodyStreamEncoder, Dispatch.DispatchTableGenerator dispatchTableGenerator, SymbolTable symbolTable)
         {
@@ -32,6 +33,12 @@ namespace Js2IL.Services.ILGenerators
             _ilGenerator = new ILMethodGenerator(variables, bclReferences, metadataBuilder, methodBodyStreamEncoder, _dispatchTableGenerator);
             _functionGenerator = new JavaScriptFunctionGenerator(variables, bclReferences, metadataBuilder, methodBodyStreamEncoder, _dispatchTableGenerator);
             this._methodBodyStreamEncoder = methodBodyStreamEncoder;
+        }
+
+        public MainGenerator(Variables variables, BaseClassLibraryReferences bclReferences, MetadataBuilder metadataBuilder, MethodBodyStreamEncoder methodBodyStreamEncoder, Dispatch.DispatchTableGenerator dispatchTableGenerator, SymbolTable symbolTable, TypeBuilder programTypeBuilder)
+            : this(variables, bclReferences, metadataBuilder, methodBodyStreamEncoder, dispatchTableGenerator, symbolTable)
+        {
+            _programTypeBuilder = programTypeBuilder ?? throw new ArgumentNullException(nameof(programTypeBuilder));
         }
 
         /// <summary>
@@ -170,7 +177,7 @@ namespace Js2IL.Services.ILGenerators
                 methodBodyAttributes = MethodBodyAttributes.InitLocals;
             }
 
-            FirstMethod = !_functionGenerator.FirstMethod.IsNil ? _functionGenerator.FirstMethod : _ilGenerator.FirstMethod;
+            // First method tracking is now handled by the specific generators that own method emission.
 
             return _methodBodyStreamEncoder.AddMethodBody(
                 _ilGenerator.IL,

--- a/Js2IL/Utilities/Ecma335/README.md
+++ b/Js2IL/Utilities/Ecma335/README.md
@@ -1,0 +1,7 @@
+# Ecma335 utilities
+
+This folder will contain helpers for emitting ECMA-335 metadata and IL constructs used by Js2IL.
+
+Planned components:
+- TypeBuilder: small helpers to define types, nested types, and signatures with safer defaults.
+

--- a/Js2IL/Utilities/Ecma335/TypeBuilder.cs
+++ b/Js2IL/Utilities/Ecma335/TypeBuilder.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection;
+
+namespace Js2IL.Utilities.Ecma335
+{
+    /// <summary>
+    /// A thin helper over MetadataBuilder that enforces ECMA-335 ordering rules for TypeDefinition
+    /// and tracks the first FieldDefinition and MethodDefinition added.
+    /// </summary>
+    internal sealed class TypeBuilder
+    {
+        private readonly MetadataBuilder _metadataBuilder;
+        private readonly string _namespaceName;
+        private readonly string _typeName;
+
+        private bool _typeDefinitionAdded;
+        private FieldDefinitionHandle _firstFieldDefinition = default;
+        private MethodDefinitionHandle _firstMethodDefinition = default;
+        private int _fieldCount;
+        private int _methodCount;
+
+        public TypeBuilder(MetadataBuilder metadataBuilder, string @namespace, string name)
+        {
+            _metadataBuilder = metadataBuilder ?? throw new ArgumentNullException(nameof(metadataBuilder));
+            _namespaceName = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
+            _typeName = name ?? throw new ArgumentNullException(nameof(name));
+        }
+
+        /// <summary>
+        /// Wrapper for MetadataBuilder.AddFieldDefinition. Tracks the first field handle and count.
+        /// Throws if AddTypeDefinition was already called.
+        /// </summary>
+        public FieldDefinitionHandle AddFieldDefinition(FieldAttributes attributes, string name, BlobHandle signature)
+        {
+            if (_typeDefinitionAdded)
+            {
+                throw new InvalidOperationException("AddFieldDefinition cannot be called after AddTypeDefinition.");
+            }
+
+            if (name is null) throw new ArgumentNullException(nameof(name));
+            var nameHandle = _metadataBuilder.GetOrAddString(name);
+            var handle = _metadataBuilder.AddFieldDefinition(attributes, nameHandle, signature);
+            if (_fieldCount == 0)
+            {
+                _firstFieldDefinition = handle;
+            }
+            _fieldCount++;
+            return handle;
+        }
+
+        /// <summary>
+        /// Wrapper for MetadataBuilder.AddMethodDefinition. Tracks the first method handle and count.
+        /// Allowed before or after AddTypeDefinition.
+        /// </summary>
+        public MethodDefinitionHandle AddMethodDefinition(
+            MethodAttributes attributes,
+            string name,
+            BlobHandle signature,
+            int bodyOffset,
+            ParameterHandle parameterList)
+        {
+            if (name is null) throw new ArgumentNullException(nameof(name));
+            var nameHandle = _metadataBuilder.GetOrAddString(name);
+            // If caller passed a nil parameter list, compute the next Param handle as required
+            var effectiveParameterList = parameterList.IsNil
+                ? MetadataTokens.ParameterHandle(_metadataBuilder.GetRowCount(TableIndex.Param) + 1)
+                : parameterList;
+            var handle = _metadataBuilder.AddMethodDefinition(attributes, MethodImplAttributes.IL, nameHandle, signature, bodyOffset, effectiveParameterList);
+            if (_methodCount == 0)
+            {
+                _firstMethodDefinition = handle;
+            }
+            _methodCount++;
+            return handle;
+        }
+
+        /// <summary>
+        /// Overload that omits parameterList; defaults to the next Param row handle.
+        /// </summary>
+        public MethodDefinitionHandle AddMethodDefinition(
+            MethodAttributes attributes,
+            string name,
+            BlobHandle signature,
+            int bodyOffset)
+        {
+            return AddMethodDefinition(attributes, name, signature, bodyOffset, default);
+        }
+
+        /// <summary>
+        /// Wrapper for MetadataBuilder.AddTypeDefinition. Can only be called once.
+        /// Supplies the first field and first method handles automatically to satisfy ECMA-335 ordering.
+        /// Uses constructor-provided namespace and name strings, resolved at call-time via GetOrAddString.
+        /// </summary>
+        public TypeDefinitionHandle AddTypeDefinition(
+            TypeAttributes attributes,
+            EntityHandle baseType)
+        {
+            if (_typeDefinitionAdded)
+            {
+                throw new InvalidOperationException("AddTypeDefinition can only be called once per TypeBuilder instance.");
+            }
+
+            // Resolve namespace and name handles at the time of type definition creation
+            var nsHandle = _metadataBuilder.GetOrAddString(_namespaceName);
+            var nameHandle = _metadataBuilder.GetOrAddString(_typeName);
+
+            // 5th parameter: first field definition handle or next row if none were added.
+            var fieldList = !_firstFieldDefinition.IsNil
+                ? _firstFieldDefinition
+                : MetadataTokens.FieldDefinitionHandle(_metadataBuilder.GetRowCount(TableIndex.Field) + 1);
+
+            // 6th parameter: first method definition handle or next row if none were added at the time of the call.
+            var methodList = !_firstMethodDefinition.IsNil
+                ? _firstMethodDefinition
+                : MetadataTokens.MethodDefinitionHandle(_metadataBuilder.GetRowCount(TableIndex.MethodDef) + 1);
+
+            var typeHandle = _metadataBuilder.AddTypeDefinition(attributes, nsHandle, nameHandle, baseType, fieldList, methodList);
+            _typeDefinitionAdded = true;
+            return typeHandle;
+        }
+
+        /// <summary>
+        /// Gets the number of fields that have been added via this builder.
+        /// </summary>
+        public int GetFieldCount() => _fieldCount;
+
+        /// <summary>
+        /// Gets the number of methods that have been added via this builder.
+        /// </summary>
+        public int GetMethodCount() => _methodCount;
+    }
+}


### PR DESCRIPTION
- Introduce Utilities/Ecma335/TypeBuilder to wrap MetadataBuilder and enforce ECMA-335 ordering (single AddTypeDefinition; first field/method auto-wiring; counters).

- Use string-based names for types/methods/fields; resolve handles internally.

- Normalize nil ParamList to next Param row; add overload to omit ParamList.

- Drop MethodImplAttributes parameter from AddMethodDefinition; default to IL.

- Refactor TypeGenerator, DispatchTableGenerator, JavaScriptFunctionGenerator, and AssemblyGenerator to use TypeBuilder; remove MainGenerator.FirstMethod.

- Remove explicit MetadataTokens.ParameterHandle usages; rely on TypeBuilder defaults except where parameters are explicitly added (function methods).

- All tests pass.