### PR TITLE
feature/nuget package

### DIFF
--- a/.github/workflows/publish-tool.yml
+++ b/.github/workflows/publish-tool.yml
@@ -1,0 +1,42 @@
+name: Publish js2il tool
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    runs-on: windows-latest
+    env:
+      NUGET_SERVER: https://api.nuget.org/v3/index.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Compute version from tag
+        shell: pwsh
+        run: |
+          $tag = "$env:GITHUB_REF_NAME"
+          if ($tag.StartsWith('v')) { $version = $tag.Substring(1) } else { $version = $tag }
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Restore
+        run: dotnet restore js2il.sln
+
+      - name: Build
+        run: dotnet build js2il.sln -c Release --no-restore
+
+      - name: Test
+        run: dotnet test js2il.sln -c Release --no-build --verbosity normal
+
+      - name: Pack tool
+        run: dotnet pack Js2IL/Js2IL.csproj -c Release -o out -p:ContinuousIntegrationBuild=true -p:Version=${{ env.VERSION }}
+
+      - name: Publish to NuGet
+        run: dotnet nuget push out/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.NUGET_SERVER }} --skip-duplicate

--- a/Js2IL/Js2IL.csproj
+++ b/Js2IL/Js2IL.csproj
@@ -34,8 +34,8 @@
     <ProjectReference Include="..\JavaScriptRuntime\JavaScriptRuntime.csproj" />
   </ItemGroup>
 
-  <!-- Include root README in the package for nuget.org rendering -->
+  <!-- Include consumer README from docs as package root README.md -->
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="" />
+    <None Include="..\docs\NuGet.README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 </Project>

--- a/Js2IL/Js2IL.csproj
+++ b/Js2IL/Js2IL.csproj
@@ -37,5 +37,6 @@
   <!-- Include consumer README from docs as package root README.md -->
   <ItemGroup>
     <None Include="..\docs\NuGet.README.md" Pack="true" PackagePath="README.md" />
+  <None Include="..\docs\ECMAScript2025_FeatureCoverage.md" Pack="true" PackagePath="docs/ECMAScript2025_FeatureCoverage.md" />
   </ItemGroup>
 </Project>

