### PR TITLE
Try/catch/finally support groundwork: catch policy, scope lifecycle refactor, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ TestResults/
 **/TestResults/
 *.trx
 
-# Old/renamed folders to ignore
-Js2IL/Scoping/
-
 # Node dependencies
 node_modules/
 

--- a/JavaScriptRuntime/Console.cs
+++ b/JavaScriptRuntime/Console.cs
@@ -10,7 +10,7 @@ namespace JavaScriptRuntime
     {
         private static IConsoleOutput _output = new DefaultConsoleOutput();
 
-        public static void SetOutput(IConsoleOutput output)
+    public static void SetOutput(IConsoleOutput output)
         {
             _output = output ?? new DefaultConsoleOutput();
         }

--- a/JavaScriptRuntime/Error.cs
+++ b/JavaScriptRuntime/Error.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace JavaScriptRuntime
+{
+    /// <summary>
+    /// Minimal JavaScript-like Error object for the runtime.
+    /// Inherits from System.Exception so it can be thrown/caught with .NET mechanics
+    /// while exposing JS-style properties (name, message, stack).
+    /// </summary>
+    public class Error : Exception
+    {
+        private readonly string _constructedStack;
+
+        // PascalCase (JS has a 'name' string property on Error instances)
+        public string Name { get; protected set; }
+
+        // JS-style aliases
+        public string name => Name;
+        public string message => base.Message;
+        public string stack
+        {
+            get
+            {
+                // If not thrown yet, StackTrace may be null; fall back to construction stack.
+                return base.StackTrace ?? _constructedStack;
+            }
+        }
+
+        // Convenience .NET-style alias (optional)
+        public string Stack => stack;
+
+        public Error() : this(string.Empty) { }
+
+        public Error(string? message) : base(message ?? string.Empty)
+        {
+            Name = "Error";
+            _constructedStack = CaptureStack();
+        }
+
+        public Error(string? message, Exception? innerException) : base(message ?? string.Empty, innerException)
+        {
+            Name = "Error";
+            _constructedStack = CaptureStack();
+        }
+
+        protected virtual string CaptureStack()
+        {
+            // Capture current .NET stack trace as a placeholder for JS stack
+            // In the future, this can be mapped to JS frame formats.
+            return Environment.StackTrace ?? string.Empty;
+        }
+
+        public override string ToString()
+            => string.IsNullOrEmpty(Message) ? Name : $"{Name}: {Message}";
+    }
+
+    public class EvalError : Error
+    {
+        public EvalError() : base() { Name = "EvalError"; }
+        public EvalError(string? message) : base(message) { Name = "EvalError"; }
+        public EvalError(string? message, Exception? inner) : base(message, inner) { Name = "EvalError"; }
+    }
+
+    public class RangeError : Error
+    {
+        public RangeError() : base() { Name = "RangeError"; }
+        public RangeError(string? message) : base(message) { Name = "RangeError"; }
+        public RangeError(string? message, Exception? inner) : base(message, inner) { Name = "RangeError"; }
+    }
+
+    public class ReferenceError : Error
+    {
+        public ReferenceError() : base() { Name = "ReferenceError"; }
+        public ReferenceError(string? message) : base(message) { Name = "ReferenceError"; }
+        public ReferenceError(string? message, Exception? inner) : base(message, inner) { Name = "ReferenceError"; }
+    }
+
+    public class SyntaxError : Error
+    {
+        public SyntaxError() : base() { Name = "SyntaxError"; }
+        public SyntaxError(string? message) : base(message) { Name = "SyntaxError"; }
+        public SyntaxError(string? message, Exception? inner) : base(message, inner) { Name = "SyntaxError"; }
+    }
+
+    public class TypeError : Error
+    {
+        public TypeError() : base() { Name = "TypeError"; }
+        public TypeError(string? message) : base(message) { Name = "TypeError"; }
+        public TypeError(string? message, Exception? inner) : base(message, inner) { Name = "TypeError"; }
+    }
+
+    public class AggregateError : Error
+    {
+        // In JS AggregateError has an iterable of errors. Represent as object[] here.
+        public object[] Errors { get; }
+        public object[] errors => Errors; // JS-style alias
+
+        public AggregateError() : this(System.Array.Empty<object>(), null) { }
+        public AggregateError(IEnumerable<object> errors) : this(errors, null) { }
+        public AggregateError(IEnumerable<object> errors, string? message) : base(message)
+        {
+            Name = "AggregateError";
+            Errors = errors?.ToArray() ?? System.Array.Empty<object>();
+        }
+
+        public AggregateError(IEnumerable<object> errors, string? message, Exception? inner) : base(message, inner)
+        {
+            Name = "AggregateError";
+            Errors = errors?.ToArray() ?? System.Array.Empty<object>();
+        }
+
+        public override string ToString()
+        {
+            var baseStr = base.ToString();
+            if (Errors.Length == 0) return baseStr;
+            return baseStr + $" (errors: {Errors.Length})";
+        }
+    }
+}

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_Break_AtThree.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_Break_AtThree.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_DoWhile_Break_AtThree
+﻿// IL code: ControlFlow_DoWhile_Break_AtThree
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -31,94 +31,12 @@
 
 		} // end of class Block_L4C14
 
-		.class nested public auto ansi beforefieldinit Block_L4C14
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x206b
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L4C14::.ctor
-
-		} // end of class Block_L4C14
-
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L3C3::.ctor
-
-	} // end of class Block_L3C3
-
-	.class nested public auto ansi beforefieldinit Block_L3C3
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Block_L4C14
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x207d
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L4C14::.ctor
-
-		} // end of class Block_L4C14
-
-		.class nested public auto ansi beforefieldinit Block_L4C14
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x2086
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L4C14::.ctor
-
-		} // end of class Block_L4C14
-
-
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,7 +77,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 162 (0xa2)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_Continue_SkipEven.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_Continue_SkipEven.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_DoWhile_Continue_SkipEven
+﻿// IL code: ControlFlow_DoWhile_Continue_SkipEven
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -31,94 +31,12 @@
 
 		} // end of class Block_L3C18
 
-		.class nested public auto ansi beforefieldinit Block_L3C18
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x206b
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L3C18::.ctor
-
-		} // end of class Block_L3C18
-
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L2C3::.ctor
-
-	} // end of class Block_L2C3
-
-	.class nested public auto ansi beforefieldinit Block_L2C3
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Block_L3C18
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x207d
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L3C18::.ctor
-
-		} // end of class Block_L3C18
-
-		.class nested public auto ansi beforefieldinit Block_L3C18
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x2086
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L3C18::.ctor
-
-		} // end of class Block_L3C18
-
-
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,7 +77,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 209 (0xd1)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_CountDownFromFive.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_CountDownFromFive.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_DoWhile_CountDownFromFive
+﻿// IL code: ControlFlow_DoWhile_CountDownFromFive
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -15,26 +15,6 @@
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L2C3::.ctor
-
-	} // end of class Block_L2C3
-
-	.class nested public auto ansi beforefieldinit Block_L2C3
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2062
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -75,7 +55,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x206c
+		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 117 (0x75)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_Break_AtThree.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_Break_AtThree.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_ForLoop_Break_AtThree
+﻿// IL code: ControlFlow_ForLoop_Break_AtThree
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -19,26 +19,6 @@
 				instance void .ctor () cil managed 
 			{
 				// Method begins at RVA 0x2062
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L3C14::.ctor
-
-		} // end of class Block_L3C14
-
-		.class nested public auto ansi beforefieldinit Block_L3C14
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x206b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -97,7 +77,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2074
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 167 (0xa7)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_Continue_SkipEven.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_Continue_SkipEven.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_ForLoop_Continue_SkipEven
+﻿// IL code: ControlFlow_ForLoop_Continue_SkipEven
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -19,26 +19,6 @@
 				instance void .ctor () cil managed 
 			{
 				// Method begins at RVA 0x2062
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L4C20::.ctor
-
-		} // end of class Block_L4C20
-
-		.class nested public auto ansi beforefieldinit Block_L4C20
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x206b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -97,7 +77,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2074
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 197 (0xc5)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_BooleanLiteral.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_BooleanLiteral.verified.txt
@@ -47,7 +47,7 @@
 
 	} // end of class Block_L3C7
 
-	.class nested public auto ansi beforefieldinit Block_L1C10
+	.class nested public auto ansi beforefieldinit Block_L6C11
 		extends [System.Runtime]System.Object
 	{
 		// Methods
@@ -63,11 +63,11 @@
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: nop
 			IL_0007: ret
-		} // end of method Block_L1C10::.ctor
+		} // end of method Block_L6C11::.ctor
 
-	} // end of class Block_L1C10
+	} // end of class Block_L6C11
 
