### PR TITLE
fix/il branching bool

### DIFF
--- a/JavaScriptRuntime/String.cs
+++ b/JavaScriptRuntime/String.cs
@@ -14,7 +14,7 @@ namespace JavaScriptRuntime
         /// Implements a subset of String.prototype.startsWith(searchString[, position]).
         /// Uses ordinal comparison and basic ToIntegerOrInfinity coercion for position.
         /// </summary>
-        public static bool StartsWith(string input, string searchString)
+    public static object StartsWith(string input, string searchString)
         {
             return StartsWith(input, searchString, null);
         }
@@ -22,7 +22,7 @@ namespace JavaScriptRuntime
         /// <summary>
         /// Implements a subset of String.prototype.startsWith with optional position argument.
         /// </summary>
-        public static bool StartsWith(string input, string searchString, object? position)
+    public static object StartsWith(string input, string searchString, object? position)
         {
             input ??= string.Empty;
             searchString ??= string.Empty;
@@ -109,7 +109,7 @@ namespace JavaScriptRuntime
         /// Supports locales (ignored) and options; recognizes options.numeric === true to enable numeric-aware comparison.
     /// Returns -1, 0, or 1 as a JavaScript number (double).
     /// </summary>
-    public static double LocaleCompare(string input, string other, object? locales, object? options)
+    public static object LocaleCompare(string input, string other, object? locales, object? options)
         {
             input ??= string.Empty;
             other ??= string.Empty;

--- a/Js2IL.Tests/Array/GeneratorTests.Array_EmptyLength_IsZero.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_EmptyLength_IsZero.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 50 (0x32)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Array/GeneratorTests.Array_Join_Basic.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_Join_Basic.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 124 (0x7c)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Array/GeneratorTests.Array_LengthProperty_ReturnsCount.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_LengthProperty_ReturnsCount.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 83 (0x53)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Array/GeneratorTests.Array_Map_Basic.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_Map_Basic.verified.txt
@@ -106,7 +106,7 @@
 		// Method begins at RVA 0x207c
 		// Header size: 12
 		// Code size: 216 (0xd8)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Array/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -182,29 +182,24 @@
 				object cb
 			) cil managed 
 		{
-			// Method begins at RVA 0x20e0
+			// Method begins at RVA 0x20f8
 			// Header size: 12
-			// Code size: 31 (0x1f)
-			.maxstack 8
-			.locals init (
-				[0] object
-			)
+			// Code size: 29 (0x1d)
+			.maxstack 32
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.1
 			IL_0002: ldelem.ref
 			IL_0003: ldfld object Scopes.Array_Map_NestedParam/outer::arr
-			IL_0008: ldc.i4.1
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.1
-			IL_0011: stelem.ref
-			IL_0012: stloc.0
-			IL_0013: ldstr "map"
-			IL_0018: ldloc.0
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_001e: ret
+			IL_0008: ldstr "map"
+			IL_000d: ldc.i4.1
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.1
+			IL_0016: stelem.ref
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_001c: ret
 		} // end of method outer::inner
 
 	} // end of class outer
@@ -219,8 +214,8 @@
 	{
 		// Method begins at RVA 0x2094
 		// Header size: 12
-		// Code size: 64 (0x40)
-		.maxstack 8
+		// Code size: 85 (0x55)
+		.maxstack 32
 		.locals init (
 			[0] object
 		)
@@ -250,8 +245,21 @@
 		IL_002e: ldnull
 		IL_002f: ldftn object Functions.ArrowFunction_L7C15::ArrowFunction_L7C15(object[], object)
 		IL_0035: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
-		IL_003a: callvirt instance !2 class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0, !1)
-		IL_003f: ret
+		IL_003a: ldc.i4.2
+		IL_003b: newarr [System.Runtime]System.Object
+		IL_0040: dup
+		IL_0041: ldc.i4.0
+		IL_0042: ldarg.0
+		IL_0043: ldc.i4.0
+		IL_0044: ldelem.ref
+		IL_0045: stelem.ref
+		IL_0046: dup
+		IL_0047: ldc.i4.1
+		IL_0048: ldloc.0
+		IL_0049: stelem.ref
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_004f: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0054: ret
 	} // end of method outer::outer
 
 } // end of class Functions.outer
@@ -263,7 +271,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x210b
+		// Method begins at RVA 0x2121
 		// Header size: 1
 		// Code size: 35 (0x23)
 		.maxstack 8
@@ -288,7 +296,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2130
+		// Method begins at RVA 0x2148
 		// Header size: 12
 		// Code size: 215 (0xd7)
 		.maxstack 8
@@ -323,7 +331,7 @@
 		IL_0043: dup
 		IL_0044: ldstr "ccc"
 		IL_0049: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_004e: callvirt instance !2 class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0, !1)
+		IL_004e: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
 		IL_0053: stfld object Scopes.Array_Map_NestedParam::result
 		IL_0058: ldloc.0
 		IL_0059: ldc.r8 0.0

--- a/Js2IL.Tests/Array/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -299,7 +299,7 @@
 		// Method begins at RVA 0x2148
 		// Header size: 12
 		// Code size: 215 (0xd7)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Array/GeneratorTests.Array_Sort_Basic.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_Sort_Basic.verified.txt
