### PR TITLE
docs(node): Node support tracking (JSON+schema+generator), ECMAScript coverage updates, console stderr fix

### DIFF
--- a/JavaScriptRuntime/Console.cs
+++ b/JavaScriptRuntime/Console.cs
@@ -9,11 +9,17 @@ namespace JavaScriptRuntime
     [IntrinsicObject("console")]
     public class Console
     {
-        private static IConsoleOutput _output = new DefaultConsoleOutput();
+    private static IConsoleOutput _output = new DefaultConsoleOutput();
+    private static IConsoleOutput _errorOutput = new DefaultErrorConsoleOutput();
 
         public static void SetOutput(IConsoleOutput output)
         {
             _output = output ?? new DefaultConsoleOutput();
+        }
+
+        public static void SetErrorOutput(IConsoleOutput output)
+        {
+            _errorOutput = output ?? new DefaultErrorConsoleOutput();
         }
 
         public static object? Log(params object?[] args)
@@ -28,7 +34,7 @@ namespace JavaScriptRuntime
         {
             var parts = args.Select(arg => DotNet2JSConversions.ToString(arg));
             var line = string.Join(" ", parts);
-            _output.WriteLine(line);
+            _errorOutput.WriteLine(line);
             return null;
         }
 
@@ -36,7 +42,7 @@ namespace JavaScriptRuntime
         {
             var parts = args.Select(arg => DotNet2JSConversions.ToString(arg));
             var line = string.Join(" ", parts);
-            _output.WriteLine(line);
+            _errorOutput.WriteLine(line);
             return null;
         }
     }

--- a/JavaScriptRuntime/IConsoleOutput.cs
+++ b/JavaScriptRuntime/IConsoleOutput.cs
@@ -14,4 +14,12 @@ namespace JavaScriptRuntime
             System.Console.WriteLine(line);
         }
     }
+
+    public class DefaultErrorConsoleOutput : IConsoleOutput
+    {
+        public void WriteLine(string line)
+        {
+            System.Console.Error.WriteLine(line);
+        }
+    }
 }

--- a/Js2IL.Tests/ConsoleTests.cs
+++ b/Js2IL.Tests/ConsoleTests.cs
@@ -66,6 +66,30 @@ namespace JavaScriptRuntime.Tests
         }
 
         [Fact]
+        public void Error_PrintsAllArgumentsWithSpaces()
+        {
+            var testOutput = new TestConsoleOutput();
+            Console.SetOutput(testOutput);
+
+            Console.Error("Hello", "World", 42d, JavaScriptRuntime.JsNull.Null);
+
+            Assert.Single(testOutput.Output);
+            Assert.Equal("Hello World 42 null", testOutput.Output[0]);
+        }
+
+        [Fact]
+        public void Warn_PrintsAllArgumentsWithSpaces()
+        {
+            var testOutput = new TestConsoleOutput();
+            Console.SetOutput(testOutput);
+
+            Console.Warn("Be", "careful", 7d);
+
+            Assert.Single(testOutput.Output);
+            Assert.Equal("Be careful 7", testOutput.Output[0]);
+        }
+
+        [Fact]
         public void Log_PrintsExpandoObjectProperties()
         {
             var testOutput = new TestConsoleOutput();

--- a/Js2IL.Tests/ConsoleTests.cs
+++ b/Js2IL.Tests/ConsoleTests.cs
@@ -16,6 +16,18 @@ namespace JavaScriptRuntime.Tests
             }
         }
 
+        private class DualTestConsoleOutput : IConsoleOutput
+        {
+            public List<string> StdOut = new();
+            public List<string> StdErr = new();
+            private readonly bool _isErr;
+            public DualTestConsoleOutput(bool isErr) { _isErr = isErr; }
+            public void WriteLine(string line)
+            {
+                if (_isErr) StdErr.Add(line); else StdOut.Add(line);
+            }
+        }
+
         [Fact]
         public void Log_PrintsAllArgumentsWithSpaces()
         {
@@ -66,27 +78,33 @@ namespace JavaScriptRuntime.Tests
         }
 
         [Fact]
-        public void Error_PrintsAllArgumentsWithSpaces()
+        public void Error_PrintsAllArgumentsWithSpaces_ToStdErr()
         {
-            var testOutput = new TestConsoleOutput();
-            Console.SetOutput(testOutput);
+            var stdout = new DualTestConsoleOutput(false);
+            var stderr = new DualTestConsoleOutput(true);
+            Console.SetOutput(stdout);
+            Console.SetErrorOutput(stderr);
 
             Console.Error("Hello", "World", 42d, JavaScriptRuntime.JsNull.Null);
 
-            Assert.Single(testOutput.Output);
-            Assert.Equal("Hello World 42 null", testOutput.Output[0]);
+            Assert.Empty(stdout.StdOut);
+            Assert.Single(stderr.StdErr);
+            Assert.Equal("Hello World 42 null", stderr.StdErr[0]);
         }
 
         [Fact]
-        public void Warn_PrintsAllArgumentsWithSpaces()
+        public void Warn_PrintsAllArgumentsWithSpaces_ToStdErr()
         {
-            var testOutput = new TestConsoleOutput();
-            Console.SetOutput(testOutput);
+            var stdout = new DualTestConsoleOutput(false);
+            var stderr = new DualTestConsoleOutput(true);
+            Console.SetOutput(stdout);
+            Console.SetErrorOutput(stderr);
 
             Console.Warn("Be", "careful", 7d);
 
-            Assert.Single(testOutput.Output);
-            Assert.Equal("Be careful 7", testOutput.Output[0]);
+            Assert.Empty(stdout.StdOut);
+            Assert.Single(stderr.StdErr);
+            Assert.Equal("Be careful 7", stderr.StdErr[0]);
         }
 
         [Fact]