-	.class nested public auto ansi beforefieldinit Block_L3C7
+	.class nested public auto ansi beforefieldinit Block_L8C7
 		extends [System.Runtime]System.Object
 	{
 		// Methods
@@ -75,86 +75,6 @@
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2074
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L3C7::.ctor
-
-	} // end of class Block_L3C7
-
-	.class nested public auto ansi beforefieldinit Block_L6C11
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x207d
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L6C11::.ctor
-
-	} // end of class Block_L6C11
-
-	.class nested public auto ansi beforefieldinit Block_L8C7
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2086
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L8C7::.ctor
-
-	} // end of class Block_L8C7
-
-	.class nested public auto ansi beforefieldinit Block_L6C11
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x208f
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L6C11::.ctor
-
-	} // end of class Block_L6C11
-
-	.class nested public auto ansi beforefieldinit Block_L8C7
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2098
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,7 +112,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20a4
+		// Method begins at RVA 0x2080
 		// Header size: 12
 		// Code size: 109 (0x6d)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_LessThan.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_LessThan.verified.txt
@@ -47,46 +47,6 @@
 
 	} // end of class Block_L3C7
 
-	.class nested public auto ansi beforefieldinit Block_L1C11
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x206b
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L1C11::.ctor
-
-	} // end of class Block_L1C11
-
-	.class nested public auto ansi beforefieldinit Block_L3C7
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L3C7::.ctor
-
-	} // end of class Block_L3C7
-
 
 	// Methods
 	.method public hidebysig specialname rtspecialname 
@@ -112,7 +72,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2080
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 106 (0x6a)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_NotFlag.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_NotFlag.verified.txt
@@ -27,26 +27,6 @@
 
 	} // end of class Block_L2C11
 
-	.class nested public auto ansi beforefieldinit Block_L2C11
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2062
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L2C11::.ctor
-
-	} // end of class Block_L2C11
-
 
 	// Fields
 	.field public object flag
@@ -75,7 +55,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x206c
+		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 64 (0x40)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_Break_AtThree.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_Break_AtThree.verified.txt
@@ -31,94 +31,12 @@
 
 		} // end of class Block_L4C14
 
-		.class nested public auto ansi beforefieldinit Block_L4C14
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x206b
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L4C14::.ctor
-
-		} // end of class Block_L4C14
-
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L3C15::.ctor
-
-	} // end of class Block_L3C15
-
-	.class nested public auto ansi beforefieldinit Block_L3C15
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Block_L4C14
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x207d
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L4C14::.ctor
-
-		} // end of class Block_L4C14
-
-		.class nested public auto ansi beforefieldinit Block_L4C14
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x2086
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L4C14::.ctor
-
-		} // end of class Block_L4C14
-
-
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,7 +77,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 167 (0xa7)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_Continue_SkipEven.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_Continue_SkipEven.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_While_Continue_SkipEven
+﻿// IL code: ControlFlow_While_Continue_SkipEven
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -31,94 +31,12 @@
 
 		} // end of class Block_L3C18
 
-		.class nested public auto ansi beforefieldinit Block_L3C18
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x206b
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L3C18::.ctor
-
-		} // end of class Block_L3C18
-
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L2C15::.ctor
-
-	} // end of class Block_L2C15
-
-	.class nested public auto ansi beforefieldinit Block_L2C15
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Block_L3C18
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x207d
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L3C18::.ctor
-
-		} // end of class Block_L3C18
-
-		.class nested public auto ansi beforefieldinit Block_L3C18
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x2086
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L3C18::.ctor
-
-		} // end of class Block_L3C18
-
-
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,7 +77,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 214 (0xd6)
 		.maxstack 8

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_CountDownFromFive.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_CountDownFromFive.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_While_CountDownFromFive
+﻿// IL code: ControlFlow_While_CountDownFromFive
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -15,26 +15,6 @@
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L2C18::.ctor
-
-	} // end of class Block_L2C18
-
-	.class nested public auto ansi beforefieldinit Block_L2C18
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2062
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -75,7 +55,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x206c
+		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 122 (0x7a)
 		.maxstack 8

--- a/Js2IL.Tests/ExecutionTests.cs
+++ b/Js2IL.Tests/ExecutionTests.cs
@@ -22,5 +22,9 @@ namespace Js2IL.Tests
 
         [Fact(Skip = "process/argv not yet supported")]
         public Task Environment_EnumerateProcessArgV() { var testName = nameof(Environment_EnumerateProcessArgV); return ExecutionTest(testName); }
+
+    // Try/Catch
+    [Fact(Skip = "try/catch not yet implemented")]
+    public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return ExecutionTest(testName); }
     }
 }

--- a/Js2IL.Tests/ExecutionTests.cs
+++ b/Js2IL.Tests/ExecutionTests.cs
@@ -23,8 +23,5 @@ namespace Js2IL.Tests
         [Fact(Skip = "process/argv not yet supported")]
         public Task Environment_EnumerateProcessArgV() { var testName = nameof(Environment_EnumerateProcessArgV); return ExecutionTest(testName); }
 
-    // Try/Catch
-    [Fact(Skip = "try/catch not yet implemented")]
-    public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return ExecutionTest(testName); }
     }
 }

--- a/Js2IL.Tests/JavaScript/TryCatch_NoBinding.js
+++ b/Js2IL.Tests/JavaScript/TryCatch_NoBinding.js
@@ -1,0 +1,8 @@
+try {
+    console.log("before throw");
+    throw new Error("test error message");
+} catch {
+    console.log("in catch");
+}
+
+console.log("after catch");

--- a/Js2IL.Tests/JavaScript/TryCatch_NoBinding_NoThrow.js
+++ b/Js2IL.Tests/JavaScript/TryCatch_NoBinding_NoThrow.js
@@ -1,0 +1,9 @@
+const global = 7;
+console.log("before try");
+try {
+  const local = global + 4;
+  console.log("Inside catch.  Calculated value is", local);
+} catch {
+  console.log("inside catch.. we should not be here");
+}
+console.log("try/catch finished.");

--- a/Js2IL.Tests/JavaScript/TryFinally_NoCatch.js
+++ b/Js2IL.Tests/JavaScript/TryFinally_NoCatch.js
@@ -1,0 +1,7 @@
+try {
+    console.log("in try");
+} finally {
+    console.log("in finally");
+}
+
+console.log("after finally");

--- a/Js2IL.Tests/JavaScript/TryFinally_NoCatch_Throw.js
+++ b/Js2IL.Tests/JavaScript/TryFinally_NoCatch_Throw.js
@@ -1,0 +1,8 @@
+try {
+    console.log("in try");
+    throw new Error("boom");
+} finally {
+    console.log("in finally");
+}
+
+console.log("after finally");

--- a/Js2IL.Tests/Literals/ExecutionTests.cs
+++ b/Js2IL.Tests/Literals/ExecutionTests.cs
@@ -9,6 +9,6 @@ namespace Js2IL.Tests.Literals
         // Literal evaluation tests
         [Fact] public Task ArrayLiteral() { var testName = nameof(ArrayLiteral); return ExecutionTest(testName); }
         [Fact] public Task ObjectLiteral() { var testName = nameof(ObjectLiteral); return ExecutionTest(testName); }
-    [Fact] public Task BooleanLiteral() { var testName = nameof(BooleanLiteral); return ExecutionTest(testName); }
+        [Fact] public Task BooleanLiteral() { var testName = nameof(BooleanLiteral); return ExecutionTest(testName); }
     }
 }

--- a/Js2IL.Tests/Literals/GeneratorTests.cs
+++ b/Js2IL.Tests/Literals/GeneratorTests.cs
@@ -9,6 +9,6 @@ namespace Js2IL.Tests.Literals
         // Literal code generation tests
         [Fact] public Task ArrayLiteral() { var testName = nameof(ArrayLiteral); return GenerateTest(testName); }
         [Fact] public Task ObjectLiteral() { var testName = nameof(ObjectLiteral); return GenerateTest(testName); }
-    [Fact(Skip = "Snapshot pending for BooleanLiteral generator")] public Task BooleanLiteral() { var testName = nameof(BooleanLiteral); return GenerateTest(testName); }
+        [Fact] public Task BooleanLiteral() { var testName = nameof(BooleanLiteral); return GenerateTest(testName); }
     }
 }

--- a/Js2IL.Tests/TryCatch/ExecutionTests.TryCatch_NoBinding.verified.txt
+++ b/Js2IL.Tests/TryCatch/ExecutionTests.TryCatch_NoBinding.verified.txt
@@ -1,0 +1,3 @@
+before throw
+in catch
+after catch