@@ -59,7 +59,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 196 (0xc4)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Array/GeneratorTests.Array_Sort_WithComparatorArrow.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_Sort_WithComparatorArrow.verified.txt
@@ -102,7 +102,7 @@
 	{
 		// Method begins at RVA 0x2074
 		// Header size: 12
-		// Code size: 278 (0x116)
+		// Code size: 293 (0x125)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -144,49 +144,56 @@
 		IL_0084: ldnull
 		IL_0085: ldftn object Functions.ArrowFunction_L2C9::ArrowFunction_L2C9(object[], object, object)
 		IL_008b: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
-		IL_0090: stelem.ref
-		IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::sort(object[])
-		IL_0096: pop
-		IL_0097: ldloc.0
-		IL_0098: ldc.r8 0.0
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: stfld object Scopes.Array_Sort_WithComparatorArrow::i
-		// loop start (head: IL_00ab)
-			IL_00ab: ldloc.0
-			IL_00ac: ldfld object Scopes.Array_Sort_WithComparatorArrow::i
-			IL_00b1: unbox.any [System.Runtime]System.Double
-			IL_00b6: ldloc.0
-			IL_00b7: ldfld object Scopes.Array_Sort_WithComparatorArrow::arr
-			IL_00bc: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00c1: blt IL_00cb
+		IL_0090: ldc.i4.1
+		IL_0091: newarr [System.Runtime]System.Object
+		IL_0096: dup
+		IL_0097: ldc.i4.0
+		IL_0098: ldloc.0
+		IL_0099: stelem.ref
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_009f: stelem.ref
+		IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::sort(object[])
+		IL_00a5: pop
+		IL_00a6: ldloc.0
+		IL_00a7: ldc.r8 0.0
+		IL_00b0: box [System.Runtime]System.Double
+		IL_00b5: stfld object Scopes.Array_Sort_WithComparatorArrow::i
+		// loop start (head: IL_00ba)
+			IL_00ba: ldloc.0
+			IL_00bb: ldfld object Scopes.Array_Sort_WithComparatorArrow::i
+			IL_00c0: unbox.any [System.Runtime]System.Double
+			IL_00c5: ldloc.0
+			IL_00c6: ldfld object Scopes.Array_Sort_WithComparatorArrow::arr
+			IL_00cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00d0: blt IL_00da
 
-			IL_00c6: br IL_0115
+			IL_00d5: br IL_0124
 
-			IL_00cb: ldc.i4.1
-			IL_00cc: newarr [System.Runtime]System.Object
-			IL_00d1: dup
-			IL_00d2: ldc.i4.0
-			IL_00d3: ldloc.0
-			IL_00d4: ldfld object Scopes.Array_Sort_WithComparatorArrow::arr
-			IL_00d9: ldloc.0
-			IL_00da: ldfld object Scopes.Array_Sort_WithComparatorArrow::i
-			IL_00df: unbox.any [System.Runtime]System.Double
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-			IL_00e9: stelem.ref
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-			IL_00ef: pop
-			IL_00f0: ldloc.0
-			IL_00f1: ldloc.0
-			IL_00f2: ldfld object Scopes.Array_Sort_WithComparatorArrow::i
-			IL_00f7: unbox.any [System.Runtime]System.Double
-			IL_00fc: ldc.r8 1
-			IL_0105: add
-			IL_0106: box [System.Runtime]System.Double
-			IL_010b: stfld object Scopes.Array_Sort_WithComparatorArrow::i
-			IL_0110: br IL_00ab
+			IL_00da: ldc.i4.1
+			IL_00db: newarr [System.Runtime]System.Object
+			IL_00e0: dup
+			IL_00e1: ldc.i4.0
+			IL_00e2: ldloc.0
+			IL_00e3: ldfld object Scopes.Array_Sort_WithComparatorArrow::arr
+			IL_00e8: ldloc.0
+			IL_00e9: ldfld object Scopes.Array_Sort_WithComparatorArrow::i
+			IL_00ee: unbox.any [System.Runtime]System.Double
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+			IL_00f8: stelem.ref
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_00fe: pop
+			IL_00ff: ldloc.0
+			IL_0100: ldloc.0
+			IL_0101: ldfld object Scopes.Array_Sort_WithComparatorArrow::i
+			IL_0106: unbox.any [System.Runtime]System.Double
+			IL_010b: ldc.r8 1
+			IL_0114: add
+			IL_0115: box [System.Runtime]System.Double
+			IL_011a: stfld object Scopes.Array_Sort_WithComparatorArrow::i
+			IL_011f: br IL_00ba
 		// end loop
 
-		IL_0115: ret
+		IL_0124: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/Array/GeneratorTests.Array_Sort_WithComparatorArrow.verified.txt
+++ b/Js2IL.Tests/Array/GeneratorTests.Array_Sort_WithComparatorArrow.verified.txt
@@ -103,7 +103,7 @@
 		// Method begins at RVA 0x2074
 		// Header size: 12
 		// Code size: 293 (0x125)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_BlockBody_Return.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_BlockBody_Return.verified.txt
@@ -87,7 +87,7 @@
 	{
 		// Method begins at RVA 0x2078
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 112 (0x70)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -100,32 +100,39 @@
 		IL_0007: ldnull
 		IL_0008: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[], object, object)
 		IL_000e: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
-		IL_0013: stfld object Scopes.ArrowFunction_BlockBody_Return::'add'
-		IL_0018: ldc.i4.2
-		IL_0019: newarr [System.Runtime]System.Object
-		IL_001e: dup
-		IL_001f: ldc.i4.0
-		IL_0020: ldstr "x is "
-		IL_0025: stelem.ref
-		IL_0026: dup
-		IL_0027: ldc.i4.1
-		IL_0028: ldloc.0
-		IL_0029: ldfld object Scopes.ArrowFunction_BlockBody_Return::'add'
-		IL_002e: ldc.i4.1
-		IL_002f: newarr [System.Runtime]System.Object
-		IL_0034: dup
-		IL_0035: ldc.i4.0
-		IL_0036: ldloc.0
-		IL_0037: stelem.ref
-		IL_0038: ldc.r8 4
-		IL_0041: box [System.Runtime]System.Double
-		IL_0046: ldc.r8 3
-		IL_004f: box [System.Runtime]System.Double
-		IL_0054: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_005f: pop
-		IL_0060: ret
+		IL_0013: ldc.i4.1
+		IL_0014: newarr [System.Runtime]System.Object
+		IL_0019: dup
+		IL_001a: ldc.i4.0
+		IL_001b: ldloc.0
+		IL_001c: stelem.ref
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0022: stfld object Scopes.ArrowFunction_BlockBody_Return::'add'
+		IL_0027: ldc.i4.2
+		IL_0028: newarr [System.Runtime]System.Object
+		IL_002d: dup
+		IL_002e: ldc.i4.0
+		IL_002f: ldstr "x is "
+		IL_0034: stelem.ref
+		IL_0035: dup
+		IL_0036: ldc.i4.1
+		IL_0037: ldloc.0
+		IL_0038: ldfld object Scopes.ArrowFunction_BlockBody_Return::'add'
+		IL_003d: ldc.i4.1
+		IL_003e: newarr [System.Runtime]System.Object
+		IL_0043: dup
+		IL_0044: ldc.i4.0
+		IL_0045: ldloc.0
+		IL_0046: stelem.ref
+		IL_0047: ldc.r8 4
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: ldc.r8 3
+		IL_005e: box [System.Runtime]System.Double
+		IL_0063: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_0068: stelem.ref
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_006e: pop
+		IL_006f: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_BlockBody_Return.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_BlockBody_Return.verified.txt
@@ -88,7 +88,7 @@
 		// Method begins at RVA 0x2078
 		// Header size: 12
 		// Code size: 112 (0x70)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
@@ -88,7 +88,7 @@
 		// Method begins at RVA 0x2080
 		// Header size: 12
 		// Code size: 118 (0x76)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
@@ -87,7 +87,7 @@
 	{
 		// Method begins at RVA 0x2080
 		// Header size: 12
-		// Code size: 103 (0x67)
+		// Code size: 118 (0x76)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -104,30 +104,37 @@
 		IL_001b: ldnull
 		IL_001c: ldftn object Functions.ArrowFunction_L2C12::ArrowFunction_L2C12(object[], object)
 		IL_0022: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
-		IL_0027: stfld object Scopes.ArrowFunction_CapturesOuterVariable::'mul'
-		IL_002c: ldc.i4.2
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldstr "product is "
-		IL_0039: stelem.ref
-		IL_003a: dup
-		IL_003b: ldc.i4.1
-		IL_003c: ldloc.0
-		IL_003d: ldfld object Scopes.ArrowFunction_CapturesOuterVariable::'mul'
-		IL_0042: ldc.i4.1
-		IL_0043: newarr [System.Runtime]System.Object
-		IL_0048: dup
-		IL_0049: ldc.i4.0
-		IL_004a: ldloc.0
-		IL_004b: stelem.ref
-		IL_004c: ldc.r8 3
-		IL_0055: box [System.Runtime]System.Double
-		IL_005a: callvirt instance !2 class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0, !1)
-		IL_005f: stelem.ref
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_0065: pop
-		IL_0066: ret
+		IL_0027: ldc.i4.1
+		IL_0028: newarr [System.Runtime]System.Object
+		IL_002d: dup
+		IL_002e: ldc.i4.0
+		IL_002f: ldloc.0
+		IL_0030: stelem.ref
+		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0036: stfld object Scopes.ArrowFunction_CapturesOuterVariable::'mul'
+		IL_003b: ldc.i4.2
+		IL_003c: newarr [System.Runtime]System.Object
+		IL_0041: dup
+		IL_0042: ldc.i4.0
+		IL_0043: ldstr "product is "
+		IL_0048: stelem.ref
+		IL_0049: dup
+		IL_004a: ldc.i4.1
+		IL_004b: ldloc.0
+		IL_004c: ldfld object Scopes.ArrowFunction_CapturesOuterVariable::'mul'
+		IL_0051: ldc.i4.1
+		IL_0052: newarr [System.Runtime]System.Object
+		IL_0057: dup
+		IL_0058: ldc.i4.0
+		IL_0059: ldloc.0
+		IL_005a: stelem.ref
+		IL_005b: ldc.r8 3
+		IL_0064: box [System.Runtime]System.Double
+		IL_0069: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_006e: stelem.ref
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_0074: pop
+		IL_0075: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -158,7 +158,7 @@
 	{
 		// Method begins at RVA 0x20e4
 		// Header size: 12
-		// Code size: 102 (0x66)
+		// Code size: 132 (0x84)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -171,36 +171,50 @@
 		IL_0007: ldnull
 		IL_0008: ldftn object Functions.ArrowFunction_L2C19::ArrowFunction_L2C19(object[])
 		IL_000e: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_0013: stfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorld
-		IL_0018: ldloc.0
-		IL_0019: ldnull
-		IL_001a: ldftn object Functions.ArrowFunction_L6C24::ArrowFunction_L6C24(object[])
-		IL_0020: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_0025: stfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorldProxy
-		IL_002a: ldloc.0
-		IL_002b: ldfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorldProxy
-		IL_0030: ldc.i4.1
-		IL_0031: newarr [System.Runtime]System.Object
-		IL_0036: dup
-		IL_0037: ldc.i4.0
-		IL_0038: ldloc.0
-		IL_0039: stelem.ref
-		IL_003a: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
-		IL_003f: pop
-		IL_0040: ldc.i4.2
-		IL_0041: newarr [System.Runtime]System.Object
-		IL_0046: dup
-		IL_0047: ldc.i4.0
-		IL_0048: ldstr "finally is now"
-		IL_004d: stelem.ref
-		IL_004e: dup
-		IL_004f: ldc.i4.1
-		IL_0050: ldc.r8 3
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: stelem.ref
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_0064: pop
-		IL_0065: ret
+		IL_0013: ldc.i4.1
+		IL_0014: newarr [System.Runtime]System.Object
+		IL_0019: dup
+		IL_001a: ldc.i4.0
+		IL_001b: ldloc.0
+		IL_001c: stelem.ref
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0022: stfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorld
+		IL_0027: ldloc.0
+		IL_0028: ldnull
+		IL_0029: ldftn object Functions.ArrowFunction_L6C24::ArrowFunction_L6C24(object[])
+		IL_002f: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_0034: ldc.i4.1
+		IL_0035: newarr [System.Runtime]System.Object
+		IL_003a: dup
+		IL_003b: ldc.i4.0
+		IL_003c: ldloc.0
+		IL_003d: stelem.ref
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0043: stfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorldProxy
+		IL_0048: ldloc.0
+		IL_0049: ldfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorldProxy
+		IL_004e: ldc.i4.1
+		IL_004f: newarr [System.Runtime]System.Object
+		IL_0054: dup
+		IL_0055: ldc.i4.0
+		IL_0056: ldloc.0
+		IL_0057: stelem.ref
+		IL_0058: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_005d: pop
+		IL_005e: ldc.i4.2
+		IL_005f: newarr [System.Runtime]System.Object
+		IL_0064: dup
+		IL_0065: ldc.i4.0
+		IL_0066: ldstr "finally is now"
+		IL_006b: stelem.ref
+		IL_006c: dup
+		IL_006d: ldc.i4.1
+		IL_006e: ldc.r8 3
+		IL_0077: box [System.Runtime]System.Double
+		IL_007c: stelem.ref
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_0082: pop
+		IL_0083: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -159,7 +159,7 @@
 		// Method begins at RVA 0x20e4
 		// Header size: 12
 		// Code size: 132 (0x84)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -138,7 +138,7 @@
 	{
 		// Method begins at RVA 0x20b8
 		// Header size: 12
-		// Code size: 47 (0x2f)
+		// Code size: 68 (0x44)
 		.maxstack 8
 		.locals init (
 			[0] object
@@ -165,7 +165,20 @@
 		IL_0027: ldloc.0
 		IL_0028: stelem.ref
 		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_002e: ret
+		IL_002e: ldc.i4.2
+		IL_002f: newarr [System.Runtime]System.Object
+		IL_0034: dup
+		IL_0035: ldc.i4.0
+		IL_0036: ldarg.0
+		IL_0037: ldc.i4.0
+		IL_0038: ldelem.ref
+		IL_0039: stelem.ref
+		IL_003a: dup
+		IL_003b: ldc.i4.1
+		IL_003c: ldloc.0
+		IL_003d: stelem.ref
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0043: ret
 	} // end of method ArrowFunction_L3C14::ArrowFunction_L3C14
 
 } // end of class Functions.ArrowFunction_L3C14
@@ -177,9 +190,9 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f4
+		// Method begins at RVA 0x2108
 		// Header size: 12
-		// Code size: 99 (0x63)
+		// Code size: 114 (0x72)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -195,31 +208,38 @@
 		IL_0012: ldnull
 		IL_0013: ldftn object Functions.ArrowFunction_L3C14::ArrowFunction_L3C14(object[], object)
 		IL_0019: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
-		IL_001e: stfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::outer
-		IL_0023: ldloc.0
-		IL_0024: ldloc.0
-		IL_0025: ldfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::outer
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
+		IL_001e: ldc.i4.1
+		IL_001f: newarr [System.Runtime]System.Object
+		IL_0024: dup
+		IL_0025: ldc.i4.0
+		IL_0026: ldloc.0
+		IL_0027: stelem.ref
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_002d: stfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::outer
 		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.r8 123
-		IL_003d: box [System.Runtime]System.Double
-		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0, !1)
-		IL_0047: stfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::f
-		IL_004c: ldloc.0
-		IL_004d: ldfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::f
-		IL_0052: ldc.i4.1
-		IL_0053: newarr [System.Runtime]System.Object
-		IL_0058: dup
-		IL_0059: ldc.i4.0
-		IL_005a: ldloc.0
-		IL_005b: stelem.ref
-		IL_005c: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
-		IL_0061: pop
-		IL_0062: ret
+		IL_0033: ldloc.0
+		IL_0034: ldfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::outer
+		IL_0039: ldc.i4.1
+		IL_003a: newarr [System.Runtime]System.Object
+		IL_003f: dup
+		IL_0040: ldc.i4.0
+		IL_0041: ldloc.0
+		IL_0042: stelem.ref
+		IL_0043: ldc.r8 123
+		IL_004c: box [System.Runtime]System.Double
+		IL_0051: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0056: stfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::f
+		IL_005b: ldloc.0
+		IL_005c: ldfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::f
+		IL_0061: ldc.i4.1
+		IL_0062: newarr [System.Runtime]System.Object
+		IL_0067: dup
+		IL_0068: ldc.i4.0
+		IL_0069: ldloc.0
+		IL_006a: stelem.ref
+		IL_006b: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_0070: pop
+		IL_0071: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -193,7 +193,7 @@
 		// Method begins at RVA 0x2108
 		// Header size: 12
 		// Code size: 114 (0x72)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionWithMultipleParameters.verified.txt
@@ -436,7 +436,7 @@
 		// Method begins at RVA 0x2174
 		// Header size: 12
 		// Code size: 631 (0x277)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_GlobalFunctionWithMultipleParameters.verified.txt
@@ -435,7 +435,7 @@
 	{
 		// Method begins at RVA 0x2174
 		// Header size: 12
-		// Code size: 541 (0x21d)
+		// Code size: 631 (0x277)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -448,135 +448,177 @@
 		IL_0007: ldnull
 		IL_0008: ldftn object Functions.ArrowFunction_L1C11::ArrowFunction_L1C11(object[], object)
 		IL_000e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
-		IL_0013: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f1
-		IL_0018: ldloc.0
-		IL_0019: ldnull
-		IL_001a: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object, object)
-		IL_0020: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
-		IL_0025: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f2
-		IL_002a: ldloc.0
-		IL_002b: ldnull
-		IL_002c: ldftn object Functions.ArrowFunction_L9C11::ArrowFunction_L9C11(object[], object, object, object)
-		IL_0032: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
-		IL_0037: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f3
+		IL_0013: ldc.i4.1
+		IL_0014: newarr [System.Runtime]System.Object
+		IL_0019: dup
+		IL_001a: ldc.i4.0
+		IL_001b: ldloc.0
+		IL_001c: stelem.ref
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0022: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f1
+		IL_0027: ldloc.0
+		IL_0028: ldnull
+		IL_0029: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object, object)
+		IL_002f: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_0034: ldc.i4.1
+		IL_0035: newarr [System.Runtime]System.Object
+		IL_003a: dup
+		IL_003b: ldc.i4.0
 		IL_003c: ldloc.0
