### PR TITLE
chore(release): cut v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+_Nothing yet._
+
+## v0.6.1 - 2026-01-12
+
 ### Fixed
 - Fixed temp-local liveness tracking for indexed stores (`LIRSetItem`) to prevent clobbering operands during `Object.SetItem` calls (restores correct `Int32Array` writes and fixes PrimeJavaScript invalid prime counts).
-
 ### Added
 - Typed-array regression tests covering Prime bit-marking paths (optimized vs naive) and related control-flow/indexing scenarios.
 

--- a/JavaScriptRuntime/JavaScriptRuntime.csproj
+++ b/JavaScriptRuntime/JavaScriptRuntime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Js2IL/Js2IL.csproj
+++ b/Js2IL/Js2IL.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>js2il</ToolCommandName>
     <PackageId>js2il</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <Authors>tomacox74</Authors>
     <Company></Company>
     <Description>Compiles JavaScript to .NET assemblies — install, run, done.</Description>


### PR DESCRIPTION
﻿Patch release v0.6.1.

Includes:
- Prime/typed-array correctness fix (SetItem temp-local liveness)
- Regression tests + snapshot updates

This PR is generated from `npm run release:patch`.
