### PR TITLE
docs: refresh two-phase pipeline milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ x is  3
 ## Status and scope
 - Experimental.
 - Not all JavaScript features are supported; `eval` is not supported.
+- Two-phase compilation pipeline work is available behind `CompilerOptions.TwoPhaseCompilation` (experimental). See `docs/TwoPhaseCompilationPipeline.md`.
 - See [JavaScript Feature Coverage](docs/ECMAScript2025_FeatureCoverage.md) for a comprehensive breakdown of supported JavaScript language features organized by specification section.
 - See [Node.js Feature Coverage](docs/NodeSupport.md) for details on supported Node.js modules, APIs, and globals.
 
@@ -86,6 +87,8 @@ Errors and exit codes
 ## Roadmap
 - Phase 1: Implement sufficient JavaScript semantics to compile most libraries without optimizations (excluding `eval`).
 - Phase 2: Apply static and runtime optimizations (e.g., unboxed integers, selective closure fields, direct call paths, shape-based optimizations) to approach or exceed typical Node.js performance.
+
+Note: the Roadmap “Phase 1/Phase 2” is a product maturity plan and is separate from the compiler’s “two-phase compilation pipeline” terminology.
 
 .NET provides a rich type system, cross-platform support, and an out-of-the-box GC implementation that has benefited from many years of optimizations.
 


### PR DESCRIPTION
## Summary
Updates documentation to match the current TwoPhaseCompilation implementation:

- Marks Milestone 1 as completed (Option B: Phase 1 declares tokens for anonymous callables and enables strict lookup-only emission)
- Moves remaining/unfinished items into Milestone 2 and sequences Milestone 2 work as 2a/2b/2c
- Removes the per-file breakdown section to keep the doc focused on milestones and invariants
- Adds a README note linking to the two-phase pipeline doc and clarifying roadmap phases vs compiler phases

## Files
- docs/TwoPhaseCompilationPipeline.md
- README.md