### PR TITLE
Support ++/-- on locals and parameters inside while conditions; add generator tests

### DIFF
--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
@@ -1,0 +1,177 @@
+﻿// IL code: Classes_ClassMethod_While_Increment_Param_Postfix
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Classes_ClassMethod_While_Increment_Param_Postfix
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Counter
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit run
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L3C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x206b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L3C18::.ctor
+
+			} // end of class Block_L3C18
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2062
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method run::.ctor
+
+		} // end of class run
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Counter::.ctor
+
+	} // end of class Counter
+
+
+	// Fields
+	.field public object Counter
+	.field public initonly object c
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Classes_ClassMethod_While_Increment_Param_Postfix::.ctor
+
+} // end of class Scopes.Classes_ClassMethod_While_Increment_Param_Postfix
+
+.class public auto ansi beforefieldinit Classes.Counter
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2074
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: ret
+	} // end of method Counter::.ctor
+
+	.method public hidebysig 
+		instance object run (
+			object ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x207c
+		// Header size: 1
+		// Code size: 55 (0x37)
+		.maxstack 8
+
+		// loop start
+			IL_0000: ldarg.1
+			IL_0001: unbox.any [System.Runtime]System.Double
+			IL_0006: ldc.r8 3
+			IL_000f: blt IL_0019
+
+			IL_0014: br IL_0035
+
+			IL_0019: ldarg.1
+			IL_001a: unbox.any [System.Runtime]System.Double
+			IL_001f: ldc.r8 1
+			IL_0028: add
+			IL_0029: box [System.Runtime]System.Double
+			IL_002e: starg.s 1
+			IL_0030: br IL_0000
+		// end loop
+
+		IL_0035: ldnull
+		IL_0036: ret
+	} // end of method Counter::run
+
+} // end of class Classes.Counter
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x20b4
+		// Header size: 12
+		// Code size: 44 (0x2c)
+		.maxstack 32
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: newobj instance void Scopes.Classes_ClassMethod_While_Increment_Param_Postfix::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: newobj instance void Classes.Counter::.ctor()
+		IL_000c: stfld object Scopes.Classes_ClassMethod_While_Increment_Param_Postfix::c
+		IL_0011: ldloc.0
+		IL_0012: ldfld object Scopes.Classes_ClassMethod_While_Increment_Param_Postfix::c
+		IL_0017: ldc.r8 0.0
+		IL_0020: box [System.Runtime]System.Double
+		IL_0025: callvirt instance object Classes.Counter::run(object)
+		IL_002a: pop
+		IL_002b: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Prefix.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Prefix.verified.txt
@@ -1,0 +1,177 @@
+﻿// IL code: Classes_ClassMethod_While_Increment_Param_Prefix
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Classes_ClassMethod_While_Increment_Param_Prefix
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Counter
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit run
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L3C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x206b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L3C18::.ctor
+
+			} // end of class Block_L3C18
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2062
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method run::.ctor
+
+		} // end of class run
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Counter::.ctor
+
+	} // end of class Counter
+
+
+	// Fields
+	.field public object Counter
+	.field public initonly object c
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Classes_ClassMethod_While_Increment_Param_Prefix::.ctor
+
+} // end of class Scopes.Classes_ClassMethod_While_Increment_Param_Prefix
+
+.class public auto ansi beforefieldinit Classes.Counter
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2074
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: ret
+	} // end of method Counter::.ctor
+
+	.method public hidebysig 
+		instance object run (
+			object ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x207c
+		// Header size: 1
+		// Code size: 55 (0x37)
+		.maxstack 8
+
+		// loop start
+			IL_0000: ldarg.1
+			IL_0001: unbox.any [System.Runtime]System.Double
+			IL_0006: ldc.r8 3
+			IL_000f: blt IL_0019
+
+			IL_0014: br IL_0035
+
+			IL_0019: ldarg.1
+			IL_001a: unbox.any [System.Runtime]System.Double
+			IL_001f: ldc.r8 1
+			IL_0028: add
+			IL_0029: box [System.Runtime]System.Double
+			IL_002e: starg.s 1
+			IL_0030: br IL_0000
+		// end loop
+
+		IL_0035: ldnull
+		IL_0036: ret
+	} // end of method Counter::run
+
+} // end of class Classes.Counter
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x20b4
+		// Header size: 12
+		// Code size: 44 (0x2c)
+		.maxstack 32
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: newobj instance void Scopes.Classes_ClassMethod_While_Increment_Param_Prefix::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: newobj instance void Classes.Counter::.ctor()
+		IL_000c: stfld object Scopes.Classes_ClassMethod_While_Increment_Param_Prefix::c
+		IL_0011: ldloc.0
+		IL_0012: ldfld object Scopes.Classes_ClassMethod_While_Increment_Param_Prefix::c
+		IL_0017: ldc.r8 0.0
+		IL_0020: box [System.Runtime]System.Double
+		IL_0025: callvirt instance object Classes.Counter::run(object)
+		IL_002a: pop
+		IL_002b: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassMethod_While_Increment_Postfix.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassMethod_While_Increment_Postfix.verified.txt
@@ -1,0 +1,195 @@
+﻿// IL code: Classes_ClassMethod_While_Increment_Postfix
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Classes_ClassMethod_While_Increment_Postfix
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Counter
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit run
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L4C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x206b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L4C18::.ctor
+
+			} // end of class Block_L4C18
+
+
+			// Fields
+			.field public object i
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2062
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method run::.ctor
+
+		} // end of class run
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Counter::.ctor
+
+	} // end of class Counter
+
+
+	// Fields
+	.field public object Counter
+	.field public initonly object c
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Classes_ClassMethod_While_Increment_Postfix::.ctor
+
+} // end of class Scopes.Classes_ClassMethod_While_Increment_Postfix
+
+.class public auto ansi beforefieldinit Classes.Counter
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2074
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: ret
+	} // end of method Counter::.ctor
+
+	.method public hidebysig 
+		instance object run (
+			object ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x207c
+		// Header size: 12
+		// Code size: 94 (0x5e)
+		.maxstack 8
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: newobj instance void Scopes.Classes_ClassMethod_While_Increment_Postfix/Counter/run::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldc.r8 0.0
+		IL_0010: box [System.Runtime]System.Double
+		IL_0015: stfld object Scopes.Classes_ClassMethod_While_Increment_Postfix/Counter/run::i
+		// loop start (head: IL_001a)
+			IL_001a: ldloc.0
+			IL_001b: ldfld object Scopes.Classes_ClassMethod_While_Increment_Postfix/Counter/run::i
+			IL_0020: unbox.any [System.Runtime]System.Double
+			IL_0025: ldarg.1
+			IL_0026: unbox.any [System.Runtime]System.Double
+			IL_002b: blt IL_0035
+
+			IL_0030: br IL_005a
+
+			IL_0035: ldloc.0
+			IL_0036: ldloc.0
+			IL_0037: ldfld object Scopes.Classes_ClassMethod_While_Increment_Postfix/Counter/run::i
+			IL_003c: unbox.any [System.Runtime]System.Double
+			IL_0041: ldc.r8 1
+			IL_004a: add
+			IL_004b: box [System.Runtime]System.Double
+			IL_0050: stfld object Scopes.Classes_ClassMethod_While_Increment_Postfix/Counter/run::i
+			IL_0055: br IL_001a
+		// end loop
+
+		IL_005a: ldnull
+		IL_005b: stloc.0
+		IL_005c: ldnull
+		IL_005d: ret
+	} // end of method Counter::run
+
+} // end of class Classes.Counter
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x20e8
+		// Header size: 12
+		// Code size: 44 (0x2c)
+		.maxstack 32
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: newobj instance void Scopes.Classes_ClassMethod_While_Increment_Postfix::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: newobj instance void Classes.Counter::.ctor()
+		IL_000c: stfld object Scopes.Classes_ClassMethod_While_Increment_Postfix::c
+		IL_0011: ldloc.0
+		IL_0012: ldfld object Scopes.Classes_ClassMethod_While_Increment_Postfix::c
+		IL_0017: ldc.r8 3
+		IL_0020: box [System.Runtime]System.Double
+		IL_0025: callvirt instance object Classes.Counter::run(object)
+		IL_002a: pop
+		IL_002b: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassMethod_While_Increment_Prefix.verified.txt
+++ b/Js2IL.Tests/Classes/GeneratorTests.Classes_ClassMethod_While_Increment_Prefix.verified.txt
@@ -1,0 +1,195 @@
+﻿// IL code: Classes_ClassMethod_While_Increment_Prefix
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Classes_ClassMethod_While_Increment_Prefix
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Counter
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit run
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L4C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x206b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L4C18::.ctor
+
+			} // end of class Block_L4C18
+
+
+			// Fields
+			.field public object i
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2062
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method run::.ctor
+
+		} // end of class run
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Counter::.ctor
+
+	} // end of class Counter
+
+
+	// Fields
+	.field public object Counter
+	.field public initonly object c
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Classes_ClassMethod_While_Increment_Prefix::.ctor
+
+} // end of class Scopes.Classes_ClassMethod_While_Increment_Prefix
+
+.class public auto ansi beforefieldinit Classes.Counter
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2074
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: ret
+	} // end of method Counter::.ctor
+
+	.method public hidebysig 
+		instance object run (
+			object ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x207c
+		// Header size: 12
+		// Code size: 94 (0x5e)
+		.maxstack 8
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: newobj instance void Scopes.Classes_ClassMethod_While_Increment_Prefix/Counter/run::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldc.r8 0.0
+		IL_0010: box [System.Runtime]System.Double
+		IL_0015: stfld object Scopes.Classes_ClassMethod_While_Increment_Prefix/Counter/run::i
+		// loop start (head: IL_001a)
+			IL_001a: ldloc.0
+			IL_001b: ldfld object Scopes.Classes_ClassMethod_While_Increment_Prefix/Counter/run::i
+			IL_0020: unbox.any [System.Runtime]System.Double
+			IL_0025: ldarg.1
+			IL_0026: unbox.any [System.Runtime]System.Double
+			IL_002b: blt IL_0035
+
+			IL_0030: br IL_005a
+
+			IL_0035: ldloc.0
+			IL_0036: ldloc.0
+			IL_0037: ldfld object Scopes.Classes_ClassMethod_While_Increment_Prefix/Counter/run::i
+			IL_003c: unbox.any [System.Runtime]System.Double
+			IL_0041: ldc.r8 1
+			IL_004a: add
+			IL_004b: box [System.Runtime]System.Double
+			IL_0050: stfld object Scopes.Classes_ClassMethod_While_Increment_Prefix/Counter/run::i
+			IL_0055: br IL_001a
+		// end loop
+
+		IL_005a: ldnull
+		IL_005b: stloc.0
+		IL_005c: ldnull
+		IL_005d: ret
+	} // end of method Counter::run
+
+} // end of class Classes.Counter
+
+.class public auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x20e8
+		// Header size: 12
+		// Code size: 44 (0x2c)
+		.maxstack 32
+		.entrypoint
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: newobj instance void Scopes.Classes_ClassMethod_While_Increment_Prefix::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: newobj instance void Classes.Counter::.ctor()
+		IL_000c: stfld object Scopes.Classes_ClassMethod_While_Increment_Prefix::c
+		IL_0011: ldloc.0
+		IL_0012: ldfld object Scopes.Classes_ClassMethod_While_Increment_Prefix::c
+		IL_0017: ldc.r8 3
+		IL_0020: box [System.Runtime]System.Double
+		IL_0025: callvirt instance object Classes.Counter::run(object)
+		IL_002a: pop
+		IL_002b: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Classes/GeneratorTests.cs
+++ b/Js2IL.Tests/Classes/GeneratorTests.cs
@@ -14,10 +14,18 @@ namespace Js2IL.Tests.Classes
         [Fact] public Task Classes_ClassProperty_DefaultAndLog() { var testName = nameof(Classes_ClassProperty_DefaultAndLog); return GenerateTest(testName); }
         [Fact] public Task Classes_ClassConstructor_Param_Field_Log() { var testName = nameof(Classes_ClassConstructor_Param_Field_Log); return GenerateTest(testName); }
         [Fact] public Task Classes_ClassConstructor_WithMultipleParameters() { var testName = nameof(Classes_ClassConstructor_WithMultipleParameters); return GenerateTest(testName); }
