### PR TITLE
chore: add tests/performance/output/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ issue-*-body.md
 
 # Generated performance build artifacts (do not commit compiled outputs)
 tests/performance/out/
+tests/performance/output/
 scripts/out/
 out/
 


### PR DESCRIPTION
Add the performance test output directory to .gitignore to prevent build artifacts from being committed.