--- a/docs/ECMAScript2025_FeatureCoverage.json
+++ b/docs/ECMAScript2025_FeatureCoverage.json
@@ -18,7 +18,10 @@
                 {
                   "feature": "Boolean literals (true/false)",
                   "status": "Supported",
-                  "testScripts": [],
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/UnaryOperator_Typeof.js",
+                    "Js2IL.Tests/JavaScript/JSON_Parse_SimpleObject.js"
+                  ],
                   "notes": "Emits proper IL for true/false and boxes when needed in arrays/log calls. See generator snapshot: Js2IL.Tests/Literals/GeneratorTests.BooleanLiteral.verified.txt."
                 }
               ]
@@ -78,7 +81,10 @@
                 {
                   "feature": "null literal",
                   "status": "Supported",
-                  "testScripts": [],
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/Literals_NullAndUndefined.js",
+                    "Js2IL.Tests/JavaScript/JSON_Parse_SimpleObject.js"
+                  ],
                   "notes": "null emission validated in literals and variable tests; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt."
                 }
               ]
@@ -91,7 +97,9 @@
                 {
                   "feature": "undefined identifier usage",
                   "status": "Supported",
-                  "testScripts": [],
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/Literals_NullAndUndefined.js"
+                  ],
                   "notes": "Handled as the ECMAScript undefined value and participates in JS truthiness; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt."
                 }
               ]

--- a/docs/ECMAScript2025_FeatureCoverage.json
+++ b/docs/ECMAScript2025_FeatureCoverage.json
@@ -37,6 +37,64 @@
                   "notes": "Concatenates quasis and expressions via runtime Operators.Add with JS string/number coercion. Tagged templates are not yet supported."
                 }
               ]
+            },
+            {
+              "paragraph": "13.1.1",
+              "title": "NumericLiteral",
+              "url": "https://tc39.es/ecma262/#sec-numeric-literals",
+              "features": [
+                {
+                  "feature": "Numeric literals (integer and decimal)",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/BinaryOperator_AddNumberNumber.js",
+                    "Js2IL.Tests/JavaScript/BinaryOperator_MulNumberNumber.js"
+                  ],
+                  "notes": "Numbers are represented as double and used pervasively across arithmetic, comparison, and control-flow tests."
+                }
+              ]
+            },
+            {
+              "paragraph": "13.1.2",
+              "title": "StringLiteral",
+              "url": "https://tc39.es/ecma262/#sec-string-literals",
+              "features": [
+                {
+                  "feature": "String literals (single/double quotes; escapes)",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/String_StartsWith_Basic.js",
+                    "Js2IL.Tests/JavaScript/String_Replace_Regex_Global.js"
+                  ],
+                  "notes": "Backed by .NET System.String; values are boxed/unboxed where needed in member calls and concatenation."
+                }
+              ]
+            },
+            {
+              "paragraph": "13.1.5",
+              "title": "NullLiteral",
+              "url": "https://tc39.es/ecma262/#sec-null-literals",
+              "features": [
+                {
+                  "feature": "null literal",
+                  "status": "Supported",
+                  "testScripts": [],
+                  "notes": "null emission validated in literals and variable tests; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt."
+                }
+              ]
+            },
+            {
+              "paragraph": "13.1.6",
+              "title": "undefined (Identifier)",
+              "url": "https://tc39.es/ecma262/#sec-undefined",
+              "features": [
+                {
+                  "feature": "undefined identifier usage",
+                  "status": "Supported",
+                  "testScripts": [],
+                  "notes": "Handled as the ECMAScript undefined value and participates in JS truthiness; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt."
+                }
+              ]
             }
           ]
         },
@@ -409,6 +467,28 @@
       "url": "https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations",
       "subsections": [
         {
+          "subsection": "14.1",
+          "title": "Return Statement",
+          "url": "https://tc39.es/ecma262/#sec-return-statement",
+          "paragraphs": [
+            {
+              "paragraph": "14.1.1",
+              "title": "Runtime Semantics: ReturnStatement Evaluation",
+              "url": "https://tc39.es/ecma262/#sec-return-statement",
+              "features": [
+                {
+                  "feature": "return statement (basic)",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/JavaScript/Function_ReturnsStaticValueAndLogs.js"
+                  ],
+                  "notes": "Function returns propagate values (boxed) to callers; validated by execution snapshot showing returned value."
+                }
+              ]
+            }
+          ]
+        },
+        {
           "subsection": "14.6",
           "title": "The if Statement",
           "url": "https://tc39.es/ecma262/#sec-if-statement",
@@ -731,7 +811,7 @@
                   "testScripts": [
                     "Js2IL.Tests/JavaScript/String_StartsWith_Basic.js"
                   ],
-                  "notes": "Reflection-based string dispatch routes CLR string receivers to JavaScriptRuntime.String.StartsWith with optional position argument."
+                  "notes": "Reflection-based string dispatch routes CLR string receivers to JavaScriptRuntime.String.StartsWith with optional position argument. Returns a boolean value (boxed)."
                 }
               ]
             },
@@ -746,7 +826,7 @@
                   "testScripts": [
                     "Js2IL.Tests/JavaScript/String_LocaleCompare_Numeric.js"
                   ],
-                  "notes": "Returns a number (double) for comparator functions; used by Array.sort comparator tests."
+                  "notes": "Returns a number (boxed double) consistent with ECMAScript compare semantics; numeric option supported."
                 }
               ]
             },

