### PR TITLE
feat: Enable two-phase compilation as default

### DIFF
--- a/Js2IL.Tests/Array/Snapshots/GeneratorTests.Array_Map_Basic.verified.txt
+++ b/Js2IL.Tests/Array/Snapshots/GeneratorTests.Array_Map_Basic.verified.txt
@@ -65,12 +65,12 @@
 
 } // end of class Scopes.Array_Map_Basic
 
-.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L2C22
+.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L2C23
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object FunctionExpression_L2C22 (
+		object FunctionExpression_L2C23 (
 			object[] scopes,
 			object x
 		) cil managed 
@@ -87,9 +87,9 @@
 
 		IL_000c: ldnull
 		IL_000d: ret
-	} // end of method FunctionExpression_L2C22::FunctionExpression_L2C22
+	} // end of method FunctionExpression_L2C23::FunctionExpression_L2C23
 
-} // end of class Functions.FunctionExpression_L2C22
+} // end of class Functions.FunctionExpression_L2C23
 
 .class public auto ansi beforefieldinit Scripts.Array_Map_Basic
 	extends [System.Runtime]System.Object
@@ -134,7 +134,7 @@
 		IL_0034: dup
 		IL_0035: ldc.i4.0
 		IL_0036: ldnull
-		IL_0037: ldftn object Functions.FunctionExpression_L2C22::FunctionExpression_L2C22(object[], object)
+		IL_0037: ldftn object Functions.FunctionExpression_L2C23::FunctionExpression_L2C23(object[], object)
 		IL_003d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0042: stelem.ref
 		IL_0043: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::map(object[])

--- a/Js2IL.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/Js2IL.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -152,118 +152,108 @@
 			IL_0021: ret
 		} // end of method outer_Nested::inner
 
+		.method public hidebysig static 
+			object outer (
+				object[] scopes,
+				object arr
+			) cil managed 
+		{
+			// Method begins at RVA 0x20b0
+			// Header size: 12
+			// Code size: 145 (0x91)
+			.maxstack 32
+			.locals init (
+				[0] class Scopes.Array_Map_NestedParam/outer
+			)
+
+			IL_0000: newobj instance void Scopes.Array_Map_NestedParam/outer::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldloc.0
+			IL_0007: ldarg.1
+			IL_0008: stfld object Scopes.Array_Map_NestedParam/outer::arr
+			IL_000d: ldloc.0
+			IL_000e: ldnull
+			IL_000f: ldftn object Functions.Array_Map_NestedParam/outer_Nested::inner(object[], object)
+			IL_0015: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+			IL_001a: stfld object Scopes.Array_Map_NestedParam/outer::inner
+			IL_001f: ldloc.0
+			IL_0020: castclass Scopes.Array_Map_NestedParam/outer
+			IL_0025: ldfld object Scopes.Array_Map_NestedParam/outer::inner
+			IL_002a: dup
+			IL_002b: brtrue.s IL_0050
+
+			IL_002d: pop
+			IL_002e: ldloc.0
+			IL_002f: ldnull
+			IL_0030: ldftn object Functions.Array_Map_NestedParam/outer_Nested::inner(object[], object)
+			IL_0036: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+			IL_003b: stfld object Scopes.Array_Map_NestedParam/outer::inner
+			IL_0040: ldloc.0
+			IL_0041: castclass Scopes.Array_Map_NestedParam/outer
+			IL_0046: ldfld object Scopes.Array_Map_NestedParam/outer::inner
+			IL_004b: br IL_0050
+
+			IL_0050: ldc.i4.2
+			IL_0051: newarr [System.Runtime]System.Object
+			IL_0056: dup
+			IL_0057: ldc.i4.0
+			IL_0058: ldarg.0
+			IL_0059: ldc.i4.0
+			IL_005a: ldelem.ref
+			IL_005b: castclass Scopes.Array_Map_NestedParam
+			IL_0060: stelem.ref
+			IL_0061: dup
+			IL_0062: ldc.i4.1
+			IL_0063: ldloc.0
+			IL_0064: stelem.ref
+			IL_0065: ldnull
+			IL_0066: ldftn object [Array_Map_NestedParam]Functions.ArrowFunction_L7C16::ArrowFunction_L7C16(object[], object)
+			IL_006c: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+			IL_0071: ldc.i4.2
+			IL_0072: newarr [System.Runtime]System.Object
+			IL_0077: dup
+			IL_0078: ldc.i4.0
+			IL_0079: ldarg.0
+			IL_007a: ldc.i4.0
+			IL_007b: ldelem.ref
+			IL_007c: castclass Scopes.Array_Map_NestedParam
+			IL_0081: stelem.ref
+			IL_0082: dup
+			IL_0083: ldc.i4.1
+			IL_0084: ldloc.0
+			IL_0085: stelem.ref
+			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+			IL_008b: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+			IL_0090: ret
+		} // end of method outer_Nested::outer
+
 	} // end of class outer_Nested
 
 
 } // end of class Functions.Array_Map_NestedParam
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L7C15
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L7C16
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L7C15 (
+		object ArrowFunction_L7C16 (
 			object[] scopes,
 			object x
 		) cil managed 
 	{
-		// Method begins at RVA 0x20b0
+		// Method begins at RVA 0x2150
 		// Header size: 12
-		// Code size: 35 (0x23)
+		// Code size: 12 (0xc)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Array_Map_NestedParam/outer/ArrowFunction_L7C15
-		)
 
-		IL_0000: newobj instance void Scopes.Array_Map_NestedParam/outer/ArrowFunction_L7C15::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Array_Map_NestedParam/outer/ArrowFunction_L7C15::x
-		IL_000d: ldloc.0
-		IL_000e: castclass Scopes.Array_Map_NestedParam/outer/ArrowFunction_L7C15
-		IL_0013: ldfld object Scopes.Array_Map_NestedParam/outer/ArrowFunction_L7C15::x
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_001d: box [System.Runtime]System.Double
-		IL_0022: ret
-	} // end of method ArrowFunction_L7C15::ArrowFunction_L7C15
+		IL_0000: ldarg.1
+		IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0006: box [System.Runtime]System.Double
+		IL_000b: ret
+	} // end of method ArrowFunction_L7C16::ArrowFunction_L7C16
 
-	.method public hidebysig static 
-		object outer (
-			object[] scopes,
-			object arr
-		) cil managed 
-	{
-		// Method begins at RVA 0x20e0
-		// Header size: 12
-		// Code size: 145 (0x91)
-		.maxstack 32
-		.locals init (
-			[0] class Scopes.Array_Map_NestedParam/outer
-		)
-
-		IL_0000: newobj instance void Scopes.Array_Map_NestedParam/outer::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Array_Map_NestedParam/outer::arr
-		IL_000d: ldloc.0
-		IL_000e: ldnull
-		IL_000f: ldftn object Functions.Array_Map_NestedParam/outer_Nested::inner(object[], object)
-		IL_0015: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
-		IL_001a: stfld object Scopes.Array_Map_NestedParam/outer::inner
-		IL_001f: ldloc.0
-		IL_0020: castclass Scopes.Array_Map_NestedParam/outer
-		IL_0025: ldfld object Scopes.Array_Map_NestedParam/outer::inner
-		IL_002a: dup
-		IL_002b: brtrue.s IL_0050
-
-		IL_002d: pop
-		IL_002e: ldloc.0
-		IL_002f: ldnull
-		IL_0030: ldftn object Functions.Array_Map_NestedParam/outer_Nested::inner(object[], object)
-		IL_0036: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
-		IL_003b: stfld object Scopes.Array_Map_NestedParam/outer::inner
-		IL_0040: ldloc.0
-		IL_0041: castclass Scopes.Array_Map_NestedParam/outer
-		IL_0046: ldfld object Scopes.Array_Map_NestedParam/outer::inner
-		IL_004b: br IL_0050
-
-		IL_0050: ldc.i4.2
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldarg.0
-		IL_0059: ldc.i4.0
-		IL_005a: ldelem.ref
-		IL_005b: castclass Scopes.Array_Map_NestedParam
-		IL_0060: stelem.ref
-		IL_0061: dup
-		IL_0062: ldc.i4.1
-		IL_0063: ldloc.0
-		IL_0064: stelem.ref
-		IL_0065: ldnull
-		IL_0066: ldftn object Functions.ArrowFunction_L7C15::ArrowFunction_L7C15(object[], object)
-		IL_006c: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
-		IL_0071: ldc.i4.2
-		IL_0072: newarr [System.Runtime]System.Object
-		IL_0077: dup
-		IL_0078: ldc.i4.0
-		IL_0079: ldarg.0
-		IL_007a: ldc.i4.0
-		IL_007b: ldelem.ref
-		IL_007c: castclass Scopes.Array_Map_NestedParam
-		IL_0081: stelem.ref
-		IL_0082: dup
-		IL_0083: ldc.i4.1
-		IL_0084: ldloc.0
-		IL_0085: stelem.ref
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_008b: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
-		IL_0090: ret
-	} // end of method ArrowFunction_L7C15::outer
-
-} // end of class Functions.ArrowFunction_L7C15
+} // end of class Functions.ArrowFunction_L7C16
 
 .class public auto ansi beforefieldinit Scripts.Array_Map_NestedParam
 	extends [System.Runtime]System.Object
@@ -278,7 +268,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2180
+		// Method begins at RVA 0x2168
 		// Header size: 12
 		// Code size: 149 (0x95)
 		.maxstack 32
@@ -303,7 +293,7 @@
 		IL_0022: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
 		IL_0027: stloc.2
 		IL_0028: ldnull
-		IL_0029: ldftn object Functions.ArrowFunction_L7C15::outer(object[], object)
+		IL_0029: ldftn object Functions.Array_Map_NestedParam/outer_Nested::outer(object[], object)
 		IL_002f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0034: ldc.i4.1
 		IL_0035: newarr [System.Runtime]System.Object
@@ -358,7 +348,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2221
+		// Method begins at RVA 0x2209
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Array/Snapshots/GeneratorTests.Array_Sort_WithComparatorArrow.verified.txt
+++ b/Js2IL.Tests/Array/Snapshots/GeneratorTests.Array_Sort_WithComparatorArrow.verified.txt
@@ -69,12 +69,12 @@
 
 } // end of class Scopes.Array_Sort_WithComparatorArrow
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C9
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C10
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C9 (
+		object ArrowFunction_L2C10 (
 			object[] scopes,
 			object a,
 			object b
@@ -82,31 +82,16 @@
 	{
 		// Method begins at RVA 0x206c
 		// Header size: 12
-		// Code size: 48 (0x30)
+		// Code size: 8 (0x8)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Array_Sort_WithComparatorArrow/ArrowFunction_L2C9
-		)
 
-		IL_0000: newobj instance void Scopes.Array_Sort_WithComparatorArrow/ArrowFunction_L2C9::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Array_Sort_WithComparatorArrow/ArrowFunction_L2C9::a
-		IL_000d: ldloc.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object Scopes.Array_Sort_WithComparatorArrow/ArrowFunction_L2C9::b
-		IL_0014: ldloc.0
-		IL_0015: castclass Scopes.Array_Sort_WithComparatorArrow/ArrowFunction_L2C9
-		IL_001a: ldfld object Scopes.Array_Sort_WithComparatorArrow/ArrowFunction_L2C9::a
-		IL_001f: ldloc.0
-		IL_0020: castclass Scopes.Array_Sort_WithComparatorArrow/ArrowFunction_L2C9
-		IL_0025: ldfld object Scopes.Array_Sort_WithComparatorArrow/ArrowFunction_L2C9::b
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Subtract(object, object)
-		IL_002f: ret
-	} // end of method ArrowFunction_L2C9::ArrowFunction_L2C9
+		IL_0000: ldarg.1
+		IL_0001: ldarg.2
+		IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Subtract(object, object)
+		IL_0007: ret
+	} // end of method ArrowFunction_L2C10::ArrowFunction_L2C10
 
-} // end of class Functions.ArrowFunction_L2C9
+} // end of class Functions.ArrowFunction_L2C10
 
 .class public auto ansi beforefieldinit Scripts.Array_Sort_WithComparatorArrow
 	extends [System.Runtime]System.Object
@@ -121,7 +106,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20a8
+		// Method begins at RVA 0x2080
 		// Header size: 12
 		// Code size: 237 (0xed)
 		.maxstack 32
@@ -161,7 +146,7 @@
 		IL_0077: dup
 		IL_0078: ldc.i4.0
 		IL_0079: ldnull
-		IL_007a: ldftn object Functions.ArrowFunction_L2C9::ArrowFunction_L2C9(object[], object, object)
+		IL_007a: ldftn object Functions.ArrowFunction_L2C10::ArrowFunction_L2C10(object[], object, object)
 		IL_0080: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_0085: ldc.i4.1
 		IL_0086: newarr [System.Runtime]System.Object
@@ -215,7 +200,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a1
+		// Method begins at RVA 0x2179
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_BlockBody_Return.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_BlockBody_Return.verified.txt
@@ -49,12 +49,12 @@
 
 } // end of class Scopes.ArrowFunction_BlockBody_Return
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C12
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C13
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C12 (
+		object ArrowFunction_L1C13 (
 			object[] scopes,
 			object a,
 			object b
@@ -74,9 +74,9 @@
 		IL_0007: stloc.0
 		IL_0008: ldloc.0
 		IL_0009: ret
-	} // end of method ArrowFunction_L1C12::ArrowFunction_L1C12
+	} // end of method ArrowFunction_L1C13::ArrowFunction_L1C13
 
-} // end of class Functions.ArrowFunction_L1C12
+} // end of class Functions.ArrowFunction_L1C13
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_BlockBody_Return
 	extends [System.Runtime]System.Object
@@ -101,7 +101,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[], object, object)
+		IL_0001: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[], object, object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -127,7 +127,7 @@
 
 		IL_003a: pop
 		IL_003b: ldnull
-		IL_003c: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[], object, object)
+		IL_003c: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[], object, object)
 		IL_0042: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_0047: stloc.1
 		IL_0048: ldloc.1

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
@@ -51,12 +51,12 @@
 
 } // end of class Scopes.ArrowFunction_CapturesOuterVariable
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C12
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C13
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C12 (
+		object ArrowFunction_L2C13 (
 			object[] scopes,
 			object x
 		) cil managed 
@@ -87,9 +87,9 @@
 		IL_002f: mul
 		IL_0030: box [System.Runtime]System.Double
 		IL_0035: ret
-	} // end of method ArrowFunction_L2C12::ArrowFunction_L2C12
+	} // end of method ArrowFunction_L2C13::ArrowFunction_L2C13
 
-} // end of class Functions.ArrowFunction_L2C12
+} // end of class Functions.ArrowFunction_L2C13
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_CapturesOuterVariable
 	extends [System.Runtime]System.Object
@@ -120,7 +120,7 @@
 		IL_0010: box [System.Runtime]System.Double
 		IL_0015: stfld object Scopes.ArrowFunction_CapturesOuterVariable::n
 		IL_001a: ldnull
-		IL_001b: ldftn object Functions.ArrowFunction_L2C12::ArrowFunction_L2C12(object[], object)
+		IL_001b: ldftn object Functions.ArrowFunction_L2C13::ArrowFunction_L2C13(object[], object)
 		IL_0021: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -146,7 +146,7 @@
 
 		IL_0054: pop
 		IL_0055: ldnull
-		IL_0056: ldftn object Functions.ArrowFunction_L2C12::ArrowFunction_L2C12(object[], object)
+		IL_0056: ldftn object Functions.ArrowFunction_L2C13::ArrowFunction_L2C13(object[], object)
 		IL_005c: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0061: stloc.1
 		IL_0062: ldloc.1

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
@@ -76,18 +76,61 @@
 .class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_ClosureMutatesOuterVariable
 	extends [System.Runtime]System.Object
 {
+	// Methods
+	.method public hidebysig static 
+		object createCounter (
+			object[] scopes,
+			object start
+		) cil managed 
+	{
+		// Method begins at RVA 0x206c
+		// Header size: 12
+		// Code size: 54 (0x36)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.ArrowFunction_ClosureMutatesOuterVariable/createCounter,
+			[1] object
+		)
+
+		IL_0000: newobj instance void Scopes.ArrowFunction_ClosureMutatesOuterVariable/createCounter::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld object Scopes.ArrowFunction_ClosureMutatesOuterVariable/createCounter::count
+		IL_000d: ldnull
+		IL_000e: ldftn object [ArrowFunction_ClosureMutatesOuterVariable]Functions.ArrowFunction_L7C23::ArrowFunction_L7C23(object[])
+		IL_0014: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_0019: ldc.i4.2
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldarg.0
+		IL_0022: ldc.i4.0
+		IL_0023: ldelem.ref
+		IL_0024: castclass Scopes.ArrowFunction_ClosureMutatesOuterVariable
+		IL_0029: stelem.ref
+		IL_002a: dup
+		IL_002b: ldc.i4.1
+		IL_002c: ldloc.0
+		IL_002d: stelem.ref
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0033: stloc.1
+		IL_0034: ldloc.1
+		IL_0035: ret
+	} // end of method ArrowFunction_ClosureMutatesOuterVariable::createCounter
+
 } // end of class Functions.ArrowFunction_ClosureMutatesOuterVariable
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L7C22
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L7C23
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L7C22 (
+		object ArrowFunction_L7C23 (
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x206c
+		// Method begins at RVA 0x20b0
 		// Header size: 12
 		// Code size: 62 (0x3e)
 		.maxstack 32
@@ -115,51 +158,9 @@
 
 		IL_003c: ldnull
 		IL_003d: ret
-	} // end of method ArrowFunction_L7C22::ArrowFunction_L7C22
+	} // end of method ArrowFunction_L7C23::ArrowFunction_L7C23
 
-	.method public hidebysig static 
-		object createCounter (
-			object[] scopes,
-			object start
-		) cil managed 
-	{
-		// Method begins at RVA 0x20b8
-		// Header size: 12
-		// Code size: 54 (0x36)
-		.maxstack 32
-		.locals init (
-			[0] class Scopes.ArrowFunction_ClosureMutatesOuterVariable/createCounter,
-			[1] object
-		)
-
-		IL_0000: newobj instance void Scopes.ArrowFunction_ClosureMutatesOuterVariable/createCounter::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.ArrowFunction_ClosureMutatesOuterVariable/createCounter::count
-		IL_000d: ldnull
-		IL_000e: ldftn object Functions.ArrowFunction_L7C22::ArrowFunction_L7C22(object[])
-		IL_0014: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_0019: ldc.i4.2
-		IL_001a: newarr [System.Runtime]System.Object
-		IL_001f: dup
-		IL_0020: ldc.i4.0
-		IL_0021: ldarg.0
-		IL_0022: ldc.i4.0
-		IL_0023: ldelem.ref
-		IL_0024: castclass Scopes.ArrowFunction_ClosureMutatesOuterVariable
-		IL_0029: stelem.ref
-		IL_002a: dup
-		IL_002b: ldc.i4.1
-		IL_002c: ldloc.0
-		IL_002d: stelem.ref
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0033: stloc.1
-		IL_0034: ldloc.1
-		IL_0035: ret
-	} // end of method ArrowFunction_L7C22::createCounter
-
-} // end of class Functions.ArrowFunction_L7C22
+} // end of class Functions.ArrowFunction_L7C23
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_ClosureMutatesOuterVariable
 	extends [System.Runtime]System.Object
@@ -187,7 +188,7 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldnull
-		IL_0008: ldftn object Functions.ArrowFunction_L7C22::createCounter(object[], object)
+		IL_0008: ldftn object Functions.ArrowFunction_ClosureMutatesOuterVariable::createCounter(object[], object)
 		IL_000e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0013: stfld object Scopes.ArrowFunction_ClosureMutatesOuterVariable::createCounter
 		IL_0018: ldloc.0
@@ -199,7 +200,7 @@
 		IL_0026: pop
 		IL_0027: ldloc.0
 		IL_0028: ldnull
-		IL_0029: ldftn object Functions.ArrowFunction_L7C22::createCounter(object[], object)
+		IL_0029: ldftn object Functions.ArrowFunction_ClosureMutatesOuterVariable::createCounter(object[], object)
 		IL_002f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0034: stfld object Scopes.ArrowFunction_ClosureMutatesOuterVariable::createCounter
 		IL_0039: ldloc.0

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_DefaultParameterExpression.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_DefaultParameterExpression.verified.txt
@@ -50,12 +50,12 @@
 
 } // end of class Scopes.ArrowFunction_DefaultParameterExpression
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C18
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C19
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C18 (
+		object ArrowFunction_L2C19 (
 			object[] scopes,
 			object a,
 			object b,
@@ -109,9 +109,9 @@
 		IL_005e: pop
 		IL_005f: ldnull
 		IL_0060: ret
-	} // end of method ArrowFunction_L2C18::ArrowFunction_L2C18
+	} // end of method ArrowFunction_L2C19::ArrowFunction_L2C19
 
-} // end of class Functions.ArrowFunction_L2C18
+} // end of class Functions.ArrowFunction_L2C19
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_DefaultParameterExpression
 	extends [System.Runtime]System.Object
@@ -136,7 +136,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L2C18::ArrowFunction_L2C18(object[], object, object, object)
+		IL_0001: ldftn object Functions.ArrowFunction_L2C19::ArrowFunction_L2C19(object[], object, object, object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -152,7 +152,7 @@
 
 		IL_0020: pop
 		IL_0021: ldnull
-		IL_0022: ldftn object Functions.ArrowFunction_L2C18::ArrowFunction_L2C18(object[], object, object, object)
+		IL_0022: ldftn object Functions.ArrowFunction_L2C19::ArrowFunction_L2C19(object[], object, object, object)
 		IL_0028: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_002d: stloc.1
 		IL_002e: ldloc.1
@@ -176,7 +176,7 @@
 
 		IL_0058: pop
 		IL_0059: ldnull
-		IL_005a: ldftn object Functions.ArrowFunction_L2C18::ArrowFunction_L2C18(object[], object, object, object)
+		IL_005a: ldftn object Functions.ArrowFunction_L2C19::ArrowFunction_L2C19(object[], object, object, object)
 		IL_0060: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_0065: stloc.1
 		IL_0066: ldloc.1
@@ -201,7 +201,7 @@
 
 		IL_009d: pop
 		IL_009e: ldnull
-		IL_009f: ldftn object Functions.ArrowFunction_L2C18::ArrowFunction_L2C18(object[], object, object, object)
+		IL_009f: ldftn object Functions.ArrowFunction_L2C19::ArrowFunction_L2C19(object[], object, object, object)
 		IL_00a5: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_00aa: stloc.1
 		IL_00ab: ldloc.1

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_DefaultParameterValue.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_DefaultParameterValue.verified.txt
@@ -97,12 +97,12 @@
 
 } // end of class Scopes.ArrowFunction_DefaultParameterValue
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C14
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C15
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C14 (
+		object ArrowFunction_L2C15 (
 			object[] scopes,
 			object name
 		) cil managed 
@@ -142,16 +142,16 @@
 		IL_0031: pop
 		IL_0032: ldnull
 		IL_0033: ret
-	} // end of method ArrowFunction_L2C14::ArrowFunction_L2C14
+	} // end of method ArrowFunction_L2C15::ArrowFunction_L2C15
 
-} // end of class Functions.ArrowFunction_L2C14
+} // end of class Functions.ArrowFunction_L2C15
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C12
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C13
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L6C12 (
+		object ArrowFunction_L6C13 (
 			object[] scopes,
 			object a,
 			object b
@@ -193,16 +193,16 @@
 		IL_0036: pop
 		IL_0037: ldnull
 		IL_0038: ret
-	} // end of method ArrowFunction_L6C12::ArrowFunction_L6C12
+	} // end of method ArrowFunction_L6C13::ArrowFunction_L6C13
 
-} // end of class Functions.ArrowFunction_L6C12
+} // end of class Functions.ArrowFunction_L6C13
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L10C14
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L10C15
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L10C14 (
+		object ArrowFunction_L10C15 (
 			object[] scopes,
 			object x,
 			object y,
@@ -263,9 +263,9 @@
 		IL_006a: pop
 		IL_006b: ldnull
 		IL_006c: ret
-	} // end of method ArrowFunction_L10C14::ArrowFunction_L10C14
+	} // end of method ArrowFunction_L10C15::ArrowFunction_L10C15
 
-} // end of class Functions.ArrowFunction_L10C14
+} // end of class Functions.ArrowFunction_L10C15
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_DefaultParameterValue
 	extends [System.Runtime]System.Object
@@ -292,7 +292,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L2C14::ArrowFunction_L2C14(object[], object)
+		IL_0001: ldftn object Functions.ArrowFunction_L2C15::ArrowFunction_L2C15(object[], object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -303,7 +303,7 @@
 		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_001b: stloc.1
 		IL_001c: ldnull
-		IL_001d: ldftn object Functions.ArrowFunction_L6C12::ArrowFunction_L6C12(object[], object, object)
+		IL_001d: ldftn object Functions.ArrowFunction_L6C13::ArrowFunction_L6C13(object[], object, object)
 		IL_0023: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_0028: ldc.i4.1
 		IL_0029: newarr [System.Runtime]System.Object
@@ -314,7 +314,7 @@
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_0037: stloc.2
 		IL_0038: ldnull
-		IL_0039: ldftn object Functions.ArrowFunction_L10C14::ArrowFunction_L10C14(object[], object, object, object)
+		IL_0039: ldftn object Functions.ArrowFunction_L10C15::ArrowFunction_L10C15(object[], object, object, object)
 		IL_003f: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_0044: ldc.i4.1
 		IL_0045: newarr [System.Runtime]System.Object
@@ -330,7 +330,7 @@
 
 		IL_0058: pop
 		IL_0059: ldnull
-		IL_005a: ldftn object Functions.ArrowFunction_L2C14::ArrowFunction_L2C14(object[], object)
+		IL_005a: ldftn object Functions.ArrowFunction_L2C15::ArrowFunction_L2C15(object[], object)
 		IL_0060: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0065: stloc.1
 		IL_0066: ldloc.1
@@ -351,7 +351,7 @@
 
 		IL_0081: pop
 		IL_0082: ldnull
-		IL_0083: ldftn object Functions.ArrowFunction_L2C14::ArrowFunction_L2C14(object[], object)
+		IL_0083: ldftn object Functions.ArrowFunction_L2C15::ArrowFunction_L2C15(object[], object)
 		IL_0089: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_008e: stloc.1
 		IL_008f: ldloc.1
@@ -372,7 +372,7 @@
 
 		IL_00ae: pop
 		IL_00af: ldnull
-		IL_00b0: ldftn object Functions.ArrowFunction_L6C12::ArrowFunction_L6C12(object[], object, object)
+		IL_00b0: ldftn object Functions.ArrowFunction_L6C13::ArrowFunction_L6C13(object[], object, object)
 		IL_00b6: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_00bb: stloc.2
 		IL_00bc: ldloc.2
@@ -395,7 +395,7 @@
 
 		IL_00e5: pop
 		IL_00e6: ldnull
-		IL_00e7: ldftn object Functions.ArrowFunction_L6C12::ArrowFunction_L6C12(object[], object, object)
+		IL_00e7: ldftn object Functions.ArrowFunction_L6C13::ArrowFunction_L6C13(object[], object, object)
 		IL_00ed: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_00f2: stloc.2
 		IL_00f3: ldloc.2
@@ -419,7 +419,7 @@
 
 		IL_0129: pop
 		IL_012a: ldnull
-		IL_012b: ldftn object Functions.ArrowFunction_L10C14::ArrowFunction_L10C14(object[], object, object, object)
+		IL_012b: ldftn object Functions.ArrowFunction_L10C15::ArrowFunction_L10C15(object[], object, object, object)
 		IL_0131: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_0136: stloc.3
 		IL_0137: ldloc.3
@@ -442,7 +442,7 @@
 
 		IL_0154: pop
 		IL_0155: ldnull
-		IL_0156: ldftn object Functions.ArrowFunction_L10C14::ArrowFunction_L10C14(object[], object, object, object)
+		IL_0156: ldftn object Functions.ArrowFunction_L10C15::ArrowFunction_L10C15(object[], object, object, object)
 		IL_015c: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_0161: stloc.3
 		IL_0162: ldloc.3
@@ -466,7 +466,7 @@
 
 		IL_018c: pop
 		IL_018d: ldnull
-		IL_018e: ldftn object Functions.ArrowFunction_L10C14::ArrowFunction_L10C14(object[], object, object, object)
+		IL_018e: ldftn object Functions.ArrowFunction_L10C15::ArrowFunction_L10C15(object[], object, object, object)
 		IL_0194: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_0199: stloc.3
 		IL_019a: ldloc.3
@@ -491,7 +491,7 @@
 
 		IL_01d1: pop
 		IL_01d2: ldnull
-		IL_01d3: ldftn object Functions.ArrowFunction_L10C14::ArrowFunction_L10C14(object[], object, object, object)
+		IL_01d3: ldftn object Functions.ArrowFunction_L10C15::ArrowFunction_L10C15(object[], object, object, object)
 		IL_01d9: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_01de: stloc.3
 		IL_01df: ldloc.3

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -68,12 +68,12 @@
 
 } // end of class Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C19
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C20
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C19 (
+		object ArrowFunction_L2C20 (
 			object[] scopes
 		) cil managed 
 	{
@@ -103,22 +103,22 @@
 		IL_002b: pop
 		IL_002c: ldnull
 		IL_002d: ret
-	} // end of method ArrowFunction_L2C19::ArrowFunction_L2C19
+	} // end of method ArrowFunction_L2C20::ArrowFunction_L2C20
 
