### PR TITLE
docs: update release process to use gh release create

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,7 +80,7 @@ js2il input.js output                           # Installed tool
  - create a release branch off of master.  The branch name should be release/0.x.y where x.y is the new version number.
 ```powershell
 npm run release:patch  # Bump version, update CHANGELOG
-git add CHANGELOG.md Js2IL/Js2IL.csproj
+git add CHANGELOG.md Js2IL/Js2IL.csproj JavaScriptRuntime/JavaScriptRuntime.csproj
 git commit -m "chore(release): cut v0.x.y"
 ```
  - create a pr back to master using the github cli

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ What it does:
 2. Extracts the `## Unreleased` section from `CHANGELOG.md`.
 3. Creates a new section: `## vNEW_VERSION - YYYY-MM-DD` populated with that content (skipping the placeholder `_Nothing yet._`).
 4. Resets the `## Unreleased` section body to the placeholder.
-5. Updates the `<Version>` element in the csproj.
+5. Updates the `<Version>` element in both `Js2IL.csproj` and `JavaScriptRuntime.csproj` (adds if not present).
 6. Prints next git commands (add/commit/tag/push).
 
 Empty Unreleased:
@@ -147,7 +147,7 @@ git checkout -b release/<new-version>
 npm run release:patch
 
 # Review changes
-git add CHANGELOG.md Js2IL/Js2IL.csproj
+git add CHANGELOG.md Js2IL/Js2IL.csproj JavaScriptRuntime/JavaScriptRuntime.csproj
 git commit -m "chore(release): cut <new-version>"
 
 # Create PR back to master


### PR DESCRIPTION
Updates the release process documentation in .github/copilot-instructions.md to correctly reflect the workflow using gh release create instead of manually creating git tags.

## Changes
- Removed manual git tag and git push --tags steps
- Added step to checkout master and pull after PR merge
- Added correct gh release create command with example
- Clarified that GitHub Actions triggers on release creation, not tag push

This reflects the actual working process we used for v0.3.4.