### PR TITLE
tests: speed up by running generated assemblies in-proc with isolated…

### DIFF
--- a/Js2IL.Tests/AssemblyInfo.cs
+++ b/Js2IL.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
… ALC; fix System.Runtime ref selection to match host; disable xUnit parallelization to avoid Console capture contention