--- a/Js2IL.Tests/TryCatch/ExecutionTests.TryCatch_NoBinding_NoThrow.verified.txt
+++ b/Js2IL.Tests/TryCatch/ExecutionTests.TryCatch_NoBinding_NoThrow.verified.txt
@@ -1,0 +1,3 @@
+before try
+Inside catch.  Calculated value is 11
+try/catch finished.

--- a/Js2IL.Tests/TryCatch/ExecutionTests.TryFinally_NoCatch.verified.txt
+++ b/Js2IL.Tests/TryCatch/ExecutionTests.TryFinally_NoCatch.verified.txt
@@ -1,0 +1,3 @@
+in try
+in finally
+after finally

--- a/Js2IL.Tests/TryCatch/ExecutionTests.TryFinally_NoCatch_Throw.verified.txt
+++ b/Js2IL.Tests/TryCatch/ExecutionTests.TryFinally_NoCatch_Throw.verified.txt
@@ -1,0 +1,3 @@
+﻿in try
+Uncaught Error: boom
+in finally

--- a/Js2IL.Tests/TryCatch/ExecutionTests.cs
+++ b/Js2IL.Tests/TryCatch/ExecutionTests.cs
@@ -11,6 +11,8 @@ namespace Js2IL.Tests.TryCatch
         // Try/Catch execution tests
         [Fact]
         public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return ExecutionTest(testName); }
+    [Fact]
+    public Task TryCatch_NoBinding_NoThrow() { var testName = nameof(TryCatch_NoBinding_NoThrow); return ExecutionTest(testName); }
         // Try/Finally (no catch)
         [Fact]
         public Task TryFinally_NoCatch() { var testName = nameof(TryFinally_NoCatch); return ExecutionTest(testName); }

--- a/Js2IL.Tests/TryCatch/ExecutionTests.cs
+++ b/Js2IL.Tests/TryCatch/ExecutionTests.cs
@@ -8,8 +8,15 @@ namespace Js2IL.Tests.TryCatch
         {
         }
 
-    // Try/Catch execution tests
-    [Fact(Skip = "try/catch not yet implemented")]
-    public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return ExecutionTest(testName); }
+        // Try/Catch execution tests
+        [Fact]
+        public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return ExecutionTest(testName); }
+        // Try/Finally (no catch)
+        [Fact]
+        public Task TryFinally_NoCatch() { var testName = nameof(TryFinally_NoCatch); return ExecutionTest(testName); }
+
+        // Try/Finally (no catch) with throw inside try: postpone unhandled-error semantics; allow crash by skipping
+        [Fact(Skip = "Unhandled JS Error semantics postponed; allow crash for now")]
+        public Task TryFinally_NoCatch_Throw() { var testName = nameof(TryFinally_NoCatch_Throw); return ExecutionTest(testName); }
     }
 }

--- a/Js2IL.Tests/TryCatch/ExecutionTests.cs
+++ b/Js2IL.Tests/TryCatch/ExecutionTests.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace Js2IL.Tests.TryCatch
+{
+    public class ExecutionTests : ExecutionTestsBase
+    {
+        public ExecutionTests() : base("TryCatch")
+        {
+        }
+
+        // Add try/catch execution tests here
+    }
+}

--- a/Js2IL.Tests/TryCatch/ExecutionTests.cs
+++ b/Js2IL.Tests/TryCatch/ExecutionTests.cs
@@ -8,6 +8,8 @@ namespace Js2IL.Tests.TryCatch
         {
         }
 
-        // Add try/catch execution tests here
+    // Try/Catch execution tests
+    [Fact(Skip = "try/catch not yet implemented")]
+    public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return ExecutionTest(testName); }
     }
 }

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding.verified.txt
@@ -1,0 +1,203 @@
+﻿// IL code: TryCatch_NoBinding
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.TryCatch_NoBinding
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Block_L1C4
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L1C4::.ctor
+
+	} // end of class Block_L1C4
+
+	.class nested public auto ansi beforefieldinit Block_L4C8
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L4C8::.ctor
+
+	} // end of class Block_L4C8
+
+	.class nested public auto ansi beforefieldinit Block_L4C8
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L4C8::.ctor
+
+	} // end of class Block_L4C8
+
+	.class nested public auto ansi beforefieldinit Block_L1C4
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L1C4::.ctor
+
+	} // end of class Block_L1C4
+
+	.class nested public auto ansi beforefieldinit Block_L4C8
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x207d
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L4C8::.ctor
+
+	} // end of class Block_L4C8
+
+	.class nested public auto ansi beforefieldinit Block_L4C8
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2086
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L4C8::.ctor
+
+	} // end of class Block_L4C8
+
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method TryCatch_NoBinding::.ctor
+
+} // end of class Scopes.TryCatch_NoBinding
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2090
+		// Header size: 12
+		// Code size: 80 (0x50)
+		.maxstack 8
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		.try
+		{
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldstr "before throw"
+			IL_000d: stelem.ref
+			IL_000e: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_0013: ldstr "test error message"
+			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_001d: throw
+
+			IL_001e: leave IL_003c
+		} // end .try
+		catch [JavaScriptRuntime]JavaScriptRuntime.Error
+		{
+			IL_0023: pop
+			IL_0024: ldc.i4.1
+			IL_0025: newarr [System.Runtime]System.Object
+			IL_002a: dup
+			IL_002b: ldc.i4.0
+			IL_002c: ldstr "in catch"
+			IL_0031: stelem.ref
+			IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_0037: leave IL_003c
+		} // end handler
+
+		IL_003c: ldc.i4.1
+		IL_003d: newarr [System.Runtime]System.Object
+		IL_0042: dup
+		IL_0043: ldc.i4.0
+		IL_0044: ldstr "after catch"
+		IL_0049: stelem.ref
+		IL_004a: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_004f: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding.verified.txt
@@ -47,86 +47,6 @@
 
 	} // end of class Block_L4C8
 
-	.class nested public auto ansi beforefieldinit Block_L4C8
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x206b
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L4C8::.ctor
-
-	} // end of class Block_L4C8
-
-	.class nested public auto ansi beforefieldinit Block_L1C4
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L1C4::.ctor
-
-	} // end of class Block_L1C4
-
-	.class nested public auto ansi beforefieldinit Block_L4C8
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x207d
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L4C8::.ctor
-
-	} // end of class Block_L4C8
-
-	.class nested public auto ansi beforefieldinit Block_L4C8
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2086
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L4C8::.ctor
-
-	} // end of class Block_L4C8
-
 
 	// Methods
 	.method public hidebysig specialname rtspecialname 
@@ -152,7 +72,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 80 (0x50)
 		.maxstack 8

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding_NoThrow.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding_NoThrow.verified.txt
@@ -50,89 +50,6 @@
 
 	} // end of class Block_L6C8
 
-	.class nested public auto ansi beforefieldinit Block_L6C8
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x206b
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L6C8::.ctor
-
-	} // end of class Block_L6C8
-
-	.class nested public auto ansi beforefieldinit Block_L3C4
-		extends [System.Runtime]System.Object
-	{
-		// Fields
-		.field public initonly object local
-
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L3C4::.ctor
-
-	} // end of class Block_L3C4
-
-	.class nested public auto ansi beforefieldinit Block_L6C8
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x207d
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L6C8::.ctor
-
-	} // end of class Block_L6C8
-
-	.class nested public auto ansi beforefieldinit Block_L6C8
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2086
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L6C8::.ctor
-
-	} // end of class Block_L6C8
-
 
 	// Fields
 	.field public initonly object global
