### PR TITLE
test: gate integration test behind RUN_INTEGRATION env (remove compile-time Skip)

### DIFF
--- a/Js2IL.Tests/Integration/CompilationTests.cs
+++ b/Js2IL.Tests/Integration/CompilationTests.cs
@@ -6,20 +6,24 @@ namespace Js2IL.Tests.Integration
 {
     public class CompilationTests
     {
-        [Fact(Skip = "Long-running integration test")]
+        [Fact]
         public void Compile_Scripts_GenerateFeatureCoverage()
         {
+            if (!string.Equals(Environment.GetEnvironmentVariable("RUN_INTEGRATION"), "1", StringComparison.Ordinal))
+                return; // treat as no-op unless explicitly enabled
+
             // Resolve repo root by walking up from the test assembly directory
             static string FindRepoRoot()
             {
                 var dir = new DirectoryInfo(AppContext.BaseDirectory);
                 while (dir != null)
                 {
-                    if (File.Exists(Path.Combine(dir.FullName, "js2il.sln")) ||
-                        Directory.Exists(Path.Combine(dir.FullName, "scripts")))
-                    {
+                    if (File.Exists(Path.Combine(dir.FullName, "js2il.sln")))
                         return dir.FullName;
-                    }
+
+                    var scriptsDir = Path.Combine(dir.FullName, "scripts");
+                    if (Directory.Exists(scriptsDir) && File.Exists(Path.Combine(scriptsDir, "generateFeatureCoverage.js")))
+                        return dir.FullName;
                     dir = dir.Parent;
                 }
                 throw new InvalidOperationException("Repository root not found from test base directory.");


### PR DESCRIPTION
Summary
- Make the long-running integration test opt-in by environment variable instead of compile-time [Skip].

Details
- Remove [Fact(Skip=…)] from Compile_Scripts_GenerateFeatureCoverage and gate at runtime: return early unless RUN_INTEGRATION=1.
- Slightly harden repo-root discovery: prefer js2il.sln; accept scripts dir only when generateFeatureCoverage.js exists.

Why
- Keeps default test runs fast and green while allowing explicit local/CI execution when desired.

How to run
- PowerShell:
  $env:RUN_INTEGRATION = '1'; dotnet test Js2IL.Tests/Js2IL.Tests.csproj -c Debug --filter FullyQualifiedName~Js2IL.Tests.Integration.CompilationTests.Compile_Scripts_GenerateFeatureCoverage; Remove-Item Env:RUN_INTEGRATION

Impact
- Tests-only change. No product code.