-    [Fact] public Task Classes_ClassConstructor_TwoParams_AddMethod() { var testName = nameof(Classes_ClassConstructor_TwoParams_AddMethod); return GenerateTest(testName); }
-    [Fact] public Task Classes_ClassConstructor_TwoParams_SubtractMethod() { var testName = nameof(Classes_ClassConstructor_TwoParams_SubtractMethod); return GenerateTest(testName); }
+        [Fact] public Task Classes_ClassConstructor_TwoParams_AddMethod() { var testName = nameof(Classes_ClassConstructor_TwoParams_AddMethod); return GenerateTest(testName); }
+        [Fact] public Task Classes_ClassConstructor_TwoParams_SubtractMethod() { var testName = nameof(Classes_ClassConstructor_TwoParams_SubtractMethod); return GenerateTest(testName); }
         [Fact] public Task Classes_ClassPrivateField_HelperMethod_Log() { var testName = nameof(Classes_ClassPrivateField_HelperMethod_Log); return GenerateTest(testName); }
-    [Fact] public Task Classes_ClassMethod_CallsAnotherMethod() { var testName = nameof(Classes_ClassMethod_CallsAnotherMethod); return GenerateTest(testName); }
-    [Fact] public Task Classes_ClassMethod_ForLoop_CallsAnotherMethod() { var testName = nameof(Classes_ClassMethod_ForLoop_CallsAnotherMethod); return GenerateTest(testName); }
+        [Fact] public Task Classes_ClassMethod_CallsAnotherMethod() { var testName = nameof(Classes_ClassMethod_CallsAnotherMethod); return GenerateTest(testName); }
+        [Fact] public Task Classes_ClassMethod_ForLoop_CallsAnotherMethod() { var testName = nameof(Classes_ClassMethod_ForLoop_CallsAnotherMethod); return GenerateTest(testName); }
+
+        // Repro for UpdateExpression inside a class method while-loop (postfix and prefix)
+        [Fact] public Task Classes_ClassMethod_While_Increment_Postfix() { var testName = nameof(Classes_ClassMethod_While_Increment_Postfix); return GenerateTest(testName); }
+        [Fact] public Task Classes_ClassMethod_While_Increment_Prefix() { var testName = nameof(Classes_ClassMethod_While_Increment_Prefix); return GenerateTest(testName); }
+
+        // Repro for UpdateExpression applied to a method parameter inside while-loop
+        [Fact] public Task Classes_ClassMethod_While_Increment_Param_Postfix() { var testName = nameof(Classes_ClassMethod_While_Increment_Param_Postfix); return GenerateTest(testName); }
+        [Fact] public Task Classes_ClassMethod_While_Increment_Param_Prefix() { var testName = nameof(Classes_ClassMethod_While_Increment_Param_Prefix); return GenerateTest(testName); }
     }
 }

