### PR TITLE
feat: optimize this.method() calls to use direct callvirt

### DIFF
--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
@@ -161,24 +161,21 @@
 	{
 		// Method begins at RVA 0x20a4
 		// Header size: 12
-		// Code size: 29 (0x1d)
+		// Code size: 18 (0x12)
 		.maxstack 32
 
 		IL_0000: ldarg.0
-		IL_0001: ldstr "prefix"
-		IL_0006: ldc.i4.0
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_0011: ldarg.0
-		IL_0012: ldfld object Classes.Greeter::name
-		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_001c: ret
+		IL_0001: callvirt instance object Classes.Greeter::prefix()
+		IL_0006: ldarg.0
+		IL_0007: ldfld object Classes.Greeter::name
+		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0011: ret
 	} // end of method Greeter::hello
 
 	.method public hidebysig 
 		instance object prefix () cil managed 
 	{
-		// Method begins at RVA 0x20d0
+		// Method begins at RVA 0x20c4
 		// Header size: 12
 		// Code size: 6 (0x6)
 		.maxstack 32
@@ -190,9 +187,9 @@
 	.method public hidebysig 
 		instance object logHello () cil managed 
 	{
-		// Method begins at RVA 0x20e4
+		// Method begins at RVA 0x20d8
 		// Header size: 12
-		// Code size: 34 (0x22)
+		// Code size: 23 (0x17)
 		.maxstack 32
 
 		IL_0000: ldc.i4.1
@@ -200,15 +197,12 @@
 		IL_0006: dup
 		IL_0007: ldc.i4.0
 		IL_0008: ldarg.0
-		IL_0009: ldstr "hello"
-		IL_000e: ldc.i4.0
-		IL_000f: newarr [System.Runtime]System.Object
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_0019: stelem.ref
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
-		IL_001f: pop
-		IL_0020: ldarg.0
-		IL_0021: ret
+		IL_0009: callvirt instance object Classes.Greeter::hello()
+		IL_000e: stelem.ref
+		IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Console::Log(object[])
+		IL_0014: pop
+		IL_0015: ldarg.0
+		IL_0016: ret
 	} // end of method Greeter::logHello
 
 } // end of class Classes.Greeter
@@ -220,7 +214,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2114
+		// Method begins at RVA 0x20fc
 		// Header size: 12
 		// Code size: 40 (0x28)
 		.maxstack 32
@@ -251,7 +245,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2148
+		// Method begins at RVA 0x2130
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
@@ -210,7 +210,7 @@
 	{
 		// Method begins at RVA 0x20cc
 		// Header size: 12
-		// Code size: 129 (0x81)
+		// Code size: 115 (0x73)
 		.maxstack 32
 		.locals init (
 			[0] class Scopes.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/addRange
@@ -231,39 +231,33 @@
 			IL_002b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0030: ble IL_003a
 
-			IL_0035: br IL_007f
+			IL_0035: br IL_0071
 
 			IL_003a: ldarg.0
-			IL_003b: ldstr "add"
-			IL_0040: ldc.i4.1
-			IL_0041: newarr [System.Runtime]System.Object
-			IL_0046: dup
-			IL_0047: ldc.i4.0
-			IL_0048: ldloc.0
-			IL_0049: castclass Scopes.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/addRange
+			IL_003b: ldloc.0
+			IL_003c: castclass Scopes.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/addRange
+			IL_0041: ldfld object Scopes.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/addRange::i
+			IL_0046: callvirt instance object Classes.Accumulator::'add'(object)
+			IL_004b: pop
+			IL_004c: ldloc.0
+			IL_004d: ldloc.0
 			IL_004e: ldfld object Scopes.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/addRange::i
-			IL_0053: stelem.ref
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0059: pop
-			IL_005a: ldloc.0
-			IL_005b: ldloc.0
-			IL_005c: ldfld object Scopes.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/addRange::i
-			IL_0061: unbox.any [System.Runtime]System.Double
-			IL_0066: ldc.r8 1
-			IL_006f: add
-			IL_0070: box [System.Runtime]System.Double
-			IL_0075: stfld object Scopes.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/addRange::i
-			IL_007a: br IL_001a
+			IL_0053: unbox.any [System.Runtime]System.Double
+			IL_0058: ldc.r8 1
+			IL_0061: add
+			IL_0062: box [System.Runtime]System.Double
+			IL_0067: stfld object Scopes.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/addRange::i
+			IL_006c: br IL_001a
 		// end loop
 
-		IL_007f: ldarg.0
-		IL_0080: ret
+		IL_0071: ldarg.0
+		IL_0072: ret
 	} // end of method Accumulator::addRange
 
 	.method public hidebysig 
 		instance object log () cil managed 
 	{
-		// Method begins at RVA 0x215c
+		// Method begins at RVA 0x214c
 		// Header size: 12
 		// Code size: 23 (0x17)
 		.maxstack 32
@@ -290,7 +284,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2180
+		// Method begins at RVA 0x2170
 		// Header size: 12
 		// Code size: 90 (0x5a)
 		.maxstack 32
@@ -335,7 +329,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e6
+		// Method begins at RVA 0x21d6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/performance/MethodCallPerformance.js
+++ b/tests/performance/MethodCallPerformance.js
@@ -1,0 +1,24 @@
+// Performance test: Class method calling another method repeatedly
+class Counter {
+    constructor() {
+        this.value = 0;
+    }
+
+    increment() {
+        this.value = this.value + 1;
+    }
+
+    runTest(iterations) {
+        for (let i = 0; i < iterations; i++) {
+            this.increment();
+        }
+    }
+}
+
+const startTime = Date.now();
+const counter = new Counter();
+counter.runTest(100000000); // 100 million iterations
+const endTime = Date.now();
+
+console.log(`Completed ${counter.value} iterations`);
+console.log(`Time: ${endTime - startTime}ms`);


### PR DESCRIPTION
## Summary
Optimizes `this.method()` calls within class instance methods to use direct `callvirt` instructions instead of reflection-based `Object.CallMember` dispatch.

## Changes
- **ILExpressionGenerator.cs**: Added special case handling for `ThisExpression` member calls in class methods
- **ClassesGenerator.cs**: Moved class registration to occur **before** method body emission (ensures class is in registry when method bodies reference it)
- Updated 2 generator test snapshots to reflect IL changes

## Performance Impact
Dramatic improvement for method call-intensive workloads:

**Benchmark: 100M method calls**
- Baseline (CallMember): ~39 seconds
- Optimized (callvirt): ~5.4 seconds
- **Result: ~7-8x faster** 🚀

## IL Comparison

**Before (Baseline)**:
```il
IL_003a: ldarg.0
IL_003b: ldstr "increment"              // Load method name string
IL_0040: ldc.i4.0                        
IL_0041: newarr [System.Runtime]System.Object  // Allocate args array
IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
```

**After (Optimized)**:
```il
IL_003a: ldarg.0
IL_003b: callvirt instance object Classes.Counter::increment()
```

## Eliminates
- String allocation for method name
- Array allocation for arguments  
- Reflection-based method lookup
- Boxing/unboxing overhead

## Testing
- All 466 tests passing
- Added performance test: `tests/performance/MethodCallPerformance.js`