--- a/docs/ECMAScript2025_FeatureCoverage.md
+++ b/docs/ECMAScript2025_FeatureCoverage.md
@@ -26,7 +26,7 @@ This file is auto-generated from ECMAScript2025_FeatureCoverage.json.
 
 | Feature | Status | Test Scripts | Notes | Section |
 |---|---|---|---|---|
-| Boolean literals (true/false) | Supported |  | Emits proper IL for true/false and boxes when needed in arrays/log calls. See generator snapshot: Js2IL.Tests/Literals/GeneratorTests.BooleanLiteral.verified.txt. | 13.1.3 |
+| Boolean literals (true/false) | Supported | `Js2IL.Tests/JavaScript/UnaryOperator_Typeof.js`<br>`Js2IL.Tests/JavaScript/JSON_Parse_SimpleObject.js` | Emits proper IL for true/false and boxes when needed in arrays/log calls. See generator snapshot: Js2IL.Tests/Literals/GeneratorTests.BooleanLiteral.verified.txt. | 13.1.3 |
 
 
 #### [Template Literals](https://tc39.es/ecma262/#sec-template-literals)
@@ -40,14 +40,14 @@ This file is auto-generated from ECMAScript2025_FeatureCoverage.json.
 
 | Feature | Status | Test Scripts | Notes | Section |
 |---|---|---|---|---|
-| null literal | Supported |  | null emission validated in literals and variable tests; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt. | 13.1.5 |
+| null literal | Supported | `Js2IL.Tests/JavaScript/Literals_NullAndUndefined.js`<br>`Js2IL.Tests/JavaScript/JSON_Parse_SimpleObject.js` | null emission validated in literals and variable tests; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt. | 13.1.5 |
 
 
 #### [undefined (Identifier)](https://tc39.es/ecma262/#sec-undefined)
 
 | Feature | Status | Test Scripts | Notes | Section |
 |---|---|---|---|---|
-| undefined identifier usage | Supported |  | Handled as the ECMAScript undefined value and participates in JS truthiness; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt. | 13.1.6 |
+| undefined identifier usage | Supported | `Js2IL.Tests/JavaScript/Literals_NullAndUndefined.js` | Handled as the ECMAScript undefined value and participates in JS truthiness; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt. | 13.1.6 |
 
 
 ### [Declarations](https://tc39.es/ecma262/#sec-declarations)

--- a/docs/ECMAScript2025_FeatureCoverage.md
+++ b/docs/ECMAScript2025_FeatureCoverage.md
@@ -8,6 +8,20 @@ This file is auto-generated from ECMAScript2025_FeatureCoverage.json.
 
 ### [Primary Expressions](https://tc39.es/ecma262/#sec-primary-expression)
 
+#### [NumericLiteral](https://tc39.es/ecma262/#sec-numeric-literals)
+
+| Feature | Status | Test Scripts | Notes | Section |
+|---|---|---|---|---|
+| Numeric literals (integer and decimal) | Supported | `Js2IL.Tests/JavaScript/BinaryOperator_AddNumberNumber.js`<br>`Js2IL.Tests/JavaScript/BinaryOperator_MulNumberNumber.js` | Numbers are represented as double and used pervasively across arithmetic, comparison, and control-flow tests. | 13.1.1 |
+
+
+#### [StringLiteral](https://tc39.es/ecma262/#sec-string-literals)
+
+| Feature | Status | Test Scripts | Notes | Section |
+|---|---|---|---|---|
+| String literals (single/double quotes; escapes) | Supported | `Js2IL.Tests/JavaScript/String_StartsWith_Basic.js`<br>`Js2IL.Tests/JavaScript/String_Replace_Regex_Global.js` | Backed by .NET System.String; values are boxed/unboxed where needed in member calls and concatenation. | 13.1.2 |
+
+
 #### [BooleanLiteral](https://tc39.es/ecma262/#sec-boolean-literals)
 
 | Feature | Status | Test Scripts | Notes | Section |
@@ -20,6 +34,20 @@ This file is auto-generated from ECMAScript2025_FeatureCoverage.json.
 | Feature | Status | Test Scripts | Notes | Section |
 |---|---|---|---|---|
 | Template literals (basic interpolation) | Supported | `Js2IL.Tests/JavaScript/String_TemplateLiteral_Basic.js` | Concatenates quasis and expressions via runtime Operators.Add with JS string/number coercion. Tagged templates are not yet supported. | 13.1.4 |
+
+
+#### [NullLiteral](https://tc39.es/ecma262/#sec-null-literals)
+
+| Feature | Status | Test Scripts | Notes | Section |
+|---|---|---|---|---|
+| null literal | Supported |  | null emission validated in literals and variable tests; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt. | 13.1.5 |
+
+
+#### [undefined (Identifier)](https://tc39.es/ecma262/#sec-undefined)
+
+| Feature | Status | Test Scripts | Notes | Section |
+|---|---|---|---|---|
+| undefined identifier usage | Supported |  | Handled as the ECMAScript undefined value and participates in JS truthiness; see execution snapshot Js2IL.Tests/Literals/ExecutionTests.Literals_NullAndUndefined.verified.txt. | 13.1.6 |
 
 
 ### [Declarations](https://tc39.es/ecma262/#sec-declarations)
@@ -204,6 +232,15 @@ This file is auto-generated from ECMAScript2025_FeatureCoverage.json.
 
 ## [ECMAScript Language: Statements and Declarations](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations)
 