-		IL_003d: ldnull
-		IL_003e: ldftn object Functions.ArrowFunction_L13C11::ArrowFunction_L13C11(object[], object, object, object, object)
-		IL_0044: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
-		IL_0049: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f4
-		IL_004e: ldloc.0
-		IL_004f: ldnull
-		IL_0050: ldftn object Functions.ArrowFunction_L17C11::ArrowFunction_L17C11(object[], object, object, object, object, object)
-		IL_0056: newobj instance void class [System.Runtime]System.Func`7<object[], object, object, object, object, object, object>::.ctor(object, native int)
-		IL_005b: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f5
-		IL_0060: ldloc.0
-		IL_0061: ldnull
-		IL_0062: ldftn object Functions.ArrowFunction_L21C11::ArrowFunction_L21C11(object[], object, object, object, object, object, object)
-		IL_0068: newobj instance void class [System.Runtime]System.Func`8<object[], object, object, object, object, object, object, object>::.ctor(object, native int)
-		IL_006d: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f6
-		IL_0072: ldloc.0
-		IL_0073: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f1
-		IL_0078: ldc.i4.1
-		IL_0079: newarr [System.Runtime]System.Object
-		IL_007e: dup
-		IL_007f: ldc.i4.0
-		IL_0080: ldloc.0
-		IL_0081: stelem.ref
-		IL_0082: ldc.r8 1
-		IL_008b: box [System.Runtime]System.Double
-		IL_0090: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
-		IL_0095: pop
-		IL_0096: ldloc.0
-		IL_0097: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f2
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: ldc.r8 1
-		IL_00af: box [System.Runtime]System.Double
-		IL_00b4: ldc.r8 2
-		IL_00bd: box [System.Runtime]System.Double
-		IL_00c2: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
-		IL_00c7: pop
-		IL_00c8: ldloc.0
-		IL_00c9: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f3
-		IL_00ce: ldc.i4.1
-		IL_00cf: newarr [System.Runtime]System.Object
-		IL_00d4: dup
-		IL_00d5: ldc.i4.0
-		IL_00d6: ldloc.0
-		IL_00d7: stelem.ref
-		IL_00d8: ldc.r8 1
-		IL_00e1: box [System.Runtime]System.Double
-		IL_00e6: ldc.r8 2
-		IL_00ef: box [System.Runtime]System.Double
-		IL_00f4: ldc.r8 3
-		IL_00fd: box [System.Runtime]System.Double
-		IL_0102: callvirt instance !4 class [System.Runtime]System.Func`5<object[], object, object, object, object>::Invoke(!0, !1, !2, !3)
-		IL_0107: pop
-		IL_0108: ldloc.0
-		IL_0109: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f4
-		IL_010e: ldc.i4.1
-		IL_010f: newarr [System.Runtime]System.Object
-		IL_0114: dup
-		IL_0115: ldc.i4.0
-		IL_0116: ldloc.0
-		IL_0117: stelem.ref
-		IL_0118: ldc.r8 1
-		IL_0121: box [System.Runtime]System.Double
-		IL_0126: ldc.r8 2
-		IL_012f: box [System.Runtime]System.Double
-		IL_0134: ldc.r8 3
-		IL_013d: box [System.Runtime]System.Double
-		IL_0142: ldc.r8 4
-		IL_014b: box [System.Runtime]System.Double
-		IL_0150: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
-		IL_0155: pop
-		IL_0156: ldloc.0
-		IL_0157: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f5
-		IL_015c: ldc.i4.1
-		IL_015d: newarr [System.Runtime]System.Object
-		IL_0162: dup
-		IL_0163: ldc.i4.0
-		IL_0164: ldloc.0
-		IL_0165: stelem.ref
-		IL_0166: ldc.r8 1
-		IL_016f: box [System.Runtime]System.Double
-		IL_0174: ldc.r8 2
-		IL_017d: box [System.Runtime]System.Double
-		IL_0182: ldc.r8 3
-		IL_018b: box [System.Runtime]System.Double
-		IL_0190: ldc.r8 4
-		IL_0199: box [System.Runtime]System.Double
-		IL_019e: ldc.r8 5
-		IL_01a7: box [System.Runtime]System.Double
-		IL_01ac: callvirt instance !6 class [System.Runtime]System.Func`7<object[], object, object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4, !5)
-		IL_01b1: pop
-		IL_01b2: ldloc.0
-		IL_01b3: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f6
-		IL_01b8: ldc.i4.1
-		IL_01b9: newarr [System.Runtime]System.Object
-		IL_01be: dup
-		IL_01bf: ldc.i4.0
-		IL_01c0: ldloc.0
-		IL_01c1: stelem.ref
-		IL_01c2: ldc.r8 1
-		IL_01cb: box [System.Runtime]System.Double
-		IL_01d0: ldc.r8 2
-		IL_01d9: box [System.Runtime]System.Double
-		IL_01de: ldc.r8 3
-		IL_01e7: box [System.Runtime]System.Double
-		IL_01ec: ldc.r8 4
-		IL_01f5: box [System.Runtime]System.Double
-		IL_01fa: ldc.r8 5
-		IL_0203: box [System.Runtime]System.Double
-		IL_0208: ldc.r8 6
-		IL_0211: box [System.Runtime]System.Double
-		IL_0216: callvirt instance !7 class [System.Runtime]System.Func`8<object[], object, object, object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4, !5, !6)
-		IL_021b: pop
-		IL_021c: ret
+		IL_003d: stelem.ref
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0043: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f2
+		IL_0048: ldloc.0
+		IL_0049: ldnull
+		IL_004a: ldftn object Functions.ArrowFunction_L9C11::ArrowFunction_L9C11(object[], object, object, object)
+		IL_0050: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0064: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f3
+		IL_0069: ldloc.0
+		IL_006a: ldnull
+		IL_006b: ldftn object Functions.ArrowFunction_L13C11::ArrowFunction_L13C11(object[], object, object, object, object)
+		IL_0071: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0085: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f4
+		IL_008a: ldloc.0
+		IL_008b: ldnull
+		IL_008c: ldftn object Functions.ArrowFunction_L17C11::ArrowFunction_L17C11(object[], object, object, object, object, object)
+		IL_0092: newobj instance void class [System.Runtime]System.Func`7<object[], object, object, object, object, object, object>::.ctor(object, native int)
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00a6: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f5
+		IL_00ab: ldloc.0
+		IL_00ac: ldnull
+		IL_00ad: ldftn object Functions.ArrowFunction_L21C11::ArrowFunction_L21C11(object[], object, object, object, object, object, object)
+		IL_00b3: newobj instance void class [System.Runtime]System.Func`8<object[], object, object, object, object, object, object, object>::.ctor(object, native int)
+		IL_00b8: ldc.i4.1
+		IL_00b9: newarr [System.Runtime]System.Object
+		IL_00be: dup
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldloc.0
+		IL_00c1: stelem.ref
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00c7: stfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f6
+		IL_00cc: ldloc.0
+		IL_00cd: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f1
+		IL_00d2: ldc.i4.1
+		IL_00d3: newarr [System.Runtime]System.Object
+		IL_00d8: dup
+		IL_00d9: ldc.i4.0
+		IL_00da: ldloc.0
+		IL_00db: stelem.ref
+		IL_00dc: ldc.r8 1
+		IL_00e5: box [System.Runtime]System.Double
+		IL_00ea: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00ef: pop
+		IL_00f0: ldloc.0
+		IL_00f1: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f2
+		IL_00f6: ldc.i4.1
+		IL_00f7: newarr [System.Runtime]System.Object
+		IL_00fc: dup
+		IL_00fd: ldc.i4.0
+		IL_00fe: ldloc.0
+		IL_00ff: stelem.ref
+		IL_0100: ldc.r8 1
+		IL_0109: box [System.Runtime]System.Double
+		IL_010e: ldc.r8 2
+		IL_0117: box [System.Runtime]System.Double
+		IL_011c: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_0121: pop
+		IL_0122: ldloc.0
+		IL_0123: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f3
+		IL_0128: ldc.i4.1
+		IL_0129: newarr [System.Runtime]System.Object
+		IL_012e: dup
+		IL_012f: ldc.i4.0
+		IL_0130: ldloc.0
+		IL_0131: stelem.ref
+		IL_0132: ldc.r8 1
+		IL_013b: box [System.Runtime]System.Double
+		IL_0140: ldc.r8 2
+		IL_0149: box [System.Runtime]System.Double
+		IL_014e: ldc.r8 3
+		IL_0157: box [System.Runtime]System.Double
+		IL_015c: callvirt instance !4 class [System.Runtime]System.Func`5<object[], object, object, object, object>::Invoke(!0, !1, !2, !3)
+		IL_0161: pop
+		IL_0162: ldloc.0
+		IL_0163: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f4
+		IL_0168: ldc.i4.1
+		IL_0169: newarr [System.Runtime]System.Object
+		IL_016e: dup
+		IL_016f: ldc.i4.0
+		IL_0170: ldloc.0
+		IL_0171: stelem.ref
+		IL_0172: ldc.r8 1
+		IL_017b: box [System.Runtime]System.Double
+		IL_0180: ldc.r8 2
+		IL_0189: box [System.Runtime]System.Double
+		IL_018e: ldc.r8 3
+		IL_0197: box [System.Runtime]System.Double
+		IL_019c: ldc.r8 4
+		IL_01a5: box [System.Runtime]System.Double
+		IL_01aa: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_01af: pop
+		IL_01b0: ldloc.0
+		IL_01b1: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f5
+		IL_01b6: ldc.i4.1
+		IL_01b7: newarr [System.Runtime]System.Object
+		IL_01bc: dup
+		IL_01bd: ldc.i4.0
+		IL_01be: ldloc.0
+		IL_01bf: stelem.ref
+		IL_01c0: ldc.r8 1
+		IL_01c9: box [System.Runtime]System.Double
+		IL_01ce: ldc.r8 2
+		IL_01d7: box [System.Runtime]System.Double
+		IL_01dc: ldc.r8 3
+		IL_01e5: box [System.Runtime]System.Double
+		IL_01ea: ldc.r8 4
+		IL_01f3: box [System.Runtime]System.Double
+		IL_01f8: ldc.r8 5
+		IL_0201: box [System.Runtime]System.Double
+		IL_0206: callvirt instance !6 class [System.Runtime]System.Func`7<object[], object, object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4, !5)
+		IL_020b: pop
+		IL_020c: ldloc.0
+		IL_020d: ldfld object Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters::f6
+		IL_0212: ldc.i4.1
+		IL_0213: newarr [System.Runtime]System.Object
+		IL_0218: dup
+		IL_0219: ldc.i4.0
+		IL_021a: ldloc.0
+		IL_021b: stelem.ref
+		IL_021c: ldc.r8 1
+		IL_0225: box [System.Runtime]System.Double
+		IL_022a: ldc.r8 2
+		IL_0233: box [System.Runtime]System.Double
+		IL_0238: ldc.r8 3
+		IL_0241: box [System.Runtime]System.Double
+		IL_0246: ldc.r8 4
+		IL_024f: box [System.Runtime]System.Double
+		IL_0254: ldc.r8 5
+		IL_025d: box [System.Runtime]System.Double
+		IL_0262: ldc.r8 6
+		IL_026b: box [System.Runtime]System.Double
+		IL_0270: callvirt instance !7 class [System.Runtime]System.Func`8<object[], object, object, object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4, !5, !6)
+		IL_0275: pop
+		IL_0276: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -221,7 +221,7 @@
 		// Method begins at RVA 0x214c
 		// Header size: 12
 		// Code size: 73 (0x49)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -160,7 +160,7 @@
 	{
 		// Method begins at RVA 0x20e8
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 86 (0x56)
 		.maxstack 8
 		.locals init (
 			[0] object
@@ -175,25 +175,38 @@
 		IL_0012: ldnull
 		IL_0013: ldftn object Functions.ArrowFunction_L6C27::ArrowFunction_L6C27(object[])
 		IL_0019: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_001e: stfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction::nestedFunction
-		IL_0023: ldloc.0
-		IL_0024: ldfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction::nestedFunction
-		IL_0029: ldc.i4.2
-		IL_002a: newarr [System.Runtime]System.Object
-		IL_002f: dup
-		IL_0030: ldc.i4.0
-		IL_0031: ldarg.0
-		IL_0032: ldc.i4.0
-		IL_0033: ldelem.ref
-		IL_0034: stelem.ref
-		IL_0035: dup
-		IL_0036: ldc.i4.1
-		IL_0037: ldloc.0
-		IL_0038: stelem.ref
-		IL_0039: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
-		IL_003e: pop
-		IL_003f: ldnull
-		IL_0040: ret
+		IL_001e: ldc.i4.2
+		IL_001f: newarr [System.Runtime]System.Object
+		IL_0024: dup
+		IL_0025: ldc.i4.0
+		IL_0026: ldarg.0
+		IL_0027: ldc.i4.0
+		IL_0028: ldelem.ref
+		IL_0029: stelem.ref
+		IL_002a: dup
+		IL_002b: ldc.i4.1
+		IL_002c: ldloc.0
+		IL_002d: stelem.ref
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0033: stfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction::nestedFunction
+		IL_0038: ldloc.0
+		IL_0039: ldfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction::nestedFunction
+		IL_003e: ldc.i4.2
+		IL_003f: newarr [System.Runtime]System.Object
+		IL_0044: dup
+		IL_0045: ldc.i4.0
+		IL_0046: ldarg.0
+		IL_0047: ldc.i4.0
+		IL_0048: ldelem.ref
+		IL_0049: stelem.ref
+		IL_004a: dup
+		IL_004b: ldc.i4.1
+		IL_004c: ldloc.0
+		IL_004d: stelem.ref
+		IL_004e: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_0053: pop
+		IL_0054: ldnull
+		IL_0055: ret
 	} // end of method ArrowFunction_L3C21::ArrowFunction_L3C21
 
 } // end of class Functions.ArrowFunction_L3C21