-} // end of class Functions.ArrowFunction_L2C19
+} // end of class Functions.ArrowFunction_L2C20
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C24
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C25
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L6C24 (
+		object ArrowFunction_L6C25 (
 			object[] scopes
 		) cil managed 
 	{
 		// Method begins at RVA 0x20a8
 		// Header size: 12
-		// Code size: 111 (0x6f)
+		// Code size: 85 (0x55)
 		.maxstack 32
 
 		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -142,31 +142,22 @@
 		IL_0032: castclass Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction
 		IL_0037: ldfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorld
 		IL_003c: dup
-		IL_003d: brtrue.s IL_0066
+		IL_003d: brtrue.s IL_0046
 
 		IL_003f: pop
-		IL_0040: ldarg.0
-		IL_0041: ldc.i4.0
-		IL_0042: ldelem.ref
-		IL_0043: ldnull
-		IL_0044: ldftn object Functions.ArrowFunction_L2C19::ArrowFunction_L2C19(object[])
-		IL_004a: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_004f: stfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorld
-		IL_0054: ldarg.0
-		IL_0055: ldc.i4.0
-		IL_0056: ldelem.ref
-		IL_0057: castclass Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction
-		IL_005c: ldfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorld
-		IL_0061: br IL_0066
+		IL_0040: ldnull
+		IL_0041: br IL_0046
 
-		IL_0066: ldarg.0
-		IL_0067: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
-		IL_006c: pop
-		IL_006d: ldnull
-		IL_006e: ret
-	} // end of method ArrowFunction_L6C24::ArrowFunction_L6C24
+		IL_0046: ldarg.0
+		IL_0047: ldc.i4.0
+		IL_0048: newarr [System.Runtime]System.Object
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0052: pop
+		IL_0053: ldnull
+		IL_0054: ret
+	} // end of method ArrowFunction_L6C25::ArrowFunction_L6C25
 
-} // end of class Functions.ArrowFunction_L6C24
+} // end of class Functions.ArrowFunction_L6C25
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_GlobalFunctionCallsGlobalFunction
 	extends [System.Runtime]System.Object
@@ -181,7 +172,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2124
+		// Method begins at RVA 0x210c
 		// Header size: 12
 		// Code size: 155 (0x9b)
 		.maxstack 32
@@ -194,7 +185,7 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldnull
-		IL_0008: ldftn object Functions.ArrowFunction_L2C19::ArrowFunction_L2C19(object[])
+		IL_0008: ldftn object Functions.ArrowFunction_L2C20::ArrowFunction_L2C20(object[])
 		IL_000e: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0013: ldc.i4.1
 		IL_0014: newarr [System.Runtime]System.Object
@@ -205,7 +196,7 @@
 		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_0022: stfld object Scopes.ArrowFunction_GlobalFunctionCallsGlobalFunction::helloWorld
 		IL_0027: ldnull
-		IL_0028: ldftn object Functions.ArrowFunction_L6C24::ArrowFunction_L6C24(object[])
+		IL_0028: ldftn object Functions.ArrowFunction_L6C25::ArrowFunction_L6C25(object[])
 		IL_002e: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0033: ldc.i4.1
 		IL_0034: newarr [System.Runtime]System.Object
@@ -221,7 +212,7 @@
 
 		IL_0047: pop
 		IL_0048: ldnull
-		IL_0049: ldftn object Functions.ArrowFunction_L6C24::ArrowFunction_L6C24(object[])
+		IL_0049: ldftn object Functions.ArrowFunction_L6C25::ArrowFunction_L6C25(object[])
 		IL_004f: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0054: stloc.1
 		IL_0055: ldloc.1
@@ -262,7 +253,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21cb
+		// Method begins at RVA 0x21b3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -73,16 +73,75 @@
 
 } // end of class Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L4C18
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C15
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L4C18 (
-			object[] scopes
+		object ArrowFunction_L3C15 (
+			object[] scopes,
+			object p
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
+		// Header size: 12
+		// Code size: 73 (0x49)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_outer,
+			[1] object
+		)
+
+		IL_0000: newobj instance void Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_outer::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_outer::p
+		IL_000d: ldnull
+		IL_000e: ldftn object [ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal]Functions.ArrowFunction_L4C19::ArrowFunction_L4C19(object[])
+		IL_0014: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_0019: ldc.i4.2
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldarg.0
+		IL_0022: ldc.i4.0
+		IL_0023: ldelem.ref
+		IL_0024: castclass Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+		IL_0029: stelem.ref
+		IL_002a: dup
+		IL_002b: ldc.i4.1
+		IL_002c: ldloc.0
+		IL_002d: stelem.ref
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0033: ldc.i4.2
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldarg.0
+		IL_003c: ldc.i4.0
+		IL_003d: ldelem.ref
+		IL_003e: stelem.ref
+		IL_003f: dup
+		IL_0040: ldc.i4.1
+		IL_0041: ldloc.0
+		IL_0042: stelem.ref
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0048: ret
+	} // end of method ArrowFunction_L3C15::ArrowFunction_L3C15
+
+} // end of class Functions.ArrowFunction_L3C15
+
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L4C19
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object ArrowFunction_L4C19 (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x20c4
 		// Header size: 12
 		// Code size: 94 (0x5e)
 		.maxstack 32
@@ -125,68 +184,9 @@
 		IL_005b: pop
 		IL_005c: ldnull
 		IL_005d: ret
-	} // end of method ArrowFunction_L4C18::ArrowFunction_L4C18
+	} // end of method ArrowFunction_L4C19::ArrowFunction_L4C19
 
-} // end of class Functions.ArrowFunction_L4C18
-
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C14
-	extends [System.Runtime]System.Object
-{
-	// Methods
-	.method public hidebysig static 
-		object ArrowFunction_L3C14 (
-			object[] scopes,
-			object p
-		) cil managed 
-	{
-		// Method begins at RVA 0x20d8
-		// Header size: 12
-		// Code size: 73 (0x49)
-		.maxstack 32
-		.locals init (
-			[0] class Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_outer,
-			[1] object
-		)
-
-		IL_0000: newobj instance void Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_outer::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_outer::p
-		IL_000d: ldnull
-		IL_000e: ldftn object Functions.ArrowFunction_L4C18::ArrowFunction_L4C18(object[])
-		IL_0014: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_0019: ldc.i4.2
-		IL_001a: newarr [System.Runtime]System.Object
-		IL_001f: dup
-		IL_0020: ldc.i4.0
-		IL_0021: ldarg.0
-		IL_0022: ldc.i4.0
-		IL_0023: ldelem.ref
-		IL_0024: castclass Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
-		IL_0029: stelem.ref
-		IL_002a: dup
-		IL_002b: ldc.i4.1
-		IL_002c: ldloc.0
-		IL_002d: stelem.ref
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0033: ldc.i4.2
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldarg.0
-		IL_003c: ldc.i4.0
-		IL_003d: ldelem.ref
-		IL_003e: stelem.ref
-		IL_003f: dup
-		IL_0040: ldc.i4.1
-		IL_0041: ldloc.0
-		IL_0042: stelem.ref
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0048: ret
-	} // end of method ArrowFunction_L3C14::ArrowFunction_L3C14
-
-} // end of class Functions.ArrowFunction_L3C14
+} // end of class Functions.ArrowFunction_L4C19
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
 	extends [System.Runtime]System.Object
@@ -217,7 +217,7 @@
 		IL_0007: ldstr "Hello"
 		IL_000c: stfld object Scopes.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::g
 		IL_0011: ldnull
-		IL_0012: ldftn object Functions.ArrowFunction_L3C14::ArrowFunction_L3C14(object[], object)
+		IL_0012: ldftn object Functions.ArrowFunction_L3C15::ArrowFunction_L3C15(object[], object)
 		IL_0018: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_001d: ldc.i4.1
 		IL_001e: newarr [System.Runtime]System.Object
@@ -233,7 +233,7 @@
 
 		IL_0031: pop
 		IL_0032: ldnull
-		IL_0033: ldftn object Functions.ArrowFunction_L3C14::ArrowFunction_L3C14(object[], object)
+		IL_0033: ldftn object Functions.ArrowFunction_L3C15::ArrowFunction_L3C15(object[], object)
 		IL_0039: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_003e: stloc.1
 		IL_003f: ldloc.1

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionWithMultipleParameters.verified.txt
@@ -178,12 +178,12 @@
 
 } // end of class Scopes.ArrowFunction_GlobalFunctionWithMultipleParameters
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C11 (
+		object ArrowFunction_L1C12 (
 			object[] scopes,
 			object a
 		) cil managed 
@@ -213,16 +213,16 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L1C11::ArrowFunction_L1C11
+	} // end of method ArrowFunction_L1C12::ArrowFunction_L1C12
 
-} // end of class Functions.ArrowFunction_L1C11
+} // end of class Functions.ArrowFunction_L1C12
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C11 (
+		object ArrowFunction_L5C12 (
 			object[] scopes,
 			object a,
 			object b
@@ -257,16 +257,16 @@
 		IL_0022: pop
 		IL_0023: ldnull
 		IL_0024: ret
-	} // end of method ArrowFunction_L5C11::ArrowFunction_L5C11
+	} // end of method ArrowFunction_L5C12::ArrowFunction_L5C12
 
-} // end of class Functions.ArrowFunction_L5C11
+} // end of class Functions.ArrowFunction_L5C12
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L9C11 (
+		object ArrowFunction_L9C12 (
 			object[] scopes,
 			object a,
 			object b,
@@ -306,16 +306,16 @@
 		IL_0026: pop
 		IL_0027: ldnull
 		IL_0028: ret
-	} // end of method ArrowFunction_L9C11::ArrowFunction_L9C11
+	} // end of method ArrowFunction_L9C12::ArrowFunction_L9C12
 
-} // end of class Functions.ArrowFunction_L9C11
+} // end of class Functions.ArrowFunction_L9C12
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L13C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L13C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L13C11 (
+		object ArrowFunction_L13C12 (
 			object[] scopes,
 			object a,
 			object b,
@@ -360,16 +360,16 @@
 		IL_002b: pop
 		IL_002c: ldnull
 		IL_002d: ret
-	} // end of method ArrowFunction_L13C11::ArrowFunction_L13C11
+	} // end of method ArrowFunction_L13C12::ArrowFunction_L13C12
 
-} // end of class Functions.ArrowFunction_L13C11
+} // end of class Functions.ArrowFunction_L13C12
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L17C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L17C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L17C11 (
+		object ArrowFunction_L17C12 (
 			object[] scopes,
 			object a,
 			object b,
@@ -419,16 +419,16 @@
 		IL_0030: pop
 		IL_0031: ldnull
 		IL_0032: ret
-	} // end of method ArrowFunction_L17C11::ArrowFunction_L17C11
+	} // end of method ArrowFunction_L17C12::ArrowFunction_L17C12
 
-} // end of class Functions.ArrowFunction_L17C11
+} // end of class Functions.ArrowFunction_L17C12
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L21C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L21C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L21C11 (
+		object ArrowFunction_L21C12 (
 			object[] scopes,
 			object a,
 			object b,
@@ -507,9 +507,9 @@
 		IL_008b: pop
 		IL_008c: ldnull
 		IL_008d: ret
-	} // end of method ArrowFunction_L21C11::ArrowFunction_L21C11
+	} // end of method ArrowFunction_L21C12::ArrowFunction_L21C12
 
-} // end of class Functions.ArrowFunction_L21C11
+} // end of class Functions.ArrowFunction_L21C12
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_GlobalFunctionWithMultipleParameters
 	extends [System.Runtime]System.Object
@@ -539,7 +539,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C11::ArrowFunction_L1C11(object[], object)
+		IL_0001: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[], object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -550,7 +550,7 @@
 		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_001b: stloc.1
 		IL_001c: ldnull
-		IL_001d: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object, object)
+		IL_001d: ldftn object Functions.ArrowFunction_L5C12::ArrowFunction_L5C12(object[], object, object)
 		IL_0023: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_0028: ldc.i4.1
 		IL_0029: newarr [System.Runtime]System.Object
@@ -561,7 +561,7 @@
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_0037: stloc.2
 		IL_0038: ldnull
-		IL_0039: ldftn object Functions.ArrowFunction_L9C11::ArrowFunction_L9C11(object[], object, object, object)
+		IL_0039: ldftn object Functions.ArrowFunction_L9C12::ArrowFunction_L9C12(object[], object, object, object)
 		IL_003f: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_0044: ldc.i4.1
 		IL_0045: newarr [System.Runtime]System.Object
@@ -572,7 +572,7 @@
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_0053: stloc.3
 		IL_0054: ldnull
-		IL_0055: ldftn object Functions.ArrowFunction_L13C11::ArrowFunction_L13C11(object[], object, object, object, object)
+		IL_0055: ldftn object Functions.ArrowFunction_L13C12::ArrowFunction_L13C12(object[], object, object, object, object)
 		IL_005b: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
 		IL_0060: ldc.i4.1
 		IL_0061: newarr [System.Runtime]System.Object
@@ -583,7 +583,7 @@
 		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_006f: stloc.s 4
 		IL_0071: ldnull
-		IL_0072: ldftn object Functions.ArrowFunction_L17C11::ArrowFunction_L17C11(object[], object, object, object, object, object)
+		IL_0072: ldftn object Functions.ArrowFunction_L17C12::ArrowFunction_L17C12(object[], object, object, object, object, object)
 		IL_0078: newobj instance void class [System.Runtime]System.Func`7<object[], object, object, object, object, object, object>::.ctor(object, native int)
 		IL_007d: ldc.i4.1
 		IL_007e: newarr [System.Runtime]System.Object
@@ -594,7 +594,7 @@
 		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_008c: stloc.s 5
 		IL_008e: ldnull
-		IL_008f: ldftn object Functions.ArrowFunction_L21C11::ArrowFunction_L21C11(object[], object, object, object, object, object, object)
+		IL_008f: ldftn object Functions.ArrowFunction_L21C12::ArrowFunction_L21C12(object[], object, object, object, object, object, object)
 		IL_0095: newobj instance void class [System.Runtime]System.Func`8<object[], object, object, object, object, object, object, object>::.ctor(object, native int)
 		IL_009a: ldc.i4.1
 		IL_009b: newarr [System.Runtime]System.Object
@@ -610,7 +610,7 @@
 
 		IL_00af: pop
 		IL_00b0: ldnull
-		IL_00b1: ldftn object Functions.ArrowFunction_L1C11::ArrowFunction_L1C11(object[], object)
+		IL_00b1: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[], object)
 		IL_00b7: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_00bc: stloc.1
 		IL_00bd: ldloc.1
@@ -632,7 +632,7 @@
 
 		IL_00e5: pop
 		IL_00e6: ldnull
-		IL_00e7: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object, object)
+		IL_00e7: ldftn object Functions.ArrowFunction_L5C12::ArrowFunction_L5C12(object[], object, object)
 		IL_00ed: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_00f2: stloc.2
 		IL_00f3: ldloc.2
@@ -656,7 +656,7 @@
 
 		IL_0129: pop
 		IL_012a: ldnull
-		IL_012b: ldftn object Functions.ArrowFunction_L9C11::ArrowFunction_L9C11(object[], object, object, object)
+		IL_012b: ldftn object Functions.ArrowFunction_L9C12::ArrowFunction_L9C12(object[], object, object, object)
 		IL_0131: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_0136: stloc.3
 		IL_0137: ldloc.3
@@ -682,7 +682,7 @@
 
 		IL_017c: pop
 		IL_017d: ldnull
-		IL_017e: ldftn object Functions.ArrowFunction_L13C11::ArrowFunction_L13C11(object[], object, object, object, object)
+		IL_017e: ldftn object Functions.ArrowFunction_L13C12::ArrowFunction_L13C12(object[], object, object, object, object)
 		IL_0184: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
 		IL_0189: stloc.s 4
 		IL_018b: ldloc.s 4
@@ -710,7 +710,7 @@
 
 		IL_01df: pop
 		IL_01e0: ldnull
-		IL_01e1: ldftn object Functions.ArrowFunction_L17C11::ArrowFunction_L17C11(object[], object, object, object, object, object)
+		IL_01e1: ldftn object Functions.ArrowFunction_L17C12::ArrowFunction_L17C12(object[], object, object, object, object, object)
 		IL_01e7: newobj instance void class [System.Runtime]System.Func`7<object[], object, object, object, object, object, object>::.ctor(object, native int)
 		IL_01ec: stloc.s 5
 		IL_01ee: ldloc.s 5
@@ -740,7 +740,7 @@
 
 		IL_0250: pop
 		IL_0251: ldnull
-		IL_0252: ldftn object Functions.ArrowFunction_L21C11::ArrowFunction_L21C11(object[], object, object, object, object, object, object)
+		IL_0252: ldftn object Functions.ArrowFunction_L21C12::ArrowFunction_L21C12(object[], object, object, object, object, object, object)
 		IL_0258: newobj instance void class [System.Runtime]System.Func`8<object[], object, object, object, object, object, object, object>::.ctor(object, native int)
 		IL_025d: stloc.s 6
 		IL_025f: ldloc.s 6

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -73,16 +73,88 @@
 
 } // end of class Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C27
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C22
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L6C27 (
+		object ArrowFunction_L3C22 (
 			object[] scopes
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
+		// Header size: 12
+		// Code size: 102 (0x66)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction,
+			[1] object
+		)
+
+		IL_0000: newobj instance void Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldstr "outer"
+		IL_000c: stfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction::outerVar
+		IL_0011: ldnull
+		IL_0012: ldftn object [ArrowFunction_NestedFunctionAccessesMultipleScopes]Functions.ArrowFunction_L6C28::ArrowFunction_L6C28(object[])
+		IL_0018: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_001d: ldc.i4.2
+		IL_001e: newarr [System.Runtime]System.Object
+		IL_0023: dup
+		IL_0024: ldc.i4.0
+		IL_0025: ldarg.0
+		IL_0026: ldc.i4.0
+		IL_0027: ldelem.ref
+		IL_0028: castclass Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes
+		IL_002d: stelem.ref
+		IL_002e: dup
+		IL_002f: ldc.i4.1
+		IL_0030: ldloc.0
+		IL_0031: stelem.ref
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0037: stloc.1
+		IL_0038: ldloc.1
+		IL_0039: dup
+		IL_003a: brtrue.s IL_0043
+
+		IL_003c: pop
+		IL_003d: ldnull
+		IL_003e: br IL_0043
+
+		IL_0043: ldc.i4.2
+		IL_0044: newarr [System.Runtime]System.Object
+		IL_0049: dup
+		IL_004a: ldc.i4.0
+		IL_004b: ldarg.0
+		IL_004c: ldc.i4.0
+		IL_004d: ldelem.ref
+		IL_004e: castclass Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes
+		IL_0053: stelem.ref
+		IL_0054: dup
+		IL_0055: ldc.i4.1
+		IL_0056: ldloc.0
+		IL_0057: stelem.ref
+		IL_0058: ldc.i4.0
+		IL_0059: newarr [System.Runtime]System.Object
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0063: pop
+		IL_0064: ldnull
+		IL_0065: ret
+	} // end of method ArrowFunction_L3C22::ArrowFunction_L3C22
+
+} // end of class Functions.ArrowFunction_L3C22
+
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C28
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object ArrowFunction_L6C28 (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x20e0
 		// Header size: 12
 		// Code size: 140 (0x8c)
 		.maxstack 32
@@ -147,83 +219,9 @@
 		IL_0089: pop
 		IL_008a: ldnull
 		IL_008b: ret
-	} // end of method ArrowFunction_L6C27::ArrowFunction_L6C27
+	} // end of method ArrowFunction_L6C28::ArrowFunction_L6C28
 
-} // end of class Functions.ArrowFunction_L6C27
-
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C21
-	extends [System.Runtime]System.Object
-{
-	// Methods
-	.method public hidebysig static 
-		object ArrowFunction_L3C21 (
-			object[] scopes
-		) cil managed 
-	{
-		// Method begins at RVA 0x2104
-		// Header size: 12
-		// Code size: 109 (0x6d)
-		.maxstack 32
-		.locals init (
-			[0] class Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction,
-			[1] object
-		)
-
-		IL_0000: newobj instance void Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldstr "outer"
-		IL_000c: stfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_testFunction::outerVar
-		IL_0011: ldnull
-		IL_0012: ldftn object Functions.ArrowFunction_L6C27::ArrowFunction_L6C27(object[])
-		IL_0018: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_001d: ldc.i4.2
-		IL_001e: newarr [System.Runtime]System.Object
-		IL_0023: dup
-		IL_0024: ldc.i4.0
-		IL_0025: ldarg.0
-		IL_0026: ldc.i4.0
-		IL_0027: ldelem.ref
-		IL_0028: castclass Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes
-		IL_002d: stelem.ref
-		IL_002e: dup
-		IL_002f: ldc.i4.1
-		IL_0030: ldloc.0
-		IL_0031: stelem.ref
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0037: stloc.1
-		IL_0038: ldloc.1
-		IL_0039: dup
-		IL_003a: brtrue.s IL_0050
-
-		IL_003c: pop
-		IL_003d: ldnull
-		IL_003e: ldftn object Functions.ArrowFunction_L6C27::ArrowFunction_L6C27(object[])
-		IL_0044: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_0049: stloc.1
-		IL_004a: ldloc.1
-		IL_004b: br IL_0050
-
-		IL_0050: ldc.i4.2
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldarg.0
-		IL_0059: ldc.i4.0
-		IL_005a: ldelem.ref
-		IL_005b: castclass Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes
-		IL_0060: stelem.ref
-		IL_0061: dup
-		IL_0062: ldc.i4.1
-		IL_0063: ldloc.0
-		IL_0064: stelem.ref
-		IL_0065: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
-		IL_006a: pop
-		IL_006b: ldnull
-		IL_006c: ret
-	} // end of method ArrowFunction_L3C21::ArrowFunction_L3C21
-
-} // end of class Functions.ArrowFunction_L3C21
+} // end of class Functions.ArrowFunction_L6C28
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_NestedFunctionAccessesMultipleScopes
 	extends [System.Runtime]System.Object
@@ -238,7 +236,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2180
+		// Method begins at RVA 0x2178
 		// Header size: 12
 		// Code size: 86 (0x56)
 		.maxstack 32
@@ -253,7 +251,7 @@
 		IL_0007: ldstr "global"
 		IL_000c: stfld object Scopes.ArrowFunction_NestedFunctionAccessesMultipleScopes::globalVar
 		IL_0011: ldnull
-		IL_0012: ldftn object Functions.ArrowFunction_L3C21::ArrowFunction_L3C21(object[])
+		IL_0012: ldftn object Functions.ArrowFunction_L3C22::ArrowFunction_L3C22(object[])
 		IL_0018: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_001d: ldc.i4.1
 		IL_001e: newarr [System.Runtime]System.Object
@@ -269,7 +267,7 @@
 
 		IL_0031: pop
 		IL_0032: ldnull
-		IL_0033: ldftn object Functions.ArrowFunction_L3C21::ArrowFunction_L3C21(object[])
+		IL_0033: ldftn object Functions.ArrowFunction_L3C22::ArrowFunction_L3C22(object[])
 		IL_0039: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_003e: stloc.1
 		IL_003f: ldloc.1
@@ -295,7 +293,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e2
+		// Method begins at RVA 0x21da
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ParameterDestructuring_Object.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ParameterDestructuring_Object.verified.txt
@@ -74,12 +74,12 @@
 
 } // end of class Scopes.ArrowFunction_ParameterDestructuring_Object
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C13 (
+		object ArrowFunction_L1C14 (
 			object[] scopes,
 			object param1
 		) cil managed 
@@ -124,16 +124,16 @@
 		IL_0059: pop
 		IL_005a: ldnull
 		IL_005b: ret
-	} // end of method ArrowFunction_L1C13::ArrowFunction_L1C13
+	} // end of method ArrowFunction_L1C14::ArrowFunction_L1C14
 
-} // end of class Functions.ArrowFunction_L1C13
+} // end of class Functions.ArrowFunction_L1C14
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L8C15
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L8C16
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L8C15 (
+		object ArrowFunction_L8C16 (
 			object[] scopes,
 			object param1
 		) cil managed 
@@ -235,9 +235,9 @@
 		IL_00f6: pop
 		IL_00f7: ldnull
 		IL_00f8: ret
-	} // end of method ArrowFunction_L8C15::ArrowFunction_L8C15
+	} // end of method ArrowFunction_L8C16::ArrowFunction_L8C16
 
-} // end of class Functions.ArrowFunction_L8C15
+} // end of class Functions.ArrowFunction_L8C16
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_ParameterDestructuring_Object
 	extends [System.Runtime]System.Object
@@ -263,7 +263,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[], object)
+		IL_0001: ldftn object Functions.ArrowFunction_L1C14::ArrowFunction_L1C14(object[], object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -279,7 +279,7 @@
 
 		IL_0020: pop
 		IL_0021: ldnull
-		IL_0022: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[], object)
+		IL_0022: ldftn object Functions.ArrowFunction_L1C14::ArrowFunction_L1C14(object[], object)
 		IL_0028: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_002d: stloc.1
 		IL_002e: ldloc.1
@@ -305,7 +305,7 @@
 		IL_0075: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
 		IL_007a: pop
 		IL_007b: ldnull
-		IL_007c: ldftn object Functions.ArrowFunction_L8C15::ArrowFunction_L8C15(object[], object)
+		IL_007c: ldftn object Functions.ArrowFunction_L8C16::ArrowFunction_L8C16(object[], object)
 		IL_0082: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -321,7 +321,7 @@
 
 		IL_009b: pop
 		IL_009c: ldnull
-		IL_009d: ldftn object Functions.ArrowFunction_L8C15::ArrowFunction_L8C15(object[], object)
+		IL_009d: ldftn object Functions.ArrowFunction_L8C16::ArrowFunction_L8C16(object[], object)
 		IL_00a3: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_00a8: stloc.2
 		IL_00a9: ldloc.2
@@ -346,7 +346,7 @@
 
 		IL_00d8: pop
 		IL_00d9: ldnull
-		IL_00da: ldftn object Functions.ArrowFunction_L8C15::ArrowFunction_L8C15(object[], object)
+		IL_00da: ldftn object Functions.ArrowFunction_L8C16::ArrowFunction_L8C16(object[], object)
 		IL_00e0: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_00e5: stloc.2
 		IL_00e6: ldloc.2
@@ -381,7 +381,7 @@
 
 		IL_013f: pop
 		IL_0140: ldnull
