### PR TITLE
fix(ir): emit LIRConvertToObject inline when source is constant

### DIFF
--- a/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualMethodReturn.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualMethodReturn.verified.txt
@@ -89,17 +89,12 @@
 	{
 		// Method begins at RVA 0x2080
 		// Header size: 12
-		// Code size: 17 (0x11)
+		// Code size: 15 (0xf)
 		.maxstack 32
-		.locals init (
-			[0] object
-		)
 
 		IL_0000: ldc.r8 4
 		IL_0009: box [System.Runtime]System.Double
-		IL_000e: stloc.0
-		IL_000f: ldloc.0
-		IL_0010: ret
+		IL_000e: ret
 	} // end of method TestClass::getValue
 
 } // end of class Classes.BinaryOperator_EqualMethodReturn.TestClass
@@ -117,7 +112,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20a0
+		// Method begins at RVA 0x209c
 		// Header size: 12
 		// Code size: 165 (0xa5)
 		.maxstack 32
@@ -201,7 +196,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2151
+		// Method begins at RVA 0x214d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_NoInstantiation.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_NoInstantiation.verified.txt
@@ -89,17 +89,12 @@
 	{
 		// Method begins at RVA 0x2080
 		// Header size: 12
-		// Code size: 17 (0x11)
+		// Code size: 15 (0xf)
 		.maxstack 32
-		.locals init (
-			[0] object
-		)
 
 		IL_0000: ldc.r8 42
 		IL_0009: box [System.Runtime]System.Double
-		IL_000e: stloc.0
-		IL_000f: ldloc.0
-		IL_0010: ret
+		IL_000e: ret
 	} // end of method Greeter::hello
 
 } // end of class Classes.Classes_ClassWithMethod_NoInstantiation.Greeter
@@ -117,7 +112,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20a0
+		// Method begins at RVA 0x209c
 		// Header size: 12
 		// Code size: 1 (0x1)
 		.maxstack 32
@@ -137,7 +132,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20ad
+		// Method begins at RVA 0x20a9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -59,11 +59,8 @@
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 42 (0x2a)
+		// Code size: 40 (0x28)
 		.maxstack 32
-		.locals init (
-			[0] object
-		)
 
 		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0005: ldc.i4.1
@@ -76,9 +73,7 @@
 		IL_0018: pop
 		IL_0019: ldc.r8 5
 		IL_0022: box [System.Runtime]System.Double
-		IL_0027: stloc.0
-		IL_0028: ldloc.0
-		IL_0029: ret
+		IL_0027: ret
 	} // end of method Function_ReturnsStaticValueAndLogs::returnsFive
 
 } // end of class Functions.Function_ReturnsStaticValueAndLogs
@@ -96,7 +91,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x209c
+		// Method begins at RVA 0x2098
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 32
@@ -143,7 +138,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e4
+		// Method begins at RVA 0x20e0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL/JsMethodCompiler.cs
+++ b/Js2IL/JsMethodCompiler.cs
@@ -893,6 +893,23 @@ internal sealed class JsMethodCompiler
             case LIRConstNull:
                 ilEncoder.LoadConstantI4((int)JavaScriptRuntime.JsNull.Null);
                 break;
+            case LIRConvertToObject convertToObject:
+                // Emit the source inline and box it
+                EmitLoadTemp(convertToObject.Source, ilEncoder, allocation, methodBody);
+                ilEncoder.OpCode(ILOpCode.Box);
+                if (convertToObject.SourceType == typeof(bool))
+                {
+                    ilEncoder.Token(_bclReferences.BooleanType);
+                }
+                else if (convertToObject.SourceType == typeof(JavaScriptRuntime.JsNull))
+                {
+                    ilEncoder.Token(_typeReferenceRegistry.GetOrAdd(typeof(JavaScriptRuntime.JsNull)));
+                }
+                else
+                {
+                    ilEncoder.Token(_bclReferences.DoubleType);
+                }
+                break;
             default:
                 throw new InvalidOperationException($"Cannot emit unmaterialized temp {temp.Index} - unsupported instruction {def.GetType().Name}");
         }


### PR DESCRIPTION
### Summary
Fix a regression where `return <constant>` statements were allocating unnecessary local variables.

### Problem
After merging PR #201 (return statement support), `return 5` was generating:
```il
stloc.0    // Store boxed 5 to local
ldloc.0    // Load from local
ret        // Return
```

### Solution
Extended inline emission to handle `LIRConvertToObject` when its source is an inline constant. Now generates:
```il
ldc.r8 5           // Load constant
box [Double]       // Box inline
ret                // Return directly
```

### Changes
- `TempLocalAllocator.CanEmitInline`: Now checks if `LIRConvertToObject` source is inlineable
- `JsMethodCompiler.EmitLoadTemp`: Added inline emission for `LIRConvertToObject`
- Updated 3 generator test snapshots

### Testing
All 757 tests pass.
