### PR TITLE
release: 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,21 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+_Nothing yet._
+
+## v0.1.7 - 2025-11-12
+
 Added
 - Functions: internal self-binding for named function expressions to enable recursion (e.g., const f = function g(){ return g(); }). Implemented via a small prologue that binds the internal name on first entry using a new runtime helper `JavaScriptRuntime.Closure.CreateSelfDelegate`.
 - Runtime: `Closure.CreateSelfDelegate(MethodBase, int paramCount)` to construct the correct `Func<object[], ... , object>` delegate shape for self-calls across arities.
 - Tests: generator and execution coverage for classic IIFE and recursive IIFE; new SymbolTable tests for IIFE scopes (anonymous and named) and internal self-binding visibility.
-
 Changed
 - Hoisting: ensure local function variables are initialized before top-level statement emission so functions can reference each other by variable name prior to IIFE invocation.
 - Scope naming: unified to `FunctionExpression_*` for function expressions; class .NET namespace unified under `Classes`.
-
 Fixed
 - IL generation: corrected call-site emission to preserve the callee delegate across null-initialization branches and maintain stack balance.
 - Named function expression recursion: eliminated NullReferenceException by eagerly binding the internal name on method entry.
 - Symbol table: removed duplicate child scope registration and added visited sets for function/arrow expressions to prevent duplicate scopes and nested type emission; TypeGenerator defensively skips duplicate nested types.
-
 
 ## v0.1.6 - 2025-09-23
 

--- a/Js2IL/Js2IL.csproj
+++ b/Js2IL/Js2IL.csproj
@@ -13,7 +13,7 @@
   <PackAsTool>true</PackAsTool>
   <ToolCommandName>js2il</ToolCommandName>
   <PackageId>js2il</PackageId>
-  <Version>0.1.6</Version>
+  <Version>0.1.7</Version>
   <Authors>tomacox74</Authors>
   <Company></Company>
   <Description>JavaScript to .NET IL prototype: parse ES into AST and emit ECMA-335 IL to run on .NET.</Description>


### PR DESCRIPTION
Release 0.1.7\n\nHighlights:\n- Self-binding for named function expressions enabling recursion\n- Runtime Closure.CreateSelfDelegate for correct arity delegates\n- Hoisting and scope naming improvements\n- IL emission stability fixes and duplicate scope/type safeguards\n\nBuild/Lint/Tests:\n- Build: PASS (Debug)\n- Tests: 391/391 passing previously; no code changes in this bump\n\nDocs:\n- CHANGELOG: finalized v0.1.7 section\n- Version bumped in Js2IL.csproj to 0.1.7