-		IL_0141: ldftn object Functions.ArrowFunction_L8C15::ArrowFunction_L8C15(object[], object)
+		IL_0141: ldftn object Functions.ArrowFunction_L8C16::ArrowFunction_L8C16(object[], object)
 		IL_0147: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_014c: stloc.2
 		IL_014d: ldloc.2

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_SimpleExpression.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_SimpleExpression.verified.txt
@@ -49,12 +49,12 @@
 
 } // end of class Scopes.ArrowFunction_SimpleExpression
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C12
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C13
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C12 (
+		object ArrowFunction_L1C13 (
 			object[] scopes,
 			object a,
 			object b
@@ -87,9 +87,9 @@
 		IL_0034: add
 		IL_0035: box [System.Runtime]System.Double
 		IL_003a: ret
-	} // end of method ArrowFunction_L1C12::ArrowFunction_L1C12
+	} // end of method ArrowFunction_L1C13::ArrowFunction_L1C13
 
-} // end of class Functions.ArrowFunction_L1C12
+} // end of class Functions.ArrowFunction_L1C13
 
 .class public auto ansi beforefieldinit Scripts.ArrowFunction_SimpleExpression
 	extends [System.Runtime]System.Object
@@ -114,7 +114,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[], object, object)
+		IL_0001: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[], object, object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -140,7 +140,7 @@
 
 		IL_003a: pop
 		IL_003b: ldnull
-		IL_003c: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[], object, object)
+		IL_003c: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[], object, object)
 		IL_0042: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_0047: stloc.1
 		IL_0048: ldloc.1

--- a/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
@@ -188,12 +188,12 @@
 
 } // end of class Functions.BinaryOperator_StrictEqualCapturedVariable
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L12C8
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L12C9
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L12C8 (
+		object ArrowFunction_L12C9 (
 			object[] scopes,
 			object id
 		) cil managed 
@@ -265,9 +265,9 @@
 
 		IL_007f: ldnull
 		IL_0080: ret
-	} // end of method ArrowFunction_L12C8::ArrowFunction_L12C8
+	} // end of method ArrowFunction_L12C9::ArrowFunction_L12C9
 
-} // end of class Functions.ArrowFunction_L12C8
+} // end of class Functions.ArrowFunction_L12C9
 
 .class public auto ansi beforefieldinit Scripts.BinaryOperator_StrictEqualCapturedVariable
 	extends [System.Runtime]System.Object
@@ -321,7 +321,7 @@
 		IL_0051: ldloc.0
 		IL_0052: stelem.ref
 		IL_0053: ldnull
-		IL_0054: ldftn object Functions.ArrowFunction_L12C8::ArrowFunction_L12C8(object[], object)
+		IL_0054: ldftn object Functions.ArrowFunction_L12C9::ArrowFunction_L12C9(object[], object)
 		IL_005a: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
@@ -114,12 +114,12 @@
 
 } // end of class Classes.Classes_ClassConstructor_New_In_ArrowFunction.PrimeSieve
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L7C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L7C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L7C13 (
+		object ArrowFunction_L7C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -132,9 +132,9 @@
 		IL_0009: box [System.Runtime]System.Double
 		IL_000e: newobj instance void Classes.Classes_ClassConstructor_New_In_ArrowFunction.PrimeSieve::.ctor(object)
 		IL_0013: ret
-	} // end of method ArrowFunction_L7C13::ArrowFunction_L7C13
+	} // end of method ArrowFunction_L7C14::ArrowFunction_L7C14
 
-} // end of class Functions.ArrowFunction_L7C13
+} // end of class Functions.ArrowFunction_L7C14
 
 .class public auto ansi beforefieldinit Scripts.Classes_ClassConstructor_New_In_ArrowFunction
 	extends [System.Runtime]System.Object
@@ -160,7 +160,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L7C13::ArrowFunction_L7C13(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L7C14::ArrowFunction_L7C14(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -176,7 +176,7 @@
 
 		IL_0020: pop
 		IL_0021: ldnull
-		IL_0022: ldftn object Functions.ArrowFunction_L7C13::ArrowFunction_L7C13(object[])
+		IL_0022: ldftn object Functions.ArrowFunction_L7C14::ArrowFunction_L7C14(object[])
 		IL_0028: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_002d: stloc.1
 		IL_002e: ldloc.1

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -164,12 +164,12 @@
 
 } // end of class Classes.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.MyClass
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C26
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C27
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L3C26 (
+		object ArrowFunction_L3C27 (
 			object[] scopes
 		) cil managed 
 	{
@@ -207,9 +207,9 @@
 		IL_0032: pop
 		IL_0033: ldnull
 		IL_0034: ret
-	} // end of method ArrowFunction_L3C26::ArrowFunction_L3C26
+	} // end of method ArrowFunction_L3C27::ArrowFunction_L3C27
 
-} // end of class Functions.ArrowFunction_L3C26
+} // end of class Functions.ArrowFunction_L3C27
 
 .class public auto ansi beforefieldinit Scripts.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log
 	extends [System.Runtime]System.Object
@@ -239,7 +239,7 @@
 		IL_0007: ldstr "Hello from global"
 		IL_000c: stfld object Scopes.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log::GLOBAL_VALUE
 		IL_0011: ldnull
-		IL_0012: ldftn object Functions.ArrowFunction_L3C26::ArrowFunction_L3C26(object[])
+		IL_0012: ldftn object Functions.ArrowFunction_L3C27::ArrowFunction_L3C27(object[])
 		IL_0018: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_001d: ldc.i4.1
 		IL_001e: newarr [System.Runtime]System.Object
@@ -255,7 +255,7 @@
 
 		IL_0031: pop
 		IL_0032: ldnull
-		IL_0033: ldftn object Functions.ArrowFunction_L3C26::ArrowFunction_L3C26(object[])
+		IL_0033: ldftn object Functions.ArrowFunction_L3C27::ArrowFunction_L3C27(object[])
 		IL_0039: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_003e: stloc.1
 		IL_003f: ldloc.1

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -146,12 +146,12 @@
 
 } // end of class Classes.Classes_ClassMethod_AccessArrowFunctionVariable_Log.MyClass
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C26
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C27
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C26 (
+		object ArrowFunction_L1C27 (
 			object[] scopes
 		) cil managed 
 	{
@@ -189,9 +189,9 @@
 		IL_0032: pop
 		IL_0033: ldnull
 		IL_0034: ret
-	} // end of method ArrowFunction_L1C26::ArrowFunction_L1C26
+	} // end of method ArrowFunction_L1C27::ArrowFunction_L1C27
 
-} // end of class Functions.ArrowFunction_L1C26
+} // end of class Functions.ArrowFunction_L1C27
 
 .class public auto ansi beforefieldinit Scripts.Classes_ClassMethod_AccessArrowFunctionVariable_Log
 	extends [System.Runtime]System.Object
@@ -216,7 +216,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C26::ArrowFunction_L1C26(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C27::ArrowFunction_L1C27(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -232,7 +232,7 @@
 
 		IL_0020: pop
 		IL_0021: ldnull
-		IL_0022: ldftn object Functions.ArrowFunction_L1C26::ArrowFunction_L1C26(object[])
+		IL_0022: ldftn object Functions.ArrowFunction_L1C27::ArrowFunction_L1C27(object[])
 		IL_0028: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_002d: stloc.1
 		IL_002e: ldloc.1

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -301,12 +301,12 @@
 
 } // end of class Classes.CommonJS_Export_ClassWithConstructor_Lib.Person
 
-.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L16C18
+.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L16C19
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object FunctionExpression_L16C18 (
+		object FunctionExpression_L16C19 (
 			object[] scopes,
 			object name,
 			object age
@@ -324,9 +324,9 @@
 
 		IL_0008: ldnull
 		IL_0009: ret
-	} // end of method FunctionExpression_L16C18::FunctionExpression_L16C18
+	} // end of method FunctionExpression_L16C19::FunctionExpression_L16C19
 
-} // end of class Functions.FunctionExpression_L16C18
+} // end of class Functions.FunctionExpression_L16C19
 
 .class public auto ansi beforefieldinit Scripts.CommonJS_Export_ClassWithConstructor_Lib
 	extends [System.Runtime]System.Object
@@ -355,7 +355,7 @@
 		IL_000b: dup
 		IL_000c: ldstr "createPerson"
 		IL_0011: ldnull
-		IL_0012: ldftn object Functions.FunctionExpression_L16C18::FunctionExpression_L16C18(object[], object, object)
+		IL_0012: ldftn object Functions.FunctionExpression_L16C19::FunctionExpression_L16C19(object[], object, object)
 		IL_0018: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_001d: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
 		IL_0022: dup

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
@@ -271,12 +271,12 @@
 
 } // end of class Scripts.CommonJS_Export_NestedObjects_Main
 
-.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L7C13
+.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L7C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object FunctionExpression_L7C13 (
+		object FunctionExpression_L7C14 (
 			object[] scopes,
 			object a,
 			object b
@@ -297,16 +297,16 @@
 
 		IL_0013: ldnull
 		IL_0014: ret
-	} // end of method FunctionExpression_L7C13::FunctionExpression_L7C13
+	} // end of method FunctionExpression_L7C14::FunctionExpression_L7C14
 
-} // end of class Functions.FunctionExpression_L7C13
+} // end of class Functions.FunctionExpression_L7C14
 
-.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L10C18
+.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L10C19
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object FunctionExpression_L10C18 (
+		object FunctionExpression_L10C19 (
 			object[] scopes,
 			object a,
 			object b
@@ -327,16 +327,16 @@
 
 		IL_0013: ldnull
 		IL_0014: ret
-	} // end of method FunctionExpression_L10C18::FunctionExpression_L10C18
+	} // end of method FunctionExpression_L10C19::FunctionExpression_L10C19
 
-} // end of class Functions.FunctionExpression_L10C18
+} // end of class Functions.FunctionExpression_L10C19
 
-.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L16C19
+.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L16C20
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object FunctionExpression_L16C19 (
+		object FunctionExpression_L16C20 (
 			object[] scopes,
 			object 'value'
 		) cil managed 
@@ -353,9 +353,9 @@
 
 		IL_000c: ldnull
 		IL_000d: ret
-	} // end of method FunctionExpression_L16C19::FunctionExpression_L16C19
+	} // end of method FunctionExpression_L16C20::FunctionExpression_L16C20
 
-} // end of class Functions.FunctionExpression_L16C19
+} // end of class Functions.FunctionExpression_L16C20
 
 .class public auto ansi beforefieldinit Scripts.CommonJS_Export_NestedObjects_Lib
 	extends [System.Runtime]System.Object
@@ -396,13 +396,13 @@
 		IL_003f: dup
 		IL_0040: ldstr "add"
 		IL_0045: ldnull
-		IL_0046: ldftn object Functions.FunctionExpression_L7C13::FunctionExpression_L7C13(object[], object, object)
+		IL_0046: ldftn object Functions.FunctionExpression_L7C14::FunctionExpression_L7C14(object[], object, object)
 		IL_004c: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_0051: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
 		IL_0056: dup
 		IL_0057: ldstr "multiply"
 		IL_005c: ldnull
-		IL_005d: ldftn object Functions.FunctionExpression_L10C18::FunctionExpression_L10C18(object[], object, object)
+		IL_005d: ldftn object Functions.FunctionExpression_L10C19::FunctionExpression_L10C19(object[], object, object)
 		IL_0063: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_0068: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
 		IL_006d: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
@@ -416,7 +416,7 @@
 		IL_008d: dup
 		IL_008e: ldstr "formatNum"
 		IL_0093: ldnull
-		IL_0094: ldftn object Functions.FunctionExpression_L16C19::FunctionExpression_L16C19(object[], object)
+		IL_0094: ldftn object Functions.FunctionExpression_L16C20::FunctionExpression_L16C20(object[], object)
 		IL_009a: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_009f: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
 		IL_00a4: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -321,36 +321,26 @@
 
 } // end of class Functions.CommonJS_Require_Basic
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C8
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C9
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C8 (
+		object ArrowFunction_L1C9 (
 			object[] scopes,
 			object x
 		) cil managed 
 	{
 		// Method begins at RVA 0x2160
 		// Header size: 12
-		// Code size: 25 (0x19)
+		// Code size: 2 (0x2)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.CommonJS_Require_Basic/ArrowFunction_L1C8
-		)
 
-		IL_0000: newobj instance void Scopes.CommonJS_Require_Basic/ArrowFunction_L1C8::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.CommonJS_Require_Basic/ArrowFunction_L1C8::x
-		IL_000d: ldloc.0
-		IL_000e: castclass Scopes.CommonJS_Require_Basic/ArrowFunction_L1C8
-		IL_0013: ldfld object Scopes.CommonJS_Require_Basic/ArrowFunction_L1C8::x
-		IL_0018: ret
-	} // end of method ArrowFunction_L1C8::ArrowFunction_L1C8
+		IL_0000: ldarg.1
+		IL_0001: ret
+	} // end of method ArrowFunction_L1C9::ArrowFunction_L1C9
 
-} // end of class Functions.ArrowFunction_L1C8
+} // end of class Functions.ArrowFunction_L1C9
 
 .class public auto ansi beforefieldinit Scripts.CommonJS_Require_Basic
 	extends [System.Runtime]System.Object
@@ -365,7 +355,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2188
+		// Method begins at RVA 0x2170
 		// Header size: 12
 		// Code size: 248 (0xf8)
 		.maxstack 32
@@ -392,7 +382,7 @@
 		IL_003d: dup
 		IL_003e: ldc.i4.0
 		IL_003f: ldnull
-		IL_0040: ldftn object Functions.ArrowFunction_L1C8::ArrowFunction_L1C8(object[], object)
+		IL_0040: ldftn object Functions.ArrowFunction_L1C9::ArrowFunction_L1C9(object[], object)
 		IL_0046: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_004b: ldc.i4.1
 		IL_004c: newarr [System.Runtime]System.Object
@@ -475,7 +465,7 @@
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x228c
+		// Method begins at RVA 0x2274
 		// Header size: 12
 		// Code size: 14 (0xe)
 		.maxstack 32
@@ -491,7 +481,7 @@
 	.method public hidebysig 
 		instance object Log () cil managed 
 	{
-		// Method begins at RVA 0x22a8
+		// Method begins at RVA 0x2290
 		// Header size: 12
 		// Code size: 65 (0x41)
 		.maxstack 32
@@ -530,7 +520,7 @@
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x22f8
+		// Method begins at RVA 0x22e0
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 32
@@ -559,36 +549,26 @@
 
 } // end of class Functions.CommonJS_Require_Dependency
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C8
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C9
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C8 (
+		object ArrowFunction_L1C9 (
 			object[] scopes,
 			object x
 		) cil managed 
 	{
-		// Method begins at RVA 0x2340
+		// Method begins at RVA 0x2328
 		// Header size: 12
-		// Code size: 25 (0x19)
+		// Code size: 2 (0x2)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.CommonJS_Require_Dependency/ArrowFunction_L1C8
-		)
 
-		IL_0000: newobj instance void Scopes.CommonJS_Require_Dependency/ArrowFunction_L1C8::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.CommonJS_Require_Dependency/ArrowFunction_L1C8::x
-		IL_000d: ldloc.0
-		IL_000e: castclass Scopes.CommonJS_Require_Dependency/ArrowFunction_L1C8
-		IL_0013: ldfld object Scopes.CommonJS_Require_Dependency/ArrowFunction_L1C8::x
-		IL_0018: ret
-	} // end of method ArrowFunction_L1C8::ArrowFunction_L1C8
+		IL_0000: ldarg.1
+		IL_0001: ret
+	} // end of method ArrowFunction_L1C9::ArrowFunction_L1C9
 
-} // end of class Functions.ArrowFunction_L1C8
+} // end of class Functions.ArrowFunction_L1C9
 
 .class public auto ansi beforefieldinit Scripts.CommonJS_Require_Dependency
 	extends [System.Runtime]System.Object
@@ -603,7 +583,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2368
+		// Method begins at RVA 0x2338
 		// Header size: 12
 		// Code size: 206 (0xce)
 		.maxstack 32
@@ -630,7 +610,7 @@
 		IL_003d: dup
 		IL_003e: ldc.i4.0
 		IL_003f: ldnull
-		IL_0040: ldftn object Functions.ArrowFunction_L1C8::ArrowFunction_L1C8(object[], object)
+		IL_0040: ldftn object Functions.ArrowFunction_L1C9::ArrowFunction_L1C9(object[], object)
 		IL_0046: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_004b: ldc.i4.1
 		IL_004c: newarr [System.Runtime]System.Object
@@ -694,7 +674,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2442
+		// Method begins at RVA 0x2412
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -385,36 +385,26 @@
 
 } // end of class Functions.b
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C8
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C9
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C8 (
+		object ArrowFunction_L1C9 (
 			object[] scopes,
 			object x
 		) cil managed 
 	{
 		// Method begins at RVA 0x21ac
 		// Header size: 12
-		// Code size: 25 (0x19)
+		// Code size: 2 (0x2)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.b/ArrowFunction_L1C8
-		)
 
-		IL_0000: newobj instance void Scopes.b/ArrowFunction_L1C8::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.b/ArrowFunction_L1C8::x
-		IL_000d: ldloc.0
-		IL_000e: castclass Scopes.b/ArrowFunction_L1C8
-		IL_0013: ldfld object Scopes.b/ArrowFunction_L1C8::x
-		IL_0018: ret
-	} // end of method ArrowFunction_L1C8::ArrowFunction_L1C8
+		IL_0000: ldarg.1
+		IL_0001: ret
+	} // end of method ArrowFunction_L1C9::ArrowFunction_L1C9
 
-} // end of class Functions.ArrowFunction_L1C8
+} // end of class Functions.ArrowFunction_L1C9
 
 .class public auto ansi beforefieldinit Scripts.b
 	extends [System.Runtime]System.Object
@@ -429,7 +419,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21d4
+		// Method begins at RVA 0x21bc
 		// Header size: 12
 		// Code size: 206 (0xce)
 		.maxstack 32
@@ -456,7 +446,7 @@
 		IL_003d: dup
 		IL_003e: ldc.i4.0
 		IL_003f: ldnull
-		IL_0040: ldftn object Functions.ArrowFunction_L1C8::ArrowFunction_L1C8(object[], object)
+		IL_0040: ldftn object Functions.ArrowFunction_L1C9::ArrowFunction_L1C9(object[], object)
 		IL_0046: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_004b: ldc.i4.1
 		IL_004c: newarr [System.Runtime]System.Object
@@ -525,7 +515,7 @@
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x22b0
+		// Method begins at RVA 0x2298
 		// Header size: 12
 		// Code size: 14 (0xe)
 		.maxstack 32
@@ -541,7 +531,7 @@
 	.method public hidebysig 
 		instance object Log () cil managed 
 	{
-		// Method begins at RVA 0x22cc
+		// Method begins at RVA 0x22b4
 		// Header size: 12
 		// Code size: 65 (0x41)
 		.maxstack 32
@@ -580,7 +570,7 @@
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x231c
+		// Method begins at RVA 0x2304
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 32
@@ -609,36 +599,26 @@
 
 } // end of class Functions.helpers_b
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C8
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C9
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C8 (
+		object ArrowFunction_L1C9 (
 			object[] scopes,
 			object x
 		) cil managed 
 	{
-		// Method begins at RVA 0x2364
+		// Method begins at RVA 0x234c
 		// Header size: 12
-		// Code size: 25 (0x19)
+		// Code size: 2 (0x2)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.helpers_b/ArrowFunction_L1C8
-		)
 
-		IL_0000: newobj instance void Scopes.helpers_b/ArrowFunction_L1C8::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.helpers_b/ArrowFunction_L1C8::x
-		IL_000d: ldloc.0
-		IL_000e: castclass Scopes.helpers_b/ArrowFunction_L1C8
-		IL_0013: ldfld object Scopes.helpers_b/ArrowFunction_L1C8::x
-		IL_0018: ret
-	} // end of method ArrowFunction_L1C8::ArrowFunction_L1C8
+		IL_0000: ldarg.1
+		IL_0001: ret
+	} // end of method ArrowFunction_L1C9::ArrowFunction_L1C9
 
-} // end of class Functions.ArrowFunction_L1C8
+} // end of class Functions.ArrowFunction_L1C9
 
 .class public auto ansi beforefieldinit Scripts.helpers_b
 	extends [System.Runtime]System.Object
@@ -653,7 +633,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x238c
+		// Method begins at RVA 0x235c
 		// Header size: 12
 		// Code size: 206 (0xce)
 		.maxstack 32
@@ -680,7 +660,7 @@
 		IL_003d: dup
 		IL_003e: ldc.i4.0
 		IL_003f: ldnull
-		IL_0040: ldftn object Functions.ArrowFunction_L1C8::ArrowFunction_L1C8(object[], object)
+		IL_0040: ldftn object Functions.ArrowFunction_L1C9::ArrowFunction_L1C9(object[], object)
 		IL_0046: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_004b: ldc.i4.1
 		IL_004c: newarr [System.Runtime]System.Object
@@ -744,7 +724,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2466
+		// Method begins at RVA 0x2436
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Classic.verified.txt
+++ b/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Classic.verified.txt
@@ -45,12 +45,12 @@
 
 } // end of class Scopes.Function_IIFE_Classic
 
-.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L1C1
+.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L1C2
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object FunctionExpression_L1C1 (
+		object FunctionExpression_L1C2 (
 			object[] scopes
 		) cil managed 
 	{
@@ -71,9 +71,9 @@
 		IL_001d: pop
 		IL_001e: ldnull
 		IL_001f: ret
-	} // end of method FunctionExpression_L1C1::FunctionExpression_L1C1
+	} // end of method FunctionExpression_L1C2::FunctionExpression_L1C2
 
-} // end of class Functions.FunctionExpression_L1C1
+} // end of class Functions.FunctionExpression_L1C2
 
 .class public auto ansi beforefieldinit Scripts.Function_IIFE_Classic
 	extends [System.Runtime]System.Object
@@ -97,7 +97,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.FunctionExpression_L1C1::FunctionExpression_L1C1(object[])
+		IL_0001: ldftn object Functions.FunctionExpression_L1C2::FunctionExpression_L1C2(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
+++ b/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
@@ -90,12 +90,12 @@
 
 } // end of class Scopes.Function_IIFE_Recursive
 
-.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L2C1
+.class public auto ansi abstract sealed beforefieldinit Functions.FunctionExpression_L2C2
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object FunctionExpression_L2C1 (
+		object FunctionExpression_L2C2 (
 			object[] scopes,
 			object node,
 			object depth
@@ -224,9 +224,9 @@
 
 		IL_0123: ldnull
 		IL_0124: ret
-	} // end of method FunctionExpression_L2C1::FunctionExpression_L2C1
+	} // end of method FunctionExpression_L2C2::FunctionExpression_L2C2
 
-} // end of class Functions.FunctionExpression_L2C1
+} // end of class Functions.FunctionExpression_L2C2
 
 .class public auto ansi beforefieldinit Scripts.Function_IIFE_Recursive
 	extends [System.Runtime]System.Object
@@ -250,7 +250,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.FunctionExpression_L2C1::FunctionExpression_L2C1(object[], object, object)
+		IL_0001: ldftn object Functions.FunctionExpression_L2C2::FunctionExpression_L2C2(object[], object, object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Integration/TwoPhaseCompilationTests.cs
+++ b/Js2IL.Tests/Integration/TwoPhaseCompilationTests.cs
@@ -151,7 +151,6 @@ console.log(calc.getValue());
                 var options = new CompilerOptions
                 {
                     OutputDirectory = outputDir,
-                    TwoPhaseCompilation = true,
                     Verbose = true
                 };
 

--- a/Js2IL.Tests/Math/Snapshots/GeneratorTests.Math_Round_Trunc_NegativeHalves.verified.txt
+++ b/Js2IL.Tests/Math/Snapshots/GeneratorTests.Math_Round_Trunc_NegativeHalves.verified.txt
@@ -138,12 +138,12 @@
 
 } // end of class Functions.Math_Round_Trunc_NegativeHalves
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C19
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C20
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L3C19 (
+		object ArrowFunction_L3C20 (
 			object[] scopes,
 			object n
 		) cil managed 
@@ -166,16 +166,16 @@
 		IL_0013: ldfld object Scopes.Math_Round_Trunc_NegativeHalves/ArrowFunction_r::n
 		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Math::round(object)
 		IL_001d: ret
-	} // end of method ArrowFunction_L3C19::ArrowFunction_L3C19
+	} // end of method ArrowFunction_L3C20::ArrowFunction_L3C20
 
-} // end of class Functions.ArrowFunction_L3C19
+} // end of class Functions.ArrowFunction_L3C20
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L4C19
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L4C20
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L4C19 (
+		object ArrowFunction_L4C20 (
 			object[] scopes,
 			object n
 		) cil managed 
@@ -198,9 +198,9 @@
 		IL_0013: ldfld object Scopes.Math_Round_Trunc_NegativeHalves/ArrowFunction_t::n
 		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Math::trunc(object)
 		IL_001d: ret
-	} // end of method ArrowFunction_L4C19::ArrowFunction_L4C19
+	} // end of method ArrowFunction_L4C20::ArrowFunction_L4C20
 
-} // end of class Functions.ArrowFunction_L4C19
+} // end of class Functions.ArrowFunction_L4C20
 
 .class public auto ansi beforefieldinit Scripts.Math_Round_Trunc_NegativeHalves
 	extends [System.Runtime]System.Object
@@ -285,7 +285,7 @@
 		IL_00fd: dup
 		IL_00fe: ldc.i4.0
 		IL_00ff: ldnull
-		IL_0100: ldftn object Functions.ArrowFunction_L3C19::ArrowFunction_L3C19(object[], object)
+		IL_0100: ldftn object Functions.ArrowFunction_L3C20::ArrowFunction_L3C20(object[], object)
 		IL_0106: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_010b: ldc.i4.1
 		IL_010c: newarr [System.Runtime]System.Object
@@ -304,7 +304,7 @@
 		IL_012d: dup
 		IL_012e: ldc.i4.0
 		IL_012f: ldnull
-		IL_0130: ldftn object Functions.ArrowFunction_L4C19::ArrowFunction_L4C19(object[], object)
+		IL_0130: ldftn object Functions.ArrowFunction_L4C20::ArrowFunction_L4C20(object[], object)
 		IL_0136: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_013b: ldc.i4.1
 		IL_013c: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Math/Snapshots/GeneratorTests.Math_Sign_ZeroVariants.verified.txt
+++ b/Js2IL.Tests/Math/Snapshots/GeneratorTests.Math_Sign_ZeroVariants.verified.txt
@@ -115,12 +115,12 @@
 
 } // end of class Functions.Math_Sign_ZeroVariants
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C21
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C22
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L3C21 (
+		object ArrowFunction_L3C22 (
 			object[] scopes,
 			object v
 		) cil managed 
@@ -143,9 +143,9 @@
 		IL_0013: ldfld object Scopes.Math_Sign_ZeroVariants/ArrowFunction_out::v
 		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Math::sign(object)
 		IL_001d: ret
-	} // end of method ArrowFunction_L3C21::ArrowFunction_L3C21
+	} // end of method ArrowFunction_L3C22::ArrowFunction_L3C22
 
-} // end of class Functions.ArrowFunction_L3C21
+} // end of class Functions.ArrowFunction_L3C22
 
 .class public auto ansi beforefieldinit Scripts.Math_Sign_ZeroVariants
 	extends [System.Runtime]System.Object
@@ -225,7 +225,7 @@
 		IL_00dd: dup
 		IL_00de: ldc.i4.0
 		IL_00df: ldnull
-		IL_00e0: ldftn object Functions.ArrowFunction_L3C21::ArrowFunction_L3C21(object[], object)
+		IL_00e0: ldftn object Functions.ArrowFunction_L3C22::ArrowFunction_L3C22(object[], object)
 		IL_00e6: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_00eb: ldc.i4.1
 		IL_00ec: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.ClearImmediate_CancelsCallback.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.ClearImmediate_CancelsCallback.verified.txt