@@ -205,9 +218,9 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2138
+		// Method begins at RVA 0x214c
 		// Header size: 12
-		// Code size: 58 (0x3a)
+		// Code size: 73 (0x49)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -223,18 +236,25 @@
 		IL_0012: ldnull
 		IL_0013: ldftn object Functions.ArrowFunction_L3C21::ArrowFunction_L3C21(object[])
 		IL_0019: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_001e: stfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes::testFunction
-		IL_0023: ldloc.0
-		IL_0024: ldfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes::testFunction
-		IL_0029: ldc.i4.1
-		IL_002a: newarr [System.Runtime]System.Object
-		IL_002f: dup
-		IL_0030: ldc.i4.0
-		IL_0031: ldloc.0
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
-		IL_0038: pop
-		IL_0039: ret
+		IL_001e: ldc.i4.1
+		IL_001f: newarr [System.Runtime]System.Object
+		IL_0024: dup
+		IL_0025: ldc.i4.0
+		IL_0026: ldloc.0
+		IL_0027: stelem.ref
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_002d: stfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes::testFunction
+		IL_0032: ldloc.0
+		IL_0033: ldfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes::testFunction
+		IL_0038: ldc.i4.1
+		IL_0039: newarr [System.Runtime]System.Object
+		IL_003e: dup
+		IL_003f: ldc.i4.0
+		IL_0040: ldloc.0
+		IL_0041: stelem.ref
+		IL_0042: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_0047: pop
+		IL_0048: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_SimpleExpression.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_SimpleExpression.verified.txt
@@ -85,7 +85,7 @@
 		// Method begins at RVA 0x2078
 		// Header size: 12
 		// Code size: 112 (0x70)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_SimpleExpression.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/GeneratorTests.ArrowFunction_SimpleExpression.verified.txt
@@ -84,7 +84,7 @@
 	{
 		// Method begins at RVA 0x2078
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 112 (0x70)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -97,32 +97,39 @@
 		IL_0007: ldnull
 		IL_0008: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[], object, object)
 		IL_000e: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
-		IL_0013: stfld object Scopes.ArrowFunction_SimpleExpression::'add'
-		IL_0018: ldc.i4.2
-		IL_0019: newarr [System.Runtime]System.Object
-		IL_001e: dup
-		IL_001f: ldc.i4.0
-		IL_0020: ldstr "x is "
-		IL_0025: stelem.ref
-		IL_0026: dup
-		IL_0027: ldc.i4.1
-		IL_0028: ldloc.0
-		IL_0029: ldfld object Scopes.ArrowFunction_SimpleExpression::'add'
-		IL_002e: ldc.i4.1
-		IL_002f: newarr [System.Runtime]System.Object
-		IL_0034: dup
-		IL_0035: ldc.i4.0
-		IL_0036: ldloc.0
-		IL_0037: stelem.ref
-		IL_0038: ldc.r8 1
-		IL_0041: box [System.Runtime]System.Double
-		IL_0046: ldc.r8 2
-		IL_004f: box [System.Runtime]System.Double
-		IL_0054: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_005f: pop
-		IL_0060: ret
+		IL_0013: ldc.i4.1
+		IL_0014: newarr [System.Runtime]System.Object
+		IL_0019: dup
+		IL_001a: ldc.i4.0
+		IL_001b: ldloc.0
+		IL_001c: stelem.ref
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0022: stfld object Scopes.ArrowFunction_SimpleExpression::'add'
+		IL_0027: ldc.i4.2
+		IL_0028: newarr [System.Runtime]System.Object
+		IL_002d: dup
+		IL_002e: ldc.i4.0
+		IL_002f: ldstr "x is "
+		IL_0034: stelem.ref
+		IL_0035: dup
+		IL_0036: ldc.i4.1
+		IL_0037: ldloc.0
+		IL_0038: ldfld object Scopes.ArrowFunction_SimpleExpression::'add'
+		IL_003d: ldc.i4.1
+		IL_003e: newarr [System.Runtime]System.Object
+		IL_0043: dup
+		IL_0044: ldc.i4.0
+		IL_0045: ldloc.0
+		IL_0046: stelem.ref
+		IL_0047: ldc.r8 1
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: ldc.r8 2
+		IL_005e: box [System.Runtime]System.Double
+		IL_0063: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_0068: stelem.ref
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_006e: pop
+		IL_006f: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/BinaryOperator/ExecutionTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/ExecutionTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
@@ -1,0 +1,3 @@
+false
+false
+true