@@ -161,7 +78,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 163 (0xa3)
 		.maxstack 8

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding_NoThrow.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding_NoThrow.verified.txt
@@ -1,0 +1,239 @@
+﻿// IL code: TryCatch_NoBinding_NoThrow
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.TryCatch_NoBinding_NoThrow
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Block_L3C4
+		extends [System.Runtime]System.Object
+	{
+		// Fields
+		.field public initonly object local
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L3C4::.ctor
+
+	} // end of class Block_L3C4
+
+	.class nested public auto ansi beforefieldinit Block_L6C8
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L6C8::.ctor
+
+	} // end of class Block_L6C8
+
+	.class nested public auto ansi beforefieldinit Block_L6C8
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L6C8::.ctor
+
+	} // end of class Block_L6C8
+
+	.class nested public auto ansi beforefieldinit Block_L3C4
+		extends [System.Runtime]System.Object
+	{
+		// Fields
+		.field public initonly object local
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L3C4::.ctor
+
+	} // end of class Block_L3C4
+
+	.class nested public auto ansi beforefieldinit Block_L6C8
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x207d
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L6C8::.ctor
+
+	} // end of class Block_L6C8
+
+	.class nested public auto ansi beforefieldinit Block_L6C8
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2086
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L6C8::.ctor
+
+	} // end of class Block_L6C8
+
+
+	// Fields
+	.field public initonly object global
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method TryCatch_NoBinding_NoThrow::.ctor
+
+} // end of class Scopes.TryCatch_NoBinding_NoThrow
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2090
+		// Header size: 12
+		// Code size: 163 (0xa3)
+		.maxstack 8
+		.entrypoint
+		.locals init (
+			[0] object,
+			[1] object
+		)
+
+		IL_0000: newobj instance void Scopes.TryCatch_NoBinding_NoThrow::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldc.r8 7
+		IL_0010: box [System.Runtime]System.Double
+		IL_0015: stfld object Scopes.TryCatch_NoBinding_NoThrow::global
+		IL_001a: ldc.i4.1
+		IL_001b: newarr [System.Runtime]System.Object
+		IL_0020: dup
+		IL_0021: ldc.i4.0
+		IL_0022: ldstr "before try"
+		IL_0027: stelem.ref
+		IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		.try
+		{
+			IL_002d: newobj instance void Scopes.TryCatch_NoBinding_NoThrow/Block_L3C4::.ctor()
+			IL_0032: stloc.1
+			IL_0033: ldloc.1
+			IL_0034: ldloc.0
+			IL_0035: ldfld object Scopes.TryCatch_NoBinding_NoThrow::global
+			IL_003a: unbox.any [System.Runtime]System.Double
+			IL_003f: ldc.r8 4
+			IL_0048: add
+			IL_0049: box [System.Runtime]System.Double
+			IL_004e: stfld object Scopes.TryCatch_NoBinding_NoThrow/Block_L3C4::local
+			IL_0053: ldc.i4.2
+			IL_0054: newarr [System.Runtime]System.Object
+			IL_0059: dup
+			IL_005a: ldc.i4.0
+			IL_005b: ldstr "Inside catch.  Calculated value is"
+			IL_0060: stelem.ref
+			IL_0061: dup
+			IL_0062: ldc.i4.1
+			IL_0063: ldloc.1
+			IL_0064: ldfld object Scopes.TryCatch_NoBinding_NoThrow/Block_L3C4::local
+			IL_0069: stelem.ref
+			IL_006a: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_006f: ldnull
+			IL_0070: stloc.1
+			IL_0071: leave IL_008f
+		} // end .try
+		catch [JavaScriptRuntime]JavaScriptRuntime.Error
+		{
+			IL_0076: pop
+			IL_0077: ldc.i4.1
+			IL_0078: newarr [System.Runtime]System.Object
+			IL_007d: dup
+			IL_007e: ldc.i4.0
+			IL_007f: ldstr "inside catch.. we should not be here"
+			IL_0084: stelem.ref
+			IL_0085: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_008a: leave IL_008f
+		} // end handler
+
+		IL_008f: ldc.i4.1
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldstr "try/catch finished."
+		IL_009c: stelem.ref
+		IL_009d: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_00a2: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch.verified.txt
@@ -47,46 +47,6 @@
 
 	} // end of class Block_L3C10
 
-	.class nested public auto ansi beforefieldinit Block_L1C4
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x206b
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L1C4::.ctor
-
-	} // end of class Block_L1C4
-
-	.class nested public auto ansi beforefieldinit Block_L3C10
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L3C10::.ctor
-
-	} // end of class Block_L3C10
-
 
 	// Methods
 	.method public hidebysig specialname rtspecialname 
@@ -112,7 +72,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2080
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 64 (0x40)
 		.maxstack 8

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch.verified.txt
@@ -1,0 +1,158 @@
+﻿// IL code: TryFinally_NoCatch
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.TryFinally_NoCatch
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Block_L1C4
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L1C4::.ctor
+
+	} // end of class Block_L1C4
+
+	.class nested public auto ansi beforefieldinit Block_L3C10
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L3C10::.ctor
+
+	} // end of class Block_L3C10
+
+	.class nested public auto ansi beforefieldinit Block_L1C4
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L1C4::.ctor
+
+	} // end of class Block_L1C4
+
+	.class nested public auto ansi beforefieldinit Block_L3C10
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L3C10::.ctor
+
+	} // end of class Block_L3C10
+
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method TryFinally_NoCatch::.ctor
+
+} // end of class Scopes.TryFinally_NoCatch
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2080
+		// Header size: 12
+		// Code size: 64 (0x40)
+		.maxstack 8
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		.try
+		{
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldstr "in try"
+			IL_000d: stelem.ref
+			IL_000e: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_0013: leave IL_002c
+		} // end .try
+		finally
+		{
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: ldstr "in finally"
+			IL_0025: stelem.ref
+			IL_0026: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_002b: endfinally
+		} // end handler
+
+		IL_002c: ldc.i4.1
+		IL_002d: newarr [System.Runtime]System.Object
+		IL_0032: dup
+		IL_0033: ldc.i4.0
+		IL_0034: ldstr "after finally"
+		IL_0039: stelem.ref
+		IL_003a: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_003f: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch_Throw.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch_Throw.verified.txt
@@ -1,0 +1,162 @@
+﻿// IL code: TryFinally_NoCatch_Throw
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.TryFinally_NoCatch_Throw
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Block_L1C4
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L1C4::.ctor
+
+	} // end of class Block_L1C4
+
+	.class nested public auto ansi beforefieldinit Block_L4C10
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L4C10::.ctor
+
+	} // end of class Block_L4C10
+
+	.class nested public auto ansi beforefieldinit Block_L1C4
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L1C4::.ctor
+
+	} // end of class Block_L1C4
+
+	.class nested public auto ansi beforefieldinit Block_L4C10
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L4C10::.ctor
+
+	} // end of class Block_L4C10
+
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method TryFinally_NoCatch_Throw::.ctor
+
+} // end of class Scopes.TryFinally_NoCatch_Throw
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2080
+		// Header size: 12
+		// Code size: 75 (0x4b)
+		.maxstack 8
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		.try
+		{
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldstr "in try"
+			IL_000d: stelem.ref
+			IL_000e: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_0013: ldstr "boom"
+			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_001d: throw
+
+			IL_001e: leave IL_0037
+		} // end .try
+		finally
+		{
+			IL_0023: ldc.i4.1
+			IL_0024: newarr [System.Runtime]System.Object
+			IL_0029: dup
+			IL_002a: ldc.i4.0
+			IL_002b: ldstr "in finally"
+			IL_0030: stelem.ref
+			IL_0031: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_0036: endfinally
+		} // end handler
+
+		IL_0037: ldc.i4.1
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: dup
+		IL_003e: ldc.i4.0
+		IL_003f: ldstr "after finally"
+		IL_0044: stelem.ref
+		IL_0045: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_004a: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch_Throw.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch_Throw.verified.txt
@@ -47,46 +47,6 @@
 
 	} // end of class Block_L4C10
 
-	.class nested public auto ansi beforefieldinit Block_L1C4
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x206b
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L1C4::.ctor
-
-	} // end of class Block_L1C4
-
-	.class nested public auto ansi beforefieldinit Block_L4C10
-		extends [System.Runtime]System.Object
-	{
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2074
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Block_L4C10::.ctor
-
-	} // end of class Block_L4C10
-
 
 	// Methods
 	.method public hidebysig specialname rtspecialname 
@@ -112,7 +72,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2080
+		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 75 (0x4b)
 		.maxstack 8

--- a/Js2IL.Tests/TryCatch/GeneratorTests.cs
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace Js2IL.Tests.TryCatch
+{
+    public class GeneratorTests : GeneratorTestsBase
+    {
+        public GeneratorTests() : base("TryCatch")
+        {
+        }
+
+        // Add try/catch generator tests here
+    }
+}

--- a/Js2IL.Tests/TryCatch/GeneratorTests.cs
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.cs
@@ -12,6 +12,10 @@ namespace Js2IL.Tests.TryCatch
         [Fact]
         public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return GenerateTest(testName); }
 
+    // Try/Catch where no exception is thrown inside try
+    [Fact]
+    public Task TryCatch_NoBinding_NoThrow() { var testName = nameof(TryCatch_NoBinding_NoThrow); return GenerateTest(testName); }
+
     // Try/Finally (no catch) generator test
     [Fact]
     public Task TryFinally_NoCatch() { var testName = nameof(TryFinally_NoCatch); return GenerateTest(testName); }

--- a/Js2IL.Tests/TryCatch/GeneratorTests.cs
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.cs
@@ -9,7 +9,15 @@ namespace Js2IL.Tests.TryCatch
         }
 
         // Add try/catch generator tests here
+        [Fact]
+        public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return GenerateTest(testName); }
+
+    // Try/Finally (no catch) generator test
     [Fact]
