### PR TITLE
tests: skip long-running integration test; robust repo-root resolution

### DIFF
--- a/Js2IL.Tests/Integration/CompilationTests.cs
+++ b/Js2IL.Tests/Integration/CompilationTests.cs
@@ -6,10 +6,26 @@ namespace Js2IL.Tests.Integration
 {
     public class CompilationTests
     {
-        [Fact(Skip = "Manual integration test: compiles scripts/generateFeatureCoverage.js; do not run in CI")]
+        [Fact(Skip = "Long-running integration test")]
         public void Compile_Scripts_GenerateFeatureCoverage()
         {
-            var repoRoot = Directory.GetCurrentDirectory();
+            // Resolve repo root by walking up from the test assembly directory
+            static string FindRepoRoot()
+            {
+                var dir = new DirectoryInfo(AppContext.BaseDirectory);
+                while (dir != null)
+                {
+                    if (File.Exists(Path.Combine(dir.FullName, "js2il.sln")) ||
+                        Directory.Exists(Path.Combine(dir.FullName, "scripts")))
+                    {
+                        return dir.FullName;
+                    }
+                    dir = dir.Parent;
+                }
+                throw new InvalidOperationException("Repository root not found from test base directory.");
+            }
+
+            var repoRoot = FindRepoRoot();
             var scriptPath = Path.Combine(repoRoot, "scripts", "generateFeatureCoverage.js");
             Assert.True(File.Exists(scriptPath), $"Script file not found: {scriptPath}");
 


### PR DESCRIPTION
- **IL emit: centralize boxing via TypeCoercion.boxResult; remove redundant site-level boxing (#20)**
- **Classes: constructors, instance fields/methods, static methods; docs updated (#21)**
- **ci: add linux smoke test workflow (install tool from NuGet, convert tests/simple.js, run and verify output) (#22)**
- **CI: linux-smoke  pin to latest tag, add NuGet retry, tolerate missing --version**
- **minor fix for simple.js**
- **test fix**
- **feat(boolean): support boolean literals (true/false) in emitter; add execution test and resource; generator snapshot pending**
- **test(boolean): add execution test for if with boolean literals; skip generator snapshot for now**
- **test(binary==): add boolean equality tests (generator+execution); fix equality unboxing for booleans**
- **Boolean support: literals, conditional branching, equality, logical not; handle nested BinaryExpression values; add isEven and !flag tests; update generator snapshots; ignore *.received.* and .vscode**
- **Docs: update ECMAScript2025 coverage with boolean literals, logical not (!), boolean equality, and if-conditions using booleans (incl. isEven + !flag)**
- **Docs: regenerate ECMAScript2025_FeatureCoverage.md from updated JSON**
- **misc fix**
- **refactor(emit): streamline value emission and boolean branching\n\n- Unify LoadValue path for nested BinaryExpression\n- Tighter selective unboxing for numbers/booleans in equality\n- Clean up conditional emission around LogicalNot and if conditions\n- Minor readability and guard improvements in ILMethodGenerator/BinaryOperators**
- **refactor(emit): extract UnaryExpression handling into helper and fix conditional branching handoff**
- **Tests: add and verify Classes_ClassConstructor_WithMultipleParameters (execution + generator); update snapshots for BooleanLiteral and ControlFlow_If_BooleanLiteral**
- **Runtime: add Operators.Add for JS '+' semantics; Generator: route dynamic '+' to runtime, keep literal concat fast-path; Fix >>> IL conversion; Add class Adder test (string+string and number+number).**
- **Tests: add Classes_ClassConstructor_TwoParams_SubtractMethod (NaN for string-string, numeric subtract); Runtime: Operators.Subtract with JS ToNumber coercion; Generator: route '-' through runtime and box operands appropriately.**
- **Generator: '+' numeric fast-path for identifiers/literals; '-' defers and uses numeric IL when both operands numeric, else runtime Subtract; fix ArrowFunction_SimpleExpression and BinaryOperator_SubNumberNumber snapshots.**
- **Tests: add placeholders for class static property (skipped). Add JS source file and expected output for future support.**
- **Classes: support static class fields (emit static field and .cctor; allow MemberExpression to read via ldsfld). Enable tests for static property access; update generator snapshot.**
- **Tests: remove underscore-based pseudo-private property tests; keep only true #private field test (skipped).**
- **Classes: mangle private field names in generated types; support #private access end-to-end; update generator snapshot and unskip tests**
- **Docs: regenerate feature coverage (add static fields, #private fields; update operator test references)**
- **Tests: remove underscore pseudo-private class property test and snapshot per review; prefer true #private fields only**
- **Refactor: simplify subtraction handling in BinaryOperators; Runtime: improve JS ToNumber parsing (trim, empty string=0, 0x hex).**
- **Feature: initial while-statement support in ILMethodGenerator; tests for while countdown (execution passes), generator snapshot skipped pending acceptance.**
- **ControlFlow: add DoWhileStatement support; tests + snapshots; update While snapshot. All ControlFlow tests passing**
- **Tests: add continue keyword coverage (for-loop odd-only) with fixture and snapshots; marked skipped until continue support is implemented**
- **ControlFlow: finalize continue support - Update generator snapshot for ForLoop_Continue_SkipEven - Fix equality branching with numeric unboxing for arithmetic results - Support expression initializer in for-loops and wire continue labels across for/while/do-while**
- **ControlFlow: add while-continue tests - JS fixture and execution snapshot for ControlFlow_While_Continue_SkipEven - Execution/generator tests wired; generator test skipped pending IL snapshot - Fix infinite loop in fixture by incrementing before continue**
- **ControlFlow: finalize while-continue - Unskip generator test and update verified IL snapshot - Normalize snapshot formatting to match emitted IL**
- **ControlFlow: add do-while continue tests - JS fixture and execution snapshot for ControlFlow_DoWhile_Continue_SkipEven - Generator test placeholder (skipped)**
- **ControlFlow: finalize do-while continue generator snapshot - Update verified IL to match emission formatting**
- **control flow: implement break statements for for/while loops; add execution+generator tests and JS fixtures; align snapshots (for-loop). while-break exec passes; generator snapshot added and will be aligned next**
- **tests(control flow): add do-while break tests (exec + generator) with JS fixture; align generator snapshot formatting (CRLF)**
- **docs: update ECMAScript2025 feature coverage for while/do-while and continue/break support with test references**
- **docs: regenerate ECMAScript2025_FeatureCoverage.md after adding while/do-while and continue/break**
- **tests(control flow): update ControlFlow Execution/Generator tests (add/align If_NotFlag and break/continue cases)**
- **tests(control flow): normalize While_Break generator snapshot (trailing whitespace)**
- **test fix**
- **runtime: add JS Error hierarchy and make Error : System.Exception; expose name/message/stack with JS-style aliases**
- **tests: add JS resource and skipped execution test TryCatch_NoBinding for simple try/catch without binding**
- **tests(TryCatch): add subgroup with empty Execution and Generator test classes**
- **tests(TryCatch): move TryCatch_NoBinding execution test into TryCatch subgroup**
- **tests(TryCatch): fix GeneratorTests to call GenerateTest, not ExecutionTest**
- **Try/catch/finally: catch only JS Error; add try/finally tests; defer unhandled Error semantics (skip throw exec test); centralize runtime refs; remove AppDomain unhandled hook for now**
- **Rename GenerateStatements to GenerateStatementsForBody and update call sites**
- **try/catch support groundwork: centralize runtime Error, catch policy, scope lifecycle refactor, and tests**
- **docs: record try/catch/throw coverage and regenerate ECMAScript2025_FeatureCoverage.md**
- **tests(verify): update IL generator snapshots after scope lifecycle refactor and fix duplicate block scopes; try/catch/finally snapshots refreshed**
- **Updated .gitignore**
- **feat(runtime): add Require.require(string): object with whitelist for Node core modules; seed node:fs (readFileSync/writeFileSync) and node:path (join)**
- **Node require support: attribute-based module discovery, lazy load, emitter params handling; add path.join tests; move generator test under Node and remove duplicate snapshot**
- **Refactor: extract intrinsic instance call emission into helper for readability; add null-safety checks**
- **Runtime: add IntrinsicObjectAttribute and annotate Console as [IntrinsicObject(" console\)]**
- **Tests: use Verify scrubber for OS-agnostic path output; add Path runtime unit tests; refactor ExecutionTest to allow settings; normalize Require_Path_Join_Basic snapshot**
- **Const reassignment TypeError: emit throw on const Identifier assignment/update; use registry BindingKind; mark const fields initonly; add verified snapshot**
- **Docs: mark const reassignment TypeError as Supported; regenerate feature coverage**
- **Tooling: add cleanUnusedSnapshots.js and npm scripts; JS port of CleanUnusedSnapshots.ps1**
- **Tooling: remove legacy CleanUnusedSnapshots.ps1 (replaced by JS script)**
- **Tooling: port Update-VerifiedFiles.ps1 to JS (updateVerifiedFiles.js) and add npm scripts**
- **Tooling: remove legacy Update-VerifiedFiles.ps1 (replaced by updateVerifiedFiles.js)**
- **docs(changelog): backfill summaries for preview.3..preview.7**
- **tests(JSON): add Generator test for JSON_Parse_SimpleObject with placeholder snapshot**
- **tests(JSON): copy JSON_Parse_SimpleObject execution test and fixture from const-reassignment branch**
- **tests(JSON): add execution test and JS fixture for JSON_Parse_SimpleObject (skipped)**
- **tests: move UnaryOperator tests to subgroup and remove duplicate snapshots; feat: JSON.parse host intrinsic with typeof and Object.GetProperty; fix: strict equality/null handling; chore: update snapshots**
- **tests(unary): add typeof generator+execution tests and JS fixture; snapshot verified**
- **docs(coverage): mark typeof operator as Supported under 13.4; link test and runtime helper**
- **docs(coverage): regenerate ECMAScript2025_FeatureCoverage.md after adding typeof support**
- **docs(coverage): add JSON.parse (24.5.1) as Partially Supported; regenerate coverage MD; add runtime tests for JSON.Parse**
- **IL helpers: add ILEmitHelpers (Ldstr, EmitThrowError, EmitNewArray) and adopt InstructionEncoder.Call; standardize array/ldstr emission; add require(...) call handling and runtime intrinsic tagging for Node modules; fix class instance call resolution; update generators and runtime calls accordingly. All tests passing.**
- **String.replace regex support: add JavaScriptRuntime.StringHelpers.ReplaceRegex and compile String(x).replace(/pattern/flags, replacement) to it (global + ignoreCase flags). Update Runtime for bool signatures. All tests still passing.**
- **Rename StringHelpers.cs to String.cs; class is now JavaScriptRuntime.String with [IntrinsicObject(String)] and method Replace.**
- **IL: Add dynamic String.replace(/regex/flags, str) support via IntrinsicObjectRegistry; Runtime: JavaScriptRuntime.String.Replace; Tests: new String generator+execution tests; Robust regex literal extraction (case-insensitive + Raw parsing); Update snapshots**
- **Docs: Mark String.prototype.replace (regex literal + string replacement) as partially supported with tests and notes**
- **updated feature coverage doc**
- **Tests(ControlFlow): add conditional operator (?:) generator + execution tests (skipped pending codegen); add JS resource and snapshots**
- **feat(string): add Template Literal support and tests; implement TemplateLiteral IL emission via Operators.Add; docs: mark template literals supported and regenerate coverage MD; add ternary operator coverage entry**
- **feat(node): add __dirname codegen + runtime context; tests and snapshots; stabilize generator snapshots with targeted scrubbers; fix expression-statement stack balance (discard call/new/ternary results)**
- **docs(changelog): v0.1.1 latest changes  String.replace, ternary, template literals, Node __dirname; test stability and emit fixes**
- **fix(node): set default __dirname/__filename from entry assembly when out-of-proc; fix CI Verify mismatch for __dirname test**
- **refactor(il): add ILExpressionGenerator implementing IMethodExpressionEmitter (thin wrapper for future decoupling)**
- **runtime(console): finalize Console.cs behavior; tests: update verified snapshots after expression/call refactors (moved call emission + intrinsic dispatch + scope helper to ILExpressionGenerator; array literal tagging)**
- **refactor(expressions): move call emission and intrinsic dispatch to ILExpressionGenerator; move call-scope helper; update IMethodExpressionEmitter; adjust method and variable generators; minor cleanup**
- **refactor(expressions): centralize call emission and intrinsic dispatch in ILExpressionGenerator; Emit now returns ExpressionResult { JsType, ClrType }; propagate RuntimeIntrinsicType on init/assign; remove require-specific tagging in ILMethodGenerator; update BinaryOperators and interface**
- **test(array): add Array test subgroup with length property tests (count and empty)**
- **test(array): add GeneratorTests and verified IL snapshots for array length cases**
- **test(array): normalize GeneratorTests verified snapshots to received output formatting**
- **runtime(array): add Array.sort(); tests: add Array_Sort_Basic execution + generator with snapshot**
- **docs: update ECMAScript coverage with Array objects (length, sort default comparator) and test references**
- **updated generated markdown**
- **generator: support FunctionExpression emission; runtime: add Object.GetLength and use it for length; tests: add verified snapshots for Array_Map_Basic and update length snapshots**
- **tests(array): update verified generator snapshots to match new IL emission (FunctionExpression + Object.GetLength)**
- **tests: update verified snapshots (GetLength emission) for Function_GlobalFunctionWithArrayIteration and ArrayLiteral**
- **docs: add Array.prototype.map to feature coverage and regenerate markdown; update Array.length note to GetLength**
- **chore(changelog): move pending v0.1.2 notes under [Unreleased] per Keep a Changelog**
- **minor refactor.. added test for process exitcode**
- **Node process globals: compile-time GlobalVariables property resolution; process.exitCode as JS number (double) with IL updates; enable and snapshot Environment_EnumerateProcessArgV generator test**
- **JS null vs undefined: represent JSON null as JsNull; typeof(null) => object, typeof(undefined) => undefined; equality to null literal matches null or JsNull. Update tests and snapshots.**
- **Tests(Literals): add execution test that logs null and undefined; update runtime print semantics so console.log matches (undefined vs null).**
- **Tests(Array): add execution test for Array.sort with arrow comparator**
- **Runtime(Array): make Array.sort honor a comparator callback (supports arrow functions); fix test**
- **Node(fs): support 'utf8' option for readFileSync/writeFileSync; writeFileSync returns undefined (null)**
- **Tests(Node): add generator test FS_ReadWrite_Utf8 and verified snapshot**
- **Tests(Node): remove scrubbers from GeneratorTests; update verified snapshots to exact output**
- **Tests(Node/Generator): remove scrubbers and align verified snapshots to exact IL output (line endings, spacing, unicode escapes)**
- **tests(node/generator): update verified snapshots to match received outputs (exact bytes, LF)**
- **tests(array/generator): add Array_Sort_WithComparatorArrow and snapshot**
- **chore: add .editorconfig (indent_style=space, indent_size=4)**
- **tests(literals): add Array_Spread_Copy execution test (skipped) and snapshot**
- **tests(literals): avoid for..of in Array_Spread_Copy test (use index loop)**
- **feat(literals): support spread in array literals; enable Array_Spread_Copy test**
- **misc**
- **String.localeCompare: implement numeric option and JS-number return; fix comparator boxing to avoid NRE; generator+execution tests added and verified**
- **String: centralize instance call emission; implement replace routing (regex literal -> 5-arg helper, string pattern -> 3-arg overload). Add String.Replace(string, object, object) runtime overload. All tests green.**
- **String codegen: reflection-based dispatch for string instance methods. Prefer regex-literal expansion for replace; pad optional params for overloads like localeCompare. Maintain receiver ToString coercion. Tests green.**
- **String: add startsWith runtime + execution test; route CLR string receiver calls to string dispatcher; add verified output**
- **String: add generator test and verified snapshot for String_StartsWith_Basic (UTF-8 BOM to match generator output)**
- **fixed snapshot**
- **ControlFlow: implement for-of over arrays/strings via Object.GetLength/GetItem; add execution and generator tests with snapshots. Also wire Runtime.InvokeGetLengthFromObject and use object locals for iter/len/idx.**
- **String: add tests for plus-equals (+=) append and implement compound assignment for identifiers using Operators.Add; update generator snapshot.**
- **Docs: update feature coverage with array spread in literals, String.startsWith, String.localeCompare, compound += for strings, and for-of over arrays.**
- **Docs: regenerate ECMAScript2025_FeatureCoverage.md from JSON**
- **Docs: update CHANGELOG with array spread, string APIs, for-of, and +=**
- **Chore: add PR body for feature/process**
- **Docs: mention process.argv support in Unreleased and PR body**
- **Tests: fix process.argv init for in-proc execution by setting module context on runtime in Default ALC**
- **Node: initialize process.argv in static ctor for out-of-proc runs to avoid emptyString on CI fallback**
- **Env: add GetCommandLineArgs to IEnvironment and provider; keep deterministic argv initialization for tests**
- **Node: initialize process.argv from EnvironmentProvider.GetCommandLineArgs with argv[0] normalized; Tests: scrub dynamic args to keep snapshot stable**
- **Node: remove Process.SetArgv; derive process.argv from EnvironmentProvider.GetProcessArgs with argv[0] normalized**
- **code review comment**
- **Tests: add manual integration test to compile scripts/generateFeatureCoverage.js (skipped in CI)**
- **Changelog: cut v0.1.2 and add Unreleased entries (truthiness, logical OR/AND) (#37)**
- **tests: skip long-running integration test and robust repo root resolution via AppContext.BaseDirectory traversal**