--- a/Js2IL.Tests/BinaryOperator/ExecutionTests.cs
+++ b/Js2IL.Tests/BinaryOperator/ExecutionTests.cs
@@ -78,5 +78,8 @@ namespace Js2IL.Tests.BinaryOperator
 
     [Fact]
     public Task BinaryOperator_LogicalAnd_Value() { var testName = nameof(BinaryOperator_LogicalAnd_Value); return ExecutionTest(testName); }
+
+    [Fact]
+    public Task BinaryOperator_LogicalOr_ArrayHasData() { var testName = nameof(BinaryOperator_LogicalOr_ArrayHasData); return ExecutionTest(testName); }
     }
 }

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_AddNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_AddNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 66 (0x42)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_AddStringNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_AddStringNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 57 (0x39)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_AddStringString.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_AddStringString.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 57 (0x39)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_BitwiseAndNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_BitwiseAndNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 69 (0x45)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_BitwiseOrNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_BitwiseOrNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 69 (0x45)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_BitwiseXorNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_BitwiseXorNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 69 (0x45)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_DivNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_DivNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 66 (0x42)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_Equal.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_Equal.verified.txt
@@ -37,7 +37,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 127 (0x7f)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_EqualBoolean.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_EqualBoolean.verified.txt
@@ -37,7 +37,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 95 (0x5f)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_ExpNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_ExpNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 70 (0x46)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_GreaterThan.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_GreaterThan.verified.txt
@@ -37,7 +37,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 127 (0x7f)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_GreaterThanOrEqual.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_GreaterThanOrEqual.verified.txt
@@ -38,7 +38,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 196 (0xc4)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LeftShiftNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LeftShiftNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 69 (0x45)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LessThan.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LessThan.verified.txt
@@ -37,7 +37,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 127 (0x7f)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LessThanOrEqual.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LessThanOrEqual.verified.txt
@@ -38,7 +38,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 196 (0xc4)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LogicalAnd_Value.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LogicalAnd_Value.verified.txt
@@ -38,7 +38,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 94 (0x5e)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LogicalOr_Value.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_LogicalOr_Value.verified.txt
@@ -38,7 +38,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 94 (0x5e)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_ModNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_ModNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 66 (0x42)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_MulNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_MulNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 66 (0x42)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_RightShiftNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_RightShiftNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 69 (0x45)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_SubNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_SubNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 66 (0x42)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_UnsignedRightShiftNumberNumber.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/GeneratorTests.BinaryOperator_UnsignedRightShiftNumberNumber.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 70 (0x46)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
@@ -149,7 +149,7 @@
 		// Method begins at RVA 0x209c
 		// Header size: 12
 		// Code size: 35 (0x23)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassConstructor_WithMultipleParameters.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassConstructor_WithMultipleParameters.verified.txt
@@ -574,7 +574,7 @@
 		// Method begins at RVA 0x21c8
 		// Header size: 12
 		// Code size: 367 (0x16f)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
@@ -127,7 +127,7 @@
 		// Method begins at RVA 0x2098
 		// Header size: 12
 		// Code size: 30 (0x1e)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassProperty_DefaultAndLog.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassProperty_DefaultAndLog.verified.txt
@@ -84,7 +84,7 @@
 		// Method begins at RVA 0x2078
 		// Header size: 12
 		// Code size: 44 (0x2c)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassWithMethod_HelloWorld.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassWithMethod_HelloWorld.verified.txt
@@ -120,7 +120,7 @@
 		// Method begins at RVA 0x208c
 		// Header size: 12
 		// Code size: 30 (0x1e)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassWithMethod_NoInstantiation.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassWithMethod_NoInstantiation.verified.txt
@@ -112,7 +112,7 @@
 		// Method begins at RVA 0x2084
 		// Header size: 12
 		// Code size: 7 (0x7)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
@@ -119,7 +119,7 @@
 		// Method begins at RVA 0x208c
 		// Header size: 12
 		// Code size: 13 (0xd)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_DeclareEmptyClass.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_DeclareEmptyClass.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_DeclareEmptyClass