+### [Return Statement](https://tc39.es/ecma262/#sec-return-statement)
+
+#### [Runtime Semantics: ReturnStatement Evaluation](https://tc39.es/ecma262/#sec-return-statement)
+
+| Feature | Status | Test Scripts | Notes | Section |
+|---|---|---|---|---|
+| return statement (basic) | Supported | `Js2IL.Tests/JavaScript/Function_ReturnsStaticValueAndLogs.js` | Function returns propagate values (boxed) to callers; validated by execution snapshot showing returned value. | 14.1.1 |
+
+
 ### [The if Statement](https://tc39.es/ecma262/#sec-if-statement)
 
 #### [Runtime Semantics: Evaluation](https://tc39.es/ecma262/#sec-if-statement)
@@ -330,7 +367,7 @@ This file is auto-generated from ECMAScript2025_FeatureCoverage.json.
 
 | Feature | Status | Test Scripts | Notes | Section |
 |---|---|---|---|---|
-| String.prototype.startsWith | Supported | `Js2IL.Tests/JavaScript/String_StartsWith_Basic.js` | Reflection-based string dispatch routes CLR string receivers to JavaScriptRuntime.String.StartsWith with optional position argument. | 24.1.3 |
+| String.prototype.startsWith | Supported | `Js2IL.Tests/JavaScript/String_StartsWith_Basic.js` | Reflection-based string dispatch routes CLR string receivers to JavaScriptRuntime.String.StartsWith with optional position argument. Returns a boolean value (boxed). | 24.1.3 |
 
 
 #### [String.prototype.replace](https://tc39.es/ecma262/#sec-string.prototype.replace)
@@ -344,7 +381,7 @@ This file is auto-generated from ECMAScript2025_FeatureCoverage.json.
 
 | Feature | Status | Test Scripts | Notes | Section |
 |---|---|---|---|---|
-| String.prototype.localeCompare (numeric compare) | Supported | `Js2IL.Tests/JavaScript/String_LocaleCompare_Numeric.js` | Returns a number (double) for comparator functions; used by Array.sort comparator tests. | 24.1.4 |
+| String.prototype.localeCompare (numeric compare) | Supported | `Js2IL.Tests/JavaScript/String_LocaleCompare_Numeric.js` | Returns a number (boxed double) consistent with ECMAScript compare semantics; numeric option supported. | 24.1.4 |
 
 
 ### [JSON Object](https://tc39.es/ecma262/#sec-json-object)

--- a/docs/NodeSupport.json
+++ b/docs/NodeSupport.json
@@ -161,6 +161,30 @@
           "file": "Js2IL.Tests/ConsoleTests.cs"
         }
       ]