--- a/Js2IL/Js2IL.csproj
+++ b/Js2IL/Js2IL.csproj
@@ -5,10 +5,24 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Enable self-contained publishing -->
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>true</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
+  <!-- Tool packages cannot be self-contained/single-file/trimmed -->
+  <SelfContained>false</SelfContained>
+  <PublishSingleFile>false</PublishSingleFile>
+  <PublishTrimmed>false</PublishTrimmed>
+  <!-- NuGet tool packaging -->
+  <PackAsTool>true</PackAsTool>
+  <ToolCommandName>js2il</ToolCommandName>
+  <PackageId>js2il</PackageId>
+  <Version>0.1.0-preview.2</Version>
+  <Authors>tomacox74</Authors>
+  <Company></Company>
+  <Description>JavaScript to .NET IL prototype: parse ES into AST and emit ECMA-335 IL to run on .NET.</Description>
+  <RepositoryUrl>https://github.com/tomacox74/js2il</RepositoryUrl>
+  <RepositoryType>git</RepositoryType>
+  <PackageReadmeFile>README.md</PackageReadmeFile>
+  <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+  <PackageTags>javascript;js;il;ecma-335;dotnet;compiler;transpiler;tool</PackageTags>
+  <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,5 +32,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\JavaScriptRuntime\JavaScriptRuntime.csproj" />
+  </ItemGroup>
+
+  <!-- Include root README in the package for nuget.org rendering -->
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/Js2IL/Program.cs
+++ b/Js2IL/Program.cs
@@ -35,8 +35,12 @@ class Program
 {
     static void Main(string[] args)
     {
-        JavaScriptRuntime.Console.Log("1", "2");
-
+        // Quick help/usage path
+        if (args.Length == 0 || args.Contains("--help") || args.Contains("-h") || args.Contains("/?"))
+        {
+            PrintUsage();
+            return;
+        }
 
         try
         {
@@ -161,7 +165,8 @@ class Program
         catch (ArgException ex)
         {
             Console.WriteLine(ex.Message);
-            Console.WriteLine(ArgUsage.GenerateUsageFromTemplate<Js2ILArgs>());
+            // Avoid potential template generation issues by printing a simple usage message
+            PrintUsage();
         }
         catch (Exception ex)
         {
@@ -194,5 +199,16 @@ class Program
         {
             PrintScopeTree(child, indentLevel + 1);
         }
+    }
+
+    private static void PrintUsage()
+    {
+        Console.WriteLine("Usage - Js2IL <InputFile> [<OutputPath>] -options");
+        Console.WriteLine();
+        Console.WriteLine("GlobalOption         Description");
+        Console.WriteLine("InputFile* (-I)      The JavaScript file to convert");
+        Console.WriteLine("OutputPath (-O)      The output path for the generated IL");
+        Console.WriteLine("Verbose (-V)         Enable verbose output");
+        Console.WriteLine("AnalyzeUnused (-A)   Analyze and report unused properties and methods");
     }
 }

--- a/docs/NuGet.README.md
+++ b/docs/NuGet.README.md
@@ -1,0 +1,87 @@
+# js2il – JavaScript to .NET IL (consumer guide)
+
+js2il is a .NET global tool that parses JavaScript (ES) and emits ECMA‑335 IL you can run on .NET.
+
+## Install
+
+- Prerequisite: .NET 8.0 SDK or runtime installed.
+- Install the tool globally:
+
+```powershell
+dotnet tool install --global js2il
+```
+
+Update later:
+
+```powershell
+dotnet tool update --global js2il
+```
+
+Uninstall:
+
+```powershell
+dotnet tool uninstall --global js2il
+```
+
+## Usage
+
+```powershell
+js2il <InputFile> [<OutputPath>] [-V] [-A]
+```
+
+- InputFile (-I)       The JavaScript file to convert (required)
+- OutputPath (-O)      Output folder for the generated IL/assembly (defaults to the input file directory)
+- Verbose (-V)         Prints AST and scope info
+- AnalyzeUnused (-A)   Reports unused functions/properties/variables
+
+Example:
+
+```powershell
+# Convert tests\simple.js and write output next to the file
+js2il .\tests\simple.js
+
+# Convert to a specific directory with verbose output
+js2il .\tests\simple.js .\out -V
+```
+
+## What gets generated?
+
+Given an input like `C:\code\sample.js`, js2il will emit the following into the output directory (default: alongside the input file):
+
+- `sample.dll`
+	- A .NET assembly (targeting net8.0) containing IL corresponding to your JavaScript.
+	- The assembly name is the input file name without extension.
+	- Contains a `Program.Main` entry point that executes your script when run.
+- `sample.runtimeconfig.json`
+	- Runtime configuration for the `dotnet` host (framework: .NET 8).
+- `JavaScriptRuntime.dll` (+ optional `JavaScriptRuntime.pdb` if available)
+	- Required runtime support library that provides JS primitives (e.g., `console.log`, arrays, objects) used by the emitted IL.
+	- This file is copied next to your generated assembly and must be present at runtime.
+
+Run it with:
+
+```powershell
+dotnet .\sample.dll
+```
+
+Notes:
+
+- Console output (e.g., `console.log`) is implemented via the bundled `JavaScriptRuntime.dll`.
+- This is a prototype and doesn’t yet support all JavaScript features. See the repo docs for supported syntax and feature coverage.
+
+## Limitations
+
+- Target framework: net8.0
+- Not all JS features are supported; some constructs may be validated and rejected with explanations.
+- Emitted IL and runtime surface are subject to change between previews.
+
+## Troubleshooting
+
+- Ensure the .NET 8.0 SDK/runtime is on PATH: `dotnet --info`
+- Use `-V` to print extra diagnostics.
+- File an issue with a minimal JS sample if you suspect a bug.
+
+## Links
+
+- Source, issues, docs: https://github.com/tomacox74/js2il
+- License: Apache-2.0


### PR DESCRIPTION
﻿## Summary
Prepare js2il for NuGet distribution as a .NET global tool and add consumer-facing docs.

## Changes
- Package as .NET tool (PackAsTool) with metadata; disabled self-contained/single-file/trim to support tool packaging.
- Add consumer README at `docs/NuGet.README.md` and wire it as package `README.md` (NuGet rendering).
- Add prominent preview disclaimer (tool is not feature-complete; APIs may change).
- Include `docs/ECMAScript2025_FeatureCoverage.md` in the nupkg under `docs/`.
- Improve CLI UX: `--help` path and friendly usage; remove stray debug log.
- Add GitHub Actions workflow for tag-based pack + publish to NuGet (`.github/workflows/publish-tool.yml`).

## Validation
- Packed locally and installed from the generated nupkg; `js2il --help` runs clean.

## Next steps
- Add repo secret `NUGET_API_KEY` for nuget.org.
- Tag a version (e.g., `v0.1.0-preview.2`) to publish via CI.