+﻿// IL code: Classes_DeclareEmptyClass
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -77,7 +77,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 7 (0x7)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_Conditional_Ternary.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_Conditional_Ternary.verified.txt
@@ -39,7 +39,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 195 (0xc3)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_Break_AtThree.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_Break_AtThree.verified.txt
@@ -80,7 +80,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 163 (0xa3)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_Continue_SkipEven.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_Continue_SkipEven.verified.txt
@@ -80,7 +80,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 210 (0xd2)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_CountDownFromFive.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_DoWhile_CountDownFromFive.verified.txt
@@ -58,7 +58,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 118 (0x76)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_Break_AtThree.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_Break_AtThree.verified.txt
@@ -80,7 +80,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 168 (0xa8)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_Continue_SkipEven.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_Continue_SkipEven.verified.txt
@@ -80,7 +80,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 198 (0xc6)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_CountDownFromFive.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_CountDownFromFive.verified.txt
@@ -58,7 +58,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 123 (0x7b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_CountToFive.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_CountToFive.verified.txt
@@ -58,7 +58,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 123 (0x7b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_GreaterThanOrEqual.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_GreaterThanOrEqual.verified.txt
@@ -58,7 +58,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 123 (0x7b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_LessThanOrEqual.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForLoop_LessThanOrEqual.verified.txt
@@ -58,7 +58,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 123 (0x7b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForOf_Array_Basic.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_ForOf_Array_Basic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_ForOf_Array_Basic
+﻿// IL code: ControlFlow_ForOf_Array_Basic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -59,7 +59,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 201 (0xc9)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object,

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_BooleanLiteral.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_BooleanLiteral.verified.txt
@@ -115,7 +115,7 @@
 		// Method begins at RVA 0x2080
 		// Header size: 12
 		// Code size: 113 (0x71)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_LessThan.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_LessThan.verified.txt
@@ -75,7 +75,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 108 (0x6c)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_NotFlag.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_NotFlag.verified.txt
@@ -58,7 +58,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 80 (0x50)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_Truthiness.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_If_Truthiness.verified.txt
@@ -118,7 +118,7 @@
 		// Method begins at RVA 0x2080
 		// Header size: 12
 		// Code size: 161 (0xa1)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_Break_AtThree.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_Break_AtThree.verified.txt
@@ -80,7 +80,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 168 (0xa8)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_Continue_SkipEven.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_Continue_SkipEven.verified.txt
@@ -80,7 +80,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 215 (0xd7)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_CountDownFromFive.verified.txt
+++ b/Js2IL.Tests/ControlFlow/GeneratorTests.ControlFlow_While_CountDownFromFive.verified.txt
@@ -58,7 +58,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 123 (0x7b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -187,7 +187,7 @@
 		// Method begins at RVA 0x2114
 		// Header size: 12
 		// Code size: 93 (0x5d)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -90,7 +90,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 65 (0x41)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.2
 		IL_0001: newarr [System.Runtime]System.Object
@@ -128,10 +128,10 @@
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x20b9
-		// Header size: 1
+		// Method begins at RVA 0x20bc
+		// Header size: 12
 		// Code size: 39 (0x27)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.2
 		IL_0001: newarr [System.Runtime]System.Object
@@ -159,7 +159,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x20e1
+		// Method begins at RVA 0x20ef
 		// Header size: 1
 		// Code size: 35 (0x23)
 		.maxstack 8
@@ -184,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2108
+		// Method begins at RVA 0x2114
 		// Header size: 12
 		// Code size: 93 (0x5d)
 		.maxstack 8

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -70,7 +70,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 151 (0x97)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.4
 		IL_0001: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -178,7 +178,7 @@
 		// Method begins at RVA 0x211c
 		// Header size: 12
 		// Code size: 168 (0xa8)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
@@ -223,7 +223,7 @@
 		// Method begins at RVA 0x2144
 		// Header size: 12
 		// Code size: 119 (0x77)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
@@ -97,10 +97,10 @@
 				object[] scopes
 			) cil managed 
 		{
-			// Method begins at RVA 0x20f5
-			// Header size: 1
+			// Method begins at RVA 0x20f8
+			// Header size: 12
 			// Code size: 26 (0x1a)
-			.maxstack 8
+			.maxstack 32
 
 			IL_0000: ldc.i4.1
 			IL_0001: newarr [System.Runtime]System.Object
@@ -126,7 +126,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 125 (0x7d)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)
@@ -167,7 +167,7 @@
 		IL_004d: ldc.i4.1
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
-		IL_0050: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
+		IL_0050: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
 		IL_0055: stfld object Scopes.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::result
 		IL_005a: ldc.i4.2
 		IL_005b: newarr [System.Runtime]System.Object
@@ -195,7 +195,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x2110
+		// Method begins at RVA 0x211e
 		// Header size: 1
 		// Code size: 35 (0x23)
 		.maxstack 8
@@ -220,7 +220,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2134
+		// Method begins at RVA 0x2144
 		// Header size: 12
 		// Code size: 119 (0x77)
 		.maxstack 8
@@ -252,7 +252,7 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldloc.0
 		IL_003a: stelem.ref
-		IL_003b: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
+		IL_003b: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
 		IL_0040: stfld object Scopes.Function_GlobalFunctionDeclaresAndCallsNestedFunction::mainResult
 		IL_0045: ldc.i4.2
 		IL_0046: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -70,7 +70,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 64 (0x40)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.2
 		IL_0001: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -139,7 +139,7 @@
 		// Method begins at RVA 0x20c4
 		// Header size: 12
 		// Code size: 76 (0x4c)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -218,7 +218,7 @@
 		// Method begins at RVA 0x211c
 		// Header size: 12
 		// Code size: 97 (0x61)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -101,7 +101,7 @@
 			// Method begins at RVA 0x20ac
 			// Header size: 12
 			// Code size: 64 (0x40)
-			.maxstack 8
+			.maxstack 32
 
 			IL_0000: ldc.i4.2
 			IL_0001: newarr [System.Runtime]System.Object
@@ -150,7 +150,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 52 (0x34)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)
@@ -244,7 +244,7 @@
 		IL_0031: stelem.ref
 		IL_0032: ldc.r8 123
 		IL_003b: box [System.Runtime]System.Double
-		IL_0040: callvirt instance !2 class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0, !1)
+		IL_0040: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
 		IL_0045: stfld object Scopes.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::f
 		IL_004a: ldloc.0
 		IL_004b: ldfld object Scopes.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::f

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -94,7 +94,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 214 (0xd6)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -197,7 +197,7 @@
 		// Method begins at RVA 0x2164
 		// Header size: 12
 		// Code size: 45 (0x2d)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
@@ -460,7 +460,7 @@
 		// Method begins at RVA 0x2234
 		// Header size: 12
 		// Code size: 504 (0x1f8)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
@@ -176,10 +176,10 @@
 			object a
 		) cil managed 
 	{
-		// Method begins at RVA 0x208f
-		// Header size: 1
+		// Method begins at RVA 0x2090
+		// Header size: 12
 		// Code size: 26 (0x1a)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.2
 		IL_0001: newarr [System.Runtime]System.Object
@@ -204,10 +204,10 @@
 			object b
 		) cil managed 
 	{
-		// Method begins at RVA 0x20aa
-		// Header size: 1
+		// Method begins at RVA 0x20b8
+		// Header size: 12
 		// Code size: 30 (0x1e)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.3
 		IL_0001: newarr [System.Runtime]System.Object
@@ -237,10 +237,10 @@
 			object c
 		) cil managed 
 	{
-		// Method begins at RVA 0x20c9
-		// Header size: 1
+		// Method begins at RVA 0x20e4
+		// Header size: 12
 		// Code size: 34 (0x22)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.4
 		IL_0001: newarr [System.Runtime]System.Object
@@ -275,10 +275,10 @@
 			object d
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ec
-		// Header size: 1
+		// Method begins at RVA 0x2114
+		// Header size: 12
 		// Code size: 39 (0x27)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.5
 		IL_0001: newarr [System.Runtime]System.Object
@@ -318,10 +318,10 @@
 			object e
 		) cil managed 
 	{
-		// Method begins at RVA 0x2114
-		// Header size: 1
+		// Method begins at RVA 0x2148
+		// Header size: 12
 		// Code size: 44 (0x2c)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.6
 		IL_0001: newarr [System.Runtime]System.Object
@@ -366,10 +366,10 @@
 			object f
 		) cil managed 
 	{
-		// Method begins at RVA 0x2141
-		// Header size: 1
+		// Method begins at RVA 0x2180
+		// Header size: 12
 		// Code size: 49 (0x31)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.7
 		IL_0001: newarr [System.Runtime]System.Object
@@ -416,7 +416,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x2174
+		// Method begins at RVA 0x21c0
 		// Header size: 12
 		// Code size: 103 (0x67)
 		.maxstack 8
@@ -457,7 +457,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e8
+		// Method begins at RVA 0x2234
 		// Header size: 12
 		// Code size: 504 (0x1f8)
 		.maxstack 8

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
@@ -120,7 +120,7 @@
 		// Method begins at RVA 0x20a0
 		// Header size: 12
 		// Code size: 59 (0x3b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
@@ -66,10 +66,10 @@
 			object 'value'
 		) cil managed 
 	{
-		// Method begins at RVA 0x2062
-		// Header size: 1
+		// Method begins at RVA 0x2064
+		// Header size: 12
 		// Code size: 26 (0x1a)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.2
 		IL_0001: newarr [System.Runtime]System.Object
@@ -96,7 +96,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x207d
+		// Method begins at RVA 0x208a
 		// Header size: 1
 		// Code size: 18 (0x12)
 		.maxstack 8
@@ -117,7 +117,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x20a0
 		// Header size: 12
 		// Code size: 59 (0x3b)
 		.maxstack 8

--- a/Js2IL.Tests/Function/GeneratorTests.Function_HelloWorld.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_HelloWorld.verified.txt
@@ -120,7 +120,7 @@
 		// Method begins at RVA 0x20ac
 		// Header size: 12
 		// Code size: 45 (0x2d)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_HelloWorld.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_HelloWorld.verified.txt
@@ -65,10 +65,10 @@
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x2062
-		// Header size: 1
+		// Method begins at RVA 0x2064
+		// Header size: 12
 		// Code size: 39 (0x27)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.i4.2
 		IL_0001: newarr [System.Runtime]System.Object
@@ -96,7 +96,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x208a
+		// Method begins at RVA 0x2097
 		// Header size: 1
 		// Code size: 18 (0x12)
 		.maxstack 8
@@ -117,7 +117,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20a0
+		// Method begins at RVA 0x20ac
 		// Header size: 12
 		// Code size: 45 (0x2d)
 		.maxstack 8

--- a/Js2IL.Tests/Function/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -242,7 +242,7 @@
 		// Method begins at RVA 0x2154
 		// Header size: 12
 		// Code size: 56 (0x38)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -103,7 +103,7 @@
 			// Method begins at RVA 0x20b4
 			// Header size: 12
 			// Code size: 110 (0x6e)
-			.maxstack 8
+			.maxstack 32
 			.locals init (
 				[0] object
 			)
@@ -172,7 +172,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 58 (0x3a)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)

--- a/Js2IL.Tests/Function/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
@@ -96,10 +96,10 @@
 				object[] scopes
 			) cil managed 
 		{
-			// Method begins at RVA 0x20ae
-			// Header size: 1
+			// Method begins at RVA 0x20b0
+			// Header size: 12
 			// Code size: 33 (0x21)
-			.maxstack 8
+			.maxstack 32
 
 			IL_0000: ldc.i4.2
 			IL_0001: newarr [System.Runtime]System.Object
@@ -133,7 +133,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 54 (0x36)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)
@@ -175,7 +175,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x20d0
+		// Method begins at RVA 0x20dd
 		// Header size: 1
 		// Code size: 35 (0x23)
 		.maxstack 8
@@ -200,7 +200,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f4
+		// Method begins at RVA 0x2104
 		// Header size: 12
 		// Code size: 59 (0x3b)
 		.maxstack 8

--- a/Js2IL.Tests/Function/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
@@ -203,7 +203,7 @@
 		// Method begins at RVA 0x2104
 		// Header size: 12
 		// Code size: 59 (0x3b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -109,7 +109,7 @@
 		// Method begins at RVA 0x2094
 		// Header size: 12
 		// Code size: 79 (0x4f)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Function/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/Js2IL.Tests/Function/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -66,10 +66,10 @@
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x2062
-		// Header size: 1
+		// Method begins at RVA 0x2064
+		// Header size: 12
 		// Code size: 15 (0xf)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldc.r8 1234
 		IL_0009: box [System.Runtime]System.Double
@@ -85,7 +85,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x2072
+		// Method begins at RVA 0x207f
 		// Header size: 1
 		// Code size: 18 (0x12)
 		.maxstack 8
@@ -106,7 +106,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2088
+		// Method begins at RVA 0x2094
 		// Header size: 12
 		// Code size: 79 (0x4f)
 		.maxstack 8
@@ -130,7 +130,7 @@
 		IL_0024: ldc.i4.0
 		IL_0025: ldloc.0
 		IL_0026: stelem.ref