+    },
+    {
+      "name": "console.error",
+      "status": "supported",
+      "implementation": "JavaScriptRuntime/Console.cs",
+      "docs": "https://nodejs.org/api/console.html#consoleerrordata-args",
+      "tests": [
+        {
+          "name": "JavaScriptRuntime.Tests.ConsoleTests.Error_PrintsAllArgumentsWithSpaces",
+          "file": "Js2IL.Tests/ConsoleTests.cs"
+        }
+      ]
+    },
+    {
+      "name": "console.warn",
+      "status": "supported",
+      "implementation": "JavaScriptRuntime/Console.cs",
+      "docs": "https://nodejs.org/api/console.html#consolewarndata-args",
+      "tests": [
+        {
+          "name": "JavaScriptRuntime.Tests.ConsoleTests.Warn_PrintsAllArgumentsWithSpaces",
+          "file": "Js2IL.Tests/ConsoleTests.cs"
+        }
+      ]
     }
   ],
   "limitations": [

--- a/docs/NodeSupport.json
+++ b/docs/NodeSupport.json
@@ -167,6 +167,7 @@
       "status": "supported",
       "implementation": "JavaScriptRuntime/Console.cs",
       "docs": "https://nodejs.org/api/console.html#consoleerrordata-args",
+  "notes": "Writes to stderr.",
       "tests": [
         {
           "name": "JavaScriptRuntime.Tests.ConsoleTests.Error_PrintsAllArgumentsWithSpaces",
@@ -179,6 +180,7 @@
       "status": "supported",
       "implementation": "JavaScriptRuntime/Console.cs",
       "docs": "https://nodejs.org/api/console.html#consolewarndata-args",
+  "notes": "Writes to stderr.",
       "tests": [
         {
           "name": "JavaScriptRuntime.Tests.ConsoleTests.Warn_PrintsAllArgumentsWithSpaces",

--- a/docs/NodeSupport.json
+++ b/docs/NodeSupport.json
@@ -1,0 +1,171 @@
+{
+  "nodeVersionTarget": "22.x LTS",
+  "generatedAtUtc": "${UTC_NOW}",
+  "modules": [
+    {
+      "name": "path",
+      "status": "partial",
+      "implementation": "JavaScriptRuntime/Node/Path.cs",
+      "docs": "https://nodejs.org/api/path.html",
+      "apis": [
+        {
+          "name": "join(...parts)",
+          "kind": "function",
+          "status": "supported",
+          "docs": "https://nodejs.org/api/path.html#pathjoinpaths",
+          "tests": [
+            {
+              "name": "Js2IL.Tests.Node.ExecutionTests.Require_Path_Join_Basic",
+              "file": "Js2IL.Tests/Node/ExecutionTests.cs#L9"
+            },
+            {
+              "name": "Js2IL.Tests.Node.ExecutionTests.Require_Path_Join_NestedFunction",
+              "file": "Js2IL.Tests/Node/ExecutionTests.cs#L13"
+            },
+            {
+              "name": "Js2IL.Tests.Node.GeneratorTests.Require_Path_Join_Basic",
+              "file": "Js2IL.Tests/Node/GeneratorTests.cs"
+            },
+            {
+              "name": "Js2IL.Tests.Node.GeneratorTests.Require_Path_Join_NestedFunction",
+              "file": "Js2IL.Tests/Node/GeneratorTests.cs"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fs",
+      "status": "partial",
+      "implementation": "JavaScriptRuntime/Node/FS.cs",
+      "docs": "https://nodejs.org/api/fs.html",
+      "apis": [
+        {
+          "name": "readFileSync(path[, options])",
+          "kind": "function",
+          "status": "supported",
+          "notes": "Text-only, returns UTF-8 string. Buffer is not implemented.",
+          "docs": "https://nodejs.org/api/fs.html#fsreadfilesyncpath-options",
+          "tests": [
+            {
+              "name": "Js2IL.Tests.Node.ExecutionTests.FS_ReadWrite_Utf8",
+              "file": "Js2IL.Tests/Node/ExecutionTests.cs#L36"
+            },
+            {
+              "name": "Js2IL.Tests.Node.GeneratorTests.FS_ReadWrite_Utf8",
+              "file": "Js2IL.Tests/Node/GeneratorTests.cs"
+            }
+          ]
+        },
+        {
+          "name": "writeFileSync(path, data[, options])",
+          "kind": "function",
+          "status": "supported",
+          "notes": "Text-only, accepts stringifiable data. Writes UTF-8.",
+          "docs": "https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options",
+          "tests": [
+            {
+              "name": "Js2IL.Tests.Node.ExecutionTests.FS_ReadWrite_Utf8",
+              "file": "Js2IL.Tests/Node/ExecutionTests.cs#L36"
+            },
+            {
+              "name": "Js2IL.Tests.Node.GeneratorTests.FS_ReadWrite_Utf8",
+              "file": "Js2IL.Tests/Node/GeneratorTests.cs"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "process",
+      "status": "partial",
+      "implementation": [
+        "JavaScriptRuntime/Node/Process.cs",
+        "JavaScriptRuntime/Node/GlobalVariables.cs"
+      ],
+      "docs": "https://nodejs.org/api/process.html",
+      "apis": [
+        {
+          "name": "exitCode",
+          "kind": "property",
+          "status": "supported",
+          "docs": "https://nodejs.org/api/process.html#processexitcode",
+          "tests": [
+            {
+              "name": "Js2IL.Tests.Node.ProcessExitCodeTests.Process_exitCode_getter_setter_mirrors_Environment",
+              "file": "Js2IL.Tests/Node/ProcessExitCodeTests.cs"
+            }
+          ]
+        },
+        {
+          "name": "argv",
+          "kind": "property",
+          "status": "supported",
+          "notes": "argv[0] normalized to current script filename; extra host args trimmed in tests.",
+          "docs": "https://nodejs.org/api/process.html#processargv",
+          "tests": [
+            {
+              "name": "Js2IL.Tests.Node.ExecutionTests.Environment_EnumerateProcessArgV",
+              "file": "Js2IL.Tests/Node/ExecutionTests.cs#L21"
+            },
+            {
+              "name": "Js2IL.Tests.Node.GeneratorTests.Environment_EnumerateProcessArgV",
+              "file": "Js2IL.Tests/Node/GeneratorTests.cs"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "globals": [
+    {
+      "name": "__dirname",
+      "status": "supported",
+      "implementation": "JavaScriptRuntime/Node/GlobalVariables.cs",
+      "docs": "https://nodejs.org/api/modules.html#dirname",
+      "tests": [
+        {
+          "name": "Js2IL.Tests.Node.ExecutionTests.Global___dirname_PrintsDirectory",
+          "file": "Js2IL.Tests/Node/ExecutionTests.cs#L15"
+        },
+        {
+          "name": "Js2IL.Tests.Node.GeneratorTests.Global___dirname_PrintsDirectory",
+          "file": "Js2IL.Tests/Node/GeneratorTests.cs"
+        }
+      ]
+    },
+    {
+      "name": "__filename",
+      "status": "supported",
+      "implementation": "JavaScriptRuntime/Node/GlobalVariables.cs",
+      "docs": "https://nodejs.org/api/modules.html#filename",
+      "tests": [
+        {
+          "name": "Js2IL.Tests.Node.ExecutionTests.Environment_EnumerateProcessArgV",
+          "file": "Js2IL.Tests/Node/ExecutionTests.cs#L21"
+        },
+        {
+          "name": "Js2IL.Tests.Node.GeneratorTests.Environment_EnumerateProcessArgV",
+          "file": "Js2IL.Tests/Node/GeneratorTests.cs"
+        }
+      ]
+    },
+    {
+      "name": "console.log",
+      "status": "supported",
+      "implementation": "JavaScriptRuntime/Console.cs",
+      "docs": "https://nodejs.org/api/console.html#consolelogdata-args",
+      "tests": [
+        {
+          "name": "Js2IL.Tests.ConsoleTests",
+          "file": "Js2IL.Tests/ConsoleTests.cs"
+        }
+      ]
+    }
+  ],
+  "limitations": [
+    "No Buffer support yet; fs APIs operate on UTF-8 text only.",
+    "CommonJS globals (__dirname/__filename) are supported; ESM import.meta.url is not.",
+    "Only a small subset of Node is implemented to support tests; many APIs are unimplemented."
+  ]
+}

--- a/docs/NodeSupport.md
+++ b/docs/NodeSupport.md
@@ -1,7 +1,7 @@
 # Node Support Coverage
 
 Target: `22.x LTS`
-Generated: `2025-09-05T17:15:11Z`
+Generated: `2025-09-05T17:27:47Z`
 
 
 ## Modules

--- a/docs/NodeSupport.md
+++ b/docs/NodeSupport.md
@@ -1,0 +1,92 @@
+# Node Support Coverage
+
+Target: `22.x LTS`
+Generated: `2025-09-05T16:53:29Z`
+
+
+## Modules
+
+### path (status: partial)
+Docs: [https://nodejs.org/api/path.html](https://nodejs.org/api/path.html)
+Implementation:
+- `JavaScriptRuntime/Node/Path.cs`
+
+| API | Kind | Status | Docs |
+| --- | ---- | ------ | ---- |
+| join(...parts) | function | supported | [docs](https://nodejs.org/api/path.html#pathjoinpaths) |
+
+Tests:
+- `join(...parts)`
+  - `Js2IL.Tests.Node.ExecutionTests.Require_Path_Join_Basic` (`Js2IL.Tests/Node/ExecutionTests.cs#L9`)
+  - `Js2IL.Tests.Node.ExecutionTests.Require_Path_Join_NestedFunction` (`Js2IL.Tests/Node/ExecutionTests.cs#L13`)
+  - `Js2IL.Tests.Node.GeneratorTests.Require_Path_Join_Basic` (`Js2IL.Tests/Node/GeneratorTests.cs`)
+  - `Js2IL.Tests.Node.GeneratorTests.Require_Path_Join_NestedFunction` (`Js2IL.Tests/Node/GeneratorTests.cs`)
+
+### fs (status: partial)
+Docs: [https://nodejs.org/api/fs.html](https://nodejs.org/api/fs.html)
+Implementation:
+- `JavaScriptRuntime/Node/FS.cs`
+
+| API | Kind | Status | Docs |
+| --- | ---- | ------ | ---- |
+| readFileSync(path[, options]) | function | supported | [docs](https://nodejs.org/api/fs.html#fsreadfilesyncpath-options) |
+| writeFileSync(path, data[, options]) | function | supported | [docs](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options) |
+
+Tests:
+- `readFileSync(path[, options])`
+  - `Js2IL.Tests.Node.ExecutionTests.FS_ReadWrite_Utf8` (`Js2IL.Tests/Node/ExecutionTests.cs#L36`)
+  - `Js2IL.Tests.Node.GeneratorTests.FS_ReadWrite_Utf8` (`Js2IL.Tests/Node/GeneratorTests.cs`)
+- `writeFileSync(path, data[, options])`
+  - `Js2IL.Tests.Node.ExecutionTests.FS_ReadWrite_Utf8` (`Js2IL.Tests/Node/ExecutionTests.cs#L36`)
+  - `Js2IL.Tests.Node.GeneratorTests.FS_ReadWrite_Utf8` (`Js2IL.Tests/Node/GeneratorTests.cs`)
+
+### process (status: partial)
+Docs: [https://nodejs.org/api/process.html](https://nodejs.org/api/process.html)
+Implementation:
+- `JavaScriptRuntime/Node/Process.cs`
+- `JavaScriptRuntime/Node/GlobalVariables.cs`
+
+| API | Kind | Status | Docs |
+| --- | ---- | ------ | ---- |
+| exitCode | property | supported | [docs](https://nodejs.org/api/process.html#processexitcode) |
+| argv | property | supported | [docs](https://nodejs.org/api/process.html#processargv) |
+
+Tests:
+- `exitCode`
+  - `Js2IL.Tests.Node.ProcessExitCodeTests.Process_exitCode_getter_setter_mirrors_Environment` (`Js2IL.Tests/Node/ProcessExitCodeTests.cs`)
+- `argv`
+  - `Js2IL.Tests.Node.ExecutionTests.Environment_EnumerateProcessArgV` (`Js2IL.Tests/Node/ExecutionTests.cs#L21`)
+  - `Js2IL.Tests.Node.GeneratorTests.Environment_EnumerateProcessArgV` (`Js2IL.Tests/Node/GeneratorTests.cs`)
+
+
+## Globals
+
+### __dirname (status: supported)
+Docs: [https://nodejs.org/api/modules.html#dirname](https://nodejs.org/api/modules.html#dirname)
+Implementation:
+- `JavaScriptRuntime/Node/GlobalVariables.cs`
+Tests:
+- `Js2IL.Tests.Node.ExecutionTests.Global___dirname_PrintsDirectory` (`Js2IL.Tests/Node/ExecutionTests.cs#L15`)
+- `Js2IL.Tests.Node.GeneratorTests.Global___dirname_PrintsDirectory` (`Js2IL.Tests/Node/GeneratorTests.cs`)
+
+### __filename (status: supported)
+Docs: [https://nodejs.org/api/modules.html#filename](https://nodejs.org/api/modules.html#filename)
+Implementation:
+- `JavaScriptRuntime/Node/GlobalVariables.cs`
+Tests:
+- `Js2IL.Tests.Node.ExecutionTests.Environment_EnumerateProcessArgV` (`Js2IL.Tests/Node/ExecutionTests.cs#L21`)
+- `Js2IL.Tests.Node.GeneratorTests.Environment_EnumerateProcessArgV` (`Js2IL.Tests/Node/GeneratorTests.cs`)
+
+### console.log (status: supported)
+Docs: [https://nodejs.org/api/console.html#consolelogdata-args](https://nodejs.org/api/console.html#consolelogdata-args)
+Implementation:
+- `JavaScriptRuntime/Console.cs`
+Tests:
+- `Js2IL.Tests.ConsoleTests` (`Js2IL.Tests/ConsoleTests.cs`)
+
+
+## Limitations
+
+- No Buffer support yet; fs APIs operate on UTF-8 text only.
+- CommonJS globals (__dirname/__filename) are supported; ESM import.meta.url is not.
+- Only a small subset of Node is implemented to support tests; many APIs are unimplemented.

--- a/docs/NodeSupport.md
+++ b/docs/NodeSupport.md
@@ -1,7 +1,7 @@
 # Node Support Coverage
 
 Target: `22.x LTS`
-Generated: `2025-09-05T17:10:31Z`
+Generated: `2025-09-05T17:15:11Z`
 
 
 ## Modules
@@ -88,6 +88,8 @@ Tests:
 Docs: [https://nodejs.org/api/console.html#consoleerrordata-args](https://nodejs.org/api/console.html#consoleerrordata-args)
 Implementation:
 - `JavaScriptRuntime/Console.cs`
+Notes:
+Writes to stderr.
 Tests:
 - `JavaScriptRuntime.Tests.ConsoleTests.Error_PrintsAllArgumentsWithSpaces` (`Js2IL.Tests/ConsoleTests.cs`)
 
@@ -95,6 +97,8 @@ Tests:
 Docs: [https://nodejs.org/api/console.html#consolewarndata-args](https://nodejs.org/api/console.html#consolewarndata-args)
 Implementation:
 - `JavaScriptRuntime/Console.cs`
+Notes:
+Writes to stderr.
 Tests:
 - `JavaScriptRuntime.Tests.ConsoleTests.Warn_PrintsAllArgumentsWithSpaces` (`Js2IL.Tests/ConsoleTests.cs`)
 

--- a/docs/NodeSupport.md
+++ b/docs/NodeSupport.md
@@ -1,7 +1,7 @@
 # Node Support Coverage
 
 Target: `22.x LTS`
-Generated: `2025-09-05T16:53:29Z`
+Generated: `2025-09-05T17:10:31Z`
 
 
 ## Modules
@@ -83,6 +83,20 @@ Implementation:
 - `JavaScriptRuntime/Console.cs`
 Tests:
 - `Js2IL.Tests.ConsoleTests` (`Js2IL.Tests/ConsoleTests.cs`)
+
+### console.error (status: supported)
+Docs: [https://nodejs.org/api/console.html#consoleerrordata-args](https://nodejs.org/api/console.html#consoleerrordata-args)
+Implementation:
+- `JavaScriptRuntime/Console.cs`
+Tests:
+- `JavaScriptRuntime.Tests.ConsoleTests.Error_PrintsAllArgumentsWithSpaces` (`Js2IL.Tests/ConsoleTests.cs`)
+
+### console.warn (status: supported)
+Docs: [https://nodejs.org/api/console.html#consolewarndata-args](https://nodejs.org/api/console.html#consolewarndata-args)
+Implementation:
+- `JavaScriptRuntime/Console.cs`
+Tests:
+- `JavaScriptRuntime.Tests.ConsoleTests.Warn_PrintsAllArgumentsWithSpaces` (`Js2IL.Tests/ConsoleTests.cs`)
 
 
 ## Limitations

--- a/docs/NodeSupport.schema.json
+++ b/docs/NodeSupport.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "NodeSupport",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nodeVersionTarget": {
+      "type": "string",
+      "description": "Target Node.js version range (e.g. '22.x LTS')."
+    },
+    "generatedAtUtc": {
+      "type": "string",
+      "description": "UTC timestamp string or placeholder (e.g. ${UTC_NOW})."
+    },
+    "modules": {
+      "type": "array",
+      "description": "Supported Node.js modules and their APIs.",
+      "uniqueItemProperties": ["name"],
+      "items": { "$ref": "#/definitions/moduleEntry" }
+    },
+    "globals": {
+      "type": "array",
+      "description": "Supported Node.js-like globals (e.g., __dirname).",
+      "uniqueItemProperties": ["name"],
+      "items": { "$ref": "#/definitions/globalEntry" }
+    },
+    "limitations": {
+      "type": "array",
+      "description": "Known limitations and caveats.",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["nodeVersionTarget", "modules", "globals"],
+  "definitions": {
+    "status": {
+      "type": "string",
+      "enum": ["supported", "partial", "not-supported"],
+      "description": "Support level."
+    },
+    "apiKind": {
+      "type": "string",
+      "enum": ["function", "property"],
+      "description": "API kind."
+    },
+    "testRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "description": "Fully qualified test name." },
+        "file": { "type": "string", "description": "Path to test file (optionally with line)." }
+      },
+      "required": ["name", "file"]
+    },
+    "implementationPath": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ],
+      "description": "Relative source path(s) implementing the feature."
+    },
+    "api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "description": "API signature or name." },
+        "kind": { "$ref": "#/definitions/apiKind" },
+        "status": { "$ref": "#/definitions/status" },
+        "docs": { "type": "string", "format": "uri", "description": "Link to Node.js docs." },
+        "notes": { "type": "string", "description": "Additional notes." },
+        "tests": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/testRef" },
+          "default": []
+        }
+      },
+      "required": ["name", "kind", "status"]
+    },
+    "moduleEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "description": "Module name (e.g., 'path')." },
+        "status": { "$ref": "#/definitions/status" },
+        "implementation": { "$ref": "#/definitions/implementationPath" },
+        "docs": { "type": "string", "format": "uri" },
+        "apis": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/api" },
+          "default": []
+        }
+      },
+      "required": ["name", "status", "apis"]
+    },
+    "globalEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "description": "Global name (e.g., '__dirname')." },
+        "status": { "$ref": "#/definitions/status" },
+        "implementation": { "$ref": "#/definitions/implementationPath" },
+        "docs": { "type": "string", "format": "uri" },
+        "tests": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/testRef" },
+          "default": []
+        },
+        "notes": { "type": "string" }
+      },
+      "required": ["name", "status", "implementation", "docs"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "clean:snapshots": "node scripts/cleanUnusedSnapshots.js",
   "clean:snapshots:delete": "node scripts/cleanUnusedSnapshots.js --delete",
   "verify:update": "node scripts/updateVerifiedFiles.js",
-  "verify:update:root": "node scripts/updateVerifiedFiles.js --root Js2IL.Tests"
+  "verify:update:root": "node scripts/updateVerifiedFiles.js --root Js2IL.Tests",
+  "generate:node-support": "node scripts/generateNodeSupportMd.js"
   },
   "dependencies": {
     "ajv-cli": "^5.0.0",

--- a/scripts/generateNodeSupportMd.js
+++ b/scripts/generateNodeSupportMd.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/*
+ Generates docs/NodeSupport.md from docs/NodeSupport.json.
+*/
+const fs = require('fs');
+const path = require('path');
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function asArray(v) { return Array.isArray(v) ? v : (v == null ? [] : [v]); }
+
+function fmtCode(s) { return s ? '`' + s + '`' : ''; }
+
+function link(href, text) { return href ? `[${text || href}](${href})` : (text || ''); }
+
+function renderHeader(ns) {
+  const dt = new Date().toISOString().replace(/\..+Z$/, 'Z');
+  const lines = [];
+  lines.push(`# Node Support Coverage`);
+  lines.push('');
+  if (ns.nodeVersionTarget) lines.push(`Target: ${fmtCode(ns.nodeVersionTarget)}`);
+  lines.push(`Generated: ${fmtCode(dt)}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderImplementation(impl) {
+  const parts = asArray(impl);
+  if (!parts.length) return '';
+  return parts.map(p => `- ${fmtCode(p)}`).join('\n');
+}
+
+function renderApisTable(apis) {
+  if (!apis || !apis.length) return '';
+  const rows = [];
+  rows.push('| API | Kind | Status | Docs |');
+  rows.push('| --- | ---- | ------ | ---- |');
+  for (const api of apis) {
+    rows.push(`| ${api.name || ''} | ${api.kind || ''} | ${api.status || ''} | ${api.docs ? link(api.docs, 'docs') : ''} |`);
+  }
+  return rows.join('\n');
+}
+
+function renderApiTests(apis) {
+  const lines = [];
+  for (const api of apis || []) {
+    if (!api.tests || !api.tests.length) continue;
+    lines.push(`- ${fmtCode(api.name || '')}`);
+    for (const t of api.tests) {
+      const label = t.name ? fmtCode(t.name) : '';
+      const file = t.file ? ` (${fmtCode(t.file)})` : '';
+      lines.push(`  - ${label}${file}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function renderModules(ns) {
+  const lines = [];
+  lines.push('## Modules');
+  lines.push('');
+  for (const m of ns.modules || []) {
+    lines.push(`### ${m.name} (status: ${m.status})`);
+    if (m.docs) lines.push(`Docs: ${link(m.docs)}`);
+    if (m.implementation) {
+      lines.push('Implementation:');
+      lines.push(renderImplementation(m.implementation));
+    }
+    lines.push('');
+    const table = renderApisTable(m.apis || []);
+    if (table) {
+      lines.push(table);
+      lines.push('');
+    }
+    const tests = renderApiTests(m.apis || []);
+    if (tests) {
+      lines.push('Tests:');
+      lines.push(tests);
+      lines.push('');
+    }
+  }
+  return lines.join('\n');
+}
+
+function renderGlobals(ns) {
+  const lines = [];
+  lines.push('## Globals');
+  lines.push('');
+  for (const g of ns.globals || []) {
+    lines.push(`### ${g.name} (status: ${g.status})`);
+    if (g.docs) lines.push(`Docs: ${link(g.docs)}`);
+    if (g.implementation) {
+      lines.push('Implementation:');
+      lines.push(renderImplementation(g.implementation));
+    }
+    if (g.notes) {
+      lines.push('Notes:');
+      lines.push(g.notes);
+    }
+    if (g.tests && g.tests.length) {
+      lines.push('Tests:');
+      for (const t of g.tests) {
+        const label = t.name ? fmtCode(t.name) : '';
+        const file = t.file ? ` (${fmtCode(t.file)})` : '';
+        lines.push(`- ${label}${file}`);
+      }
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function renderLimitations(ns) {
+  const items = ns.limitations || [];
+  if (!items.length) return '';
+  const lines = [];
+  lines.push('## Limitations');
+  lines.push('');
+  for (const it of items) lines.push(`- ${it}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+function main() {
+  const repoRoot = path.resolve(__dirname, '..');
+  const jsonPath = path.join(repoRoot, 'docs', 'NodeSupport.json');
+  const outPath = path.join(repoRoot, 'docs', 'NodeSupport.md');
+  const ns = readJson(jsonPath);
+
+  const parts = [];
+  parts.push(renderHeader(ns));
+  parts.push(renderModules(ns));
+  parts.push(renderGlobals(ns));
+  const lim = renderLimitations(ns);
+  if (lim) parts.push(lim);
+  const md = parts.join('\n\n').replace(/\r?\n/g, '\n');
+  fs.writeFileSync(outPath, md, 'utf8');
+  console.log(`Wrote ${path.relative(repoRoot, outPath)}`);
+}
+
+main();


### PR DESCRIPTION
This PR adds a Node support tracking pipeline and small runtime fix.

Highlights
- Node support artifacts: NodeSupport.json + JSON Schema + generator script; generated NodeSupport.md
- ECMAScript coverage: add numeric/string/null/undefined literals, return statement; boxed-return notes for String.startsWith/localeCompare
- Console: console.error and console.warn now write to stderr; tests added

Testing
- Unit tests build and pass locally
- Docs regenerated via scripts

Follow-ups
- Expand Node API surface (e.g., more fs/path methods)
- Add generator tests for console.error/warn if desired
