### PR TITLE
perf(stackify): inline safe intrinsic static getters

### DIFF
--- a/JavaScriptRuntime/GlobalThis.cs
+++ b/JavaScriptRuntime/GlobalThis.cs
@@ -31,6 +31,7 @@ namespace JavaScriptRuntime
         /// </summary>
         public static JavaScriptRuntime.Console console 
         {
+            [StackifyInline]
             get => _serviceProvider.Value!.Resolve<JavaScriptRuntime.Console>();
         }
 

--- a/JavaScriptRuntime/StackifyInlineAttribute.cs
+++ b/JavaScriptRuntime/StackifyInlineAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Marks a static runtime method (including property getters) as safe for Stackify to inline/re-emit.
+/// Intended only for pure, side-effect-free methods.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class StackifyInlineAttribute : Attribute
+{
+}

--- a/Js2IL/IL/IntrinsicInlining.cs
+++ b/Js2IL/IL/IntrinsicInlining.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Js2IL.IR;
+
+namespace Js2IL.IL;
+
+internal static class IntrinsicInlining
+{
+    /// <summary>
+    /// Returns true when the intrinsic static call is safe for Stackify to inline/re-emit.
+    /// This feature is intentionally limited to zero-argument methods.
+    /// </summary>
+    public static bool IsStackifyInlineable(LIRCallIntrinsicStatic instruction)
+    {
+        if (instruction.Arguments.Count != 0)
+        {
+            return false;
+        }
+
+        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(instruction.IntrinsicName);
+        if (intrinsicType == null)
+        {
+            return false;
+        }
+
+        // Limit to true zero-parameter methods (no params object[] fallback).
+        var chosen = ResolveZeroArgMethod(intrinsicType, instruction.MethodName);
+        if (chosen == null)
+        {
+            return false;
+        }
+
+        return chosen.IsDefined(typeof(JavaScriptRuntime.StackifyInlineAttribute), inherit: false);
+    }
+
+    private static MethodInfo? ResolveZeroArgMethod(Type intrinsicType, string methodName)
+    {
+        var allMethods = intrinsicType.GetMethods(BindingFlags.Public | BindingFlags.Static);
+        return allMethods
+            .Where(mi => string.Equals(mi.Name, methodName, StringComparison.OrdinalIgnoreCase))
+            .FirstOrDefault(mi => mi.GetParameters().Length == 0);
+    }
+}

--- a/Js2IL/IL/LIRToILCompiler.cs
+++ b/Js2IL/IL/LIRToILCompiler.cs
@@ -490,6 +490,11 @@ internal sealed class LIRToILCompiler
                 EmitInstanceMethodCall(callInstance, ilEncoder, allocation, methodDescriptor);
                 break;
             case LIRCallIntrinsicStatic callIntrinsicStatic:
+                if (!IsMaterialized(callIntrinsicStatic.Result, allocation) && IntrinsicInlining.IsStackifyInlineable(callIntrinsicStatic))
+                {
+                    // Safe, side-effect-free call marked for stackify inlining. It will be emitted at the load site.
+                    break;
+                }
                 EmitIntrinsicStaticCall(callIntrinsicStatic, ilEncoder, allocation, methodDescriptor);
                 break;
             case LIRConvertToObject convertToObject:

--- a/Js2IL/IL/Stackify.cs
+++ b/Js2IL/IL/Stackify.cs
@@ -366,8 +366,8 @@ internal static class Stackify
                 return false;
 
             // LIRCallIntrinsicStatic calls a static method on an intrinsic type (e.g., Array.isArray).
-            case LIRCallIntrinsicStatic:
-                return false;
+            case LIRCallIntrinsicStatic callStatic:
+                return IntrinsicInlining.IsStackifyInlineable(callStatic);
 
             // LIRCallFunction calls a user-defined function.
             case LIRCallFunction:


### PR DESCRIPTION
Adds [StackifyInline] attribute for pure runtime static methods/getters and enables Stackify to inline zero-arg LIRCallIntrinsicStatic when annotated. Applies attribute to GlobalThis.console getter and avoids duplicate emission in LIRToILCompiler.