-		IL_0027: callvirt instance !1 class [System.Runtime]System.Func`2<class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0)
+		IL_0027: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
 		IL_002c: stfld object Scopes.Function_ReturnsStaticValueAndLogs::'value'
 		IL_0031: ldc.i4.2
 		IL_0032: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/JSON/GeneratorTests.JSON_Parse_SimpleObject.verified.txt
+++ b/Js2IL.Tests/JSON/GeneratorTests.JSON_Parse_SimpleObject.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 158 (0x9e)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/JavaScript/BinaryOperator_LogicalOr_ArrayHasData.js
+++ b/Js2IL.Tests/JavaScript/BinaryOperator_LogicalOr_ArrayHasData.js
@@ -1,0 +1,10 @@
+function arrayHasData(arr) {
+    if (!arr || !arr.length) {
+        return false;
+    }
+    return true;
+}
+
+console.log(arrayHasData(undefined));
+console.log(arrayHasData([]));
+console.log(arrayHasData([1,2,3]));

--- a/Js2IL.Tests/Js2IL.Tests.csproj
+++ b/Js2IL.Tests/Js2IL.Tests.csproj
@@ -41,5 +41,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Js2IL\Js2IL.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Js2IL.Tests/Literals/GeneratorTests.ArrayLiteral.verified.txt
+++ b/Js2IL.Tests/Literals/GeneratorTests.ArrayLiteral.verified.txt
@@ -59,7 +59,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 186 (0xba)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Literals/GeneratorTests.Array_Spread_Copy.verified.txt
+++ b/Js2IL.Tests/Literals/GeneratorTests.Array_Spread_Copy.verified.txt
@@ -60,7 +60,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 229 (0xe5)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Literals/GeneratorTests.BooleanLiteral.verified.txt
+++ b/Js2IL.Tests/Literals/GeneratorTests.BooleanLiteral.verified.txt
@@ -33,7 +33,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 43 (0x2b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Literals/GeneratorTests.ObjectLiteral.verified.txt
+++ b/Js2IL.Tests/Literals/GeneratorTests.ObjectLiteral.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 88 (0x58)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Node/GeneratorTests.Environment_EnumerateProcessArgV.verified.txt
+++ b/Js2IL.Tests/Node/GeneratorTests.Environment_EnumerateProcessArgV.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Environment_EnumerateProcessArgV
+﻿// IL code: Environment_EnumerateProcessArgV
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -58,7 +58,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 141 (0x8d)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Node/GeneratorTests.FS_ReadWrite_Utf8.verified.txt
+++ b/Js2IL.Tests/Node/GeneratorTests.FS_ReadWrite_Utf8.verified.txt
@@ -39,7 +39,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 155 (0x9b)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Node/GeneratorTests.Global___dirname_PrintsDirectory.verified.txt
+++ b/Js2IL.Tests/Node/GeneratorTests.Global___dirname_PrintsDirectory.verified.txt
@@ -33,7 +33,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 46 (0x2e)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Node/GeneratorTests.Require_Path_Join_Basic.verified.txt
+++ b/Js2IL.Tests/Node/GeneratorTests.Require_Path_Join_Basic.verified.txt
@@ -37,7 +37,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 83 (0x53)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Node/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/Js2IL.Tests/Node/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -219,7 +219,7 @@
 		// Method begins at RVA 0x2120
 		// Header size: 12
 		// Code size: 61 (0x3d)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Node/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/Js2IL.Tests/Node/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -101,9 +101,9 @@
 			) cil managed 
 		{
 			// Method begins at RVA 0x20d0
-			// Header size: 1
+			// Header size: 12
 			// Code size: 32 (0x20)
-			.maxstack 8
+			.maxstack 32
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.0
@@ -139,7 +139,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 88 (0x58)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)
@@ -191,7 +191,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x20f1
+		// Method begins at RVA 0x20fc
 		// Header size: 1
 		// Code size: 35 (0x23)
 		.maxstack 8
@@ -216,7 +216,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2118
+		// Method begins at RVA 0x2120
 		// Header size: 12
 		// Code size: 61 (0x3d)
 		.maxstack 8

--- a/Js2IL.Tests/String/GeneratorTests.String_LocaleCompare_Numeric.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_LocaleCompare_Numeric.verified.txt
@@ -111,7 +111,7 @@
 		// Method begins at RVA 0x2094
 		// Header size: 12
 		// Code size: 226 (0xe2)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/String/GeneratorTests.String_LocaleCompare_Numeric.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_LocaleCompare_Numeric.verified.txt
@@ -1,4 +1,4 @@
-// IL code: String_LocaleCompare_Numeric
+﻿// IL code: String_LocaleCompare_Numeric
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x206b
 		// Header size: 1
-		// Code size: 45 (0x2d)
+		// Code size: 40 (0x28)
 		.maxstack 8
 
 		IL_0000: ldarg.1
@@ -95,9 +95,8 @@
 		IL_0017: ldc.i4.1
 		IL_0018: box [System.Runtime]System.Boolean
 		IL_001d: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
-		IL_0022: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LocaleCompare(string, string, object, object)
-		IL_0027: box [System.Runtime]System.Double
-		IL_002c: ret
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.String::LocaleCompare(string, string, object, object)
+		IL_0027: ret
 	} // end of method ArrowFunction_L2C11::ArrowFunction_L2C11
 
 } // end of class Functions.ArrowFunction_L2C11
@@ -109,9 +108,9 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x209c
+		// Method begins at RVA 0x2094
 		// Header size: 12
-		// Code size: 211 (0xd3)
+		// Code size: 226 (0xe2)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -142,49 +141,56 @@
 		IL_0041: ldnull
 		IL_0042: ldftn object Functions.ArrowFunction_L2C11::ArrowFunction_L2C11(object[], object, object)
 		IL_0048: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
-		IL_004d: stelem.ref
-		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::sort(object[])
-		IL_0053: pop
-		IL_0054: ldloc.0
-		IL_0055: ldc.r8 0.0
-		IL_005e: box [System.Runtime]System.Double
-		IL_0063: stfld object Scopes.String_LocaleCompare_Numeric::i
-		// loop start (head: IL_0068)
-			IL_0068: ldloc.0
-			IL_0069: ldfld object Scopes.String_LocaleCompare_Numeric::i
-			IL_006e: unbox.any [System.Runtime]System.Double
-			IL_0073: ldloc.0
-			IL_0074: ldfld object Scopes.String_LocaleCompare_Numeric::items
-			IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_007e: blt IL_0088
+		IL_004d: ldc.i4.1
+		IL_004e: newarr [System.Runtime]System.Object
+		IL_0053: dup
+		IL_0054: ldc.i4.0
+		IL_0055: ldloc.0
+		IL_0056: stelem.ref
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_005c: stelem.ref
+		IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::sort(object[])
+		IL_0062: pop
+		IL_0063: ldloc.0
+		IL_0064: ldc.r8 0.0
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: stfld object Scopes.String_LocaleCompare_Numeric::i
+		// loop start (head: IL_0077)
+			IL_0077: ldloc.0
+			IL_0078: ldfld object Scopes.String_LocaleCompare_Numeric::i
+			IL_007d: unbox.any [System.Runtime]System.Double
+			IL_0082: ldloc.0
+			IL_0083: ldfld object Scopes.String_LocaleCompare_Numeric::items
+			IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_008d: blt IL_0097
 
-			IL_0083: br IL_00d2
+			IL_0092: br IL_00e1
 
-			IL_0088: ldc.i4.1
-			IL_0089: newarr [System.Runtime]System.Object
-			IL_008e: dup
-			IL_008f: ldc.i4.0
-			IL_0090: ldloc.0
-			IL_0091: ldfld object Scopes.String_LocaleCompare_Numeric::items
-			IL_0096: ldloc.0
-			IL_0097: ldfld object Scopes.String_LocaleCompare_Numeric::i
-			IL_009c: unbox.any [System.Runtime]System.Double
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-			IL_00a6: stelem.ref
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-			IL_00ac: pop
-			IL_00ad: ldloc.0
-			IL_00ae: ldloc.0
-			IL_00af: ldfld object Scopes.String_LocaleCompare_Numeric::i
-			IL_00b4: unbox.any [System.Runtime]System.Double
-			IL_00b9: ldc.r8 1
-			IL_00c2: add
-			IL_00c3: box [System.Runtime]System.Double
-			IL_00c8: stfld object Scopes.String_LocaleCompare_Numeric::i
-			IL_00cd: br IL_0068
+			IL_0097: ldc.i4.1
+			IL_0098: newarr [System.Runtime]System.Object
+			IL_009d: dup
+			IL_009e: ldc.i4.0
+			IL_009f: ldloc.0
+			IL_00a0: ldfld object Scopes.String_LocaleCompare_Numeric::items
+			IL_00a5: ldloc.0
+			IL_00a6: ldfld object Scopes.String_LocaleCompare_Numeric::i
+			IL_00ab: unbox.any [System.Runtime]System.Double
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+			IL_00b5: stelem.ref
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+			IL_00bb: pop
+			IL_00bc: ldloc.0
+			IL_00bd: ldloc.0
+			IL_00be: ldfld object Scopes.String_LocaleCompare_Numeric::i
+			IL_00c3: unbox.any [System.Runtime]System.Double
+			IL_00c8: ldc.r8 1
+			IL_00d1: add
+			IL_00d2: box [System.Runtime]System.Double
+			IL_00d7: stfld object Scopes.String_LocaleCompare_Numeric::i
+			IL_00dc: br IL_0077
 		// end loop
 
-		IL_00d2: ret
+		IL_00e1: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/String/GeneratorTests.String_PlusEquals_Append.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_PlusEquals_Append.verified.txt
@@ -1,4 +1,4 @@
-// IL code: String_PlusEquals_Append
+﻿// IL code: String_PlusEquals_Append
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 61 (0x3d)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/String/GeneratorTests.String_Replace_CallOnExpression.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_Replace_CallOnExpression.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 56 (0x38)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/String/GeneratorTests.String_Replace_Regex_Global.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_Replace_Regex_Global.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 56 (0x38)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/String/GeneratorTests.String_StartsWith_Basic.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_StartsWith_Basic.verified.txt
@@ -35,7 +35,7 @@
 	{
 		// Method begins at RVA 0x205c
 		// Header size: 12
-		// Code size: 240 (0xf0)
+		// Code size: 215 (0xd7)
 		.maxstack 8
 		.entrypoint
 		.locals init (
@@ -54,66 +54,61 @@
 		IL_0019: ldloc.0
 		IL_001a: ldfld object Scopes.String_StartsWith_Basic::s
 		IL_001f: ldstr "he"
-		IL_0024: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_0029: box [System.Runtime]System.Boolean
-		IL_002e: stelem.ref
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_0034: pop
-		IL_0035: ldc.i4.1
-		IL_0036: newarr [System.Runtime]System.Object
-		IL_003b: dup
-		IL_003c: ldc.i4.0
-		IL_003d: ldloc.0
-		IL_003e: ldfld object Scopes.String_StartsWith_Basic::s
-		IL_0043: ldstr "el"
-		IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_004d: box [System.Runtime]System.Boolean
-		IL_0052: stelem.ref
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_0058: pop
-		IL_0059: ldc.i4.1
-		IL_005a: newarr [System.Runtime]System.Object
-		IL_005f: dup
-		IL_0060: ldc.i4.0
-		IL_0061: ldloc.0
-		IL_0062: ldfld object Scopes.String_StartsWith_Basic::s
-		IL_0067: ldstr "el"
-		IL_006c: ldc.r8 1
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string, object)
-		IL_007f: box [System.Runtime]System.Boolean
-		IL_0084: stelem.ref
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_008a: pop
-		IL_008b: ldc.i4.1
-		IL_008c: newarr [System.Runtime]System.Object
-		IL_0091: dup
-		IL_0092: ldc.i4.0
-		IL_0093: ldloc.0
-		IL_0094: ldfld object Scopes.String_StartsWith_Basic::s
-		IL_0099: ldstr "lo"
-		IL_009e: ldc.r8 3
-		IL_00a7: box [System.Runtime]System.Double
-		IL_00ac: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string, object)
-		IL_00b1: box [System.Runtime]System.Boolean
-		IL_00b6: stelem.ref
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_00bc: pop
-		IL_00bd: ldc.i4.1
-		IL_00be: newarr [System.Runtime]System.Object
-		IL_00c3: dup
-		IL_00c4: ldc.i4.0
-		IL_00c5: ldloc.0
-		IL_00c6: ldfld object Scopes.String_StartsWith_Basic::s
-		IL_00cb: ldstr ""
-		IL_00d0: ldc.r8 100
-		IL_00d9: box [System.Runtime]System.Double
-		IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string, object)
-		IL_00e3: box [System.Runtime]System.Boolean
-		IL_00e8: stelem.ref
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_00ee: pop
-		IL_00ef: ret
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_0029: stelem.ref
+		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_002f: pop
+		IL_0030: ldc.i4.1
+		IL_0031: newarr [System.Runtime]System.Object
+		IL_0036: dup
+		IL_0037: ldc.i4.0
+		IL_0038: ldloc.0
+		IL_0039: ldfld object Scopes.String_StartsWith_Basic::s
+		IL_003e: ldstr "el"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_0048: stelem.ref
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_004e: pop
+		IL_004f: ldc.i4.1
+		IL_0050: newarr [System.Runtime]System.Object
+		IL_0055: dup
+		IL_0056: ldc.i4.0
+		IL_0057: ldloc.0
+		IL_0058: ldfld object Scopes.String_StartsWith_Basic::s
+		IL_005d: ldstr "el"
+		IL_0062: ldc.r8 1
+		IL_006b: box [System.Runtime]System.Double
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string, object)
+		IL_0075: stelem.ref
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_007b: pop
+		IL_007c: ldc.i4.1
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: dup
+		IL_0083: ldc.i4.0
+		IL_0084: ldloc.0
+		IL_0085: ldfld object Scopes.String_StartsWith_Basic::s
+		IL_008a: ldstr "lo"
+		IL_008f: ldc.r8 3
+		IL_0098: box [System.Runtime]System.Double
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string, object)
+		IL_00a2: stelem.ref
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_00a8: pop
+		IL_00a9: ldc.i4.1
+		IL_00aa: newarr [System.Runtime]System.Object
+		IL_00af: dup
+		IL_00b0: ldc.i4.0
+		IL_00b1: ldloc.0
+		IL_00b2: ldfld object Scopes.String_StartsWith_Basic::s
+		IL_00b7: ldstr ""
+		IL_00bc: ldc.r8 100
+		IL_00c5: box [System.Runtime]System.Double
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string, object)
+		IL_00cf: stelem.ref
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_00d5: pop
+		IL_00d6: ret
 	} // end of method Program::Main
 
 } // end of class Program

--- a/Js2IL.Tests/String/GeneratorTests.String_StartsWith_Basic.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_StartsWith_Basic.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 215 (0xd7)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/String/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -199,7 +199,7 @@
 		// Method begins at RVA 0x2104
 		// Header size: 12
 		// Code size: 64 (0x40)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/String/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -99,27 +99,22 @@
 		{
 			// Method begins at RVA 0x20b4
 			// Header size: 12
-			// Code size: 31 (0x1f)
-			.maxstack 8
-			.locals init (
-				[0] object
-			)
+			// Code size: 29 (0x1d)
+			.maxstack 32
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.1
 			IL_0002: ldelem.ref
 			IL_0003: ldfld object Scopes.String_StartsWith_NestedParam/outer::s
-			IL_0008: ldc.i4.1
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.1
-			IL_0011: stelem.ref
-			IL_0012: stloc.0
-			IL_0013: ldstr "startsWith"
-			IL_0018: ldloc.0
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_001e: ret
+			IL_0008: ldstr "startsWith"
+			IL_000d: ldc.i4.1
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.1
+			IL_0016: stelem.ref
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_001c: ret
 		} // end of method outer::inner
 
 	} // end of class outer
@@ -135,7 +130,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 57 (0x39)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)
@@ -163,7 +158,7 @@
 		IL_002c: ldloc.0
 		IL_002d: stelem.ref
 		IL_002e: ldstr "He"
-		IL_0033: callvirt instance !2 class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0, !1)
+		IL_0033: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
 		IL_0038: ret
 	} // end of method outer::outer
 
@@ -176,7 +171,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x20df
+		// Method begins at RVA 0x20dd
 		// Header size: 1
 		// Code size: 35 (0x23)
 		.maxstack 8
@@ -229,7 +224,7 @@
 		IL_002c: ldloc.0
 		IL_002d: stelem.ref
 		IL_002e: ldstr "Hello, world!"
-		IL_0033: callvirt instance !2 class [System.Runtime]System.Func`3<class [System.Runtime]System.Object, class [System.Runtime]System.Object, class [System.Runtime]System.Object>::Invoke(!0, !1)
+		IL_0033: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
 		IL_0038: stelem.ref
 		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
 		IL_003e: pop

