### PR TITLE
fix(validator): detect 'this' in arrow functions inside class methods

### DIFF
--- a/Js2IL.Tests/ValidatorTests.cs
+++ b/Js2IL.Tests/ValidatorTests.cs
@@ -321,6 +321,63 @@ public class ValidatorTests
     }
 
     [Fact]
+    public void Validate_ThisInArrowFunctionInsideClassConstructor_ReportsError()
+    {
+        // Issue #244: 'this' in arrow function inside class constructor is not yet supported
+        var js = @"
+class Counter {
+    constructor(initial) {
+        this.count = initial;
+        this.increment = () => {
+            this.count = this.count + 1;
+        };
+    }
+}";
+        var ast = _parser.ParseJavaScript(js, "test.js");
+        var result = _validator.Validate(ast);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("Arrow functions or nested functions using 'this' inside class constructors/methods are not yet supported"));
+    }
+
+    [Fact]
+    public void Validate_ThisInArrowFunctionInsideClassMethod_ReportsError()
+    {
+        // Issue #244: 'this' in arrow function inside class method is not yet supported
+        var js = @"
+class Counter {
+    doSomething() {
+        const callback = () => {
+            return this.value;
+        };
+        return callback();
+    }
+}";
+        var ast = _parser.ParseJavaScript(js, "test.js");
+        var result = _validator.Validate(ast);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("Arrow functions or nested functions using 'this' inside class constructors/methods are not yet supported"));
+    }
+
+    [Fact]
+    public void Validate_ThisInNestedFunctionExpressionInsideClassMethod_ReportsError()
+    {
+        // Issue #244: 'this' in function expression inside class method is not yet supported
+        var js = @"
+class Counter {
+    doSomething() {
+        const callback = function() {
+            return this.value;
+        };
+        return callback();
+    }
+}";
+        var ast = _parser.ParseJavaScript(js, "test.js");
+        var result = _validator.Validate(ast);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("Arrow functions or nested functions using 'this' inside class constructors/methods are not yet supported"));
+    }
+
+    [Fact]
     public void Validate_FunctionWithMoreThan6Parameters_ReportsError()
     {
         // Issue #220: Functions with >6 parameters are not supported


### PR DESCRIPTION
## Summary

Fixes #244 

The `JavaScriptAstValidator` now properly catches the unsupported case of using `this` inside an arrow function or nested function within a class constructor/method.

## Problem

Previously, when a user wrote code like:

```javascript
class Counter {
    constructor(initial) {
        this.count = initial;
        this.increment = () => {
            this.count = this.count + 1;  // 'this' in nested arrow function
        };
    }
}
```

The validator would pass (because `this` was technically inside a class method), but IL generation would fail with the confusing error:
> "Unsupported 'this' expression outside of class context"

## Solution

Modified `JavaScriptAstValidator` to:
1. Track when we're inside a nested function (arrow function, function expression, or function declaration) within a class method
2. Distinguish between the method body's function expression and actual nested functions by tracking `MethodDefinition.Value`
3. Report a clear validation error when `this` is used in a nested function context

The new error message is:
> "Arrow functions or nested functions using 'this' inside class constructors/methods are not yet supported (line X)"

## Changes

- **Js2IL/Validation/JavaScriptAstValidator.cs**:
  - Added `IsInNestedFunctionInClassMethod` flag to `ValidationContext`
  - Added `MethodDefinitionFunctionValue` to track the method body (to avoid false positives)
  - Updated context stack logic to push/pop for nested functions
  - Updated `ThisExpression` validation to check for nested function context

- **Js2IL.Tests/ValidatorTests.cs**:
  - Added `Validate_ThisInArrowFunctionInsideClassConstructor_ReportsError`
  - Added `Validate_ThisInArrowFunctionInsideClassMethod_ReportsError`
  - Added `Validate_ThisInNestedFunctionExpressionInsideClassMethod_ReportsError`

## Testing

All 35 validator tests pass, including the 3 new tests and existing tests for `this` in class methods/constructors.
