### PR TITLE
Remove obsolete LIR instructions

### DIFF
--- a/Js2IL/IL/LIRToILCompiler.cs
+++ b/Js2IL/IL/LIRToILCompiler.cs
@@ -291,9 +291,6 @@ internal sealed class LIRToILCompiler
                 EmitOperatorsMultiply(ilEncoder);
                 EmitStoreTemp(mulDynamic.Result, ilEncoder, allocation);
                 break;
-            case LIRBeginInitArrayElement:
-                // Pure SSA LIR lowering does not rely on stack tricks; this is a no-op hint.
-                break;
             case LIRConstNumber constNumber:
                 if (!IsMaterialized(constNumber.Result, allocation))
                 {
@@ -500,16 +497,6 @@ internal sealed class LIRToILCompiler
                 ilEncoder.OpCode(ILOpCode.Ceq);
                 EmitStoreTemp(cmpBoolNe.Result, ilEncoder, allocation);
                 break;
-            case LIRNewObjectArray newObjectArray:
-                if (!IsMaterialized(newObjectArray.Result, allocation))
-                {
-                    break;
-                }
-                ilEncoder.LoadConstantI4(newObjectArray.ElementCount);
-                ilEncoder.OpCode(ILOpCode.Newarr);
-                ilEncoder.Token(_bclReferences.ObjectType);
-                EmitStoreTemp(newObjectArray.Result, ilEncoder, allocation);
-                break;
             case LIRBuildArray buildArray:
                 {
                     if (!IsMaterialized(buildArray.Result, allocation))
@@ -539,15 +526,6 @@ internal sealed class LIRToILCompiler
                 EmitLoadTemp(lirReturn.ReturnValue, ilEncoder, allocation, methodDescriptor);
                 ilEncoder.OpCode(ILOpCode.Ret);
                 break;
-            case LIRStoreElementRef:
-                {
-                    var store = (LIRStoreElementRef)instruction;
-                    EmitLoadTemp(store.Array, ilEncoder, allocation, methodDescriptor);
-                    ilEncoder.LoadConstantI4(store.Index);
-                    EmitLoadTemp(store.Value, ilEncoder, allocation, methodDescriptor);
-                    ilEncoder.OpCode(ILOpCode.Stelem_ref);
-                    break;
-                }
             case LIRCreateScopesArray createScopes:
                 {
                     if (!IsMaterialized(createScopes.Result, allocation))

--- a/Js2IL/IL/Stackify.cs
+++ b/Js2IL/IL/Stackify.cs
@@ -353,7 +353,6 @@ internal static class Stackify
             case LIRConstUndefined:
             case LIRConstNull:
             case LIRGetIntrinsicGlobal:
-            case LIRNewObjectArray:
             case LIRLoadParameter:
             case LIRCreateScopesArray:
                 return (0, 1);
@@ -404,10 +403,6 @@ internal static class Stackify
             case LIRCallFunction call:
                 return (1 + call.Arguments.Count, 1);
 
-            // StoreElementRef: consumes array + value, produces nothing
-            case LIRStoreElementRef:
-                return (2, 0);
-
             // Return: consumes return value
             case LIRReturn:
                 return (1, 0);
@@ -417,7 +412,6 @@ internal static class Stackify
                 return (1, 0);
 
             // Hints and control flow have no stack effect at LIR level
-            case LIRBeginInitArrayElement:
             case LIRLabel:
             case LIRBranch:
                 return (0, 0);

--- a/Js2IL/IL/TempLocalAllocator.cs
+++ b/Js2IL/IL/TempLocalAllocator.cs
@@ -214,9 +214,6 @@ internal static class TempLocalAllocator
                 yield return mulDyn.Left;
                 yield return mulDyn.Right;
                 break;
-            case LIRBeginInitArrayElement begin:
-                yield return begin.Array;
-                break;
             case LIRCallIntrinsic call:
                 yield return call.IntrinsicObject;
                 yield return call.ArgumentsArray;
@@ -264,10 +261,6 @@ internal static class TempLocalAllocator
             case LIRCompareBooleanNotEqual cmp:
                 yield return cmp.Left;
                 yield return cmp.Right;
-                break;
-            case LIRStoreElementRef store:
-                yield return store.Array;
-                yield return store.Value;
                 break;
             case LIRReturn ret:
                 yield return ret.ReturnValue;
@@ -336,9 +329,6 @@ internal static class TempLocalAllocator
                 return true;
             case LIRGetIntrinsicGlobal g:
                 defined = g.Result;
-                return true;
-            case LIRNewObjectArray n:
-                defined = n.Result;
                 return true;
             case LIRAddNumber add:
                 defined = add.Result;

--- a/Js2IL/IR/LIR/LIRInstructions.cs
+++ b/Js2IL/IR/LIR/LIRInstructions.cs
@@ -50,8 +50,6 @@ public record LIRConstNull(TempVariable Result) : LIRInstruction;
 
 public record LIRGetIntrinsicGlobal(string Name, TempVariable Result) : LIRInstruction;
 
-public record LIRNewObjectArray(int ElementCount, TempVariable Result) : LIRInstruction;
-
 /// <summary>
 /// Creates and initializes an object array with the given elements in a single operation.
 /// All element temps must be computed before this instruction executes.
@@ -59,13 +57,6 @@ public record LIRNewObjectArray(int ElementCount, TempVariable Result) : LIRInst
 /// newarr Object, [dup, ldc.i4 index, ldtemp, stelem.ref]*, leaving array on stack.
 /// </summary>
 public record LIRBuildArray(IReadOnlyList<TempVariable> Elements, TempVariable Result) : LIRInstruction;
-
-/// <summary>
-/// Begins initialization of an array element (for multi-step initialization).  This is a hint.
-/// </summary>
-public record LIRBeginInitArrayElement(TempVariable Array, int Index) : LIRInstruction;
-
-public record LIRStoreElementRef(TempVariable Array, int Index, TempVariable Value) : LIRInstruction;
 
 public record LIRCallIntrinsic(TempVariable IntrinsicObject, string Name, TempVariable ArgumentsArray, TempVariable Result) : LIRInstruction;
 


### PR DESCRIPTION
## Summary

Remove obsolete LIR instructions that became dead code after the introduction of `LIRBuildArray`.

Closes #227

## Background

`LIRBuildArray` bundles array creation and initialization into a single efficient operation using the `dup` pattern:
```
newarr Object, [dup, ldc.i4 index, ldtemp, stelem.ref]*, leaving array on stack
```

This made the old 3-instruction sequence obsolete:
- `LIRNewObjectArray` - create array
- `LIRBeginInitArrayElement` - hint for multi-step init  
- `LIRStoreElementRef` - store each element

## Changes

### Removed from LIRInstructions.cs
- `LIRNewObjectArray` record definition
- `LIRBeginInitArrayElement` record definition
- `LIRStoreElementRef` record definition

### Removed from LIRToILCompiler.cs
- `case LIRNewObjectArray` handler
- `case LIRBeginInitArrayElement` handler (was no-op)
- `case LIRStoreElementRef` handler

### Removed from Stackify.cs
- `LIRNewObjectArray` from GetStackEffect
- `LIRBeginInitArrayElement` from GetStackEffect  
- `LIRStoreElementRef` from GetStackEffect

### Removed from TempLocalAllocator.cs
- `LIRBeginInitArrayElement` from EnumerateUsedTemps
- `LIRStoreElementRef` from EnumerateUsedTemps
- `LIRNewObjectArray` from TryGetDefinedTemp

## Impact

- **-47 lines** of dead code removed
- All 816 tests pass
- Simpler LIR instruction set
- No code generation changes (these instructions were already not being generated)