-    public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return GenerateTest(testName); }
+    public Task TryFinally_NoCatch() { var testName = nameof(TryFinally_NoCatch); return GenerateTest(testName); }
+
+    // Try/Finally (no catch) with throw inside try
+    [Fact]
+    public Task TryFinally_NoCatch_Throw() { var testName = nameof(TryFinally_NoCatch_Throw); return GenerateTest(testName); }
     }
 }

--- a/Js2IL.Tests/TryCatch/GeneratorTests.cs
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.cs
@@ -9,5 +9,7 @@ namespace Js2IL.Tests.TryCatch
         }
 
         // Add try/catch generator tests here
+    [Fact]
+    public Task TryCatch_NoBinding() { var testName = nameof(TryCatch_NoBinding); return GenerateTest(testName); }
     }
 }

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_LetBlockScope.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_LetBlockScope.verified.txt
@@ -60,7 +60,7 @@
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 93 (0x5d)
+		// Code size: 95 (0x5f)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -88,15 +88,17 @@
 		IL_003d: ldfld object Scopes.Variable_LetBlockScope/Block_L2C0::x
 		IL_0042: stelem.ref
 		IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_0048: ldc.i4.1
-		IL_0049: newarr [System.Runtime]System.Object
-		IL_004e: dup
-		IL_004f: ldc.i4.0
-		IL_0050: ldloc.0
-		IL_0051: ldfld object Scopes.Variable_LetBlockScope::x
-		IL_0056: stelem.ref
-		IL_0057: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_005c: ret
+		IL_0048: ldnull
+		IL_0049: stloc.1
+		IL_004a: ldc.i4.1
+		IL_004b: newarr [System.Runtime]System.Object
+		IL_0050: dup
+		IL_0051: ldc.i4.0
+		IL_0052: ldloc.0
+		IL_0053: ldfld object Scopes.Variable_LetBlockScope::x
+		IL_0058: stelem.ref
+		IL_0059: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_005e: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_LetNestedShadowingChain.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_LetNestedShadowingChain.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_LetNestedShadowingChain
+﻿// IL code: Variable_LetNestedShadowingChain
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -110,7 +110,7 @@
 	{
 		// Method begins at RVA 0x2074
 		// Header size: 12
-		// Code size: 225 (0xe1)
+		// Code size: 231 (0xe7)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -168,33 +168,38 @@
 		IL_0099: ldfld object Scopes.Variable_LetNestedShadowingChain/Block_L2C0/Block_L5C2/Block_L8C4::v
 		IL_009e: stelem.ref
 		IL_009f: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_00a4: ldc.i4.1
-		IL_00a5: newarr [System.Runtime]System.Object
-		IL_00aa: dup
-		IL_00ab: ldc.i4.0
-		IL_00ac: ldloc.2
-		IL_00ad: ldfld object Scopes.Variable_LetNestedShadowingChain/Block_L2C0/Block_L5C2::v
-		IL_00b2: stelem.ref
-		IL_00b3: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_00b8: ldc.i4.1
-		IL_00b9: newarr [System.Runtime]System.Object
-		IL_00be: dup
-		IL_00bf: ldc.i4.0
-		IL_00c0: ldloc.1
-		IL_00c1: ldfld object Scopes.Variable_LetNestedShadowingChain/Block_L2C0::v
-		IL_00c6: stelem.ref
-		IL_00c7: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_00cc: ldc.i4.1
-		IL_00cd: newarr [System.Runtime]System.Object
-		IL_00d2: dup
-		IL_00d3: ldc.i4.0
-		IL_00d4: ldloc.0
-		IL_00d5: ldfld object Scopes.Variable_LetNestedShadowingChain::v
-		IL_00da: stelem.ref
-		IL_00db: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_00e0: ret
+		IL_00a4: ldnull
+		IL_00a5: stloc.3
+		IL_00a6: ldc.i4.1
+		IL_00a7: newarr [System.Runtime]System.Object
+		IL_00ac: dup
+		IL_00ad: ldc.i4.0
+		IL_00ae: ldloc.2
+		IL_00af: ldfld object Scopes.Variable_LetNestedShadowingChain/Block_L2C0/Block_L5C2::v
+		IL_00b4: stelem.ref
+		IL_00b5: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_00ba: ldnull
+		IL_00bb: stloc.2
+		IL_00bc: ldc.i4.1
+		IL_00bd: newarr [System.Runtime]System.Object
+		IL_00c2: dup
+		IL_00c3: ldc.i4.0
+		IL_00c4: ldloc.1
+		IL_00c5: ldfld object Scopes.Variable_LetNestedShadowingChain/Block_L2C0::v
+		IL_00ca: stelem.ref
+		IL_00cb: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_00d0: ldnull
+		IL_00d1: stloc.1
+		IL_00d2: ldc.i4.1
+		IL_00d3: newarr [System.Runtime]System.Object
+		IL_00d8: dup
+		IL_00d9: ldc.i4.0
+		IL_00da: ldloc.0
+		IL_00db: ldfld object Scopes.Variable_LetNestedShadowingChain::v
+		IL_00e0: stelem.ref
+		IL_00e1: call void [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_00e6: ret
 	} // end of method Program::Main
 
 } // end of class Program
-
 

--- a/Js2IL/Services/BaseClassLibraryReferences.cs
+++ b/Js2IL/Services/BaseClassLibraryReferences.cs
@@ -81,6 +81,13 @@ namespace Js2IL.Services
                 metadataBuilder.GetOrAddString("String")
             );            
 
+            // System.Exception Reference (for catch handlers)
+            this.ExceptionType = metadataBuilder.AddTypeReference(
+                this.SystemRuntimeAssembly,
+                metadataBuilder.GetOrAddString("System"),
+                metadataBuilder.GetOrAddString("Exception")
+            );
+
             // System.Math References
             this.SystemMathType = metadataBuilder.AddTypeReference(
                 this.SystemRuntimeAssembly,
@@ -124,6 +131,7 @@ namespace Js2IL.Services
         public TypeReferenceHandle DoubleType { get; private init; }
         public TypeReferenceHandle ObjectType { get; private init; }
         public TypeReferenceHandle StringType { get; private init; }
+    public TypeReferenceHandle ExceptionType { get; private init; }
         public TypeReferenceHandle SystemMathType { get; private init; }
 
     // Removed legacy Action<> delegate references (now using Func returning object)

--- a/Js2IL/Services/ILGenerators/ClassesGenerator.cs
+++ b/Js2IL/Services/ILGenerators/ClassesGenerator.cs
@@ -311,7 +311,7 @@ namespace Js2IL.Services.ILGenerators
             // Emit constructor body statements (no default return value emission)
             if (ctorFunc.Body is BlockStatement bstmt)
             {
-                ilGen.GenerateStatementsForBody(bstmt.Body);
+                ilGen.GenerateStatementsForBody(methodVariables.GetLeafScopeName(), false, bstmt.Body);
             }
 
             // Return from constructor (void)
@@ -363,7 +363,7 @@ namespace Js2IL.Services.ILGenerators
             if (element.Value is FunctionExpression fexpr && fexpr.Body is BlockStatement bstmt)
             {
                 hasExplicitReturn = bstmt.Body.Any(s => s is ReturnStatement);
-                ilGen.GenerateStatementsForBody(bstmt.Body);
+                ilGen.GenerateStatementsForBody(methodVariables.GetLeafScopeName(), false, bstmt.Body);
             }
             else
             {

--- a/Js2IL/Services/ILGenerators/ClassesGenerator.cs
+++ b/Js2IL/Services/ILGenerators/ClassesGenerator.cs
@@ -311,7 +311,7 @@ namespace Js2IL.Services.ILGenerators
             // Emit constructor body statements (no default return value emission)
             if (ctorFunc.Body is BlockStatement bstmt)
             {
-                ilGen.GenerateStatements(bstmt.Body);
+                ilGen.GenerateStatementsForBody(bstmt.Body);
             }
 
             // Return from constructor (void)
@@ -363,7 +363,7 @@ namespace Js2IL.Services.ILGenerators
             if (element.Value is FunctionExpression fexpr && fexpr.Body is BlockStatement bstmt)
             {
                 hasExplicitReturn = bstmt.Body.Any(s => s is ReturnStatement);
-                ilGen.GenerateStatements(bstmt.Body);
+                ilGen.GenerateStatementsForBody(bstmt.Body);
             }
             else
             {

--- a/Js2IL/Services/ILGenerators/ILMethodGenerator.cs
+++ b/Js2IL/Services/ILGenerators/ILMethodGenerator.cs
@@ -134,7 +134,7 @@ namespace Js2IL.Services.ILGenerators
             }
         }
 
-        public void GenerateStatements(NodeList<Statement> statements)
+    public void GenerateStatementsForBody(NodeList<Statement> statements)
         {
             // Iterate through each statement in the block
             foreach (var statement in statements.Where(s => s is not FunctionDeclaration))
@@ -270,7 +270,7 @@ namespace Js2IL.Services.ILGenerators
             // If no lexical declarations, just emit statements directly.
             if (!hasLexical)
             {
-                GenerateStatements(blockStatement.Body);
+                GenerateStatementsForBody(blockStatement.Body);
                 return;
             }
 
@@ -308,7 +308,7 @@ namespace Js2IL.Services.ILGenerators
             }
 
             // Emit inner statements (variables inside will resolve to the block scope fields via registry name match)
-            GenerateStatements(blockStatement.Body);
+            GenerateStatementsForBody(blockStatement.Body);
 
             if (blockLocalIndex.HasValue)
             {
@@ -1714,7 +1714,7 @@ namespace Js2IL.Services.ILGenerators
                     }
 
                     // Emit statements using the child generator
-                    childGen.GenerateStatements(block.Body);
+                    childGen.GenerateStatementsForBody(block.Body);
                     // If no explicit return executed, fall through and return null
                     il.OpCode(ILOpCode.Ldnull);
                     il.OpCode(ILOpCode.Ret);

--- a/Js2IL/Services/ILGenerators/JavaScriptFunctionGenerator.cs
+++ b/Js2IL/Services/ILGenerators/JavaScriptFunctionGenerator.cs
@@ -248,7 +248,7 @@ namespace Js2IL.Services.ILGenerators
                 methodGenerator.InitializeLocalFunctionVariables(nestedFunctions);
             }
             