--- a/Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_While_Increment_Param_Postfix.js
+++ b/Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_While_Increment_Param_Postfix.js
@@ -1,0 +1,10 @@
+class Counter {
+  run(n) {
+    while (n < 3) {
+      n++;
+    }
+  }
+}
+
+const c = new Counter();
+c.run(0);

--- a/Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_While_Increment_Param_Prefix.js
+++ b/Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_While_Increment_Param_Prefix.js
@@ -1,0 +1,10 @@
+class Counter {
+  run(n) {
+    while (n < 3) {
+      ++n;
+    }
+  }
+}
+
+const c = new Counter();
+c.run(0);

--- a/Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_While_Increment_Postfix.js
+++ b/Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_While_Increment_Postfix.js
@@ -1,0 +1,11 @@
+class Counter {
+  run(n) {
+    let i = 0;
+    while (i < n) {
+      i++;
+    }
+  }
+}
+
+const c = new Counter();
+c.run(3);

--- a/Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_While_Increment_Prefix.js
+++ b/Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_While_Increment_Prefix.js
@@ -1,0 +1,11 @@
+class Counter {
+  run(n) {
+    let i = 0;
+    while (i < n) {
+      ++i;
+    }
+  }
+}
+
+const c = new Counter();
+c.run(3);


### PR DESCRIPTION
Title: Feature: Truthiness in conditionals, logical OR/AND with short-circuit, and env-gated integration compile test

