### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+_Nothing yet._
+
+## v0.3.0 - 2025-11-25
+
 ### Fixed
 - Classes: class methods and constructors can now access variables from all ancestor scopes (global, function, block), not just the global scope. The `DetermineParentScopesForClassMethod` now walks the scope tree to build the complete parent scope chain, enabling proper multi-level scope access for classes declared inside functions. Both `EmitMethod` and `EmitExplicitConstructor` use this mechanism to provide consistent scope access.
 - Classes: class methods now correctly access parent scope variables through `this._scopes` field instead of incorrectly casting `this` to array. Modified `BinaryOperators.LoadVariable` to check class method context and emit proper IL for scope field access.
 - IL Generation: conditional `_scopes` field generation for classes - only classes that reference parent scope variables now include the field and constructor parameter, avoiding unnecessary overhead for simple classes.
 - Code quality: fixed indentation in `BinaryOperators.cs` to conform to C# coding guidelines (4-space indentation).
-
 ### Changed
 - Architecture: refactored free variable analysis from `ClassesGenerator` into `SymbolTable` infrastructure for better separation of concerns. Analysis now happens once during symbol table construction with results cached in `Scope.ReferencesParentScopeVariables` property.
 - Symbol Table: added `ReferencesParentScopeVariables` property to `Scope` class to track whether a scope references variables from parent scopes.

--- a/Js2IL/Js2IL.csproj
+++ b/Js2IL/Js2IL.csproj
@@ -13,7 +13,7 @@
   <PackAsTool>true</PackAsTool>
   <ToolCommandName>js2il</ToolCommandName>
   <PackageId>js2il</PackageId>
-  <Version>0.2.0</Version>
+  <Version>0.3.0</Version>
   <Authors>tomacox74</Authors>
   <Company></Company>
   <Description>JavaScript to .NET IL prototype: parse ES into AST and emit ECMA-335 IL to run on .NET.</Description>


### PR DESCRIPTION
## Release v0.3.0

This PR merges the v0.3.0 release back to master.

### Changes

- Bumped version from 0.2.0 to 0.3.0
- Updated CHANGELOG.md with release notes
- Tagged as v0.3.0

### Changelog

See CHANGELOG.md for full details of changes included in this release.