### PR TITLE
Changelog: cut v0.1.2 and add Unreleased entries (truthiness, logical OR/AND)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased]
+
+Added
+- (none)
+
+Changed
+- (none)
+
+Fixed
+- (none)
+
+Docs
+- (none)
+
+Tests
+- (none)
+
 ## v0.1.2 - 2025-09-03
 
 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project are documented here.
 ## [Unreleased]
 
 Added
-- (none)
+- Control flow: truthiness in conditionals (if/while/ternary) using JavaScript ToBoolean semantics; execution and generator tests.
+- Operators: logical OR (||) and logical AND (&&) with correct short-circuit semantics in both value and branching contexts; execution and generator tests.
 
 Changed
 - (none)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here.
 
-## [Unreleased]
+## v0.1.2 - 2025-09-03
 
 Added
 - Arrays: Array.prototype.map (basic value-callback) returning a new array; execution and generator tests.


### PR DESCRIPTION
This PR updates CHANGELOG.md only.\n\n- Cut v0.1.2 (2025-09-03).\n- Added an Unreleased section and populated Added with:\n  - Truthiness in conditionals (if/while/ternary) using JS ToBoolean semantics.\n  - Logical OR (||) and logical AND (&&) with short-circuit in value/branching contexts.\n\nNo code changes.