-            methodGenerator.GenerateStatements(blockStatement.Body);
+            methodGenerator.GenerateStatementsForBody(blockStatement.Body);
             if (!hasExplicitReturn)
             {
                 // Implicit return undefined => null

--- a/Js2IL/Services/ILGenerators/JavaScriptFunctionGenerator.cs
+++ b/Js2IL/Services/ILGenerators/JavaScriptFunctionGenerator.cs
@@ -248,7 +248,7 @@ namespace Js2IL.Services.ILGenerators
                 methodGenerator.InitializeLocalFunctionVariables(nestedFunctions);
             }
             
-            methodGenerator.GenerateStatementsForBody(blockStatement.Body);
+            methodGenerator.GenerateStatementsForBody(functionVariables.GetLeafScopeName(), false, blockStatement.Body);
             if (!hasExplicitReturn)
             {
                 // Implicit return undefined => null

--- a/Js2IL/Services/ILGenerators/MainGenerator.cs
+++ b/Js2IL/Services/ILGenerators/MainGenerator.cs
@@ -76,7 +76,7 @@ namespace Js2IL.Services.ILGenerators
                 _ilGenerator.InitializeLocalFunctionVariables(ast.Body.OfType<Acornima.Ast.FunctionDeclaration>());
             }
 
-            _ilGenerator.GenerateStatementsForBody(ast.Body);
+            _ilGenerator.GenerateStatementsForBody(variables.GetLeafScopeName(), false, ast.Body);
 
             _ilGenerator.IL.OpCode(ILOpCode.Ret);
 

--- a/Js2IL/Services/ILGenerators/MainGenerator.cs
+++ b/Js2IL/Services/ILGenerators/MainGenerator.cs
@@ -76,7 +76,7 @@ namespace Js2IL.Services.ILGenerators
                 _ilGenerator.InitializeLocalFunctionVariables(ast.Body.OfType<Acornima.Ast.FunctionDeclaration>());
             }
 
-            _ilGenerator.GenerateStatements(ast.Body);
+            _ilGenerator.GenerateStatementsForBody(ast.Body);
 
             _ilGenerator.IL.OpCode(ILOpCode.Ret);
 

--- a/Js2IL/Services/Runtime.cs
+++ b/Js2IL/Services/Runtime.cs
@@ -10,7 +10,9 @@ namespace Js2IL.Services
 {
     internal class Runtime
     {
-        private MemberReferenceHandle _toStringMethodRef;
+        private readonly MetadataBuilder _metadataBuilder;
+        private AssemblyReferenceHandle _runtimeAssemblyReference;
+        private readonly Dictionary<string, TypeReferenceHandle> _runtimeTypeCache = new(StringComparer.Ordinal);
         private MemberReferenceHandle _consoleLogMethodRef;
         private MemberReferenceHandle _objectGetItem;
         private MemberReferenceHandle _arrayCtorRef;
@@ -23,6 +25,7 @@ namespace Js2IL.Services
         public Runtime(MetadataBuilder metadataBuilder, InstructionEncoder il) 
         { 
             _il = il;
+            _metadataBuilder = metadataBuilder;
 
             var runtimeAssembly = typeof(JavaScriptRuntime.Console).Assembly;
             var runtimeAssemblyName = runtimeAssembly.GetName();
@@ -36,184 +39,28 @@ namespace Js2IL.Services
                 flags: 0,
                 hashValue: default
             );
+            _runtimeAssemblyReference = runtimeAssemblyReference;
 
             var dotNet2JsType = metadataBuilder.AddTypeReference(
                 runtimeAssemblyReference,
                 metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
                 metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime.DotNet2JSConversions))
             );
+            // Initialize references to JavaScriptRuntime.Operators methods
+            InitializeOperators();
 
-            var operatorsType = metadataBuilder.AddTypeReference(
-                runtimeAssemblyReference,
-                metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
-                metadataBuilder.GetOrAddString("Operators")
-            );
+            // Initialize JavaScriptRuntime.Console.Log
+            InitializeConsole();
 
-
-            // Create method signature: void ToString(object)
-            var toStringSigBuilder = new BlobBuilder();
-            new BlobEncoder(toStringSigBuilder)
-                .MethodSignature(isInstanceMethod: false)
-                .Parameters(1,
-                    returnType => returnType.Type().String(),
-                    parameters => {
-                        parameters.AddParameter().Type().Object();
-                    });
-            var toStringSig = metadataBuilder.GetOrAddBlob(toStringSigBuilder);
+            // Initialize JavaScriptRuntime.Array method references
+            InitializeArray();
 
 
-            _toStringMethodRef = metadataBuilder.AddMemberReference(
-                dotNet2JsType,
-                metadataBuilder.GetOrAddString("ToString"),
-                toStringSig);
+            // Initialize JavaScriptRuntime.Object.GetItem
+            InitializeObject();
 
