### PR TITLE
fix: resolve nullable reference warnings in JavaScriptRuntime project

### DIFF
--- a/JavaScriptRuntime/Array.cs
+++ b/JavaScriptRuntime/Array.cs
@@ -159,7 +159,7 @@ namespace JavaScriptRuntime
                     return d < 0d ? -1 : 1;
                 }
 
-                this.Sort((a, b) => CompareUsingCallback(a, b));
+                this.Sort((a, b) => CompareUsingCallback(a!, b!));
                 return this;
             }
 

--- a/JavaScriptRuntime/CommonJS/Require.cs
+++ b/JavaScriptRuntime/CommonJS/Require.cs
@@ -11,7 +11,7 @@ namespace JavaScriptRuntime.CommonJS
         private readonly Dictionary<string, Module> _modules = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _notFound = new(StringComparer.OrdinalIgnoreCase);
 
-        private readonly Assembly _localModulesAssembly;
+        private readonly Assembly? _localModulesAssembly;
         
         // Track the current parent module for establishing parent-child relationships
         private Module? _currentParentModule;
@@ -19,7 +19,7 @@ namespace JavaScriptRuntime.CommonJS
         public Require(LocalModulesAssembly localModulesAssembly)
         {
             // Preload local modules from the provided assembly
-            this._localModulesAssembly = localModulesAssembly.ModulesAssembly;
+            _localModulesAssembly = localModulesAssembly.ModulesAssembly;
         }
 
         /// <summary>
@@ -87,6 +87,9 @@ namespace JavaScriptRuntime.CommonJS
         /// </summary>
         private object? RequireLocalModule(string key)
         {
+            if (_localModulesAssembly == null)
+                throw new ReferenceError($"Cannot require local module '{key}': no local modules assembly provided");
+            
             var moduleId = ModuleName.GetModuleIdFromSpecifier(key);
             var TypeName = $"Scripts.{moduleId}";
             var localType = _localModulesAssembly.GetType(TypeName);
@@ -157,7 +160,7 @@ namespace JavaScriptRuntime.CommonJS
 
             // Return module.exports (which may have been reassigned during execution)
             // Update cache with final exports value
-            _instances[key] = module.exports;
+            _instances[key] = module.exports!;
             return module.exports;
         }
 

--- a/JavaScriptRuntime/GlobalThis.cs
+++ b/JavaScriptRuntime/GlobalThis.cs
@@ -72,7 +72,7 @@ namespace JavaScriptRuntime
             return GetTimers().setTimeout(callback, delay, args);
         }
 
-        public static object clearTimeout(object handle)
+        public static object? clearTimeout(object handle)
         {
             return GetTimers().clearTimeout(handle);
         }
@@ -87,12 +87,12 @@ namespace JavaScriptRuntime
             return GetTimers().setInterval(callback, delay, args);
         }
 
-        public static object clearImmediate(object handle)
+        public static object? clearImmediate(object handle)
         {
             return GetTimers().clearImmediate(handle);
         }
 
-        public static object clearInterval(object handle)
+        public static object? clearInterval(object handle)
         {
             return GetTimers().clearInterval(handle);
         }

--- a/JavaScriptRuntime/Int32Array.cs
+++ b/JavaScriptRuntime/Int32Array.cs
@@ -41,7 +41,7 @@ namespace JavaScriptRuntime
             {
                 int len = jsArray.Count;
                 var buf = new int[len];
-                for (int i = 0; i < len; i++) buf[i] = ToInt32(jsArray[i]);
+                for (int i = 0; i < len; i++) buf[i] = ToInt32(jsArray[i]!);
                 _buffer = buf;
                 return;
             }
@@ -120,7 +120,7 @@ namespace JavaScriptRuntime
             {
                 for (int i = 0; i < jsArray.Count && (offset + i) < _buffer.Length; i++)
                 {
-                    _buffer[offset + i] = ToInt32(jsArray[i]);
+                    _buffer[offset + i] = ToInt32(jsArray[i]!);
                 }
                 return null!;
             }

--- a/JavaScriptRuntime/JavaScriptRuntime.csproj
+++ b/JavaScriptRuntime/JavaScriptRuntime.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/JavaScriptRuntime/LocalModulesAssembly.cs
+++ b/JavaScriptRuntime/LocalModulesAssembly.cs
@@ -2,5 +2,5 @@ using System.Reflection;
 
 class LocalModulesAssembly
 {
-    public Assembly ModulesAssembly { get; set; }
+    public Assembly? ModulesAssembly { get; set; }
 }

--- a/JavaScriptRuntime/Object.cs
+++ b/JavaScriptRuntime/Object.cs
@@ -181,7 +181,7 @@ namespace JavaScriptRuntime
                 {
                     return null!; // undefined
                 }
-                return array[intIndex];
+                return array[intIndex]!;
             }
             else if (obj is Int32Array i32)
             {

--- a/JavaScriptRuntime/Timers.cs
+++ b/JavaScriptRuntime/Timers.cs
@@ -42,7 +42,7 @@ internal class Timers
         return handle;
     }
 
-    public object clearTimeout(object handle)
+    public object? clearTimeout(object handle)
     {
         if (handle != null)
         {
@@ -81,7 +81,7 @@ internal class Timers
         return handle;
     }
 
-    public object clearInterval(object handle)
+    public object? clearInterval(object handle)
     {
         if (handle != null)
         {
@@ -114,7 +114,7 @@ internal class Timers
         return handle;
     }
 
-    public object clearImmediate(object handle)
+    public object? clearImmediate(object handle)
     {
         if (handle != null)
         {


### PR DESCRIPTION
## Summary
Fixes all 10 nullable reference warnings in the JavaScriptRuntime project and enables TreatWarningsAsErrors to prevent regressions.

## Changes

### Warning Fixes
- **LocalModulesAssembly.cs**: Make \ModulesAssembly\ property nullable (\Assembly?\)
- **Require.cs**: Make \_localModulesAssembly\ field nullable with explicit null check
- **Array.cs**: Add null-forgiving operator in Sort callback
- **Timers.cs**: Change \clearTimeout\, \clearInterval\, \clearImmediate\ to return \object?\
- **GlobalThis.cs**: Update wrapper methods to match Timers return types
- **Int32Array.cs**: Add null-forgiving operators for array element access
- **Object.cs**: Add null-forgiving operator for array indexer return

### Build Configuration
- **JavaScriptRuntime.csproj**: Added \<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\ to prevent future warning regressions

## Result
- **Before**: 10 warnings
- **After**: 0 warnings (and warnings now fail the build)