@@ -45,12 +45,12 @@
 
 } // end of class Scopes.ClearImmediate_CancelsCallback
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C28
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C29
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C28 (
+		object ArrowFunction_L1C29 (
 			object[] scopes
 		) cil managed 
 	{
@@ -69,9 +69,9 @@
 		IL_0017: stelem.ref
 		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001d: ret
-	} // end of method ArrowFunction_L1C28::ArrowFunction_L1C28
+	} // end of method ArrowFunction_L1C29::ArrowFunction_L1C29
 
-} // end of class Functions.ArrowFunction_L1C28
+} // end of class Functions.ArrowFunction_L1C29
 
 .class public auto ansi beforefieldinit Scripts.ClearImmediate_CancelsCallback
 	extends [System.Runtime]System.Object
@@ -96,7 +96,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C28::ArrowFunction_L1C28(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C29::ArrowFunction_L1C29(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.ClearTimeout_MultipleZeroDelay_ClearSecondTimer.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.ClearTimeout_MultipleZeroDelay_ClearSecondTimer.verified.txt
@@ -85,12 +85,12 @@
 
 } // end of class Scopes.ClearTimeout_MultipleZeroDelay_ClearSecondTimer
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C13 (
+		object ArrowFunction_L1C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -115,16 +115,16 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L1C13::ArrowFunction_L1C13
+	} // end of method ArrowFunction_L1C14::ArrowFunction_L1C14
 
-} // end of class Functions.ArrowFunction_L1C13
+} // end of class Functions.ArrowFunction_L1C14
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C13 (
+		object ArrowFunction_L5C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -149,16 +149,16 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L5C13::ArrowFunction_L5C13
+	} // end of method ArrowFunction_L5C14::ArrowFunction_L5C14
 
-} // end of class Functions.ArrowFunction_L5C13
+} // end of class Functions.ArrowFunction_L5C14
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L9C13 (
+		object ArrowFunction_L9C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -183,9 +183,9 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L9C13::ArrowFunction_L9C13
+	} // end of method ArrowFunction_L9C14::ArrowFunction_L9C14
 
-} // end of class Functions.ArrowFunction_L9C13
+} // end of class Functions.ArrowFunction_L9C14
 
 .class public auto ansi beforefieldinit Scripts.ClearTimeout_MultipleZeroDelay_ClearSecondTimer
 	extends [System.Runtime]System.Object
@@ -213,7 +213,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C14::ArrowFunction_L1C14(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -224,7 +224,7 @@
 		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_001b: stloc.1
 		IL_001c: ldnull
-		IL_001d: ldftn object Functions.ArrowFunction_L5C13::ArrowFunction_L5C13(object[])
+		IL_001d: ldftn object Functions.ArrowFunction_L5C14::ArrowFunction_L5C14(object[])
 		IL_0023: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0028: ldc.i4.1
 		IL_0029: newarr [System.Runtime]System.Object
@@ -235,7 +235,7 @@
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_0037: stloc.2
 		IL_0038: ldnull
-		IL_0039: ldftn object Functions.ArrowFunction_L9C13::ArrowFunction_L9C13(object[])
+		IL_0039: ldftn object Functions.ArrowFunction_L9C14::ArrowFunction_L9C14(object[])
 		IL_003f: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0044: ldc.i4.1
 		IL_0045: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.ClearTimeout_ZeroDelay.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.ClearTimeout_ZeroDelay.verified.txt
@@ -45,12 +45,12 @@
 
 } // end of class Scopes.ClearTimeout_ZeroDelay
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C17
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C18
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C17 (
+		object ArrowFunction_L1C18 (
 			object[] scopes
 		) cil managed 
 	{
@@ -75,9 +75,9 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L1C17::ArrowFunction_L1C17
+	} // end of method ArrowFunction_L1C18::ArrowFunction_L1C18
 
-} // end of class Functions.ArrowFunction_L1C17
+} // end of class Functions.ArrowFunction_L1C18
 
 .class public auto ansi beforefieldinit Scripts.ClearTimeout_ZeroDelay
 	extends [System.Runtime]System.Object
@@ -103,7 +103,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C17::ArrowFunction_L1C17(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C18::ArrowFunction_L1C18(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetImmediate_ExecutesBeforeSetTimeout.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetImmediate_ExecutesBeforeSetTimeout.verified.txt
@@ -65,12 +65,12 @@
 
 } // end of class Scopes.SetImmediate_ExecutesBeforeSetTimeout
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C11 (
+		object ArrowFunction_L1C12 (
 			object[] scopes
 		) cil managed 
 	{
@@ -89,16 +89,16 @@
 		IL_0017: stelem.ref
 		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001d: ret
-	} // end of method ArrowFunction_L1C11::ArrowFunction_L1C11
+	} // end of method ArrowFunction_L1C12::ArrowFunction_L1C12
 
-} // end of class Functions.ArrowFunction_L1C11
+} // end of class Functions.ArrowFunction_L1C12
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C13 (
+		object ArrowFunction_L2C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -117,9 +117,9 @@
 		IL_0017: stelem.ref
 		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001d: ret
-	} // end of method ArrowFunction_L2C13::ArrowFunction_L2C13
+	} // end of method ArrowFunction_L2C14::ArrowFunction_L2C14
 
-} // end of class Functions.ArrowFunction_L2C13
+} // end of class Functions.ArrowFunction_L2C14
 
 .class public auto ansi beforefieldinit Scripts.SetImmediate_ExecutesBeforeSetTimeout
 	extends [System.Runtime]System.Object
@@ -143,7 +143,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C11::ArrowFunction_L1C11(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C12::ArrowFunction_L1C12(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -158,7 +158,7 @@
 		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
 		IL_0033: pop
 		IL_0034: ldnull
-		IL_0035: ldftn object Functions.ArrowFunction_L2C13::ArrowFunction_L2C13(object[])
+		IL_0035: ldftn object Functions.ArrowFunction_L2C14::ArrowFunction_L2C14(object[])
 		IL_003b: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0040: ldc.i4.1
 		IL_0041: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetImmediate_ExecutesCallback.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetImmediate_ExecutesCallback.verified.txt
@@ -45,12 +45,12 @@
 
 } // end of class Scopes.SetImmediate_ExecutesCallback
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C17
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C18
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C17 (
+		object ArrowFunction_L1C18 (
 			object[] scopes
 		) cil managed 
 	{
@@ -75,9 +75,9 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L1C17::ArrowFunction_L1C17
+	} // end of method ArrowFunction_L1C18::ArrowFunction_L1C18
 
-} // end of class Functions.ArrowFunction_L1C17
+} // end of class Functions.ArrowFunction_L1C18
 
 .class public auto ansi beforefieldinit Scripts.SetImmediate_ExecutesCallback
 	extends [System.Runtime]System.Object
@@ -102,7 +102,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C17::ArrowFunction_L1C17(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C18::ArrowFunction_L1C18(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetImmediate_Multiple_ExecuteInOrder.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetImmediate_Multiple_ExecuteInOrder.verified.txt
@@ -85,12 +85,12 @@
 
 } // end of class Scopes.SetImmediate_Multiple_ExecuteInOrder
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C13 (
+		object ArrowFunction_L1C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -109,16 +109,16 @@
 		IL_0017: stelem.ref
 		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001d: ret
-	} // end of method ArrowFunction_L1C13::ArrowFunction_L1C13
+	} // end of method ArrowFunction_L1C14::ArrowFunction_L1C14
 
-} // end of class Functions.ArrowFunction_L1C13
+} // end of class Functions.ArrowFunction_L1C14
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C13 (
+		object ArrowFunction_L2C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -137,16 +137,16 @@
 		IL_0017: stelem.ref
 		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001d: ret
-	} // end of method ArrowFunction_L2C13::ArrowFunction_L2C13
+	} // end of method ArrowFunction_L2C14::ArrowFunction_L2C14
 
-} // end of class Functions.ArrowFunction_L2C13
+} // end of class Functions.ArrowFunction_L2C14
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L3C13 (
+		object ArrowFunction_L3C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -165,9 +165,9 @@
 		IL_0017: stelem.ref
 		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001d: ret
-	} // end of method ArrowFunction_L3C13::ArrowFunction_L3C13
+	} // end of method ArrowFunction_L3C14::ArrowFunction_L3C14
 
-} // end of class Functions.ArrowFunction_L3C13
+} // end of class Functions.ArrowFunction_L3C14
 
 .class public auto ansi beforefieldinit Scripts.SetImmediate_Multiple_ExecuteInOrder
 	extends [System.Runtime]System.Object
@@ -191,7 +191,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C14::ArrowFunction_L1C14(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -204,7 +204,7 @@
 		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
 		IL_0025: pop
 		IL_0026: ldnull
-		IL_0027: ldftn object Functions.ArrowFunction_L2C13::ArrowFunction_L2C13(object[])
+		IL_0027: ldftn object Functions.ArrowFunction_L2C14::ArrowFunction_L2C14(object[])
 		IL_002d: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0032: ldc.i4.1
 		IL_0033: newarr [System.Runtime]System.Object
@@ -217,7 +217,7 @@
 		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
 		IL_004b: pop
 		IL_004c: ldnull
-		IL_004d: ldftn object Functions.ArrowFunction_L3C13::ArrowFunction_L3C13(object[])
+		IL_004d: ldftn object Functions.ArrowFunction_L3C14::ArrowFunction_L3C14(object[])
 		IL_0053: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetImmediate_Nested_ExecutesInNextIteration.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetImmediate_Nested_ExecutesInNextIteration.verified.txt
@@ -67,44 +67,16 @@
 
 } // end of class Scopes.SetImmediate_Nested_ExecutesInNextIteration
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C17
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L3C17 (
+		object ArrowFunction_L1C14 (
 			object[] scopes
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
-		// Header size: 12
-		// Code size: 30 (0x1e)
-		.maxstack 32
-
-		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_000a: ldc.i4.1
-		IL_000b: newarr [System.Runtime]System.Object
-		IL_0010: dup
-		IL_0011: ldc.i4.0
-		IL_0012: ldstr "inner"
-		IL_0017: stelem.ref
-		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_001d: ret
-	} // end of method ArrowFunction_L3C17::ArrowFunction_L3C17
-
-} // end of class Functions.ArrowFunction_L3C17
-
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C13
-	extends [System.Runtime]System.Object
-{
-	// Methods
-	.method public hidebysig static 
-		object ArrowFunction_L1C13 (
-			object[] scopes
-		) cil managed 
-	{
-		// Method begins at RVA 0x2098
 		// Header size: 12
 		// Code size: 77 (0x4d)
 		.maxstack 32
@@ -120,7 +92,7 @@
 		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001d: pop
 		IL_001e: ldnull
-		IL_001f: ldftn object Functions.ArrowFunction_L3C17::ArrowFunction_L3C17(object[])
+		IL_001f: ldftn object [SetImmediate_Nested_ExecutesInNextIteration]Functions.ArrowFunction_L3C18::ArrowFunction_L3C18(object[])
 		IL_0025: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_002a: ldc.i4.1
 		IL_002b: newarr [System.Runtime]System.Object
@@ -137,9 +109,37 @@
 		IL_004a: pop
 		IL_004b: ldnull
 		IL_004c: ret
-	} // end of method ArrowFunction_L1C13::ArrowFunction_L1C13
+	} // end of method ArrowFunction_L1C14::ArrowFunction_L1C14
 
-} // end of class Functions.ArrowFunction_L1C13
+} // end of class Functions.ArrowFunction_L1C14
+
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C18
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object ArrowFunction_L3C18 (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x20c8
+		// Header size: 12
+		// Code size: 30 (0x1e)
+		.maxstack 32
+
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.1
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "inner"
+		IL_0017: stelem.ref
+		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_001d: ret
+	} // end of method ArrowFunction_L3C18::ArrowFunction_L3C18
+
+} // end of class Functions.ArrowFunction_L3C18
 
 .class public auto ansi beforefieldinit Scripts.SetImmediate_Nested_ExecutesInNextIteration
 	extends [System.Runtime]System.Object
@@ -163,7 +163,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C14::ArrowFunction_L1C14(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetInterval_ExecutesThreeTimes_ThenClears.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetInterval_ExecutesThreeTimes_ThenClears.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.SetInterval_ExecutesThreeTimes_ThenClears
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C23
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L3C24
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L3C23 (
+		object ArrowFunction_L3C24 (
 			object[] scopes
 		) cil managed 
 	{
@@ -155,9 +155,9 @@
 
 		IL_00ca: ldnull
 		IL_00cb: ret
-	} // end of method ArrowFunction_L3C23::ArrowFunction_L3C23
+	} // end of method ArrowFunction_L3C24::ArrowFunction_L3C24
 
-} // end of class Functions.ArrowFunction_L3C23
+} // end of class Functions.ArrowFunction_L3C24
 
 .class public auto ansi beforefieldinit Scripts.SetInterval_ExecutesThreeTimes_ThenClears
 	extends [System.Runtime]System.Object
@@ -188,7 +188,7 @@
 		IL_0015: stfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::count
 		IL_001a: ldloc.0
 		IL_001b: ldnull
-		IL_001c: ldftn object Functions.ArrowFunction_L3C23::ArrowFunction_L3C23(object[])
+		IL_001c: ldftn object Functions.ArrowFunction_L3C24::ArrowFunction_L3C24(object[])
 		IL_0022: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0027: ldc.i4.1
 		IL_0028: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetTimeout_MultipleZeroDelay_ExecutedInOrder.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetTimeout_MultipleZeroDelay_ExecutedInOrder.verified.txt
@@ -85,12 +85,12 @@
 
 } // end of class Scopes.SetTimeout_MultipleZeroDelay_ExecutedInOrder
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C13 (
+		object ArrowFunction_L1C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -115,16 +115,16 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L1C13::ArrowFunction_L1C13
+	} // end of method ArrowFunction_L1C14::ArrowFunction_L1C14
 
-} // end of class Functions.ArrowFunction_L1C13
+} // end of class Functions.ArrowFunction_L1C14
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C13 (
+		object ArrowFunction_L5C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -149,16 +149,16 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L5C13::ArrowFunction_L5C13
+	} // end of method ArrowFunction_L5C14::ArrowFunction_L5C14
 
-} // end of class Functions.ArrowFunction_L5C13
+} // end of class Functions.ArrowFunction_L5C14
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L9C13 (
+		object ArrowFunction_L9C14 (
 			object[] scopes
 		) cil managed 
 	{
@@ -183,9 +183,9 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L9C13::ArrowFunction_L9C13
+	} // end of method ArrowFunction_L9C14::ArrowFunction_L9C14
 
-} // end of class Functions.ArrowFunction_L9C13
+} // end of class Functions.ArrowFunction_L9C14
 
 .class public auto ansi beforefieldinit Scripts.SetTimeout_MultipleZeroDelay_ExecutedInOrder
 	extends [System.Runtime]System.Object
@@ -212,7 +212,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C13::ArrowFunction_L1C13(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C14::ArrowFunction_L1C14(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -223,7 +223,7 @@
 		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_001b: stloc.1
 		IL_001c: ldnull
-		IL_001d: ldftn object Functions.ArrowFunction_L5C13::ArrowFunction_L5C13(object[])
+		IL_001d: ldftn object Functions.ArrowFunction_L5C14::ArrowFunction_L5C14(object[])
 		IL_0023: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0028: ldc.i4.1
 		IL_0029: newarr [System.Runtime]System.Object
@@ -234,7 +234,7 @@
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
 		IL_0037: stloc.2
 		IL_0038: ldnull
-		IL_0039: ldftn object Functions.ArrowFunction_L9C13::ArrowFunction_L9C13(object[])
+		IL_0039: ldftn object Functions.ArrowFunction_L9C14::ArrowFunction_L9C14(object[])
 		IL_003f: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0044: ldc.i4.1
 		IL_0045: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetTimeout_OneSecondDelay.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetTimeout_OneSecondDelay.verified.txt
@@ -45,12 +45,12 @@
 
 } // end of class Scopes.SetTimeout_OneSecondDelay
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C17
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C18
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C17 (
+		object ArrowFunction_L1C18 (
 			object[] scopes
 		) cil managed 
 	{
@@ -75,9 +75,9 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L1C17::ArrowFunction_L1C17
+	} // end of method ArrowFunction_L1C18::ArrowFunction_L1C18
 
-} // end of class Functions.ArrowFunction_L1C17
+} // end of class Functions.ArrowFunction_L1C18
 
 .class public auto ansi beforefieldinit Scripts.SetTimeout_OneSecondDelay
 	extends [System.Runtime]System.Object
@@ -102,7 +102,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C17::ArrowFunction_L1C17(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C18::ArrowFunction_L1C18(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetTimeout_ZeroDelay.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetTimeout_ZeroDelay.verified.txt
@@ -45,12 +45,12 @@
 
 } // end of class Scopes.SetTimeout_ZeroDelay
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C17
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C18
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C17 (
+		object ArrowFunction_L1C18 (
 			object[] scopes
 		) cil managed 
 	{
@@ -75,9 +75,9 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L1C17::ArrowFunction_L1C17
+	} // end of method ArrowFunction_L1C18::ArrowFunction_L1C18
 
-} // end of class Functions.ArrowFunction_L1C17
+} // end of class Functions.ArrowFunction_L1C18
 
 .class public auto ansi beforefieldinit Scripts.SetTimeout_ZeroDelay
 	extends [System.Runtime]System.Object
@@ -102,7 +102,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C17::ArrowFunction_L1C17(object[])
+		IL_0001: ldftn object Functions.ArrowFunction_L1C18::ArrowFunction_L1C18(object[])
 		IL_0007: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetTimeout_ZeroDelay_WithArgs.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetTimeout_ZeroDelay_WithArgs.verified.txt
@@ -50,12 +50,12 @@
 
 } // end of class Scopes.SetTimeout_ZeroDelay_WithArgs
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C19
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C20
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C19 (
+		object ArrowFunction_L1C20 (
 			object[] scopes,
 			object name,
 			object age,
@@ -125,9 +125,9 @@
 		IL_006e: pop
 		IL_006f: ldnull
 		IL_0070: ret
-	} // end of method ArrowFunction_L1C19::ArrowFunction_L1C19
+	} // end of method ArrowFunction_L1C20::ArrowFunction_L1C20
 
-} // end of class Functions.ArrowFunction_L1C19
+} // end of class Functions.ArrowFunction_L1C20
 
 .class public auto ansi beforefieldinit Scripts.SetTimeout_ZeroDelay_WithArgs
 	extends [System.Runtime]System.Object