-            // JavaScriptRuntime.Operators.Add(object, object) -> object
-            var addSigBuilder = new BlobBuilder();
-            new BlobEncoder(addSigBuilder)
-                .MethodSignature(isInstanceMethod: false)
-                .Parameters(2,
-                    returnType => returnType.Type().Object(),
-                    parameters => {
-                        parameters.AddParameter().Type().Object();
-                        parameters.AddParameter().Type().Object();
-                    });
-            var addSig = metadataBuilder.GetOrAddBlob(addSigBuilder);
-            _operatorsAddRef = metadataBuilder.AddMemberReference(
-                operatorsType,
-                metadataBuilder.GetOrAddString("Add"),
-                addSig);
-
-            // JavaScriptRuntime.Operators.Subtract(object, object) -> object
-            var subSigBuilder = new BlobBuilder();
-            new BlobEncoder(subSigBuilder)
-                .MethodSignature(isInstanceMethod: false)
-                .Parameters(2,
-                    returnType => returnType.Type().Object(),
-                    parameters => {
-                        parameters.AddParameter().Type().Object();
-                        parameters.AddParameter().Type().Object();
-                    });
-            var subSig = metadataBuilder.GetOrAddBlob(subSigBuilder);
-            _operatorsSubtractRef = metadataBuilder.AddMemberReference(
-                operatorsType,
-                metadataBuilder.GetOrAddString("Subtract"),
-                subSig);
-
-            // create the method body for Console.Log(params object[] args)
-            var consoleLogSigBuilder = new BlobBuilder();
-            new BlobEncoder(consoleLogSigBuilder)
-                .MethodSignature(isInstanceMethod: false)
-                .Parameters(1,
-                    returnType => returnType.Void(),
-                    parameters => {
-                        parameters.AddParameter().Type().SZArray().Object();
-                    });
-            var consoleLogSig = metadataBuilder.GetOrAddBlob(consoleLogSigBuilder);
-
-            var consoleType = metadataBuilder.AddTypeReference(
-                runtimeAssemblyReference,
-                metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
-                metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime.Console))
-            );
-
-            _consoleLogMethodRef = metadataBuilder.AddMemberReference(
-                consoleType,
-                metadataBuilder.GetOrAddString("Log"),
-                consoleLogSig);
-
-            // Array type ---------
-            var arrayType = metadataBuilder.AddTypeReference(
-                runtimeAssemblyReference,
-                metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
-                metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime.Array)));
-
-            //  - Constructor
-            var arraySigBuilder = new BlobBuilder();
-            new BlobEncoder(arraySigBuilder)
-                .MethodSignature(isInstanceMethod: true)
-                .Parameters(1, returnType => returnType.Void(), parameters => 
-                 { 
-                     parameters.AddParameter().Type().Int32(); 
-                 });
-            var arrayCtorSig = metadataBuilder.GetOrAddBlob(arraySigBuilder);
-            _arrayCtorRef = metadataBuilder.AddMemberReference(
-                arrayType,
-                metadataBuilder.GetOrAddString(".ctor"),
-                arrayCtorSig);
-
-            // - length
-            var arrayLengthSigBuilder = new BlobBuilder();
-            new BlobEncoder(arrayLengthSigBuilder)
-                .MethodSignature(isInstanceMethod: true)
-                .Parameters(0, returnType => returnType.Type().Double(), parameters => { });
-            var arrayLengthSig = metadataBuilder.GetOrAddBlob(arrayLengthSigBuilder);
-            _arrayLengthRef = metadataBuilder.AddMemberReference(
-                arrayType,
-                metadataBuilder.GetOrAddString("get_length"),
-                arrayLengthSig);
-
-
-            var objectType = metadataBuilder.AddTypeReference(
-                runtimeAssemblyReference,
-                metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
-                metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime.Object)));
-
-            var objectGetItemSigBuilder = new BlobBuilder();
-            new BlobEncoder(objectGetItemSigBuilder)
-                .MethodSignature(isInstanceMethod: false)
-                .Parameters(2, returnType => returnType.Type().Object(), parameters => 
-                { 
-                    parameters.AddParameter().Type().Object();
-                    parameters.AddParameter().Type().Double();
-                });
-            var objectGetItemSig = metadataBuilder.GetOrAddBlob(objectGetItemSigBuilder);
-            _objectGetItem = metadataBuilder.AddMemberReference(
-                objectType,
-                metadataBuilder.GetOrAddString("GetItem"),
-                objectGetItemSig);
-
-            // JavaScriptRuntime.Closure.Bind(object, object[])
-            var runtimeAsmName = typeof(JavaScriptRuntime.Closure).Assembly.GetName();
-            var rtAssembly = metadataBuilder.AddAssemblyReference(
-                name: metadataBuilder.GetOrAddString(runtimeAsmName.Name!),
-                version: runtimeAsmName.Version!,
-                culture: default,
-                publicKeyOrToken: default,
-                flags: 0,
-                hashValue: default
-            );
-            var closureType = metadataBuilder.AddTypeReference(
-                rtAssembly,
-                metadataBuilder.GetOrAddString("JavaScriptRuntime"),
-                metadataBuilder.GetOrAddString("Closure")
-            );
-            var bindSig = new BlobBuilder();
-            new BlobEncoder(bindSig)
-                .MethodSignature(isInstanceMethod: false)
-                .Parameters(2,
-                    returnType => returnType.Type().Object(),
-                    parameters => {
-                        parameters.AddParameter().Type().Object();
-                        parameters.AddParameter().Type().SZArray().Object();
-                    });
-            var bindSigHandle = metadataBuilder.GetOrAddBlob(bindSig);
-            _closureBindObjectRef = metadataBuilder.AddMemberReference(
-                closureType,
-                metadataBuilder.GetOrAddString("Bind"),
-                bindSigHandle);
-        }
-
-        /// <summary>
-        /// Inserts IL to convert what ever is on the stack to a string representation.
-        /// </summary>
-        /// <remarks>
-        /// Currently takes a dependency on a external libary.  Stretch goal is to append runtime il to the generated assembly.
-        /// </remarks>
-        public void InvokeToString()
-        {
-            // we assume the object to covert to a string is already on the stack
-            _il.OpCode(ILOpCode.Call);
-            _il.Token(_toStringMethodRef);
+            // Initialize JavaScriptRuntime.Closure.Bind
+            InitializeClosure();
         }
 
         /// <summary>
@@ -269,6 +116,225 @@ namespace Js2IL.Services
             // assumes [delegateAsObject] [scopesArray] are on the stack
             _il.OpCode(ILOpCode.Call);
             _il.Token(_closureBindObjectRef);
+        }
+
+        /// <summary>
+        /// Initializes references for JavaScriptRuntime.Operators methods (Add/Subtract).
+        /// </summary>
+        private void InitializeOperators()
+        {
+            var operatorsType = _metadataBuilder.AddTypeReference(
+                _runtimeAssemblyReference,
+                _metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
+                _metadataBuilder.GetOrAddString("Operators")
+            );
+
+            // JavaScriptRuntime.Operators.Add(object, object) -> object
+            var addSigBuilder = new BlobBuilder();
+            new BlobEncoder(addSigBuilder)
+                .MethodSignature(isInstanceMethod: false)
+                .Parameters(2,
+                    returnType => returnType.Type().Object(),
+                    parameters =>
+                    {
+                        parameters.AddParameter().Type().Object();
+                        parameters.AddParameter().Type().Object();
+                    });
+            var addSig = _metadataBuilder.GetOrAddBlob(addSigBuilder);
+            _operatorsAddRef = _metadataBuilder.AddMemberReference(
+                operatorsType,
+                _metadataBuilder.GetOrAddString("Add"),
+                addSig);
+
+            // JavaScriptRuntime.Operators.Subtract(object, object) -> object
+            var subSigBuilder = new BlobBuilder();
+            new BlobEncoder(subSigBuilder)
+                .MethodSignature(isInstanceMethod: false)
+                .Parameters(2,
+                    returnType => returnType.Type().Object(),
+                    parameters =>
+                    {
+                        parameters.AddParameter().Type().Object();
+                        parameters.AddParameter().Type().Object();
+                    });
+            var subSig = _metadataBuilder.GetOrAddBlob(subSigBuilder);
+            _operatorsSubtractRef = _metadataBuilder.AddMemberReference(
+                operatorsType,
+                _metadataBuilder.GetOrAddString("Subtract"),
+                subSig);
+        }
+
+        /// <summary>
+        /// Initializes reference for JavaScriptRuntime.Console.Log(object[]).
+        /// </summary>
+        private void InitializeConsole()
+        {
+            var consoleLogSigBuilder = new BlobBuilder();
+            new BlobEncoder(consoleLogSigBuilder)
+                .MethodSignature(isInstanceMethod: false)
+                .Parameters(1,
+                    returnType => returnType.Void(),
+                    parameters =>
+                    {
+                        parameters.AddParameter().Type().SZArray().Object();
+                    });
+            var consoleLogSig = _metadataBuilder.GetOrAddBlob(consoleLogSigBuilder);
+
+            var consoleType = _metadataBuilder.AddTypeReference(
+                _runtimeAssemblyReference,
+                _metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
+                _metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime.Console))
+            );
+
+            _consoleLogMethodRef = _metadataBuilder.AddMemberReference(
+                consoleType,
+                _metadataBuilder.GetOrAddString("Log"),
+                consoleLogSig);
+        }
+
+        /// <summary>
+        /// Initializes reference for JavaScriptRuntime.Object.GetItem(object, double) -> object.
+        /// </summary>
+        private void InitializeObject()
+        {
+            var objectType = _metadataBuilder.AddTypeReference(
+                _runtimeAssemblyReference,
+                _metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
+                _metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime.Object)));
+
+            var objectGetItemSigBuilder = new BlobBuilder();
+            new BlobEncoder(objectGetItemSigBuilder)
+                .MethodSignature(isInstanceMethod: false)
+                .Parameters(2, rt => rt.Type().Object(), p =>
+                {
+                    p.AddParameter().Type().Object();
+                    p.AddParameter().Type().Double();
+                });
+            var objectGetItemSig = _metadataBuilder.GetOrAddBlob(objectGetItemSigBuilder);
+            _objectGetItem = _metadataBuilder.AddMemberReference(
+                objectType,
+                _metadataBuilder.GetOrAddString("GetItem"),
+                objectGetItemSig);
+        }
+
+        /// <summary>
+        /// Initializes reference for JavaScriptRuntime.Closure.Bind(object, object[]) -> object.
+        /// </summary>
+        private void InitializeClosure()
+        {
+            // Use the same runtime assembly reference we already captured
+            var closureType = _metadataBuilder.AddTypeReference(
+                _runtimeAssemblyReference,
+                _metadataBuilder.GetOrAddString("JavaScriptRuntime"),
+                _metadataBuilder.GetOrAddString("Closure")
+            );
+
+            var bindSig = new BlobBuilder();
+            new BlobEncoder(bindSig)
+                .MethodSignature(isInstanceMethod: false)
+                .Parameters(2,
+                    rt => rt.Type().Object(),
+                    p =>
+                    {
+                        p.AddParameter().Type().Object();
+                        p.AddParameter().Type().SZArray().Object();
+                    });
+            var bindSigHandle = _metadataBuilder.GetOrAddBlob(bindSig);
+            _closureBindObjectRef = _metadataBuilder.AddMemberReference(
+                closureType,
+                _metadataBuilder.GetOrAddString("Bind"),
+                bindSigHandle);
+        }
+
+        /// <summary>
+        /// Initializes references for JavaScriptRuntime.Array (.ctor and get_length).
+        /// </summary>
+        private void InitializeArray()
+        {
+            var arrayType = _metadataBuilder.AddTypeReference(
+                _runtimeAssemblyReference,
+                _metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
+                _metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime.Array)));
+
+            // Constructor: .ctor(int capacity)
+            var arraySigBuilder = new BlobBuilder();
+            new BlobEncoder(arraySigBuilder)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(1, rt => rt.Void(), p =>
+                {
+                    p.AddParameter().Type().Int32();
+                });
+            var arrayCtorSig = _metadataBuilder.GetOrAddBlob(arraySigBuilder);
+            _arrayCtorRef = _metadataBuilder.AddMemberReference(
+                arrayType,
+                _metadataBuilder.GetOrAddString(".ctor"),
+                arrayCtorSig);
+
+            // Property getter: double get_length()
+            var arrayLengthSigBuilder = new BlobBuilder();
+            new BlobEncoder(arrayLengthSigBuilder)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(0, rt => rt.Type().Double(), p => { });
+            var arrayLengthSig = _metadataBuilder.GetOrAddBlob(arrayLengthSigBuilder);
+            _arrayLengthRef = _metadataBuilder.AddMemberReference(
+                arrayType,
+                _metadataBuilder.GetOrAddString("get_length"),
+                arrayLengthSig);
+        }
+
+        /// <summary>
+        /// Gets (and caches) a TypeReferenceHandle to a type in the JavaScriptRuntime assembly.
+        /// </summary>
+        private TypeReferenceHandle GetJavaScriptRuntimeType(string typeName)
+        {
+            if (_runtimeTypeCache.TryGetValue(typeName, out var handle))
+            {
+                return handle;
+            }
+            var tref = _metadataBuilder.AddTypeReference(
+                _runtimeAssemblyReference,
+                _metadataBuilder.GetOrAddString(nameof(JavaScriptRuntime)),
+                _metadataBuilder.GetOrAddString(typeName));
+            _runtimeTypeCache[typeName] = tref;
+            return tref;
+        }
+
+        /// <summary>
+        /// Returns a MemberReferenceHandle for the .ctor of a JavaScriptRuntime Error type (Error, TypeError, etc.).
+        /// Supports 0 or 1 string parameter.
+        /// </summary>
+        public MemberReferenceHandle GetErrorCtorRef(string errorTypeName, int argumentCount)
+        {
+            if (argumentCount < 0 || argumentCount > 1)
+            {
+                throw new NotSupportedException($"Only up to 1 constructor argument supported for built-in Error types (got {argumentCount})");
+            }
+
+            var errorTypeRef = GetJavaScriptRuntimeType(errorTypeName);
+
+            var sig = new BlobBuilder();
+            new BlobEncoder(sig)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(argumentCount,
+                    r => r.Void(),
+                    p =>
+                    {
+                        for (int i = 0; i < argumentCount; i++)
+                        {
+                            // Error(string message)
+                            p.AddParameter().Type().String();
+                        }
+                    });
+            var ctorSig = _metadataBuilder.GetOrAddBlob(sig);
+            return _metadataBuilder.AddMemberReference(errorTypeRef, _metadataBuilder.GetOrAddString(".ctor"), ctorSig);
+        }
+
+        /// <summary>
+        /// Returns a TypeReferenceHandle for JavaScriptRuntime.Error (base JS error type).
+        /// </summary>
+        public TypeReferenceHandle GetErrorTypeRef()
+        {
+            return GetJavaScriptRuntimeType("Error");
         }
     }
 }

