### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+_Nothing yet._
+
+## v0.2.0 - 2025-11-22
+
 Added
 - Functions: basic object parameter destructuring for function declarations, function expressions, and arrow functions. Supports shorthand properties (`{a,b}`) and simple aliasing (`{ a: x }`). Each destructured identifier is bound into the function's lexical scope prior to body execution.
 - Symbol/Table & IL Generation: parameter ObjectPattern binding and emission across all function kinds (declaration/expression/arrow) retrieving properties via `JavaScriptRuntime.Object.GetProperty` and storing into scope fields.
 - Docs: updated `ECMAScript2025_FeatureCoverage.json` and regenerated `ECMAScript2025_FeatureCoverage.md` to reflect support for object parameter destructuring.
-
 Changed
 - Docs: arrow function feature notes no longer list parameter destructuring as unsupported; new feature entry added under binding patterns.
 - Tests: adopted received generator snapshots for destructuring tests (Function/Arrow) to align verified output with current emitter formatting and reduce non-semantic churn.
-
 Fixed
 - Parameter destructuring: previously emitted undefined values due to missing binding/shorthand handling for `{a,b}` and alias patterns; now bindings populate scope fields correctly and execution snapshots log expected values.
 - Build: upgrade branch targets .NET 10 (net10.0) for early compatibility testing; CI workflow updated to use 10.0.x SDK. Master remains on net8.0 until upgrade validated.

--- a/Js2IL/Js2IL.csproj
+++ b/Js2IL/Js2IL.csproj
@@ -13,7 +13,7 @@
   <PackAsTool>true</PackAsTool>
   <ToolCommandName>js2il</ToolCommandName>
   <PackageId>js2il</PackageId>
-  <Version>0.1.7</Version>
+  <Version>0.2.0</Version>
   <Authors>tomacox74</Authors>
   <Company></Company>
   <Description>JavaScript to .NET IL prototype: parse ES into AST and emit ECMA-335 IL to run on .NET.</Description>


### PR DESCRIPTION
Cut js2il 0.2.0

- Version: 0.1.7 -> 0.2.0
- Includes .NET 10 upgrade and object parameter destructuring
- Tests passing on net10.0

After merging, please:
- Create an annotated tag:  git tag -a v0.2.0 -m 'Release 0.2.0'
- Push the tag:             git push origin v0.2.0

This will trigger the existing release workflow (.github/workflows/release.yml).