Summary
- Adds JS truthiness coercion for conditionals and implements logical operators (||, &&) with full short-circuit semantics. Includes a long-running integration test gated by RUN_INTEGRATION=1 that compiles scripts/generateFeatureCoverage.js. Updates coverage docs and changelog.

Changes
- Added
	- Control flow: truthiness in if/ternary conditions via JavaScriptRuntime.TypeUtilities.ToBoolean; generator and execution tests (e.g., ControlFlow_If_Truthiness).
	- Operators: logical OR (||) and logical AND (&&) supporting both value and branching contexts with short-circuit; tests under BinaryOperator Execution/Generator.
	- Integration: Js2IL.Tests.Integration.CompilationTests.Compile_Scripts_GenerateFeatureCoverage (gated by RUN_INTEGRATION env var) to compile scripts/generateFeatureCoverage.js.
- Changed
	- IL generation: conditional branching now coerces non-boolean test expressions using ToBoolean; centralized boxing rules in ILExpressionGenerator.
	- Binary operator emitter updated to correctly handle boxing in short-circuit paths (no double-boxing), fixing incorrect outputs.
- Docs/Changelog
	- Updated ECMAScript2025_FeatureCoverage.json (+ regenerated .md) to include truthiness and logical ||/&&.
	- CHANGELOG: documented truthiness, logical operators, and the disabled integration test.

Notes
- The integration test is intentionally gated by an environment variable to keep CI time reasonable; it validates end-to-end parsing and IL generation for the docs generator script.
- Snapshot updates for new generator tests may be handled in a follow-up if necessary.

Checklist
- [x] Tests added/updated
- [x] Docs updated (coverage JSON/MD)
- [x] Integration test added and skipped
- [x] No breaking public API changes noted

