### PR TITLE
docs: expand lowering pipeline punch list

### DIFF
--- a/docs/LoweringPipeline_Migration_PunchList.md
+++ b/docs/LoweringPipeline_Migration_PunchList.md
@@ -139,11 +139,26 @@ Based on the legacy emitters:
   - [x] PL3.3a built-in Error types
   - [ ] PL3.3b user-defined classes
   - [ ] PL3.3c argument count checking (match legacy)
+  - [ ] PL3.3d built-in Array constructor (`new Array()` / `new Array(n)` / `new Array(a, b, ...)`) semantics
+  - [ ] PL3.3e built-in String constructor (`new String()` / `new String(x)`) as syntactic sugar for native strings
+  - [ ] PL3.3f built-in Boolean/Number constructors (`new Boolean(x)`, `new Number(x)`) wrapper/sugar semantics
+  - [ ] PL3.3g built-in constructors for remaining existing runtime intrinsics (e.g., Date, RegExp, Set, Promise, Int32Array)
 - [ ] PL3.4 `TemplateLiteral` (including interpolation)
 - [ ] PL3.5 `ThisExpression` (especially important for class methods)
 - [ ] PL3.6 `FunctionExpression` as an expression (closure creation)
 - [ ] PL3.7 `ArrowFunctionExpression` as an expression (closure creation)
   - [ ] PL3.7a concise-body arrows must wrap implicit return
+
+### 8) Intrinsic constructor-like calls (no `new`)
+These are `CallExpression` forms (e.g., `Date(x)`, `Boolean()`) and are distinct from `NewExpression`.
+
+- [ ] PL8.1 Primitive conversion callables: `String(x)`, `Number(x)`, `Boolean(x)`
+- [ ] PL8.2 `Date(...)` callable form (returns string per JS semantics)
+- [ ] PL8.3 `RegExp(pattern, flags?)` callable form
+- [ ] PL8.4 Error callables: `Error(message?)` and derived errors (TypeError, RangeError, etc.)
+- [ ] PL8.5 `Array(...)` callable form
+- [ ] PL8.6 `Object(value?)` callable form
+- [ ] PL8.7 Other callable-only intrinsics: `Symbol(description?)`, `BigInt(value)`
 
 ### 4) Variable declarators & assignment targets
 The new HIR currently only supports identifier declarators and identifier assignment LHS.


### PR DESCRIPTION
Adds explicit punch list tracking for NewExpression coverage (Array/String/Boolean/Number + remaining runtime intrinsics) and introduces a dedicated section for intrinsic constructor-like call expressions (e.g., Date(), String()).