### PR TITLE
fix(il): ignore directive prologues (e.g., 'use strict')

### DIFF
--- a/Js2IL/Services/ILGenerators/ILMethodGenerator.cs
+++ b/Js2IL/Services/ILGenerators/ILMethodGenerator.cs
@@ -542,6 +542,14 @@ namespace Js2IL.Services.ILGenerators
 
         public void GenerateExpressionStatement(Acornima.Ast.ExpressionStatement expressionStatement)
         {
+            // Ignore directive prologue string literals like "use strict".
+            // A standalone string literal as an expression statement in JS is a directive, not a value-producing expression.
+            // Emitting it would leave an unconsumed value on the stack and cause InvalidProgramException at method return.
+            if (expressionStatement.Expression is Acornima.Ast.Literal lit && lit.Value is string)
+            {
+                return;
+            }
+
             _ = _expressionEmitter.Emit(expressionStatement.Expression, new TypeCoercion(), CallSiteContext.Statement);
             if (expressionStatement.Expression is NewExpression || expressionStatement.Expression is ConditionalExpression || expressionStatement.Expression is CallExpression)
             {


### PR DESCRIPTION
Ignore directive prologue strings like "use strict" in expression statements.

Why
- JS allows directive prologues at the top of a function or script (e.g., "use strict"). As standalone expression statements they should not produce a value.
- Emitting them as ldstr leaves an extra value on the IL evaluation stack, leading to InvalidProgramException at method return.

What changed
- ILMethodGenerator.GenerateExpressionStatement: detect Literal string expression statements and skip emission.
- No other behavior changes; solution builds locally.
