### PR TITLE
Feature: Truthiness in conditionals, logical OR/AND with short-circuit, and disabled integration compile test

### DIFF
--- a/Js2IL.Tests/Integration/CompilationTests.cs
+++ b/Js2IL.Tests/Integration/CompilationTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using Js2IL.Services;
+
+namespace Js2IL.Tests.Integration
+{
+    public class CompilationTests
+    {
+        [Fact(Skip = "Manual integration test: compiles scripts/generateFeatureCoverage.js; do not run in CI")]
+        public void Compile_Scripts_GenerateFeatureCoverage()
+        {
+            var repoRoot = Directory.GetCurrentDirectory();
+            var scriptPath = Path.Combine(repoRoot, "scripts", "generateFeatureCoverage.js");
+            Assert.True(File.Exists(scriptPath), $"Script file not found: {scriptPath}");
+
+            var js = File.ReadAllText(scriptPath);
+
+            var parser = new JavaScriptParser();
+            var ast = parser.ParseJavaScript(js, scriptPath);
+
+            var validator = new JavaScriptAstValidator();
+            var validation = validator.Validate(ast);
+            Assert.True(validation.IsValid, "Validation failed: " + string.Join("; ", validation.Errors));
+
+            var outputDir = Path.Combine(Path.GetTempPath(), "Js2IL.Tests", "Integration", "Compilation");
+            Directory.CreateDirectory(outputDir);
+
+            var assemblyName = "GenerateFeatureCoverage_Script";
+            var generator = new AssemblyGenerator();
+            generator.Generate(ast, assemblyName, outputDir);
+
+            var outputDll = Path.Combine(outputDir, assemblyName + ".dll");
+            Assert.True(File.Exists(outputDll), $"Output assembly missing: {outputDll}");
+            Assert.True(new FileInfo(outputDll).Length > 0, "Output assembly is empty");
+        }
+    }
+}


### PR DESCRIPTION
Title: Feature: Truthiness in conditionals, logical OR/AND with short-circuit, and disabled integration compile test

Summary
- Adds JS truthiness coercion for conditionals and implements logical operators (||, &&) with full short-circuit semantics. Includes a long-running integration test (skipped) that compiles scripts/generateFeatureCoverage.js. Updates coverage docs and changelog.

Changes
- Added
	- Control flow: truthiness in if/ternary conditions via JavaScriptRuntime.TypeUtilities.ToBoolean; generator and execution tests (e.g., ControlFlow_If_Truthiness).
	- Operators: logical OR (||) and logical AND (&&) supporting both value and branching contexts with short-circuit; tests under BinaryOperator Execution/Generator.
	- Integration: Js2IL.Tests.Integration.CompilationTests.Compile_Scripts_GenerateFeatureCoverage (marked [Skip]) to compile scripts/generateFeatureCoverage.js.
- Changed
	- IL generation: conditional branching now coerces non-boolean test expressions using ToBoolean; centralized boxing rules in ILExpressionGenerator.
	- Binary operator emitter updated to correctly handle boxing in short-circuit paths (no double-boxing), fixing incorrect outputs.
- Docs/Changelog
	- Updated ECMAScript2025_FeatureCoverage.json (+ regenerated .md) to include truthiness and logical ||/&&.
	- CHANGELOG: documented truthiness, logical operators, and the disabled integration test.

Notes
- The integration test is intentionally skipped to keep CI time reasonable; it validates end-to-end parsing and IL generation for the docs generator script.
- Snapshot updates for new generator tests may be handled in a follow-up if necessary.

Checklist
- [x] Tests added/updated
- [x] Docs updated (coverage JSON/MD)
- [x] Integration test added and skipped
- [x] No breaking public API changes noted

