### PR TITLE
docs(changelog): record perf changes from #312

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+### Performance
+- Removed redundant `castclass` in emitted IL for intrinsic globals (e.g., `GlobalThis.get_console()`).
+- Avoided boxing for numeric indexed reads/writes by selecting typed runtime overloads where possible (`Object.GetItem(object, double)` / `Object.SetItem(object, double, double)`).
+- Lowered safe user-class field loads/stores to direct CLR field access for `this.field` and `this["field"]` (including supported compound assignments).
+- Inlined JavaScript `*`/`*=` as `ToNumber` coercions plus native IL `mul`.
+
+_Follow-up: #311 tracks avoiding boxing typed-array read values._
 
 ## v0.6.1 - 2026-01-12
 


### PR DESCRIPTION
﻿Adds the missing changelog entry for the performance work merged in #312.

Includes:
- Removed redundant IL casts for intrinsic globals
- Avoided boxing for numeric GetItem/SetItem by selecting typed overloads
- Direct user-class field loads/stores for this.field and this["field"]
- Inlined '*' and '*=' as ToNumber + IL mul
