### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+## v0.3.3 - 2025-11-28
+
 ### Added
 - Compound Assignment Operators: implemented all 11 compound assignment operators with proper type conversions:
   - Bitwise operators: `|=`, `&=`, `^=`, `<<=`, `>>=`, `>>>=` (convert to int32, apply operation, convert back to double)
@@ -13,12 +15,16 @@ All notable changes to this project are documented here.
   - Comprehensive test coverage with 11 test cases verifying execution results and IL generation
 - Tests: added `CompoundAssignment` test group with JavaScript test files and snapshot verification for all compound operators
 - Tests: added `BinaryOperator_LeftShiftBit31` test to verify left shift of bit 31 produces correct signed result
+- Runtime: added `Object.CoerceToInt32` public static method for safe type conversion following JavaScript semantics (handles null, numeric types, strings, booleans)
 
 ### Fixed
 - Int32Array: fixed `InvalidCastException` when calling Int32Array methods via reflection by changing indexer signature from `int this[int]` to `object this[object]`. Indexer now returns boxed double values to match JavaScript number semantics.
 - IL Generation: added `CoerceToJsNumber` helper in `Object.CallInstanceMethod` to convert all primitive numeric CLR types (int, float, long, short, byte, etc.) to double before reflection invoke, ensuring type compatibility.
 - IL Generation: updated Int32Array fast path to pass boxed values to get_Item/set_Item methods instead of unboxing parameters.
+- IL Generation: null values now coerce to 0.0 in numeric contexts instead of passing through as null, matching JavaScript semantics.
 - Compound Assignments: added support for compound bitwise operations (`|=`, `&=`, `^=`, `<<=`, `>>=`, `>>>=`) on dynamically-accessed array elements (e.g., `this.array[i] |= value`). Operations now correctly: 1) get current value, 2) apply operation, 3) store result, instead of replacing the value.
+- IL Generation: dynamic fallback path now uses `CoerceToInt32` instead of unsafe `Unbox_any` cast, preventing `InvalidCastException` for non-numeric objects.
+- IL Generation: extracted duplicate compound operator mapping into `GetCompoundBitwiseOpCode` helper method to eliminate code duplication.
 - Equality comparisons: fixed boxing issues in equality operators by introducing explicit `IsBoxed` property to `ExpressionResult`. Replaced brittle AST-based heuristics with explicit boxing state tracking. Fixes:
   - Method return value comparisons (e.g., `methodResult == 4` and `4 == methodResult` now both work)
   - Boolean literal over-unboxing (raw boolean values no longer incorrectly unboxed)

--- a/Js2IL/Js2IL.csproj
+++ b/Js2IL/Js2IL.csproj
@@ -13,7 +13,7 @@
   <PackAsTool>true</PackAsTool>
   <ToolCommandName>js2il</ToolCommandName>
   <PackageId>js2il</PackageId>
-  <Version>0.3.2</Version>
+  <Version>0.3.3</Version>
   <Authors>tomacox74</Authors>
   <Company></Company>
   <Description>JavaScript to .NET IL prototype: parse ES into AST and emit ECMA-335 IL to run on .NET.</Description>


### PR DESCRIPTION
## Release v0.3.3

### Summary
This release includes Int32Array boxing fixes, compound assignment operators, and type safety improvements from PR #96 and related work.

### Key Changes

**Int32Array Fixes:**
- Fixed InvalidCastException when calling Int32Array methods via reflection
- Changed indexer signature from int this[int] to object this[object]
- Returns boxed double values to match JavaScript number semantics

**Compound Assignment Operators:**
- Implemented all 11 compound assignment operators (|=, &=, ^=, <<=, >>=, >>>=, -=, *=, /=, %=, **=)
- Added support for compound bitwise operations on dynamically-accessed array elements
- Comprehensive test coverage with 11 test cases

**Type Safety & Code Quality:**
- Added Object.CoerceToInt32 for safe type conversion following JavaScript semantics
- Added CoerceToJsNumber helper to convert primitive numeric CLR types to double
- Fixed null handling to coerce to 0.0 in numeric contexts (JavaScript semantics)
- Extracted duplicate operator mapping into helper method

**Other Improvements:**
- Fixed equality comparison boxing issues with explicit IsBoxed tracking
- Aligned console.log array formatting with Node.js output
- Updated test snapshots for new signatures

### Version
- Updated package version from 0.3.2 to 0.3.3
- Updated CHANGELOG.md with all changes