### PR TITLE
docs: Add installation instructions to Try it section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ dotnet .\out\simple.dll
 
 ### Try it
 
+First, install js2il as a global tool:
+
+```powershell
+dotnet tool install -g js2il
+```
+
 Use the sample script at `tests/simple.js`:
 
 ```javascript


### PR DESCRIPTION
Adds dotnet tool install -g js2il command to the Try it section so first-time users know how to install js2il before trying it.