@@ -152,7 +152,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C19::ArrowFunction_L1C19(object[], object, object, object)
+		IL_0001: ldftn object Functions.ArrowFunction_L1C20::ArrowFunction_L1C20(object[], object, object, object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`5<object[], object, object, object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_AllRejected.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_AllRejected.verified.txt
@@ -48,106 +48,90 @@
 
 } // end of class Scopes.Promise_AllSettled_AllRejected
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L4C34
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L4C35
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L4C34 (
+		object ArrowFunction_L4C35 (
 			object[] scopes,
 			object results
 		) cil managed 
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 263 (0x107)
+		// Code size: 210 (0xd2)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34::results
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.4
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Result 0 status:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34
-		IL_002d: ldfld object Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34::results
-		IL_0032: ldc.r8 0.0
-		IL_003b: box [System.Runtime]System.Double
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0045: ldstr "status"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_004f: stelem.ref
-		IL_0050: dup
-		IL_0051: ldc.i4.2
-		IL_0052: ldstr "reason:"
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.3
-		IL_005a: ldloc.0
-		IL_005b: castclass Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34
-		IL_0060: ldfld object Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34::results
-		IL_0065: ldc.r8 0.0
-		IL_006e: box [System.Runtime]System.Double
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0078: ldstr "reason"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0082: stelem.ref
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0088: pop
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008e: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0093: ldc.i4.4
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: dup
-		IL_009a: ldc.i4.0
-		IL_009b: ldstr "Result 1 status:"
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.4
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Result 0 status:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldc.r8 0.0
+		IL_0024: box [System.Runtime]System.Double
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_002e: ldstr "status"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0038: stelem.ref
+		IL_0039: dup
+		IL_003a: ldc.i4.2
+		IL_003b: ldstr "reason:"
+		IL_0040: stelem.ref
+		IL_0041: dup
+		IL_0042: ldc.i4.3
+		IL_0043: ldarg.1
+		IL_0044: ldc.r8 0.0
+		IL_004d: box [System.Runtime]System.Double
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0057: ldstr "reason"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0061: stelem.ref
+		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0067: pop
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_0072: ldc.i4.4
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldstr "Result 1 status:"
+		IL_007f: stelem.ref
+		IL_0080: dup
+		IL_0081: ldc.i4.1
+		IL_0082: ldarg.1
+		IL_0083: ldc.r8 1
+		IL_008c: box [System.Runtime]System.Double
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0096: ldstr "status"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
 		IL_00a0: stelem.ref
 		IL_00a1: dup
-		IL_00a2: ldc.i4.1
-		IL_00a3: ldloc.0
-		IL_00a4: castclass Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34
-		IL_00a9: ldfld object Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34::results
-		IL_00ae: ldc.r8 1
-		IL_00b7: box [System.Runtime]System.Double
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00c1: ldstr "status"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00cb: stelem.ref
-		IL_00cc: dup
-		IL_00cd: ldc.i4.2
-		IL_00ce: ldstr "reason:"
-		IL_00d3: stelem.ref
-		IL_00d4: dup
-		IL_00d5: ldc.i4.3
-		IL_00d6: ldloc.0
-		IL_00d7: castclass Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34
-		IL_00dc: ldfld object Scopes.Promise_AllSettled_AllRejected/ArrowFunction_L4C34::results
-		IL_00e1: ldc.r8 1
-		IL_00ea: box [System.Runtime]System.Double
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00f4: ldstr "reason"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00fe: stelem.ref
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0104: pop
-		IL_0105: ldnull
-		IL_0106: ret
-	} // end of method ArrowFunction_L4C34::ArrowFunction_L4C34
+		IL_00a2: ldc.i4.2
+		IL_00a3: ldstr "reason:"
+		IL_00a8: stelem.ref
+		IL_00a9: dup
+		IL_00aa: ldc.i4.3
+		IL_00ab: ldarg.1
+		IL_00ac: ldc.r8 1
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00bf: ldstr "reason"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_00c9: stelem.ref
+		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00cf: pop
+		IL_00d0: ldnull
+		IL_00d1: ret
+	} // end of method ArrowFunction_L4C35::ArrowFunction_L4C35
 
-} // end of class Functions.ArrowFunction_L4C34
+} // end of class Functions.ArrowFunction_L4C35
 
 .class public auto ansi beforefieldinit Scripts.Promise_AllSettled_AllRejected
 	extends [System.Runtime]System.Object
@@ -162,7 +146,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2178
+		// Method begins at RVA 0x2144
 		// Header size: 12
 		// Code size: 95 (0x5f)
 		.maxstack 32
@@ -193,7 +177,7 @@
 		IL_003a: dup
 		IL_003b: ldc.i4.0
 		IL_003c: ldnull
-		IL_003d: ldftn object Functions.ArrowFunction_L4C34::ArrowFunction_L4C34(object[], object)
+		IL_003d: ldftn object Functions.ArrowFunction_L4C35::ArrowFunction_L4C35(object[], object)
 		IL_0043: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0048: ldc.i4.1
 		IL_0049: newarr [System.Runtime]System.Object
@@ -217,7 +201,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e3
+		// Method begins at RVA 0x21af
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_AllResolved.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_AllResolved.verified.txt
@@ -48,142 +48,122 @@
 
 } // end of class Scopes.Promise_AllSettled_AllResolved
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C38
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C39
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C38 (
+		object ArrowFunction_L5C39 (
 			object[] scopes,
 			object results
 		) cil managed 
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 387 (0x183)
+		// Code size: 314 (0x13a)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38::results
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.4
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Result 0 status:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38
-		IL_002d: ldfld object Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38::results
-		IL_0032: ldc.r8 0.0
-		IL_003b: box [System.Runtime]System.Double
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0045: ldstr "status"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_004f: stelem.ref
-		IL_0050: dup
-		IL_0051: ldc.i4.2
-		IL_0052: ldstr "value:"
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.3
-		IL_005a: ldloc.0
-		IL_005b: castclass Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38
-		IL_0060: ldfld object Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38::results
-		IL_0065: ldc.r8 0.0
-		IL_006e: box [System.Runtime]System.Double
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0078: ldstr "value"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0082: stelem.ref
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0088: pop
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008e: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0093: ldc.i4.4
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: dup
-		IL_009a: ldc.i4.0
-		IL_009b: ldstr "Result 1 status:"
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.4
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Result 0 status:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldc.r8 0.0
+		IL_0024: box [System.Runtime]System.Double
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_002e: ldstr "status"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0038: stelem.ref
+		IL_0039: dup
+		IL_003a: ldc.i4.2
+		IL_003b: ldstr "value:"
+		IL_0040: stelem.ref
+		IL_0041: dup
+		IL_0042: ldc.i4.3
+		IL_0043: ldarg.1
+		IL_0044: ldc.r8 0.0
+		IL_004d: box [System.Runtime]System.Double
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0057: ldstr "value"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0061: stelem.ref
+		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0067: pop
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_0072: ldc.i4.4
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldstr "Result 1 status:"
+		IL_007f: stelem.ref
+		IL_0080: dup
+		IL_0081: ldc.i4.1
+		IL_0082: ldarg.1
+		IL_0083: ldc.r8 1
+		IL_008c: box [System.Runtime]System.Double
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0096: ldstr "status"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
 		IL_00a0: stelem.ref
 		IL_00a1: dup
-		IL_00a2: ldc.i4.1
-		IL_00a3: ldloc.0
-		IL_00a4: castclass Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38
-		IL_00a9: ldfld object Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38::results
-		IL_00ae: ldc.r8 1
-		IL_00b7: box [System.Runtime]System.Double
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00c1: ldstr "status"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00cb: stelem.ref
-		IL_00cc: dup
-		IL_00cd: ldc.i4.2
-		IL_00ce: ldstr "value:"
-		IL_00d3: stelem.ref
-		IL_00d4: dup
-		IL_00d5: ldc.i4.3
-		IL_00d6: ldloc.0
-		IL_00d7: castclass Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38
-		IL_00dc: ldfld object Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38::results
-		IL_00e1: ldc.r8 1
-		IL_00ea: box [System.Runtime]System.Double
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00f4: ldstr "value"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00fe: stelem.ref
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0104: pop
-		IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010a: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_010f: ldc.i4.4
-		IL_0110: newarr [System.Runtime]System.Object
-		IL_0115: dup
-		IL_0116: ldc.i4.0
-		IL_0117: ldstr "Result 2 status:"
-		IL_011c: stelem.ref
-		IL_011d: dup
-		IL_011e: ldc.i4.1
-		IL_011f: ldloc.0
-		IL_0120: castclass Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38
-		IL_0125: ldfld object Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38::results
-		IL_012a: ldc.r8 2
-		IL_0133: box [System.Runtime]System.Double
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_013d: ldstr "status"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0147: stelem.ref
-		IL_0148: dup
-		IL_0149: ldc.i4.2
-		IL_014a: ldstr "value:"
-		IL_014f: stelem.ref
-		IL_0150: dup
-		IL_0151: ldc.i4.3
-		IL_0152: ldloc.0
-		IL_0153: castclass Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38
-		IL_0158: ldfld object Scopes.Promise_AllSettled_AllResolved/ArrowFunction_L5C38::results
-		IL_015d: ldc.r8 2
-		IL_0166: box [System.Runtime]System.Double
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0170: ldstr "value"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_017a: stelem.ref
-		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0180: pop
-		IL_0181: ldnull
-		IL_0182: ret
-	} // end of method ArrowFunction_L5C38::ArrowFunction_L5C38
+		IL_00a2: ldc.i4.2
+		IL_00a3: ldstr "value:"
+		IL_00a8: stelem.ref
+		IL_00a9: dup
+		IL_00aa: ldc.i4.3
+		IL_00ab: ldarg.1
+		IL_00ac: ldc.r8 1
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00bf: ldstr "value"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_00c9: stelem.ref
+		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00cf: pop
+		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d5: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_00da: ldc.i4.4
+		IL_00db: newarr [System.Runtime]System.Object
+		IL_00e0: dup
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldstr "Result 2 status:"
+		IL_00e7: stelem.ref
+		IL_00e8: dup
+		IL_00e9: ldc.i4.1
+		IL_00ea: ldarg.1
+		IL_00eb: ldc.r8 2
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00fe: ldstr "status"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0108: stelem.ref
+		IL_0109: dup
+		IL_010a: ldc.i4.2
+		IL_010b: ldstr "value:"
+		IL_0110: stelem.ref
+		IL_0111: dup
+		IL_0112: ldc.i4.3
+		IL_0113: ldarg.1
+		IL_0114: ldc.r8 2
+		IL_011d: box [System.Runtime]System.Double
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0127: ldstr "value"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0131: stelem.ref
+		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0137: pop
+		IL_0138: ldnull
+		IL_0139: ret
+	} // end of method ArrowFunction_L5C39::ArrowFunction_L5C39
 
-} // end of class Functions.ArrowFunction_L5C38
+} // end of class Functions.ArrowFunction_L5C39
 
 .class public auto ansi beforefieldinit Scripts.Promise_AllSettled_AllResolved
 	extends [System.Runtime]System.Object
@@ -198,7 +178,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21f4
+		// Method begins at RVA 0x21ac
 		// Header size: 12
 		// Code size: 140 (0x8c)
 		.maxstack 32
@@ -239,7 +219,7 @@
 		IL_0067: dup
 		IL_0068: ldc.i4.0
 		IL_0069: ldnull
-		IL_006a: ldftn object Functions.ArrowFunction_L5C38::ArrowFunction_L5C38(object[], object)
+		IL_006a: ldftn object Functions.ArrowFunction_L5C39::ArrowFunction_L5C39(object[], object)
 		IL_0070: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0075: ldc.i4.1
 		IL_0076: newarr [System.Runtime]System.Object
@@ -263,7 +243,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x228c
+		// Method begins at RVA 0x2244
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_EmptyArray.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_EmptyArray.verified.txt
@@ -48,12 +48,12 @@
 
 } // end of class Scopes.Promise_AllSettled_EmptyArray
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C28
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C29
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C28 (
+		object ArrowFunction_L1C29 (
 			object[] scopes,
 			object results
 		) cil managed 
@@ -85,9 +85,9 @@
 		IL_0028: pop
 		IL_0029: ldnull
 		IL_002a: ret
-	} // end of method ArrowFunction_L1C28::ArrowFunction_L1C28
+	} // end of method ArrowFunction_L1C29::ArrowFunction_L1C29
 
-} // end of class Functions.ArrowFunction_L1C28
+} // end of class Functions.ArrowFunction_L1C29
 
 .class public auto ansi beforefieldinit Scripts.Promise_AllSettled_EmptyArray
 	extends [System.Runtime]System.Object
@@ -119,7 +119,7 @@
 		IL_0016: dup
 		IL_0017: ldc.i4.0
 		IL_0018: ldnull
-		IL_0019: ldftn object Functions.ArrowFunction_L1C28::ArrowFunction_L1C28(object[], object)
+		IL_0019: ldftn object Functions.ArrowFunction_L1C29::ArrowFunction_L1C29(object[], object)
 		IL_001f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0024: ldc.i4.1
 		IL_0025: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_MixedResults.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_MixedResults.verified.txt
@@ -48,142 +48,122 @@
 
 } // end of class Scopes.Promise_AllSettled_MixedResults
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C38
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C39
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C38 (
+		object ArrowFunction_L5C39 (
 			object[] scopes,
 			object results
 		) cil managed 
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 387 (0x183)
+		// Code size: 314 (0x13a)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38::results
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.4
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Result 0 status:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38
-		IL_002d: ldfld object Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38::results
-		IL_0032: ldc.r8 0.0
-		IL_003b: box [System.Runtime]System.Double
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0045: ldstr "status"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_004f: stelem.ref
-		IL_0050: dup
-		IL_0051: ldc.i4.2
-		IL_0052: ldstr "value:"
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.3
-		IL_005a: ldloc.0
-		IL_005b: castclass Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38
-		IL_0060: ldfld object Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38::results
-		IL_0065: ldc.r8 0.0
-		IL_006e: box [System.Runtime]System.Double
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0078: ldstr "value"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0082: stelem.ref
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0088: pop
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008e: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0093: ldc.i4.4
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: dup
-		IL_009a: ldc.i4.0
-		IL_009b: ldstr "Result 1 status:"
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.4
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Result 0 status:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldc.r8 0.0
+		IL_0024: box [System.Runtime]System.Double
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_002e: ldstr "status"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0038: stelem.ref
+		IL_0039: dup
+		IL_003a: ldc.i4.2
+		IL_003b: ldstr "value:"
+		IL_0040: stelem.ref
+		IL_0041: dup
+		IL_0042: ldc.i4.3
+		IL_0043: ldarg.1
+		IL_0044: ldc.r8 0.0
+		IL_004d: box [System.Runtime]System.Double
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0057: ldstr "value"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0061: stelem.ref
+		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0067: pop
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_0072: ldc.i4.4
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldstr "Result 1 status:"
+		IL_007f: stelem.ref
+		IL_0080: dup
+		IL_0081: ldc.i4.1
+		IL_0082: ldarg.1
+		IL_0083: ldc.r8 1
+		IL_008c: box [System.Runtime]System.Double
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0096: ldstr "status"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
 		IL_00a0: stelem.ref
 		IL_00a1: dup
-		IL_00a2: ldc.i4.1
-		IL_00a3: ldloc.0
-		IL_00a4: castclass Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38
-		IL_00a9: ldfld object Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38::results
-		IL_00ae: ldc.r8 1
-		IL_00b7: box [System.Runtime]System.Double
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00c1: ldstr "status"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00cb: stelem.ref
-		IL_00cc: dup
-		IL_00cd: ldc.i4.2
-		IL_00ce: ldstr "reason:"
-		IL_00d3: stelem.ref
-		IL_00d4: dup
-		IL_00d5: ldc.i4.3
-		IL_00d6: ldloc.0
-		IL_00d7: castclass Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38
-		IL_00dc: ldfld object Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38::results
-		IL_00e1: ldc.r8 1
-		IL_00ea: box [System.Runtime]System.Double
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00f4: ldstr "reason"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00fe: stelem.ref
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0104: pop
-		IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010a: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_010f: ldc.i4.4
-		IL_0110: newarr [System.Runtime]System.Object
-		IL_0115: dup
-		IL_0116: ldc.i4.0
-		IL_0117: ldstr "Result 2 status:"
-		IL_011c: stelem.ref
-		IL_011d: dup
-		IL_011e: ldc.i4.1
-		IL_011f: ldloc.0
-		IL_0120: castclass Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38
-		IL_0125: ldfld object Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38::results
-		IL_012a: ldc.r8 2
-		IL_0133: box [System.Runtime]System.Double
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_013d: ldstr "status"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0147: stelem.ref
-		IL_0148: dup
-		IL_0149: ldc.i4.2
-		IL_014a: ldstr "value:"
-		IL_014f: stelem.ref
-		IL_0150: dup
-		IL_0151: ldc.i4.3
-		IL_0152: ldloc.0
-		IL_0153: castclass Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38
-		IL_0158: ldfld object Scopes.Promise_AllSettled_MixedResults/ArrowFunction_L5C38::results
-		IL_015d: ldc.r8 2
-		IL_0166: box [System.Runtime]System.Double
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0170: ldstr "value"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_017a: stelem.ref
-		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0180: pop
-		IL_0181: ldnull
-		IL_0182: ret
-	} // end of method ArrowFunction_L5C38::ArrowFunction_L5C38
+		IL_00a2: ldc.i4.2
+		IL_00a3: ldstr "reason:"
+		IL_00a8: stelem.ref
+		IL_00a9: dup
+		IL_00aa: ldc.i4.3
+		IL_00ab: ldarg.1
+		IL_00ac: ldc.r8 1
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00bf: ldstr "reason"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_00c9: stelem.ref
+		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00cf: pop
+		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d5: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_00da: ldc.i4.4
+		IL_00db: newarr [System.Runtime]System.Object
+		IL_00e0: dup
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldstr "Result 2 status:"
+		IL_00e7: stelem.ref
+		IL_00e8: dup
+		IL_00e9: ldc.i4.1
+		IL_00ea: ldarg.1
+		IL_00eb: ldc.r8 2
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00fe: ldstr "status"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0108: stelem.ref
+		IL_0109: dup
+		IL_010a: ldc.i4.2
+		IL_010b: ldstr "value:"
+		IL_0110: stelem.ref
+		IL_0111: dup
+		IL_0112: ldc.i4.3
+		IL_0113: ldarg.1
+		IL_0114: ldc.r8 2
+		IL_011d: box [System.Runtime]System.Double
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0127: ldstr "value"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0131: stelem.ref
+		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0137: pop
+		IL_0138: ldnull
+		IL_0139: ret
+	} // end of method ArrowFunction_L5C39::ArrowFunction_L5C39
 
-} // end of class Functions.ArrowFunction_L5C38
+} // end of class Functions.ArrowFunction_L5C39
 
 .class public auto ansi beforefieldinit Scripts.Promise_AllSettled_MixedResults
 	extends [System.Runtime]System.Object
@@ -198,7 +178,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21f4
+		// Method begins at RVA 0x21ac
 		// Header size: 12
 		// Code size: 131 (0x83)
 		.maxstack 32
@@ -238,7 +218,7 @@
 		IL_005e: dup
 		IL_005f: ldc.i4.0
 		IL_0060: ldnull
-		IL_0061: ldftn object Functions.ArrowFunction_L5C38::ArrowFunction_L5C38(object[], object)
+		IL_0061: ldftn object Functions.ArrowFunction_L5C39::ArrowFunction_L5C39(object[], object)
 		IL_0067: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.1
 		IL_006d: newarr [System.Runtime]System.Object
@@ -262,7 +242,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2283
+		// Method begins at RVA 0x223b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_MixedValues.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_MixedValues.verified.txt
@@ -48,142 +48,122 @@
 
 } // end of class Scopes.Promise_AllSettled_MixedValues
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C42
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C43
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C42 (
+		object ArrowFunction_L5C43 (
 			object[] scopes,
 			object results
 		) cil managed 
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 387 (0x183)
+		// Code size: 314 (0x13a)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42::results
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.4
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Result 0 status:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42
-		IL_002d: ldfld object Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42::results
-		IL_0032: ldc.r8 0.0
-		IL_003b: box [System.Runtime]System.Double
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0045: ldstr "status"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_004f: stelem.ref
-		IL_0050: dup
-		IL_0051: ldc.i4.2
-		IL_0052: ldstr "value:"
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.3
-		IL_005a: ldloc.0
-		IL_005b: castclass Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42
-		IL_0060: ldfld object Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42::results
-		IL_0065: ldc.r8 0.0
-		IL_006e: box [System.Runtime]System.Double
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0078: ldstr "value"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0082: stelem.ref
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0088: pop
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008e: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0093: ldc.i4.4
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: dup
-		IL_009a: ldc.i4.0
-		IL_009b: ldstr "Result 1 status:"
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.4
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Result 0 status:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldc.r8 0.0
+		IL_0024: box [System.Runtime]System.Double
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_002e: ldstr "status"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0038: stelem.ref
+		IL_0039: dup
+		IL_003a: ldc.i4.2
+		IL_003b: ldstr "value:"
+		IL_0040: stelem.ref
+		IL_0041: dup
+		IL_0042: ldc.i4.3
+		IL_0043: ldarg.1
+		IL_0044: ldc.r8 0.0
+		IL_004d: box [System.Runtime]System.Double
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0057: ldstr "value"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0061: stelem.ref
+		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0067: pop
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_0072: ldc.i4.4
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldstr "Result 1 status:"
+		IL_007f: stelem.ref
+		IL_0080: dup
+		IL_0081: ldc.i4.1
+		IL_0082: ldarg.1
+		IL_0083: ldc.r8 1
+		IL_008c: box [System.Runtime]System.Double
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0096: ldstr "status"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
 		IL_00a0: stelem.ref
 		IL_00a1: dup
-		IL_00a2: ldc.i4.1
-		IL_00a3: ldloc.0
-		IL_00a4: castclass Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42
-		IL_00a9: ldfld object Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42::results
-		IL_00ae: ldc.r8 1
-		IL_00b7: box [System.Runtime]System.Double
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00c1: ldstr "status"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00cb: stelem.ref
-		IL_00cc: dup
-		IL_00cd: ldc.i4.2
-		IL_00ce: ldstr "value:"
-		IL_00d3: stelem.ref
-		IL_00d4: dup
-		IL_00d5: ldc.i4.3
-		IL_00d6: ldloc.0
-		IL_00d7: castclass Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42
-		IL_00dc: ldfld object Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42::results
-		IL_00e1: ldc.r8 1
-		IL_00ea: box [System.Runtime]System.Double
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00f4: ldstr "value"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00fe: stelem.ref
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0104: pop
-		IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010a: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_010f: ldc.i4.4
-		IL_0110: newarr [System.Runtime]System.Object
-		IL_0115: dup
-		IL_0116: ldc.i4.0
-		IL_0117: ldstr "Result 2 status:"
-		IL_011c: stelem.ref
-		IL_011d: dup
-		IL_011e: ldc.i4.1
-		IL_011f: ldloc.0
-		IL_0120: castclass Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42
-		IL_0125: ldfld object Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42::results
-		IL_012a: ldc.r8 2
-		IL_0133: box [System.Runtime]System.Double
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_013d: ldstr "status"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0147: stelem.ref
-		IL_0148: dup
-		IL_0149: ldc.i4.2
-		IL_014a: ldstr "value:"
-		IL_014f: stelem.ref
-		IL_0150: dup
-		IL_0151: ldc.i4.3
-		IL_0152: ldloc.0
-		IL_0153: castclass Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42
-		IL_0158: ldfld object Scopes.Promise_AllSettled_MixedValues/ArrowFunction_L5C42::results
-		IL_015d: ldc.r8 2
-		IL_0166: box [System.Runtime]System.Double
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0170: ldstr "value"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_017a: stelem.ref
-		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0180: pop
-		IL_0181: ldnull
-		IL_0182: ret
-	} // end of method ArrowFunction_L5C42::ArrowFunction_L5C42
+		IL_00a2: ldc.i4.2
+		IL_00a3: ldstr "value:"
+		IL_00a8: stelem.ref
+		IL_00a9: dup
+		IL_00aa: ldc.i4.3
+		IL_00ab: ldarg.1
+		IL_00ac: ldc.r8 1
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00bf: ldstr "value"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_00c9: stelem.ref
+		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00cf: pop
+		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d5: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_00da: ldc.i4.4
+		IL_00db: newarr [System.Runtime]System.Object
+		IL_00e0: dup
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldstr "Result 2 status:"
+		IL_00e7: stelem.ref
+		IL_00e8: dup
+		IL_00e9: ldc.i4.1
+		IL_00ea: ldarg.1
+		IL_00eb: ldc.r8 2
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00fe: ldstr "status"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0108: stelem.ref
+		IL_0109: dup
+		IL_010a: ldc.i4.2
+		IL_010b: ldstr "value:"
+		IL_0110: stelem.ref
+		IL_0111: dup
+		IL_0112: ldc.i4.3
+		IL_0113: ldarg.1
+		IL_0114: ldc.r8 2
+		IL_011d: box [System.Runtime]System.Double
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0127: ldstr "value"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0131: stelem.ref
+		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0137: pop
+		IL_0138: ldnull
+		IL_0139: ret
+	} // end of method ArrowFunction_L5C43::ArrowFunction_L5C43
 
-} // end of class Functions.ArrowFunction_L5C42
+} // end of class Functions.ArrowFunction_L5C43
 
 .class public auto ansi beforefieldinit Scripts.Promise_AllSettled_MixedValues
 	extends [System.Runtime]System.Object
@@ -198,7 +178,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21f4
+		// Method begins at RVA 0x21ac
 		// Header size: 12
 		// Code size: 112 (0x70)
 		.maxstack 32
@@ -235,7 +215,7 @@
 		IL_004b: dup
 		IL_004c: ldc.i4.0
 		IL_004d: ldnull
-		IL_004e: ldftn object Functions.ArrowFunction_L5C42::ArrowFunction_L5C42(object[], object)
+		IL_004e: ldftn object Functions.ArrowFunction_L5C43::ArrowFunction_L5C43(object[], object)
 		IL_0054: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0059: ldc.i4.1
 		IL_005a: newarr [System.Runtime]System.Object
@@ -259,7 +239,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2270
+		// Method begins at RVA 0x2228
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_NullIterable.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_NullIterable.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_AllSettled_NullIterable
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C10 (
+		object ArrowFunction_L2C11 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -102,56 +102,46 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L2C10::ArrowFunction_L2C10
+	} // end of method ArrowFunction_L2C11::ArrowFunction_L2C11
 
-} // end of class Functions.ArrowFunction_L2C10
+} // end of class Functions.ArrowFunction_L2C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C11 (
+		object ArrowFunction_L5C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
 	{
 		// Method begins at RVA 0x2098
 		// Header size: 12
-		// Code size: 69 (0x45)
+		// Code size: 46 (0x2e)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_AllSettled_NullIterable/ArrowFunction_L5C11
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_AllSettled_NullIterable/ArrowFunction_L5C11::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_AllSettled_NullIterable/ArrowFunction_L5C11::'error'
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Caught error type:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_AllSettled_NullIterable/ArrowFunction_L5C11
-		IL_002d: ldfld object Scopes.Promise_AllSettled_NullIterable/ArrowFunction_L5C11::'error'
-		IL_0032: ldstr "name"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_003c: stelem.ref
-		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0042: pop
-		IL_0043: ldnull
-		IL_0044: ret
-	} // end of method ArrowFunction_L5C11::ArrowFunction_L5C11
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Caught error type:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldstr "name"
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0025: stelem.ref
+		IL_0026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_002b: pop
+		IL_002c: ldnull
+		IL_002d: ret
+	} // end of method ArrowFunction_L5C12::ArrowFunction_L5C12
 
-} // end of class Functions.ArrowFunction_L5C11
+} // end of class Functions.ArrowFunction_L5C12
 
 .class public auto ansi beforefieldinit Scripts.Promise_AllSettled_NullIterable
 	extends [System.Runtime]System.Object
@@ -166,7 +156,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ec
+		// Method begins at RVA 0x20d4
 		// Header size: 12
 		// Code size: 105 (0x69)
 		.maxstack 32
@@ -183,7 +173,7 @@
 		IL_0016: dup
 		IL_0017: ldc.i4.0
 		IL_0018: ldnull
-		IL_0019: ldftn object Functions.ArrowFunction_L2C10::ArrowFunction_L2C10(object[], object)
+		IL_0019: ldftn object Functions.ArrowFunction_L2C11::ArrowFunction_L2C11(object[], object)
 		IL_001f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0024: ldc.i4.1
 		IL_0025: newarr [System.Runtime]System.Object
@@ -200,7 +190,7 @@
 		IL_0044: dup
 		IL_0045: ldc.i4.0
 		IL_0046: ldnull
-		IL_0047: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object)
+		IL_0047: ldftn object Functions.ArrowFunction_L5C12::ArrowFunction_L5C12(object[], object)
 		IL_004d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0052: ldc.i4.1
 		IL_0053: newarr [System.Runtime]System.Object
@@ -224,7 +214,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2161
+		// Method begins at RVA 0x2149
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_AllResolved.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_AllResolved.verified.txt
@@ -48,12 +48,12 @@
 
 } // end of class Scopes.Promise_All_AllResolved
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C31
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C32
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C31 (
+		object ArrowFunction_L5C32 (
 			object[] scopes,
 			object results
 		) cil managed 
@@ -106,9 +106,9 @@
 		IL_0063: pop
 		IL_0064: ldnull
 		IL_0065: ret
-	} // end of method ArrowFunction_L5C31::ArrowFunction_L5C31
+	} // end of method ArrowFunction_L5C32::ArrowFunction_L5C32
 
-} // end of class Functions.ArrowFunction_L5C31
+} // end of class Functions.ArrowFunction_L5C32
 
 .class public auto ansi beforefieldinit Scripts.Promise_All_AllResolved
 	extends [System.Runtime]System.Object
@@ -164,7 +164,7 @@
 		IL_0067: dup
 		IL_0068: ldc.i4.0
 		IL_0069: ldnull
-		IL_006a: ldftn object Functions.ArrowFunction_L5C31::ArrowFunction_L5C31(object[], object)
+		IL_006a: ldftn object Functions.ArrowFunction_L5C32::ArrowFunction_L5C32(object[], object)
 		IL_0070: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0075: ldc.i4.1
 		IL_0076: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_EmptyArray.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_EmptyArray.verified.txt
@@ -48,12 +48,12 @@
 
 } // end of class Scopes.Promise_All_EmptyArray
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C21
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C22
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C21 (
+		object ArrowFunction_L1C22 (
 			object[] scopes,
 			object results
 		) cil managed 
@@ -85,9 +85,9 @@
 		IL_0028: pop
 		IL_0029: ldnull
 		IL_002a: ret
-	} // end of method ArrowFunction_L1C21::ArrowFunction_L1C21
+	} // end of method ArrowFunction_L1C22::ArrowFunction_L1C22
 
-} // end of class Functions.ArrowFunction_L1C21
+} // end of class Functions.ArrowFunction_L1C22
 
 .class public auto ansi beforefieldinit Scripts.Promise_All_EmptyArray
 	extends [System.Runtime]System.Object
@@ -119,7 +119,7 @@
 		IL_0016: dup
 		IL_0017: ldc.i4.0
 		IL_0018: ldnull
-		IL_0019: ldftn object Functions.ArrowFunction_L1C21::ArrowFunction_L1C21(object[], object)
+		IL_0019: ldftn object Functions.ArrowFunction_L1C22::ArrowFunction_L1C22(object[], object)
 		IL_001f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0024: ldc.i4.1
 		IL_0025: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_MixedValues.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_MixedValues.verified.txt
@@ -48,12 +48,12 @@
 
 } // end of class Scopes.Promise_All_MixedValues
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C35
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C36
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C35 (
+		object ArrowFunction_L5C36 (
 			object[] scopes,
 			object results
 		) cil managed 
@@ -106,9 +106,9 @@
 		IL_0063: pop
 		IL_0064: ldnull
 		IL_0065: ret
-	} // end of method ArrowFunction_L5C35::ArrowFunction_L5C35
+	} // end of method ArrowFunction_L5C36::ArrowFunction_L5C36
 
-} // end of class Functions.ArrowFunction_L5C35
+} // end of class Functions.ArrowFunction_L5C36
 
 .class public auto ansi beforefieldinit Scripts.Promise_All_MixedValues
 	extends [System.Runtime]System.Object
@@ -160,7 +160,7 @@
 		IL_004b: dup
 		IL_004c: ldc.i4.0
 		IL_004d: ldnull
-		IL_004e: ldftn object Functions.ArrowFunction_L5C35::ArrowFunction_L5C35(object[], object)
+		IL_004e: ldftn object Functions.ArrowFunction_L5C36::ArrowFunction_L5C36(object[], object)
 		IL_0054: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0059: ldc.i4.1
 		IL_005a: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_NullIterable.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_NullIterable.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_All_NullIterable
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C10 (
+		object ArrowFunction_L2C11 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -102,56 +102,46 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L2C10::ArrowFunction_L2C10
+	} // end of method ArrowFunction_L2C11::ArrowFunction_L2C11
 
-} // end of class Functions.ArrowFunction_L2C10
+} // end of class Functions.ArrowFunction_L2C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C11 (
+		object ArrowFunction_L5C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
 	{
 		// Method begins at RVA 0x2098
 		// Header size: 12
-		// Code size: 69 (0x45)
+		// Code size: 46 (0x2e)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_All_NullIterable/ArrowFunction_L5C11
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_All_NullIterable/ArrowFunction_L5C11::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_All_NullIterable/ArrowFunction_L5C11::'error'
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Caught error type:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_All_NullIterable/ArrowFunction_L5C11
-		IL_002d: ldfld object Scopes.Promise_All_NullIterable/ArrowFunction_L5C11::'error'
-		IL_0032: ldstr "name"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_003c: stelem.ref
-		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0042: pop
-		IL_0043: ldnull
-		IL_0044: ret
-	} // end of method ArrowFunction_L5C11::ArrowFunction_L5C11
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Caught error type:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldstr "name"
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0025: stelem.ref
+		IL_0026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_002b: pop
+		IL_002c: ldnull
+		IL_002d: ret
+	} // end of method ArrowFunction_L5C12::ArrowFunction_L5C12
 
-} // end of class Functions.ArrowFunction_L5C11
+} // end of class Functions.ArrowFunction_L5C12
 
 .class public auto ansi beforefieldinit Scripts.Promise_All_NullIterable
 	extends [System.Runtime]System.Object
@@ -166,7 +156,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ec
+		// Method begins at RVA 0x20d4
 		// Header size: 12
 		// Code size: 105 (0x69)
 		.maxstack 32
@@ -183,7 +173,7 @@
 		IL_0016: dup
 		IL_0017: ldc.i4.0
 		IL_0018: ldnull
-		IL_0019: ldftn object Functions.ArrowFunction_L2C10::ArrowFunction_L2C10(object[], object)
+		IL_0019: ldftn object Functions.ArrowFunction_L2C11::ArrowFunction_L2C11(object[], object)
 		IL_001f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0024: ldc.i4.1
 		IL_0025: newarr [System.Runtime]System.Object
@@ -200,7 +190,7 @@
 		IL_0044: dup
 		IL_0045: ldc.i4.0
 		IL_0046: ldnull
-		IL_0047: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object)
+		IL_0047: ldftn object Functions.ArrowFunction_L5C12::ArrowFunction_L5C12(object[], object)
 		IL_004d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0052: ldc.i4.1
 		IL_0053: newarr [System.Runtime]System.Object
@@ -224,7 +214,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2161
+		// Method begins at RVA 0x2149
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_OneRejected.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_OneRejected.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_All_OneRejected
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L6C10 (
+		object ArrowFunction_L6C11 (
 			object[] scopes,
 			object results
 		) cil managed 
@@ -102,16 +102,16 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L6C10::ArrowFunction_L6C10
+	} // end of method ArrowFunction_L6C11::ArrowFunction_L6C11
 
-} // end of class Functions.ArrowFunction_L6C10
+} // end of class Functions.ArrowFunction_L6C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L9C11 (
+		object ArrowFunction_L9C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
@@ -141,9 +141,9 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L9C11::ArrowFunction_L9C11
+	} // end of method ArrowFunction_L9C12::ArrowFunction_L9C12
 
-} // end of class Functions.ArrowFunction_L9C11
+} // end of class Functions.ArrowFunction_L9C12
 
 .class public auto ansi beforefieldinit Scripts.Promise_All_OneRejected
 	extends [System.Runtime]System.Object
@@ -198,7 +198,7 @@
 		IL_005e: dup
 		IL_005f: ldc.i4.0
 		IL_0060: ldnull
-		IL_0061: ldftn object Functions.ArrowFunction_L6C10::ArrowFunction_L6C10(object[], object)
+		IL_0061: ldftn object Functions.ArrowFunction_L6C11::ArrowFunction_L6C11(object[], object)
 		IL_0067: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.1
 		IL_006d: newarr [System.Runtime]System.Object
@@ -215,7 +215,7 @@
 		IL_008c: dup
 		IL_008d: ldc.i4.0
 		IL_008e: ldnull
-		IL_008f: ldftn object Functions.ArrowFunction_L9C11::ArrowFunction_L9C11(object[], object)
+		IL_008f: ldftn object Functions.ArrowFunction_L9C12::ArrowFunction_L9C12(object[], object)
 		IL_0095: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_009a: ldc.i4.1
 		IL_009b: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_OrderPreserved.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_All_OrderPreserved.verified.txt
@@ -117,12 +117,12 @@
 
 } // end of class Scopes.Promise_All_OrderPreserved
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C23
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C24
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C23 (
+		object ArrowFunction_L2C24 (
 			object[] scopes,
 			object resolve
 		) cil managed 
@@ -173,16 +173,16 @@
 		IL_004a: pop
 		IL_004b: ldnull
 		IL_004c: ret
-	} // end of method ArrowFunction_L2C23::ArrowFunction_L2C23
+	} // end of method ArrowFunction_L2C24::ArrowFunction_L2C24
 
-} // end of class Functions.ArrowFunction_L2C23
+} // end of class Functions.ArrowFunction_L2C24
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C23
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C24
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L6C23 (
+		object ArrowFunction_L6C24 (
 			object[] scopes,
 			object resolve
 		) cil managed 
@@ -233,16 +233,16 @@
 		IL_004a: pop
 		IL_004b: ldnull
 		IL_004c: ret
-	} // end of method ArrowFunction_L6C23::ArrowFunction_L6C23
+	} // end of method ArrowFunction_L6C24::ArrowFunction_L6C24
 
-} // end of class Functions.ArrowFunction_L6C23
+} // end of class Functions.ArrowFunction_L6C24
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L10C23
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L10C24
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L10C23 (
+		object ArrowFunction_L10C24 (
 			object[] scopes,
 			object resolve
 		) cil managed 
@@ -293,16 +293,16 @@
 		IL_004a: pop
 		IL_004b: ldnull
 		IL_004c: ret
-	} // end of method ArrowFunction_L10C23::ArrowFunction_L10C23
+	} // end of method ArrowFunction_L10C24::ArrowFunction_L10C24
 
-} // end of class Functions.ArrowFunction_L10C23
+} // end of class Functions.ArrowFunction_L10C24
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L14C31
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L14C32
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L14C31 (
+		object ArrowFunction_L14C32 (
 			object[] scopes,
 			object results
 		) cil managed 
@@ -355,9 +355,9 @@
 		IL_0063: pop
 		IL_0064: ldnull
 		IL_0065: ret
-	} // end of method ArrowFunction_L14C31::ArrowFunction_L14C31
+	} // end of method ArrowFunction_L14C32::ArrowFunction_L14C32
 
-} // end of class Functions.ArrowFunction_L14C31
+} // end of class Functions.ArrowFunction_L14C32
 
 .class public auto ansi beforefieldinit Scripts.Promise_All_OrderPreserved
 	extends [System.Runtime]System.Object
@@ -384,7 +384,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L2C23::ArrowFunction_L2C23(object[], object)
+		IL_0001: ldftn object Functions.ArrowFunction_L2C24::ArrowFunction_L2C24(object[], object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -396,7 +396,7 @@
 		IL_001b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 		IL_0020: stloc.1
 		IL_0021: ldnull
-		IL_0022: ldftn object Functions.ArrowFunction_L6C23::ArrowFunction_L6C23(object[], object)
+		IL_0022: ldftn object Functions.ArrowFunction_L6C24::ArrowFunction_L6C24(object[], object)
 		IL_0028: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_002d: ldc.i4.1
 		IL_002e: newarr [System.Runtime]System.Object
@@ -408,7 +408,7 @@
 		IL_003c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
 		IL_0041: stloc.2
 		IL_0042: ldnull
-		IL_0043: ldftn object Functions.ArrowFunction_L10C23::ArrowFunction_L10C23(object[], object)
+		IL_0043: ldftn object Functions.ArrowFunction_L10C24::ArrowFunction_L10C24(object[], object)
 		IL_0049: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_004e: ldc.i4.1
 		IL_004f: newarr [System.Runtime]System.Object
@@ -437,7 +437,7 @@
 		IL_008e: dup
 		IL_008f: ldc.i4.0
 		IL_0090: ldnull
-		IL_0091: ldftn object Functions.ArrowFunction_L14C31::ArrowFunction_L14C31(object[], object)
+		IL_0091: ldftn object Functions.ArrowFunction_L14C32::ArrowFunction_L14C32(object[], object)
 		IL_0097: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_009c: ldc.i4.1
 		IL_009d: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_AllRejected.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_AllRejected.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_Any_AllRejected
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L6C10 (
+		object ArrowFunction_L6C11 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -102,76 +102,64 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L6C10::ArrowFunction_L6C10
+	} // end of method ArrowFunction_L6C11::ArrowFunction_L6C11
 
-} // end of class Functions.ArrowFunction_L6C10
+} // end of class Functions.ArrowFunction_L6C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L9C11 (
+		object ArrowFunction_L9C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
 	{
 		// Method begins at RVA 0x2098
 		// Header size: 12
-		// Code size: 133 (0x85)
+		// Code size: 100 (0x64)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Any_AllRejected/ArrowFunction_L9C11
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Any_AllRejected/ArrowFunction_L9C11::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Any_AllRejected/ArrowFunction_L9C11::'error'
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "All rejected, error name:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Any_AllRejected/ArrowFunction_L9C11
-		IL_002d: ldfld object Scopes.Promise_Any_AllRejected/ArrowFunction_L9C11::'error'
-		IL_0032: ldstr "name"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_003c: stelem.ref
-		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0042: pop
-		IL_0043: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0048: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_004d: ldc.i4.2
-		IL_004e: newarr [System.Runtime]System.Object
-		IL_0053: dup
-		IL_0054: ldc.i4.0
-		IL_0055: ldstr "Errors count:"
-		IL_005a: stelem.ref
-		IL_005b: dup
-		IL_005c: ldc.i4.1
-		IL_005d: ldloc.0
-		IL_005e: castclass Scopes.Promise_Any_AllRejected/ArrowFunction_L9C11
-		IL_0063: ldfld object Scopes.Promise_Any_AllRejected/ArrowFunction_L9C11::'error'
-		IL_0068: ldstr "errors"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_0077: box [System.Runtime]System.Double
-		IL_007c: stelem.ref
-		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0082: pop
-		IL_0083: ldnull
-		IL_0084: ret
-	} // end of method ArrowFunction_L9C11::ArrowFunction_L9C11
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "All rejected, error name:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldstr "name"
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0025: stelem.ref
+		IL_0026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_002b: pop
+		IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0031: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_0036: ldc.i4.2
+		IL_0037: newarr [System.Runtime]System.Object
+		IL_003c: dup
+		IL_003d: ldc.i4.0
+		IL_003e: ldstr "Errors count:"
+		IL_0043: stelem.ref
+		IL_0044: dup
+		IL_0045: ldc.i4.1
+		IL_0046: ldarg.1
+		IL_0047: ldstr "errors"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0051: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0056: box [System.Runtime]System.Double
+		IL_005b: stelem.ref
+		IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0061: pop
+		IL_0062: ldnull
+		IL_0063: ret
+	} // end of method ArrowFunction_L9C12::ArrowFunction_L9C12
 
-} // end of class Functions.ArrowFunction_L9C11
+} // end of class Functions.ArrowFunction_L9C12
 
 .class public auto ansi beforefieldinit Scripts.Promise_Any_AllRejected
 	extends [System.Runtime]System.Object
@@ -186,7 +174,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x212c
+		// Method begins at RVA 0x2108
 		// Header size: 12
 		// Code size: 159 (0x9f)
 		.maxstack 32
@@ -224,7 +212,7 @@
 		IL_004c: dup
 		IL_004d: ldc.i4.0
 		IL_004e: ldnull
-		IL_004f: ldftn object Functions.ArrowFunction_L6C10::ArrowFunction_L6C10(object[], object)
+		IL_004f: ldftn object Functions.ArrowFunction_L6C11::ArrowFunction_L6C11(object[], object)
 		IL_0055: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_005a: ldc.i4.1
 		IL_005b: newarr [System.Runtime]System.Object
@@ -241,7 +229,7 @@
 		IL_007a: dup
 		IL_007b: ldc.i4.0
 		IL_007c: ldnull
-		IL_007d: ldftn object Functions.ArrowFunction_L9C11::ArrowFunction_L9C11(object[], object)
+		IL_007d: ldftn object Functions.ArrowFunction_L9C12::ArrowFunction_L9C12(object[], object)
 		IL_0083: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0088: ldc.i4.1
 		IL_0089: newarr [System.Runtime]System.Object
@@ -265,7 +253,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d7
+		// Method begins at RVA 0x21b3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_EmptyArray.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_EmptyArray.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_Any_EmptyArray
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C10 (
+		object ArrowFunction_L2C11 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -102,56 +102,46 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L2C10::ArrowFunction_L2C10
+	} // end of method ArrowFunction_L2C11::ArrowFunction_L2C11
 
-} // end of class Functions.ArrowFunction_L2C10
+} // end of class Functions.ArrowFunction_L2C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C11 (
+		object ArrowFunction_L5C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
 	{
 		// Method begins at RVA 0x2098
 		// Header size: 12
-		// Code size: 69 (0x45)
+		// Code size: 46 (0x2e)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Any_EmptyArray/ArrowFunction_L5C11
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Any_EmptyArray/ArrowFunction_L5C11::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Any_EmptyArray/ArrowFunction_L5C11::'error'
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Empty array rejected, error name:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Any_EmptyArray/ArrowFunction_L5C11
-		IL_002d: ldfld object Scopes.Promise_Any_EmptyArray/ArrowFunction_L5C11::'error'
-		IL_0032: ldstr "name"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_003c: stelem.ref
-		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0042: pop
-		IL_0043: ldnull
-		IL_0044: ret
-	} // end of method ArrowFunction_L5C11::ArrowFunction_L5C11
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Empty array rejected, error name:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldstr "name"
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0025: stelem.ref
+		IL_0026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_002b: pop
+		IL_002c: ldnull
+		IL_002d: ret
+	} // end of method ArrowFunction_L5C12::ArrowFunction_L5C12
 
-} // end of class Functions.ArrowFunction_L5C11
+} // end of class Functions.ArrowFunction_L5C12
 
 .class public auto ansi beforefieldinit Scripts.Promise_Any_EmptyArray
 	extends [System.Runtime]System.Object
@@ -166,7 +156,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ec
+		// Method begins at RVA 0x20d4
 		// Header size: 12
 		// Code size: 105 (0x69)
 		.maxstack 32
@@ -183,7 +173,7 @@
 		IL_0016: dup
 		IL_0017: ldc.i4.0
 		IL_0018: ldnull
-		IL_0019: ldftn object Functions.ArrowFunction_L2C10::ArrowFunction_L2C10(object[], object)
+		IL_0019: ldftn object Functions.ArrowFunction_L2C11::ArrowFunction_L2C11(object[], object)
 		IL_001f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0024: ldc.i4.1
 		IL_0025: newarr [System.Runtime]System.Object
@@ -200,7 +190,7 @@
 		IL_0044: dup
 		IL_0045: ldc.i4.0
 		IL_0046: ldnull
-		IL_0047: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object)
+		IL_0047: ldftn object Functions.ArrowFunction_L5C12::ArrowFunction_L5C12(object[], object)
 		IL_004d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0052: ldc.i4.1
 		IL_0053: newarr [System.Runtime]System.Object
@@ -224,7 +214,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2161
+		// Method begins at RVA 0x2149
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_FirstResolved.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_FirstResolved.verified.txt
@@ -48,12 +48,12 @@
 
 } // end of class Scopes.Promise_Any_FirstResolved
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C31
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C32
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C31 (
+		object ArrowFunction_L5C32 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -83,9 +83,9 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L5C31::ArrowFunction_L5C31
+	} // end of method ArrowFunction_L5C32::ArrowFunction_L5C32
 
-} // end of class Functions.ArrowFunction_L5C31
+} // end of class Functions.ArrowFunction_L5C32
 
 .class public auto ansi beforefieldinit Scripts.Promise_Any_FirstResolved
 	extends [System.Runtime]System.Object
@@ -141,7 +141,7 @@
 		IL_0067: dup
 		IL_0068: ldc.i4.0
 		IL_0069: ldnull
-		IL_006a: ldftn object Functions.ArrowFunction_L5C31::ArrowFunction_L5C31(object[], object)
+		IL_006a: ldftn object Functions.ArrowFunction_L5C32::ArrowFunction_L5C32(object[], object)
 		IL_0070: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0075: ldc.i4.1
 		IL_0076: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_NullIterable.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_NullIterable.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_Any_NullIterable
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C10 (
+		object ArrowFunction_L2C11 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -102,56 +102,46 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L2C10::ArrowFunction_L2C10
+	} // end of method ArrowFunction_L2C11::ArrowFunction_L2C11
 
-} // end of class Functions.ArrowFunction_L2C10
+} // end of class Functions.ArrowFunction_L2C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C11 (
+		object ArrowFunction_L5C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
 	{
 		// Method begins at RVA 0x2098
 		// Header size: 12
-		// Code size: 69 (0x45)
+		// Code size: 46 (0x2e)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Any_NullIterable/ArrowFunction_L5C11
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Any_NullIterable/ArrowFunction_L5C11::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Any_NullIterable/ArrowFunction_L5C11::'error'
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Caught error type:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Any_NullIterable/ArrowFunction_L5C11
-		IL_002d: ldfld object Scopes.Promise_Any_NullIterable/ArrowFunction_L5C11::'error'
-		IL_0032: ldstr "name"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_003c: stelem.ref
-		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0042: pop
-		IL_0043: ldnull
-		IL_0044: ret
-	} // end of method ArrowFunction_L5C11::ArrowFunction_L5C11
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Caught error type:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldstr "name"
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0025: stelem.ref
+		IL_0026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_002b: pop
+		IL_002c: ldnull
+		IL_002d: ret
+	} // end of method ArrowFunction_L5C12::ArrowFunction_L5C12
 
-} // end of class Functions.ArrowFunction_L5C11
+} // end of class Functions.ArrowFunction_L5C12
 
 .class public auto ansi beforefieldinit Scripts.Promise_Any_NullIterable
 	extends [System.Runtime]System.Object
@@ -166,7 +156,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ec
+		// Method begins at RVA 0x20d4
 		// Header size: 12
 		// Code size: 105 (0x69)
 		.maxstack 32
@@ -183,7 +173,7 @@
 		IL_0016: dup
 		IL_0017: ldc.i4.0
 		IL_0018: ldnull
-		IL_0019: ldftn object Functions.ArrowFunction_L2C10::ArrowFunction_L2C10(object[], object)
+		IL_0019: ldftn object Functions.ArrowFunction_L2C11::ArrowFunction_L2C11(object[], object)
 		IL_001f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0024: ldc.i4.1
 		IL_0025: newarr [System.Runtime]System.Object
@@ -200,7 +190,7 @@
 		IL_0044: dup
 		IL_0045: ldc.i4.0
 		IL_0046: ldnull
-		IL_0047: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object)
+		IL_0047: ldftn object Functions.ArrowFunction_L5C12::ArrowFunction_L5C12(object[], object)
 		IL_004d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0052: ldc.i4.1
 		IL_0053: newarr [System.Runtime]System.Object
@@ -224,7 +214,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2161
+		// Method begins at RVA 0x2149
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_OneResolved.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_OneResolved.verified.txt
@@ -48,12 +48,12 @@
 
 } // end of class Scopes.Promise_Any_OneResolved
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C31
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C32
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C31 (
+		object ArrowFunction_L5C32 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -83,9 +83,9 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L5C31::ArrowFunction_L5C31
+	} // end of method ArrowFunction_L5C32::ArrowFunction_L5C32
 
-} // end of class Functions.ArrowFunction_L5C31
+} // end of class Functions.ArrowFunction_L5C32
 
 .class public auto ansi beforefieldinit Scripts.Promise_Any_OneResolved
 	extends [System.Runtime]System.Object
@@ -138,7 +138,7 @@
 		IL_004c: dup
 		IL_004d: ldc.i4.0
 		IL_004e: ldnull
-		IL_004f: ldftn object Functions.ArrowFunction_L5C31::ArrowFunction_L5C31(object[], object)
+		IL_004f: ldftn object Functions.ArrowFunction_L5C32::ArrowFunction_L5C32(object[], object)
 		IL_0055: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_005a: ldc.i4.1
 		IL_005b: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Catch_ReturnsRejectedPromise.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Catch_ReturnsRejectedPromise.verified.txt
@@ -71,78 +71,60 @@
 
 } // end of class Scopes.Promise_Catch_ReturnsRejectedPromise
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C29
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C30
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C29 (
+		object ArrowFunction_L1C30 (
 			object[] scopes,
 			object e
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
 		// Header size: 12
-		// Code size: 24 (0x18)
+		// Code size: 11 (0xb)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L1C29
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L1C29::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L1C29::e
-		IL_000d: ldstr "err2"
-		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-		IL_0017: ret
-	} // end of method ArrowFunction_L1C29::ArrowFunction_L1C29
+		IL_0000: ldstr "err2"
+		IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+		IL_000a: ret
+	} // end of method ArrowFunction_L1C30::ArrowFunction_L1C30
 
-} // end of class Functions.ArrowFunction_L1C29
+} // end of class Functions.ArrowFunction_L1C30
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C64
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C65
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C64 (
+		object ArrowFunction_L1C65 (
 			object[] scopes,
 			object e
 		) cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x2084
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L1C64
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L1C64::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L1C64::e
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Caught:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L1C64
-		IL_002d: ldfld object Scopes.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L1C64::e
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C64::ArrowFunction_L1C64
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Caught:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C65::ArrowFunction_L1C65
 
-} // end of class Functions.ArrowFunction_L1C64
+} // end of class Functions.ArrowFunction_L1C65
 
 .class public auto ansi beforefieldinit Scripts.Promise_Catch_ReturnsRejectedPromise
 	extends [System.Runtime]System.Object
@@ -157,7 +139,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20d8
+		// Method begins at RVA 0x20b4
 		// Header size: 12
 		// Code size: 104 (0x68)
 		.maxstack 32
@@ -173,7 +155,7 @@
 		IL_0015: dup
 		IL_0016: ldc.i4.0
 		IL_0017: ldnull
-		IL_0018: ldftn object Functions.ArrowFunction_L1C29::ArrowFunction_L1C29(object[], object)
+		IL_0018: ldftn object Functions.ArrowFunction_L1C30::ArrowFunction_L1C30(object[], object)
 		IL_001e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0023: ldc.i4.1
 		IL_0024: newarr [System.Runtime]System.Object
@@ -190,7 +172,7 @@
 		IL_0043: dup
 		IL_0044: ldc.i4.0
 		IL_0045: ldnull
-		IL_0046: ldftn object Functions.ArrowFunction_L1C64::ArrowFunction_L1C64(object[], object)
+		IL_0046: ldftn object Functions.ArrowFunction_L1C65::ArrowFunction_L1C65(object[], object)
 		IL_004c: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0051: ldc.i4.1
 		IL_0052: newarr [System.Runtime]System.Object
@@ -214,7 +196,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214c
+		// Method begins at RVA 0x2128
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Catch_ReturnsResolvedPromise.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Catch_ReturnsResolvedPromise.verified.txt
@@ -71,78 +71,60 @@
 
 } // end of class Scopes.Promise_Catch_ReturnsResolvedPromise
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C28
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C29
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C28 (
+		object ArrowFunction_L1C29 (
 			object[] scopes,
 			object e
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
 		// Header size: 12
-		// Code size: 24 (0x18)
+		// Code size: 11 (0xb)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L1C28
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L1C28::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L1C28::e
-		IL_000d: ldstr "recovered"
-		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_0017: ret
-	} // end of method ArrowFunction_L1C28::ArrowFunction_L1C28
+		IL_0000: ldstr "recovered"
+		IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_000a: ret
+	} // end of method ArrowFunction_L1C29::ArrowFunction_L1C29
 
-} // end of class Functions.ArrowFunction_L1C28
+} // end of class Functions.ArrowFunction_L1C29
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C68
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C69
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C68 (
+		object ArrowFunction_L1C69 (
 			object[] scopes,
 			object v
 		) cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x2084
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L1C68
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L1C68::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L1C68::v
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Result:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L1C68
-		IL_002d: ldfld object Scopes.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L1C68::v
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C68::ArrowFunction_L1C68
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Result:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C69::ArrowFunction_L1C69
 
-} // end of class Functions.ArrowFunction_L1C68
+} // end of class Functions.ArrowFunction_L1C69
 
 .class public auto ansi beforefieldinit Scripts.Promise_Catch_ReturnsResolvedPromise
 	extends [System.Runtime]System.Object
@@ -157,7 +139,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20d8
+		// Method begins at RVA 0x20b4
 		// Header size: 12
 		// Code size: 104 (0x68)
 		.maxstack 32
@@ -173,7 +155,7 @@
 		IL_0015: dup
 		IL_0016: ldc.i4.0
 		IL_0017: ldnull
-		IL_0018: ldftn object Functions.ArrowFunction_L1C28::ArrowFunction_L1C28(object[], object)
+		IL_0018: ldftn object Functions.ArrowFunction_L1C29::ArrowFunction_L1C29(object[], object)
 		IL_001e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0023: ldc.i4.1
 		IL_0024: newarr [System.Runtime]System.Object
@@ -190,7 +172,7 @@
 		IL_0043: dup
 		IL_0044: ldc.i4.0
 		IL_0045: ldnull
-		IL_0046: ldftn object Functions.ArrowFunction_L1C68::ArrowFunction_L1C68(object[], object)
+		IL_0046: ldftn object Functions.ArrowFunction_L1C69::ArrowFunction_L1C69(object[], object)
 		IL_004c: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0051: ldc.i4.1
 		IL_0052: newarr [System.Runtime]System.Object
@@ -214,7 +196,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214c
+		// Method begins at RVA 0x2128
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Rejected.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Rejected.verified.txt
@@ -72,12 +72,12 @@
 
 } // end of class Scopes.Promise_Executor_Rejected
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C22
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C23
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C22 (
+		object ArrowFunction_L1C23 (
 			object[] scopes,
 			object resolve,
 			object reject
@@ -132,16 +132,16 @@
 		IL_0051: pop
 		IL_0052: ldnull
 		IL_0053: ret
-	} // end of method ArrowFunction_L1C22::ArrowFunction_L1C22
+	} // end of method ArrowFunction_L1C23::ArrowFunction_L1C23
 
-} // end of class Functions.ArrowFunction_L1C22
+} // end of class Functions.ArrowFunction_L1C23
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C13
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C14
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C13 (
+		object ArrowFunction_L5C14 (
 			object[] scopes,
 			object message
 		) cil managed 
@@ -171,9 +171,9 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L5C13::ArrowFunction_L5C13
+	} // end of method ArrowFunction_L5C14::ArrowFunction_L5C14
 
-} // end of class Functions.ArrowFunction_L5C13
+} // end of class Functions.ArrowFunction_L5C14
 
 .class public auto ansi beforefieldinit Scripts.Promise_Executor_Rejected
 	extends [System.Runtime]System.Object
@@ -198,7 +198,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C22::ArrowFunction_L1C22(object[], object, object)
+		IL_0001: ldftn object Functions.ArrowFunction_L1C23::ArrowFunction_L1C23(object[], object, object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -214,7 +214,7 @@
 		IL_0027: ldc.i4.0
 		IL_0028: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 		IL_002d: ldnull
-		IL_002e: ldftn object Functions.ArrowFunction_L5C13::ArrowFunction_L5C13(object[], object)
+		IL_002e: ldftn object Functions.ArrowFunction_L5C14::ArrowFunction_L5C14(object[], object)
 		IL_0034: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0039: ldc.i4.1
 		IL_003a: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Resolved.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Executor_Resolved.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_Executor_Resolved
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C22
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C23
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C22 (
+		object ArrowFunction_L1C23 (
 			object[] scopes,
 			object resolve
 		) cil managed 
@@ -127,16 +127,16 @@
 		IL_004a: pop
 		IL_004b: ldnull
 		IL_004c: ret
-	} // end of method ArrowFunction_L1C22::ArrowFunction_L1C22
+	} // end of method ArrowFunction_L1C23::ArrowFunction_L1C23
 
-} // end of class Functions.ArrowFunction_L1C22
+} // end of class Functions.ArrowFunction_L1C23
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C7
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C8
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C7 (
+		object ArrowFunction_L5C8 (
 			object[] scopes,
 			object message
 		) cil managed 
@@ -166,9 +166,9 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L5C7::ArrowFunction_L5C7
+	} // end of method ArrowFunction_L5C8::ArrowFunction_L5C8
 
-} // end of class Functions.ArrowFunction_L5C7
+} // end of class Functions.ArrowFunction_L5C8
 
 .class public auto ansi beforefieldinit Scripts.Promise_Executor_Resolved
 	extends [System.Runtime]System.Object
@@ -193,7 +193,7 @@
 		)
 
 		IL_0000: ldnull
-		IL_0001: ldftn object Functions.ArrowFunction_L1C22::ArrowFunction_L1C22(object[], object)
+		IL_0001: ldftn object Functions.ArrowFunction_L1C23::ArrowFunction_L1C23(object[], object)
 		IL_0007: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_000c: ldc.i4.1
 		IL_000d: newarr [System.Runtime]System.Object
@@ -211,7 +211,7 @@
 		IL_002d: dup
 		IL_002e: ldc.i4.0
 		IL_002f: ldnull
-		IL_0030: ldftn object Functions.ArrowFunction_L5C7::ArrowFunction_L5C7(object[], object)
+		IL_0030: ldftn object Functions.ArrowFunction_L5C8::ArrowFunction_L5C8(object[], object)
 		IL_0036: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_003b: ldc.i4.1
 		IL_003c: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsRejectedPromise.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsRejectedPromise.verified.txt
@@ -68,12 +68,12 @@
 
 } // end of class Scopes.Promise_Finally_ReturnsRejectedPromise
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C28
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C29
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C28 (
+		object ArrowFunction_L1C29 (
 			object[] scopes
 		) cil managed 
 	{
@@ -85,52 +85,42 @@
 		IL_0000: ldstr "cleanup failed"
 		IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
 		IL_000a: ret
-	} // end of method ArrowFunction_L1C28::ArrowFunction_L1C28
+	} // end of method ArrowFunction_L1C29::ArrowFunction_L1C29
 
-} // end of class Functions.ArrowFunction_L1C28
+} // end of class Functions.ArrowFunction_L1C29
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C74
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C75
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C74 (
+		object ArrowFunction_L1C75 (
 			object[] scopes,
 			object e
 		) cil managed 
 	{
 		// Method begins at RVA 0x2084
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L1C74
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L1C74::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L1C74::e
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Caught:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L1C74
-		IL_002d: ldfld object Scopes.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L1C74::e
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C74::ArrowFunction_L1C74
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Caught:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C75::ArrowFunction_L1C75
 
-} // end of class Functions.ArrowFunction_L1C74
+} // end of class Functions.ArrowFunction_L1C75
 
 .class public auto ansi beforefieldinit Scripts.Promise_Finally_ReturnsRejectedPromise
 	extends [System.Runtime]System.Object
@@ -145,7 +135,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20cc
+		// Method begins at RVA 0x20b4
 		// Header size: 12
 		// Code size: 113 (0x71)
 		.maxstack 32
@@ -162,7 +152,7 @@
 		IL_001e: dup
 		IL_001f: ldc.i4.0
 		IL_0020: ldnull
-		IL_0021: ldftn object Functions.ArrowFunction_L1C28::ArrowFunction_L1C28(object[])
+		IL_0021: ldftn object Functions.ArrowFunction_L1C29::ArrowFunction_L1C29(object[])
 		IL_0027: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_002c: ldc.i4.1
 		IL_002d: newarr [System.Runtime]System.Object
@@ -179,7 +169,7 @@
 		IL_004c: dup
 		IL_004d: ldc.i4.0
 		IL_004e: ldnull
-		IL_004f: ldftn object Functions.ArrowFunction_L1C74::ArrowFunction_L1C74(object[], object)
+		IL_004f: ldftn object Functions.ArrowFunction_L1C75::ArrowFunction_L1C75(object[], object)
 		IL_0055: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_005a: ldc.i4.1
 		IL_005b: newarr [System.Runtime]System.Object
@@ -203,7 +193,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2149
+		// Method begins at RVA 0x2131
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsResolvedPromise.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsResolvedPromise.verified.txt
@@ -68,12 +68,12 @@
 
 } // end of class Scopes.Promise_Finally_ReturnsResolvedPromise
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C28
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C29
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C28 (
+		object ArrowFunction_L1C29 (
 			object[] scopes
 		) cil managed 
 	{
@@ -86,52 +86,42 @@
 		IL_0009: box [System.Runtime]System.Double
 		IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
 		IL_0013: ret
-	} // end of method ArrowFunction_L1C28::ArrowFunction_L1C28
+	} // end of method ArrowFunction_L1C29::ArrowFunction_L1C29
 
-} // end of class Functions.ArrowFunction_L1C28
+} // end of class Functions.ArrowFunction_L1C29
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C61
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C62
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C61 (
+		object ArrowFunction_L1C62 (
 			object[] scopes,
 			object v
 		) cil managed 
 	{
 		// Method begins at RVA 0x208c
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L1C61
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L1C61::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L1C61::v
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Result:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L1C61
-		IL_002d: ldfld object Scopes.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L1C61::v
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C61::ArrowFunction_L1C61
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Result:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C62::ArrowFunction_L1C62
 
-} // end of class Functions.ArrowFunction_L1C61
+} // end of class Functions.ArrowFunction_L1C62
 
 .class public auto ansi beforefieldinit Scripts.Promise_Finally_ReturnsResolvedPromise
 	extends [System.Runtime]System.Object
@@ -146,7 +136,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20d4
+		// Method begins at RVA 0x20bc
 		// Header size: 12
 		// Code size: 113 (0x71)
 		.maxstack 32
@@ -163,7 +153,7 @@
 		IL_001e: dup
 		IL_001f: ldc.i4.0
 		IL_0020: ldnull
-		IL_0021: ldftn object Functions.ArrowFunction_L1C28::ArrowFunction_L1C28(object[])
+		IL_0021: ldftn object Functions.ArrowFunction_L1C29::ArrowFunction_L1C29(object[])
 		IL_0027: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_002c: ldc.i4.1
 		IL_002d: newarr [System.Runtime]System.Object
@@ -180,7 +170,7 @@
 		IL_004c: dup
 		IL_004d: ldc.i4.0
 		IL_004e: ldnull
-		IL_004f: ldftn object Functions.ArrowFunction_L1C61::ArrowFunction_L1C61(object[], object)
+		IL_004f: ldftn object Functions.ArrowFunction_L1C62::ArrowFunction_L1C62(object[], object)
 		IL_0055: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_005a: ldc.i4.1
 		IL_005b: newarr [System.Runtime]System.Object
@@ -204,7 +194,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2151
+		// Method begins at RVA 0x2139
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_EmptyArray.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_EmptyArray.verified.txt
@@ -91,12 +91,12 @@
 
 } // end of class Scopes.Promise_Race_EmptyArray
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C10 (
+		object ArrowFunction_L2C11 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -126,16 +126,16 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L2C10::ArrowFunction_L2C10
+	} // end of method ArrowFunction_L2C11::ArrowFunction_L2C11
 
-} // end of class Functions.ArrowFunction_L2C10
+} // end of class Functions.ArrowFunction_L2C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C11 (
+		object ArrowFunction_L5C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
@@ -165,16 +165,16 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L5C11::ArrowFunction_L5C11
+	} // end of method ArrowFunction_L5C12::ArrowFunction_L5C12
 
-} // end of class Functions.ArrowFunction_L5C11
+} // end of class Functions.ArrowFunction_L5C12
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L10C29
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L10C30
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L10C29 (
+		object ArrowFunction_L10C30 (
 			object[] scopes
 		) cil managed 
 	{
@@ -199,9 +199,9 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L10C29::ArrowFunction_L10C29
+	} // end of method ArrowFunction_L10C30::ArrowFunction_L10C30
 
-} // end of class Functions.ArrowFunction_L10C29
+} // end of class Functions.ArrowFunction_L10C30
 
 .class public auto ansi beforefieldinit Scripts.Promise_Race_EmptyArray
 	extends [System.Runtime]System.Object
@@ -233,7 +233,7 @@
 		IL_0016: dup
 		IL_0017: ldc.i4.0
 		IL_0018: ldnull
-		IL_0019: ldftn object Functions.ArrowFunction_L2C10::ArrowFunction_L2C10(object[], object)
+		IL_0019: ldftn object Functions.ArrowFunction_L2C11::ArrowFunction_L2C11(object[], object)
 		IL_001f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0024: ldc.i4.1
 		IL_0025: newarr [System.Runtime]System.Object
@@ -250,7 +250,7 @@
 		IL_0044: dup
 		IL_0045: ldc.i4.0
 		IL_0046: ldnull
-		IL_0047: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object)
+		IL_0047: ldftn object Functions.ArrowFunction_L5C12::ArrowFunction_L5C12(object[], object)
 		IL_004d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0052: ldc.i4.1
 		IL_0053: newarr [System.Runtime]System.Object
@@ -270,7 +270,7 @@
 		IL_007d: dup
 		IL_007e: ldc.i4.0
 		IL_007f: ldnull
-		IL_0080: ldftn object Functions.ArrowFunction_L10C29::ArrowFunction_L10C29(object[])
+		IL_0080: ldftn object Functions.ArrowFunction_L10C30::ArrowFunction_L10C30(object[])
 		IL_0086: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_008b: ldc.i4.1
 		IL_008c: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_FirstRejected.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_FirstRejected.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_Race_FirstRejected
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L6C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L6C10 (
+		object ArrowFunction_L6C11 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -102,16 +102,16 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L6C10::ArrowFunction_L6C10
+	} // end of method ArrowFunction_L6C11::ArrowFunction_L6C11
 
-} // end of class Functions.ArrowFunction_L6C10
+} // end of class Functions.ArrowFunction_L6C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L9C11 (
+		object ArrowFunction_L9C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
@@ -141,9 +141,9 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L9C11::ArrowFunction_L9C11
+	} // end of method ArrowFunction_L9C12::ArrowFunction_L9C12
 
-} // end of class Functions.ArrowFunction_L9C11
+} // end of class Functions.ArrowFunction_L9C12
 
 .class public auto ansi beforefieldinit Scripts.Promise_Race_FirstRejected
 	extends [System.Runtime]System.Object
@@ -198,7 +198,7 @@
 		IL_005e: dup
 		IL_005f: ldc.i4.0
 		IL_0060: ldnull
-		IL_0061: ldftn object Functions.ArrowFunction_L6C10::ArrowFunction_L6C10(object[], object)
+		IL_0061: ldftn object Functions.ArrowFunction_L6C11::ArrowFunction_L6C11(object[], object)
 		IL_0067: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.1
 		IL_006d: newarr [System.Runtime]System.Object
@@ -215,7 +215,7 @@
 		IL_008c: dup
 		IL_008d: ldc.i4.0
 		IL_008e: ldnull
-		IL_008f: ldftn object Functions.ArrowFunction_L9C11::ArrowFunction_L9C11(object[], object)
+		IL_008f: ldftn object Functions.ArrowFunction_L9C12::ArrowFunction_L9C12(object[], object)
 		IL_0095: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_009a: ldc.i4.1
 		IL_009b: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_FirstResolved.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_FirstResolved.verified.txt
@@ -48,12 +48,12 @@
 
 } // end of class Scopes.Promise_Race_FirstResolved
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C32
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C33
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C32 (
+		object ArrowFunction_L5C33 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -83,9 +83,9 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L5C32::ArrowFunction_L5C32
+	} // end of method ArrowFunction_L5C33::ArrowFunction_L5C33
 
-} // end of class Functions.ArrowFunction_L5C32
+} // end of class Functions.ArrowFunction_L5C33
 
 .class public auto ansi beforefieldinit Scripts.Promise_Race_FirstResolved
 	extends [System.Runtime]System.Object
@@ -141,7 +141,7 @@
 		IL_0067: dup
 		IL_0068: ldc.i4.0
 		IL_0069: ldnull
-		IL_006a: ldftn object Functions.ArrowFunction_L5C32::ArrowFunction_L5C32(object[], object)
+		IL_006a: ldftn object Functions.ArrowFunction_L5C33::ArrowFunction_L5C33(object[], object)
 		IL_0070: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0075: ldc.i4.1
 		IL_0076: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_MixedValues.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_MixedValues.verified.txt
@@ -48,12 +48,12 @@
 
 } // end of class Scopes.Promise_Race_MixedValues
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L4C31
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L4C32
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L4C31 (
+		object ArrowFunction_L4C32 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -83,9 +83,9 @@
 		IL_001e: pop
 		IL_001f: ldnull
 		IL_0020: ret
-	} // end of method ArrowFunction_L4C31::ArrowFunction_L4C31
+	} // end of method ArrowFunction_L4C32::ArrowFunction_L4C32
 
-} // end of class Functions.ArrowFunction_L4C31
+} // end of class Functions.ArrowFunction_L4C32
 
 .class public auto ansi beforefieldinit Scripts.Promise_Race_MixedValues
 	extends [System.Runtime]System.Object
@@ -130,7 +130,7 @@
 		IL_0035: dup
 		IL_0036: ldc.i4.0
 		IL_0037: ldnull
-		IL_0038: ldftn object Functions.ArrowFunction_L4C31::ArrowFunction_L4C31(object[], object)
+		IL_0038: ldftn object Functions.ArrowFunction_L4C32::ArrowFunction_L4C32(object[], object)
 		IL_003e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0043: ldc.i4.1
 		IL_0044: newarr [System.Runtime]System.Object

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_NullIterable.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_NullIterable.verified.txt
@@ -71,12 +71,12 @@
 
 } // end of class Scopes.Promise_Race_NullIterable
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C10
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C11
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C10 (
+		object ArrowFunction_L2C11 (
 			object[] scopes,
 			object result
 		) cil managed 
@@ -102,56 +102,46 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L2C10::ArrowFunction_L2C10
+	} // end of method ArrowFunction_L2C11::ArrowFunction_L2C11
 
-} // end of class Functions.ArrowFunction_L2C10
+} // end of class Functions.ArrowFunction_L2C11
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C11
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C12
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L5C11 (
+		object ArrowFunction_L5C12 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
 	{
 		// Method begins at RVA 0x2098
 		// Header size: 12
-		// Code size: 69 (0x45)
+		// Code size: 46 (0x2e)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Race_NullIterable/ArrowFunction_L5C11
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Race_NullIterable/ArrowFunction_L5C11::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Race_NullIterable/ArrowFunction_L5C11::'error'
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Caught error type:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Race_NullIterable/ArrowFunction_L5C11
-		IL_002d: ldfld object Scopes.Promise_Race_NullIterable/ArrowFunction_L5C11::'error'
-		IL_0032: ldstr "name"
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_003c: stelem.ref
-		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0042: pop
-		IL_0043: ldnull
-		IL_0044: ret
-	} // end of method ArrowFunction_L5C11::ArrowFunction_L5C11
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Caught error type:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: ldstr "name"
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0025: stelem.ref
+		IL_0026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_002b: pop
+		IL_002c: ldnull
+		IL_002d: ret
+	} // end of method ArrowFunction_L5C12::ArrowFunction_L5C12
 
-} // end of class Functions.ArrowFunction_L5C11
+} // end of class Functions.ArrowFunction_L5C12
 
 .class public auto ansi beforefieldinit Scripts.Promise_Race_NullIterable
 	extends [System.Runtime]System.Object
@@ -166,7 +156,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ec
+		// Method begins at RVA 0x20d4
 		// Header size: 12
 		// Code size: 105 (0x69)
 		.maxstack 32
@@ -183,7 +173,7 @@
 		IL_0016: dup
 		IL_0017: ldc.i4.0
 		IL_0018: ldnull
-		IL_0019: ldftn object Functions.ArrowFunction_L2C10::ArrowFunction_L2C10(object[], object)
+		IL_0019: ldftn object Functions.ArrowFunction_L2C11::ArrowFunction_L2C11(object[], object)
 		IL_001f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0024: ldc.i4.1
 		IL_0025: newarr [System.Runtime]System.Object
@@ -200,7 +190,7 @@
 		IL_0044: dup
 		IL_0045: ldc.i4.0
 		IL_0046: ldnull
-		IL_0047: ldftn object Functions.ArrowFunction_L5C11::ArrowFunction_L5C11(object[], object)
+		IL_0047: ldftn object Functions.ArrowFunction_L5C12::ArrowFunction_L5C12(object[], object)
 		IL_004d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0052: ldc.i4.1
 		IL_0053: newarr [System.Runtime]System.Object
@@ -224,7 +214,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2161
+		// Method begins at RVA 0x2149
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Reject_FinallyCatch.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Reject_FinallyCatch.verified.txt
@@ -68,12 +68,12 @@
 
 } // end of class Scopes.Promise_Reject_FinallyCatch
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C52
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C53
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C52 (
+		object ArrowFunction_L1C53 (
 			object[] scopes
 		) cil managed 
 	{
@@ -92,48 +92,38 @@
 		IL_0017: stelem.ref
 		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001d: ret
-	} // end of method ArrowFunction_L1C52::ArrowFunction_L1C52
+	} // end of method ArrowFunction_L1C53::ArrowFunction_L1C53
 
-} // end of class Functions.ArrowFunction_L1C52
+} // end of class Functions.ArrowFunction_L1C53
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C100
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C101
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C100 (
+		object ArrowFunction_L1C101 (
 			object[] scopes,
 			object message
 		) cil managed 
 	{
 		// Method begins at RVA 0x2098
 		// Header size: 12
-		// Code size: 49 (0x31)
+		// Code size: 26 (0x1a)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Reject_FinallyCatch/ArrowFunction_L1C100
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Reject_FinallyCatch/ArrowFunction_L1C100::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Reject_FinallyCatch/ArrowFunction_L1C100::message
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.1
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldloc.0
-		IL_0020: castclass Scopes.Promise_Reject_FinallyCatch/ArrowFunction_L1C100
-		IL_0025: ldfld object Scopes.Promise_Reject_FinallyCatch/ArrowFunction_L1C100::message
-		IL_002a: stelem.ref
-		IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0030: ret
-	} // end of method ArrowFunction_L1C100::ArrowFunction_L1C100
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.1
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldarg.1
+		IL_0013: stelem.ref
+		IL_0014: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0019: ret
+	} // end of method ArrowFunction_L1C101::ArrowFunction_L1C101
 
-} // end of class Functions.ArrowFunction_L1C100
+} // end of class Functions.ArrowFunction_L1C101
 
 .class public auto ansi beforefieldinit Scripts.Promise_Reject_FinallyCatch
 	extends [System.Runtime]System.Object
@@ -148,7 +138,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20d8
+		// Method begins at RVA 0x20c0
 		// Header size: 12
 		// Code size: 104 (0x68)
 		.maxstack 32
@@ -164,7 +154,7 @@
 		IL_0015: dup
 		IL_0016: ldc.i4.0
 		IL_0017: ldnull
-		IL_0018: ldftn object Functions.ArrowFunction_L1C52::ArrowFunction_L1C52(object[])
+		IL_0018: ldftn object Functions.ArrowFunction_L1C53::ArrowFunction_L1C53(object[])
 		IL_001e: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0023: ldc.i4.1
 		IL_0024: newarr [System.Runtime]System.Object
@@ -181,7 +171,7 @@
 		IL_0043: dup
 		IL_0044: ldc.i4.0
 		IL_0045: ldnull
-		IL_0046: ldftn object Functions.ArrowFunction_L1C100::ArrowFunction_L1C100(object[], object)
+		IL_0046: ldftn object Functions.ArrowFunction_L1C101::ArrowFunction_L1C101(object[], object)
 		IL_004c: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0051: ldc.i4.1
 		IL_0052: newarr [System.Runtime]System.Object
@@ -205,7 +195,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214c
+		// Method begins at RVA 0x2134
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Reject_Then.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Reject_Then.verified.txt
@@ -48,44 +48,34 @@
 
 } // end of class Scopes.Promise_Reject_Then
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C56
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C57
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C56 (
+		object ArrowFunction_L1C57 (
 			object[] scopes,
 			object message
 		) cil managed 
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 49 (0x31)
+		// Code size: 26 (0x1a)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Reject_Then/ArrowFunction_L1C56
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Reject_Then/ArrowFunction_L1C56::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Reject_Then/ArrowFunction_L1C56::message
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.1
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldloc.0
-		IL_0020: castclass Scopes.Promise_Reject_Then/ArrowFunction_L1C56
-		IL_0025: ldfld object Scopes.Promise_Reject_Then/ArrowFunction_L1C56::message
-		IL_002a: stelem.ref
-		IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0030: ret
-	} // end of method ArrowFunction_L1C56::ArrowFunction_L1C56
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.1
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldarg.1
+		IL_0013: stelem.ref
+		IL_0014: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0019: ret
+	} // end of method ArrowFunction_L1C57::ArrowFunction_L1C57
 
-} // end of class Functions.ArrowFunction_L1C56
+} // end of class Functions.ArrowFunction_L1C57
 
 .class public auto ansi beforefieldinit Scripts.Promise_Reject_Then
 	extends [System.Runtime]System.Object
@@ -100,7 +90,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20a4
+		// Method begins at RVA 0x208c
 		// Header size: 12
 		// Code size: 67 (0x43)
 		.maxstack 32
@@ -121,7 +111,7 @@
 		IL_001e: dup
 		IL_001f: ldc.i4.1
 		IL_0020: ldnull
-		IL_0021: ldftn object Functions.ArrowFunction_L1C56::ArrowFunction_L1C56(object[], object)
+		IL_0021: ldftn object Functions.ArrowFunction_L1C57::ArrowFunction_L1C57(object[], object)
 		IL_0027: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_002c: ldc.i4.1
 		IL_002d: newarr [System.Runtime]System.Object
@@ -145,7 +135,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f3
+		// Method begins at RVA 0x20db
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThen.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThen.verified.txt
@@ -68,12 +68,12 @@
 
 } // end of class Scopes.Promise_Resolve_FinallyThen
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C54
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C55
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C54 (
+		object ArrowFunction_L1C55 (
 			object[] scopes
 		) cil managed 
 	{
@@ -96,52 +96,42 @@
 		IL_001f: stelem.ref
 		IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_0025: ret
-	} // end of method ArrowFunction_L1C54::ArrowFunction_L1C54
+	} // end of method ArrowFunction_L1C55::ArrowFunction_L1C55
 
-} // end of class Functions.ArrowFunction_L1C54
+} // end of class Functions.ArrowFunction_L1C55
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C113
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C114
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C113 (
+		object ArrowFunction_L1C114 (
 			object[] scopes,
 			object message
 		) cil managed 
 	{
 		// Method begins at RVA 0x20a0
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Resolve_FinallyThen/ArrowFunction_L1C113
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Resolve_FinallyThen/ArrowFunction_L1C113::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Resolve_FinallyThen/ArrowFunction_L1C113::message
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "[then]"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Resolve_FinallyThen/ArrowFunction_L1C113
-		IL_002d: ldfld object Scopes.Promise_Resolve_FinallyThen/ArrowFunction_L1C113::message
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C113::ArrowFunction_L1C113
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "[then]"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C114::ArrowFunction_L1C114
 
-} // end of class Functions.ArrowFunction_L1C113
+} // end of class Functions.ArrowFunction_L1C114
 
 .class public auto ansi beforefieldinit Scripts.Promise_Resolve_FinallyThen
 	extends [System.Runtime]System.Object
@@ -156,7 +146,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20e8
+		// Method begins at RVA 0x20d0
 		// Header size: 12
 		// Code size: 104 (0x68)
 		.maxstack 32
@@ -172,7 +162,7 @@
 		IL_0015: dup
 		IL_0016: ldc.i4.0
 		IL_0017: ldnull
-		IL_0018: ldftn object Functions.ArrowFunction_L1C54::ArrowFunction_L1C54(object[])
+		IL_0018: ldftn object Functions.ArrowFunction_L1C55::ArrowFunction_L1C55(object[])
 		IL_001e: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0023: ldc.i4.1
 		IL_0024: newarr [System.Runtime]System.Object
@@ -189,7 +179,7 @@
 		IL_0043: dup
 		IL_0044: ldc.i4.0
 		IL_0045: ldnull
-		IL_0046: ldftn object Functions.ArrowFunction_L1C113::ArrowFunction_L1C113(object[], object)
+		IL_0046: ldftn object Functions.ArrowFunction_L1C114::ArrowFunction_L1C114(object[], object)
 		IL_004c: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0051: ldc.i4.1
 		IL_0052: newarr [System.Runtime]System.Object
@@ -213,7 +203,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x215c
+		// Method begins at RVA 0x2144
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThrows.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThrows.verified.txt
@@ -91,12 +91,12 @@
 
 } // end of class Scopes.Promise_Resolve_FinallyThrows
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C54
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C55
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C54 (
+		object ArrowFunction_L1C55 (
 			object[] scopes
 		) cil managed 
 	{
@@ -111,95 +111,75 @@
 
 		IL_000b: ldnull
 		IL_000c: ret
-	} // end of method ArrowFunction_L1C54::ArrowFunction_L1C54
+	} // end of method ArrowFunction_L1C55::ArrowFunction_L1C55
 
-} // end of class Functions.ArrowFunction_L1C54
+} // end of class Functions.ArrowFunction_L1C55
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C95
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C96
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C95 (
+		object ArrowFunction_L1C96 (
 			object[] scopes,
 			object message
 		) cil managed 
 	{
 		// Method begins at RVA 0x2090
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C95
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C95::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C95::message
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "[then]"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C95
-		IL_002d: ldfld object Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C95::message
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C95::ArrowFunction_L1C95
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "[then]"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C96::ArrowFunction_L1C96
 
-} // end of class Functions.ArrowFunction_L1C95
+} // end of class Functions.ArrowFunction_L1C96
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C146
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C147
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C146 (
+		object ArrowFunction_L1C147 (
 			object[] scopes,
 			object 'error'
 		) cil managed 
 	{
-		// Method begins at RVA 0x20d8
+		// Method begins at RVA 0x20c0
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C146
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C146::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C146::'error'
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "[catch]"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C146
-		IL_002d: ldfld object Scopes.Promise_Resolve_FinallyThrows/ArrowFunction_L1C146::'error'
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C146::ArrowFunction_L1C146
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "[catch]"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C147::ArrowFunction_L1C147
 
-} // end of class Functions.ArrowFunction_L1C146
+} // end of class Functions.ArrowFunction_L1C147
 
 .class public auto ansi beforefieldinit Scripts.Promise_Resolve_FinallyThrows
 	extends [System.Runtime]System.Object
@@ -214,7 +194,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2120
+		// Method begins at RVA 0x20f0
 		// Header size: 12
 		// Code size: 150 (0x96)
 		.maxstack 32
@@ -230,7 +210,7 @@
 		IL_0015: dup
 		IL_0016: ldc.i4.0
 		IL_0017: ldnull
-		IL_0018: ldftn object Functions.ArrowFunction_L1C54::ArrowFunction_L1C54(object[])
+		IL_0018: ldftn object Functions.ArrowFunction_L1C55::ArrowFunction_L1C55(object[])
 		IL_001e: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0023: ldc.i4.1
 		IL_0024: newarr [System.Runtime]System.Object
@@ -247,7 +227,7 @@
 		IL_0043: dup
 		IL_0044: ldc.i4.0
 		IL_0045: ldnull
-		IL_0046: ldftn object Functions.ArrowFunction_L1C95::ArrowFunction_L1C95(object[], object)
+		IL_0046: ldftn object Functions.ArrowFunction_L1C96::ArrowFunction_L1C96(object[], object)
 		IL_004c: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0051: ldc.i4.1
 		IL_0052: newarr [System.Runtime]System.Object
@@ -264,7 +244,7 @@
 		IL_0071: dup
 		IL_0072: ldc.i4.0
 		IL_0073: ldnull
-		IL_0074: ldftn object Functions.ArrowFunction_L1C146::ArrowFunction_L1C146(object[], object)
+		IL_0074: ldftn object Functions.ArrowFunction_L1C147::ArrowFunction_L1C147(object[], object)
 		IL_007a: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -288,7 +268,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c2
+		// Method begins at RVA 0x2192
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_Then.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_Then.verified.txt
@@ -48,44 +48,34 @@
 
 } // end of class Scopes.Promise_Resolve_Then
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C52
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C53
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C52 (
+		object ArrowFunction_L1C53 (
 			object[] scopes,
 			object message
 		) cil managed 
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 49 (0x31)
+		// Code size: 26 (0x1a)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Resolve_Then/ArrowFunction_L1C52
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Resolve_Then/ArrowFunction_L1C52::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Resolve_Then/ArrowFunction_L1C52::message
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.1
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldloc.0
-		IL_0020: castclass Scopes.Promise_Resolve_Then/ArrowFunction_L1C52
-		IL_0025: ldfld object Scopes.Promise_Resolve_Then/ArrowFunction_L1C52::message
-		IL_002a: stelem.ref
-		IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0030: ret
-	} // end of method ArrowFunction_L1C52::ArrowFunction_L1C52
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.1
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldarg.1
+		IL_0013: stelem.ref
+		IL_0014: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0019: ret
+	} // end of method ArrowFunction_L1C53::ArrowFunction_L1C53
 
-} // end of class Functions.ArrowFunction_L1C52
+} // end of class Functions.ArrowFunction_L1C53
 
 .class public auto ansi beforefieldinit Scripts.Promise_Resolve_Then
 	extends [System.Runtime]System.Object
@@ -100,7 +90,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20a4
+		// Method begins at RVA 0x208c
 		// Header size: 12
 		// Code size: 58 (0x3a)
 		.maxstack 32
@@ -116,7 +106,7 @@
 		IL_0015: dup
 		IL_0016: ldc.i4.0
 		IL_0017: ldnull
-		IL_0018: ldftn object Functions.ArrowFunction_L1C52::ArrowFunction_L1C52(object[], object)
+		IL_0018: ldftn object Functions.ArrowFunction_L1C53::ArrowFunction_L1C53(object[], object)
 		IL_001e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0023: ldc.i4.1
 		IL_0024: newarr [System.Runtime]System.Object
@@ -140,7 +130,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20ea
+		// Method begins at RVA 0x20d2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_ThenFinally.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_ThenFinally.verified.txt
@@ -68,59 +68,49 @@
 
 } // end of class Scopes.Promise_Resolve_ThenFinally
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C51
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C52
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C51 (
+		object ArrowFunction_L1C52 (
 			object[] scopes,
 			object message
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Resolve_ThenFinally/ArrowFunction_L1C51
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Resolve_ThenFinally/ArrowFunction_L1C51::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Resolve_ThenFinally/ArrowFunction_L1C51::message
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "[then]"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Resolve_ThenFinally/ArrowFunction_L1C51
-		IL_002d: ldfld object Scopes.Promise_Resolve_ThenFinally/ArrowFunction_L1C51::message
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C51::ArrowFunction_L1C51
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "[then]"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C52::ArrowFunction_L1C52
 
-} // end of class Functions.ArrowFunction_L1C51
+} // end of class Functions.ArrowFunction_L1C52
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C104
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C105
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C104 (
+		object ArrowFunction_L1C105 (
 			object[] scopes
 		) cil managed 
 	{
-		// Method begins at RVA 0x20b4
+		// Method begins at RVA 0x209c
 		// Header size: 12
 		// Code size: 38 (0x26)
 		.maxstack 32
@@ -139,9 +129,9 @@
 		IL_001f: stelem.ref
 		IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_0025: ret
-	} // end of method ArrowFunction_L1C104::ArrowFunction_L1C104
+	} // end of method ArrowFunction_L1C105::ArrowFunction_L1C105
 
-} // end of class Functions.ArrowFunction_L1C104
+} // end of class Functions.ArrowFunction_L1C105
 
 .class public auto ansi beforefieldinit Scripts.Promise_Resolve_ThenFinally
 	extends [System.Runtime]System.Object
@@ -156,7 +146,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20e8
+		// Method begins at RVA 0x20d0
 		// Header size: 12
 		// Code size: 104 (0x68)
 		.maxstack 32
@@ -172,7 +162,7 @@
 		IL_0015: dup
 		IL_0016: ldc.i4.0
 		IL_0017: ldnull
-		IL_0018: ldftn object Functions.ArrowFunction_L1C51::ArrowFunction_L1C51(object[], object)
+		IL_0018: ldftn object Functions.ArrowFunction_L1C52::ArrowFunction_L1C52(object[], object)
 		IL_001e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_0023: ldc.i4.1
 		IL_0024: newarr [System.Runtime]System.Object
@@ -189,7 +179,7 @@
 		IL_0043: dup
 		IL_0044: ldc.i4.0
 		IL_0045: ldnull
-		IL_0046: ldftn object Functions.ArrowFunction_L1C104::ArrowFunction_L1C104(object[])
+		IL_0046: ldftn object Functions.ArrowFunction_L1C105::ArrowFunction_L1C105(object[])
 		IL_004c: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
 		IL_0051: ldc.i4.1
 		IL_0052: newarr [System.Runtime]System.Object
@@ -213,7 +203,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x215c
+		// Method begins at RVA 0x2144
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Scheduling_StarvationTest.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Scheduling_StarvationTest.verified.txt
@@ -134,16 +134,109 @@
 
 } // end of class Scopes.Promise_Scheduling_StarvationTest
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C23
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C29
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L9C23 (
-			object[] scopes
+		object ArrowFunction_L5C29 (
+			object[] scopes,
+			object id
 		) cil managed 
 	{
 		// Method begins at RVA 0x2088
+		// Header size: 12
+		// Code size: 221 (0xdd)
+		.maxstack 32
+
+		IL_0000: ldarg.1
+		IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0006: ldc.r8 512
+		IL_000f: beq IL_0019
+
+		IL_0014: br IL_007b
+
+		IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_001e: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_0023: ldc.i4.2
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: dup
+		IL_002a: ldc.i4.0
+		IL_002b: ldstr "[then] scheduling a timer at promise number:"
+		IL_0030: stelem.ref
+		IL_0031: dup
+		IL_0032: ldc.i4.1
+		IL_0033: ldarg.1
+		IL_0034: stelem.ref
+		IL_0035: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_003a: pop
+		IL_003b: ldnull
+		IL_003c: ldftn object [Promise_Scheduling_StarvationTest]Functions.ArrowFunction_L9C24::ArrowFunction_L9C24(object[])
+		IL_0042: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_0047: ldc.i4.1
+		IL_0048: newarr [System.Runtime]System.Object
+		IL_004d: dup
+		IL_004e: ldc.i4.0
+		IL_004f: ldarg.0
+		IL_0050: ldc.i4.0
+		IL_0051: ldelem.ref
+		IL_0052: castclass Scopes.Promise_Scheduling_StarvationTest
+		IL_0057: stelem.ref
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_005d: ldc.r8 0.0
+		IL_0066: box [System.Runtime]System.Double
+		IL_006b: call !!0[] [System.Runtime]System.Array::Empty<object>()
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+		IL_0075: pop
+		IL_0076: br IL_007b
+
+		IL_007b: ldarg.1
+		IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0081: ldc.r8 1023
+		IL_008a: ceq
+		IL_008c: box [System.Runtime]System.Boolean
+		IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_0096: brtrue IL_00b4
+
+		IL_009b: ldarg.1
+		IL_009c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00a1: ldc.r8 2047
+		IL_00aa: beq IL_00b4
+
+		IL_00af: br IL_00db
+
+		IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b9: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_00be: ldc.i4.2
+		IL_00bf: newarr [System.Runtime]System.Object
+		IL_00c4: dup
+		IL_00c5: ldc.i4.0
+		IL_00c6: ldstr "executed promise number:"
+		IL_00cb: stelem.ref
+		IL_00cc: dup
+		IL_00cd: ldc.i4.1
+		IL_00ce: ldarg.1
+		IL_00cf: stelem.ref
+		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00d5: pop
+		IL_00d6: br IL_00db
+
+		IL_00db: ldnull
+		IL_00dc: ret
+	} // end of method ArrowFunction_L5C29::ArrowFunction_L5C29
+
+} // end of class Functions.ArrowFunction_L5C29
+
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L9C24
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object ArrowFunction_L9C24 (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x2174
 		// Header size: 12
 		// Code size: 29 (0x1d)
 		.maxstack 32
@@ -164,124 +257,9 @@
 		IL_001a: pop
 		IL_001b: ldnull
 		IL_001c: ret
-	} // end of method ArrowFunction_L9C23::ArrowFunction_L9C23
+	} // end of method ArrowFunction_L9C24::ArrowFunction_L9C24
 
-} // end of class Functions.ArrowFunction_L9C23
-
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L5C28
-	extends [System.Runtime]System.Object
-{
-	// Methods
-	.method public hidebysig static 
-		object ArrowFunction_L5C28 (
-			object[] scopes,
-			object id
-		) cil managed 
-	{
-		// Method begins at RVA 0x20b4
-		// Header size: 12
-		// Code size: 288 (0x120)
-		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28
-		)
-
-		IL_0000: newobj instance void Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28::id
-		IL_000d: ldloc.0
-		IL_000e: castclass Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28
-		IL_0013: ldfld object Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28::id
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldc.r8 512
-		IL_0026: beq IL_0030
-
-		IL_002b: br IL_00a0
-
-		IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0035: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_003a: ldc.i4.2
-		IL_003b: newarr [System.Runtime]System.Object
-		IL_0040: dup
-		IL_0041: ldc.i4.0
-		IL_0042: ldstr "[then] scheduling a timer at promise number:"
-		IL_0047: stelem.ref
-		IL_0048: dup
-		IL_0049: ldc.i4.1
-		IL_004a: ldloc.0
-		IL_004b: castclass Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28
-		IL_0050: ldfld object Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28::id
-		IL_0055: stelem.ref
-		IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_005b: pop
-		IL_005c: ldnull
-		IL_005d: ldftn object Functions.ArrowFunction_L9C23::ArrowFunction_L9C23(object[])
-		IL_0063: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
-		IL_0068: ldc.i4.2
-		IL_0069: newarr [System.Runtime]System.Object
-		IL_006e: dup
-		IL_006f: ldc.i4.0
-		IL_0070: ldarg.0
-		IL_0071: ldc.i4.0
-		IL_0072: ldelem.ref
-		IL_0073: castclass Scopes.Promise_Scheduling_StarvationTest
-		IL_0078: stelem.ref
-		IL_0079: dup
-		IL_007a: ldc.i4.1
-		IL_007b: ldloc.0
-		IL_007c: stelem.ref
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0082: ldc.r8 0.0
-		IL_008b: box [System.Runtime]System.Double
-		IL_0090: call !!0[] [System.Runtime]System.Array::Empty<object>()
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-		IL_009a: pop
-		IL_009b: br IL_00a0
-
-		IL_00a0: ldloc.0
-		IL_00a1: castclass Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28
-		IL_00a6: ldfld object Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28::id
-		IL_00ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00b0: ldc.r8 1023
-		IL_00b9: ceq
-		IL_00bb: box [System.Runtime]System.Boolean
-		IL_00c0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_00c5: brtrue IL_00ed
-
-		IL_00ca: ldloc.0
-		IL_00cb: castclass Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28
-		IL_00d0: ldfld object Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28::id
-		IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00da: ldc.r8 2047
-		IL_00e3: beq IL_00ed
-
-		IL_00e8: br IL_011e
-
-		IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f2: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_00f7: ldc.i4.2
-		IL_00f8: newarr [System.Runtime]System.Object
-		IL_00fd: dup
-		IL_00fe: ldc.i4.0
-		IL_00ff: ldstr "executed promise number:"
-		IL_0104: stelem.ref
-		IL_0105: dup
-		IL_0106: ldc.i4.1
-		IL_0107: ldloc.0
-		IL_0108: castclass Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28
-		IL_010d: ldfld object Scopes.Promise_Scheduling_StarvationTest/Block_L4C31/ArrowFunction_L5C28::id
-		IL_0112: stelem.ref
-		IL_0113: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0118: pop
-		IL_0119: br IL_011e
-
-		IL_011e: ldnull
-		IL_011f: ret
-	} // end of method ArrowFunction_L5C28::ArrowFunction_L5C28
-
-} // end of class Functions.ArrowFunction_L5C28
+} // end of class Functions.ArrowFunction_L9C24
 
 .class public auto ansi beforefieldinit Scripts.Promise_Scheduling_StarvationTest
 	extends [System.Runtime]System.Object
@@ -296,7 +274,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21e0
+		// Method begins at RVA 0x21a0
 		// Header size: 12
 		// Code size: 136 (0x88)
 		.maxstack 32
@@ -333,7 +311,7 @@
 			IL_0052: dup
 			IL_0053: ldc.i4.0
 			IL_0054: ldnull
-			IL_0055: ldftn object Functions.ArrowFunction_L5C28::ArrowFunction_L5C28(object[], object)
+			IL_0055: ldftn object Functions.ArrowFunction_L5C29::ArrowFunction_L5C29(object[], object)
 			IL_005b: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 			IL_0060: ldc.i4.1
 			IL_0061: newarr [System.Runtime]System.Object
@@ -364,7 +342,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2274
+		// Method begins at RVA 0x2234
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Then_ReturnsRejectedPromise.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Then_ReturnsRejectedPromise.verified.txt
@@ -71,78 +71,60 @@
 
 } // end of class Scopes.Promise_Then_ReturnsRejectedPromise
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C24
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C25
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C24 (
+		object ArrowFunction_L1C25 (
 			object[] scopes,
 			object x
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
 		// Header size: 12
-		// Code size: 24 (0x18)
+		// Code size: 11 (0xb)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L1C24
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L1C24::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L1C24::x
-		IL_000d: ldstr "error from then"
-		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-		IL_0017: ret
-	} // end of method ArrowFunction_L1C24::ArrowFunction_L1C24
+		IL_0000: ldstr "error from then"
+		IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+		IL_000a: ret
+	} // end of method ArrowFunction_L1C25::ArrowFunction_L1C25
 
-} // end of class Functions.ArrowFunction_L1C24
+} // end of class Functions.ArrowFunction_L1C25
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C70
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C71
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C70 (
+		object ArrowFunction_L1C71 (
 			object[] scopes,
 			object e
 		) cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x2084
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L1C70
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L1C70::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L1C70::e
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Caught:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L1C70
-		IL_002d: ldfld object Scopes.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L1C70::e
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C70::ArrowFunction_L1C70
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Caught:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C71::ArrowFunction_L1C71
 
-} // end of class Functions.ArrowFunction_L1C70
+} // end of class Functions.ArrowFunction_L1C71
 
 .class public auto ansi beforefieldinit Scripts.Promise_Then_ReturnsRejectedPromise
 	extends [System.Runtime]System.Object
@@ -157,7 +139,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20d8
+		// Method begins at RVA 0x20b4
 		// Header size: 12
 		// Code size: 113 (0x71)
 		.maxstack 32
@@ -174,7 +156,7 @@
 		IL_001e: dup
 		IL_001f: ldc.i4.0
 		IL_0020: ldnull
-		IL_0021: ldftn object Functions.ArrowFunction_L1C24::ArrowFunction_L1C24(object[], object)
+		IL_0021: ldftn object Functions.ArrowFunction_L1C25::ArrowFunction_L1C25(object[], object)
 		IL_0027: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_002c: ldc.i4.1
 		IL_002d: newarr [System.Runtime]System.Object
@@ -191,7 +173,7 @@
 		IL_004c: dup
 		IL_004d: ldc.i4.0
 		IL_004e: ldnull
-		IL_004f: ldftn object Functions.ArrowFunction_L1C70::ArrowFunction_L1C70(object[], object)
+		IL_004f: ldftn object Functions.ArrowFunction_L1C71::ArrowFunction_L1C71(object[], object)
 		IL_0055: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_005a: ldc.i4.1
 		IL_005b: newarr [System.Runtime]System.Object
@@ -215,7 +197,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2155
+		// Method begins at RVA 0x2131
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Then_ReturnsResolvedPromise.verified.txt
+++ b/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Then_ReturnsResolvedPromise.verified.txt
@@ -71,84 +71,64 @@
 
 } // end of class Scopes.Promise_Then_ReturnsResolvedPromise
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C24
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C25
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C24 (
+		object ArrowFunction_L1C25 (
 			object[] scopes,
 			object x
 		) cil managed 
 	{
 		// Method begins at RVA 0x206c
 		// Header size: 12
-		// Code size: 50 (0x32)
+		// Code size: 27 (0x1b)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C24
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C24::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C24::x
-		IL_000d: ldloc.0
-		IL_000e: castclass Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C24
-		IL_0013: ldfld object Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C24::x
-		IL_0018: unbox.any [System.Runtime]System.Double
-		IL_001d: ldc.r8 1
-		IL_0026: add
-		IL_0027: box [System.Runtime]System.Double
-		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_0031: ret
-	} // end of method ArrowFunction_L1C24::ArrowFunction_L1C24
+		IL_0000: ldarg.1
+		IL_0001: unbox.any [System.Runtime]System.Double
+		IL_0006: ldc.r8 1
+		IL_000f: add
+		IL_0010: box [System.Runtime]System.Double
+		IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_001a: ret
+	} // end of method ArrowFunction_L1C25::ArrowFunction_L1C25
 
-} // end of class Functions.ArrowFunction_L1C24
+} // end of class Functions.ArrowFunction_L1C25
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C58
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L1C59
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L1C58 (
+		object ArrowFunction_L1C59 (
 			object[] scopes,
 			object v
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ac
+		// Method begins at RVA 0x2094
 		// Header size: 12
-		// Code size: 57 (0x39)
+		// Code size: 34 (0x22)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C58
-		)
 
-		IL_0000: newobj instance void Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C58::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C58::v
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-		IL_0017: ldc.i4.2
-		IL_0018: newarr [System.Runtime]System.Object
-		IL_001d: dup
-		IL_001e: ldc.i4.0
-		IL_001f: ldstr "Result:"
-		IL_0024: stelem.ref
-		IL_0025: dup
-		IL_0026: ldc.i4.1
-		IL_0027: ldloc.0
-		IL_0028: castclass Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C58
-		IL_002d: ldfld object Scopes.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L1C58::v
-		IL_0032: stelem.ref
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0038: ret
-	} // end of method ArrowFunction_L1C58::ArrowFunction_L1C58
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+		IL_000a: ldc.i4.2
+		IL_000b: newarr [System.Runtime]System.Object
+		IL_0010: dup
+		IL_0011: ldc.i4.0
+		IL_0012: ldstr "Result:"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.1
+		IL_001a: ldarg.1
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: ret
+	} // end of method ArrowFunction_L1C59::ArrowFunction_L1C59
 
-} // end of class Functions.ArrowFunction_L1C58
+} // end of class Functions.ArrowFunction_L1C59
 
 .class public auto ansi beforefieldinit Scripts.Promise_Then_ReturnsResolvedPromise
 	extends [System.Runtime]System.Object
@@ -163,7 +143,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20f4
+		// Method begins at RVA 0x20c4
 		// Header size: 12
 		// Code size: 113 (0x71)
 		.maxstack 32
@@ -180,7 +160,7 @@
 		IL_001e: dup
 		IL_001f: ldc.i4.0
 		IL_0020: ldnull
-		IL_0021: ldftn object Functions.ArrowFunction_L1C24::ArrowFunction_L1C24(object[], object)
+		IL_0021: ldftn object Functions.ArrowFunction_L1C25::ArrowFunction_L1C25(object[], object)
 		IL_0027: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_002c: ldc.i4.1
 		IL_002d: newarr [System.Runtime]System.Object
@@ -197,7 +177,7 @@
 		IL_004c: dup
 		IL_004d: ldc.i4.0
 		IL_004e: ldnull
-		IL_004f: ldftn object Functions.ArrowFunction_L1C58::ArrowFunction_L1C58(object[], object)
+		IL_004f: ldftn object Functions.ArrowFunction_L1C59::ArrowFunction_L1C59(object[], object)
 		IL_0055: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
 		IL_005a: ldc.i4.1
 		IL_005b: newarr [System.Runtime]System.Object
@@ -221,7 +201,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2171
+		// Method begins at RVA 0x2141
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/String/Snapshots/GeneratorTests.String_LocaleCompare_Numeric.verified.txt
+++ b/Js2IL.Tests/String/Snapshots/GeneratorTests.String_LocaleCompare_Numeric.verified.txt
@@ -49,12 +49,12 @@
 
 } // end of class Scopes.String_LocaleCompare_Numeric
 
-.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C12
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L2C13
 	extends [System.Runtime]System.Object
 {
 	// Methods
 	.method public hidebysig static 
-		object ArrowFunction_L2C12 (
+		object ArrowFunction_L2C13 (
 			object[] scopes,
 			object a,
 			object b
@@ -62,50 +62,35 @@
 	{
 		// Method begins at RVA 0x2064
 		// Header size: 12
-		// Code size: 95 (0x5f)
+		// Code size: 55 (0x37)
 		.maxstack 32
-		.locals init (
-			[0] class Scopes.String_LocaleCompare_Numeric/ArrowFunction_L2C12
-		)
 
-		IL_0000: newobj instance void Scopes.String_LocaleCompare_Numeric/ArrowFunction_L2C12::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object Scopes.String_LocaleCompare_Numeric/ArrowFunction_L2C12::a
-		IL_000d: ldloc.0
+		IL_0000: ldarg.1
+		IL_0001: ldstr "localeCompare"
+		IL_0006: ldc.i4.3
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
 		IL_000e: ldarg.2
-		IL_000f: stfld object Scopes.String_LocaleCompare_Numeric/ArrowFunction_L2C12::b
-		IL_0014: ldloc.0
-		IL_0015: castclass Scopes.String_LocaleCompare_Numeric/ArrowFunction_L2C12
-		IL_001a: ldfld object Scopes.String_LocaleCompare_Numeric/ArrowFunction_L2C12::a
-		IL_001f: ldstr "localeCompare"
-		IL_0024: ldc.i4.3
-		IL_0025: newarr [System.Runtime]System.Object
-		IL_002a: dup
-		IL_002b: ldc.i4.0
-		IL_002c: ldloc.0
-		IL_002d: castclass Scopes.String_LocaleCompare_Numeric/ArrowFunction_L2C12
-		IL_0032: ldfld object Scopes.String_LocaleCompare_Numeric/ArrowFunction_L2C12::b
-		IL_0037: stelem.ref
-		IL_0038: dup
-		IL_0039: ldc.i4.1
-		IL_003a: ldstr "en"
-		IL_003f: stelem.ref
-		IL_0040: dup
-		IL_0041: ldc.i4.2
-		IL_0042: newobj instance void [System.Linq.Expressions]System.Dynamic.ExpandoObject::.ctor()
-		IL_0047: dup
-		IL_0048: ldstr "numeric"
-		IL_004d: ldc.i4.1
-		IL_004e: box [System.Runtime]System.Boolean
-		IL_0053: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
-		IL_0058: stelem.ref
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_005e: ret
-	} // end of method ArrowFunction_L2C12::ArrowFunction_L2C12
+		IL_000f: stelem.ref
+		IL_0010: dup
+		IL_0011: ldc.i4.1
+		IL_0012: ldstr "en"
+		IL_0017: stelem.ref
+		IL_0018: dup
+		IL_0019: ldc.i4.2
+		IL_001a: newobj instance void [System.Linq.Expressions]System.Dynamic.ExpandoObject::.ctor()
+		IL_001f: dup
+		IL_0020: ldstr "numeric"
+		IL_0025: ldc.i4.1
+		IL_0026: box [System.Runtime]System.Boolean
+		IL_002b: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_0030: stelem.ref
+		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0036: ret
+	} // end of method ArrowFunction_L2C13::ArrowFunction_L2C13
 
-} // end of class Functions.ArrowFunction_L2C12
+} // end of class Functions.ArrowFunction_L2C13
 
 .class public auto ansi beforefieldinit Scripts.String_LocaleCompare_Numeric
 	extends [System.Runtime]System.Object
@@ -120,7 +105,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20d0
+		// Method begins at RVA 0x20a8
 		// Header size: 12
 		// Code size: 145 (0x91)
 		.maxstack 32
@@ -150,7 +135,7 @@
 		IL_003a: dup
 		IL_003b: ldc.i4.0
 		IL_003c: ldnull
-		IL_003d: ldftn object Functions.ArrowFunction_L2C12::ArrowFunction_L2C12(object[], object, object)
+		IL_003d: ldftn object Functions.ArrowFunction_L2C13::ArrowFunction_L2C13(object[], object, object)
 		IL_0043: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
 		IL_0048: ldc.i4.1
 		IL_0049: newarr [System.Runtime]System.Object
@@ -192,7 +177,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x216d
+		// Method begins at RVA 0x2145
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL/CompilerOptions.cs
+++ b/Js2IL/CompilerOptions.cs
@@ -2,11 +2,5 @@ public class CompilerOptions
 {
     public string? OutputDirectory { get; set; } = null;
     public bool Verbose { get; set; } = false;
-    public bool AnalyzeUnused { get; set; } = false;
-    
-    /// <summary>
-    /// Enable two-phase compilation: Phase 1 declares all callables upfront,
-    /// Phase 2 compiles bodies (enabling forward references and mutual recursion).
-    /// </summary>
-    public bool TwoPhaseCompilation { get; set; } = false;
+    public bool AnalyzeUnused { get; set; } = false;    
 }

--- a/Js2IL/Services/ILGenerators/ILMethodGenerator.cs
+++ b/Js2IL/Services/ILGenerators/ILMethodGenerator.cs
@@ -1265,8 +1265,7 @@ namespace Js2IL.Services.ILGenerators
         {
             // Two-phase lookup: only short-circuit when we already have a MethodDef.
             // Phase 1 may have stored a MemberRef (signature-only) which is not a compiled body.
-            if (_twoPhaseCoordinator != null &&
-                _twoPhaseCoordinator.TryGetToken(funcExpr, out var existingToken) &&
+            if (_twoPhaseCoordinator.TryGetToken(funcExpr, out var existingToken) &&
                 existingToken.Kind == System.Reflection.Metadata.HandleKind.MethodDefinition)
             {
                 return (System.Reflection.Metadata.MethodDefinitionHandle)existingToken;
@@ -1491,7 +1490,7 @@ namespace Js2IL.Services.ILGenerators
             tb.AddTypeDefinition(TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit, _bclReferences.ObjectType);
 
             // Two-phase: register the token in the canonical CallableRegistry
-            _twoPhaseCoordinator?.RegisterToken(funcExpr, (System.Reflection.Metadata.EntityHandle)mdh);
+            _twoPhaseCoordinator.RegisterToken(funcExpr, (System.Reflection.Metadata.EntityHandle)mdh);
             
             return mdh;
         }

--- a/Js2IL/Services/ILGenerators/JavaScriptArrowFunctionGenerator.cs
+++ b/Js2IL/Services/ILGenerators/JavaScriptArrowFunctionGenerator.cs
@@ -51,8 +51,7 @@ namespace Js2IL.Services.ILGenerators
         {
             // Two-phase lookup: only skip compilation when we already have a MethodDef token.
             // Phase 1 may have populated a MemberRef token (signature-only), which is not a compiled body.
-            if (_twoPhaseCoordinator != null &&
-                _twoPhaseCoordinator.TryGetToken(arrowFunction, out var existingToken) &&
+            if (_twoPhaseCoordinator.TryGetToken(arrowFunction, out var existingToken) &&
                 existingToken.Kind == HandleKind.MethodDefinition)
             {
                 return (MethodDefinitionHandle)existingToken;
@@ -70,7 +69,7 @@ namespace Js2IL.Services.ILGenerators
                     if (!compiledMethod.IsNil)
                     {
                         // Two-phase: register the token in the canonical CallableRegistry
-                        _twoPhaseCoordinator?.RegisterToken(arrowFunction, (EntityHandle)compiledMethod);
+                        _twoPhaseCoordinator.RegisterToken(arrowFunction, (EntityHandle)compiledMethod);
                         return compiledMethod;
                     }
                 }
@@ -321,7 +320,7 @@ namespace Js2IL.Services.ILGenerators
             tb.AddTypeDefinition(TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit, _bclReferences.ObjectType);
 
             // Two-phase: register the token in the canonical CallableRegistry
-            _twoPhaseCoordinator?.RegisterToken(arrowFunction, (EntityHandle)mdh);
+            _twoPhaseCoordinator.RegisterToken(arrowFunction, (EntityHandle)mdh);
 
             return mdh;
         }

--- a/Js2IL/Services/ILGenerators/JavaScriptFunctionGenerator.cs
+++ b/Js2IL/Services/ILGenerators/JavaScriptFunctionGenerator.cs
@@ -115,7 +115,7 @@ namespace Js2IL.Services.ILGenerators
                         }
 
                         // Two-phase: register the token in the canonical CallableRegistry
-                        _twoPhaseCoordinator?.RegisterToken(nestedDecl, (EntityHandle)nestedMethod);
+                        _twoPhaseCoordinator.RegisterToken(nestedDecl, (EntityHandle)nestedMethod);
                     }
                 }
 
@@ -132,7 +132,7 @@ namespace Js2IL.Services.ILGenerators
                 }
 
                 // Two-phase: register the token in the canonical CallableRegistry
-                _twoPhaseCoordinator?.RegisterToken(functionDeclaration, (EntityHandle)methodDefinition);
+                _twoPhaseCoordinator.RegisterToken(functionDeclaration, (EntityHandle)methodDefinition);
 
                 globalMethods.Add((functionName, methodDefinition, funcScope, functionVariables, nestedTb, firstNestedMethod));
             }


### PR DESCRIPTION
## Overview

This PR enables two-phase compilation as the default compilation mode in JS2IL. Two-phase compilation improves support for complex JavaScript patterns by separating callable discovery/declaration (Phase 1) from body compilation (Phase 2).

## Key Changes

### Compiler Configuration
- **Set `TwoPhaseCompilation` to `true` by default** in `CompilerOptions.cs`
- All compilation now uses the two-phase approach with `MemberReferenceHandle` for forward references

### Phase 2 Compilation Fixes
Two critical bugs in the Phase 2 compilation path were identified and fixed:

#### 1. Parent Scope Chain Propagation
**Problem**: When compiling arrow functions and function expressions in Phase 2, the `Variables` instance passed to generators only represented the global scope, not the parent function's scope. This caused captured variables to be unresolvable.

**Solution**: 
- Added `BuildParentVariablesForCallable` helper method in `TwoPhaseCompilationCoordinator`
- This method walks the scope hierarchy and constructs a proper parent scope chain using the correct registry naming format (`{moduleName}/{scopeName}`)
- Updated `CompileArrowFunction` and `CompileFunctionExpression` to use this helper

#### 2. Column Numbering Consistency
**Problem**: Phase 1 used 1-based column numbers (from `CallableId.SourceLocation`), while Phase 2 used 0-based columns directly from the AST. This caused type name mismatches (e.g., `ArrowFunction_L7C23` vs `ArrowFunction_L7C22`), resulting in `TypeLoadException` at runtime.

**Solution**:
- Fixed `CompileArrowFunction` and `CompileFunctionExpression` to convert AST columns to 1-based: `col1Based = expr.Location.Start.Column + 1`
- Both phases now use consistent 1-based column numbering

### Test Updates
- Updated 77 generator test snapshots to reflect two-phase compilation IL output
- All snapshots now show `MemberReferenceHandle`-based forward references instead of placeholder `MethodDef`s
- All execution tests continue to pass with correct runtime behavior

## Testing

- ✅ All execution tests passing
- ✅ All generator tests passing with updated snapshots
- ✅ Verified closure semantics work correctly with captured variables
- ✅ Verified arrow functions, function expressions, and IIFEs all work in two-phase mode

## Impact

This change improves JavaScript compatibility by enabling proper support for:
- Arrow functions with captured variables
- Function expressions with closure semantics
- Complex nesting patterns with multiple scope levels
- All existing JavaScript patterns continue to work as expected

## Related Issues

Fixes issues with `ArrowFunction_ClosureMutatesOuterVariable` and other tests that rely on proper parent scope access in Phase 2 compilation.