--- a/Js2IL.Tests/String/GeneratorTests.String_TemplateLiteral_Basic.verified.txt
+++ b/Js2IL.Tests/String/GeneratorTests.String_TemplateLiteral_Basic.verified.txt
@@ -39,7 +39,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 196 (0xc4)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding.verified.txt
@@ -75,7 +75,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 83 (0x53)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding_NoThrow.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryCatch_NoBinding_NoThrow.verified.txt
@@ -81,7 +81,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 167 (0xa7)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object,

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch.verified.txt
@@ -75,7 +75,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 67 (0x43)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch_Throw.verified.txt
+++ b/Js2IL.Tests/TryCatch/GeneratorTests.TryFinally_NoCatch_Throw.verified.txt
@@ -75,7 +75,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 78 (0x4e)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/UnaryOperator/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 88 (0x58)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/UnaryOperator/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 88 (0x58)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/UnaryOperator/GeneratorTests.UnaryOperator_Typeof.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/GeneratorTests.UnaryOperator_Typeof.verified.txt
@@ -70,10 +70,10 @@
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x2062
-		// Header size: 1
+		// Method begins at RVA 0x2064
+		// Header size: 12
 		// Code size: 2 (0x2)
-		.maxstack 8
+		.maxstack 32
 
 		IL_0000: ldnull
 		IL_0001: ret
@@ -88,7 +88,7 @@
 	.method public static 
 		void _LoadDispatchTable () cil managed 
 	{
-		// Method begins at RVA 0x2065
+		// Method begins at RVA 0x2072
 		// Header size: 1
 		// Code size: 18 (0x12)
 		.maxstack 8
@@ -109,7 +109,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2078
+		// Method begins at RVA 0x2088
 		// Header size: 12
 		// Code size: 210 (0xd2)
 		.maxstack 8

--- a/Js2IL.Tests/UnaryOperator/GeneratorTests.UnaryOperator_Typeof.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/GeneratorTests.UnaryOperator_Typeof.verified.txt
@@ -112,7 +112,7 @@
 		// Method begins at RVA 0x2088
 		// Header size: 12
 		// Code size: 210 (0xd2)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_ConstSimple.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_ConstSimple.verified.txt
@@ -36,7 +36,7 @@
 		// Method begins at RVA 0x205c
 		// Header size: 12
 		// Code size: 48 (0x30)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_LetBlockScope.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_LetBlockScope.verified.txt
@@ -61,7 +61,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 97 (0x61)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object,

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
@@ -103,7 +103,7 @@
 			// Method begins at RVA 0x20d0
 			// Header size: 12
 			// Code size: 49 (0x31)
-			.maxstack 8
+			.maxstack 32
 			.locals init (
 				[0] object
 			)
@@ -139,7 +139,7 @@
 		// Method begins at RVA 0x206c
 		// Header size: 12
 		// Code size: 88 (0x58)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
@@ -219,7 +219,7 @@
 		// Method begins at RVA 0x2134
 		// Header size: 12
 		// Code size: 86 (0x56)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_LetNestedShadowingChain.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_LetNestedShadowingChain.verified.txt
@@ -111,7 +111,7 @@
 		// Method begins at RVA 0x2074
 		// Header size: 12
 		// Code size: 237 (0xed)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object,

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_LetShadowing.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_LetShadowing.verified.txt
@@ -72,7 +72,7 @@
 		// Method begins at RVA 0x2064
 		// Header size: 12
 		// Code size: 49 (0x31)
-		.maxstack 8
+		.maxstack 32
 		.locals init (
 			[0] object
 		)

--- a/Js2IL.Tests/Variable/GeneratorTests.Variable_LetShadowing.verified.txt
+++ b/Js2IL.Tests/Variable/GeneratorTests.Variable_LetShadowing.verified.txt
@@ -129,7 +129,7 @@
 		// Method begins at RVA 0x20b4
 		// Header size: 12
 		// Code size: 86 (0x56)
-		.maxstack 8
+		.maxstack 32
 		.entrypoint
 		.locals init (
 			[0] object

--- a/Js2IL/Services/ILGenerators/JavaScriptFunctionGenerator.cs
+++ b/Js2IL/Services/ILGenerators/JavaScriptFunctionGenerator.cs
@@ -18,14 +18,14 @@ namespace Js2IL.Services.ILGenerators
         private BaseClassLibraryReferences _bclReferences;
         private MetadataBuilder _metadataBuilder;
         private MethodBodyStreamEncoder _methodBodyStreamEncoder;
-    private Dispatch.DispatchTableGenerator _dispatchTableGenerator;
-    private readonly ClassRegistry _classRegistry;
+        private Dispatch.DispatchTableGenerator _dispatchTableGenerator;
+        private readonly ClassRegistry _classRegistry;
         private MethodDefinitionHandle _firstMethod = default;
 
-    // Tracks owner types in the Functions namespace
-    private readonly Dictionary<string, TypeDefinitionHandle> _globalFunctionOwnerTypes = new();
-    private readonly Dictionary<string, TypeDefinitionHandle> _nestedOwnerTypes = new();
-    private TypeDefinitionHandle _moduleOwnerType = default;
+        // Tracks owner types in the Functions namespace
+        private readonly Dictionary<string, TypeDefinitionHandle> _globalFunctionOwnerTypes = new();
+        private readonly Dictionary<string, TypeDefinitionHandle> _nestedOwnerTypes = new();
+        private TypeDefinitionHandle _moduleOwnerType = default;
 
         public MethodDefinitionHandle FirstMethod => _firstMethod;
 
@@ -274,8 +274,10 @@ namespace Js2IL.Services.ILGenerators
 
             var bodyoffset = _methodBodyStreamEncoder.AddMethodBody(
                 il,
+                maxStack: 32, // todo - keep track of the pops and pushes so as to provide a accurate value for maxStack
                 localVariablesSignature: localSignature,
                 attributes: bodyAttributes);
+                
             // Build method signature: static object (object[] scopes, object param1, ...)
             var sigBuilder = new BlobBuilder();
             var paramCount = 1 + functionDeclaration.Params.Count; // scope array + declared params

--- a/Js2IL/Services/ILGenerators/MainGenerator.cs
+++ b/Js2IL/Services/ILGenerators/MainGenerator.cs
@@ -100,6 +100,7 @@ namespace Js2IL.Services.ILGenerators
 
             return _methodBodyStreamEncoder.AddMethodBody(
                 _ilGenerator.IL,
+                maxStack: 32,
                 localVariablesSignature: localSignature,
                 attributes: methodBodyAttributes);
         }


### PR DESCRIPTION
- **Runtime String: return object from StartsWith and LocaleCompare (boxed) to match JS values and avoid invalid unbox.any on booleans/doubles**
- **Fix CLR InvalidProgramException: increase .maxstack for generated methods; add logical-or arrayHasData execution test; exclude stray NUnit integration test from xUnit build; note follow-up to compute max stack precisely**