--- a/docs/ECMAScript2025_FeatureCoverage.json
+++ b/docs/ECMAScript2025_FeatureCoverage.json
@@ -375,6 +375,47 @@
             }
           ]
         }
+        ,
+        {
+          "subsection": "14.16",
+          "title": "The try Statement",
+          "url": "https://tc39.es/ecma262/#sec-try-statement",
+          "paragraphs": [
+            {
+              "paragraph": "14.16.1",
+              "title": "Runtime Semantics: TryStatement Evaluation",
+              "url": "https://tc39.es/ecma262/#sec-try-statement",
+              "features": [
+                {
+                  "feature": "throw statement",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/TryCatch_NoBinding.js"
+                  ],
+                  "notes": "Emits throw of JavaScriptRuntime.Error; used in try/catch tests."
+                },
+                {
+                  "feature": "try/catch (no binding)",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/TryCatch_NoBinding.js",
+                    "Js2IL.Tests/JavaScript/TryCatch_NoBinding_NoThrow.js"
+                  ],
+                  "notes": "Catch blocks currently handle only JavaScriptRuntime.Error thrown within the try; exceptions thrown later (after returning a closure) are not caught by the earlier catch."
+                },
+                {
+                  "feature": "try/finally (no catch)",
+                  "status": "Partially Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/TryFinally_NoCatch.js",
+                    "Js2IL.Tests/JavaScript/TryFinally_NoCatch_Throw.js"
+                  ],
+                  "notes": "Finally emission is in place. Execution test for throw is skipped pending unhandled Error semantics at top-level; generator snapshot verifies structure."
+                }
+              ]
+            }
+          ]
+        }
       ]
     },
     {

--- a/docs/ECMAScript2025_FeatureCoverage.md
+++ b/docs/ECMAScript2025_FeatureCoverage.md
@@ -211,6 +211,17 @@ This file is auto-generated from ECMAScript2025_FeatureCoverage.json.
 | for loop: break | Supported | `Js2IL.Tests/JavaScript/ControlFlow_ForLoop_Break_AtThree.js` | Implements break by branching to loop end label (LoopContext). | 14.7.4.2 |
 
 
+### [The try Statement](https://tc39.es/ecma262/#sec-try-statement)
+
+#### [Runtime Semantics: TryStatement Evaluation](https://tc39.es/ecma262/#sec-try-statement)
+
+| Feature | Status | Test Scripts | Notes | Section |
+|---|---|---|---|---|
+| throw statement | Supported | `Js2IL.Tests/JavaScript/TryCatch_NoBinding.js` | Emits throw of JavaScriptRuntime.Error; used in try/catch tests. | 14.16.1 |
+| try/catch (no binding) | Supported | `Js2IL.Tests/JavaScript/TryCatch_NoBinding.js`<br>`Js2IL.Tests/JavaScript/TryCatch_NoBinding_NoThrow.js` | Catch blocks currently handle only JavaScriptRuntime.Error thrown within the try; exceptions thrown later (after returning a closure) are not caught by the earlier catch. | 14.16.1 |
+| try/finally (no catch) | Partially Supported | `Js2IL.Tests/JavaScript/TryFinally_NoCatch.js`<br>`Js2IL.Tests/JavaScript/TryFinally_NoCatch_Throw.js` | Finally emission is in place. Execution test for throw is skipped pending unhandled Error semantics at top-level; generator snapshot verifies structure. | 14.16.1 |
+
+
 ## [ECMAScript Language: Classes](https://tc39.es/ecma262/#sec-ecmascript-language-classes)
 
 ### [Class Definitions](https://tc39.es/ecma262/#sec-class-definitions)


### PR DESCRIPTION
This PR introduces groundwork for try/catch/finally handling and related refactors.

Highlights:
- Runtime: JavaScriptRuntime.Error hierarchy; centralized runtime member refs (Error ctor/type, Operators, Array, Console, Object, Closure)
- IL Gen: GenerateStatements -> GenerateStatementsForBody(scopeName, createScopeInstance); GenerateBlock assigns Block_L{line}C{col}; centralized block-scope creation/cleanup; null local after PopLexicalScope; catch only JavaScriptRuntime.Error
- Tests: new TryCatch_NoBinding_NoThrow (gen+exec), TryFinally_NoCatch (gen+exec), TryFinally_NoCatch_Throw (gen snapshot + exec skipped)
- Docs: updated ECMAScript2025_FeatureCoverage.json and regenerated markdown to reflect try/catch/throw coverage

Notes:
- Unhandled JS Error semantics at top-level are deferred; Throw inside try/finally is snapshot-tested; execution case intentionally skipped.

Closes: N/A