### PR TITLE
test: cover closure binding when functions escape (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project are documented here.
 ### Fixed
 - Destructuring now throws a Node/V8-style `TypeError` when the source value is `null` or `undefined`, including a more precise message that includes source/target binding names.
 
+### Added
+- Regression tests covering closure binding when functions escape scope via object literals and CommonJS exports (#167).
+
 ### Performance
 - Inlined destructuring null/undefined guards so the runtime helper is only invoked on exceptional paths.
 - Stackify can now inline `LIRIsInstanceOf` (with corresponding IL emission support), reducing unnecessary temp materialization.

--- a/Js2IL.Tests/CommonJS/ExecutionTests.cs
+++ b/Js2IL.Tests/CommonJS/ExecutionTests.cs
@@ -169,5 +169,14 @@ namespace Js2IL.Tests.CommonJS
                 "CommonJS_Export_NestedObjects_Main",
                 additionalScripts: new[] { "CommonJS_Export_NestedObjects_Lib" });
         }
+
+        [Fact]
+        public Task CommonJS_Export_ObjectWithClosure()
+        {
+            // Issue #167 repro: imported object contains functions that capture module/function scope.
+            return ExecutionTest(
+                "CommonJS_Export_ObjectWithClosure_Main",
+                additionalScripts: new[] { "CommonJS_Export_ObjectWithClosure_Lib" });
+        }
     }
 }

--- a/Js2IL.Tests/CommonJS/GeneratorTests.cs
+++ b/Js2IL.Tests/CommonJS/GeneratorTests.cs
@@ -169,5 +169,14 @@ namespace Js2IL.Tests.CommonJS
                 "CommonJS_Export_NestedObjects_Main",
                 new[] { "CommonJS_Export_NestedObjects_Lib" });
         }
+
+        [Fact]
+        public Task CommonJS_Export_ObjectWithClosure()
+        {
+            // Issue #167 repro: imported object contains functions that capture module/function scope.
+            return GenerateTest(
+                "CommonJS_Export_ObjectWithClosure_Main",
+                new[] { "CommonJS_Export_ObjectWithClosure_Lib" });
+        }
     }
 }

--- a/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Export_ObjectWithClosure_Lib.js
+++ b/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Export_ObjectWithClosure_Lib.js
@@ -1,0 +1,23 @@
+// Issue #167 repro lib: exported functions capture variables and escape their defining scope.
+
+const moduleFactor = 7;
+
+function multiplyModuleFactor(x) {
+    return x * moduleFactor;
+}
+
+function createCalculator(factor) {
+    function multiply(x) {
+        return x * factor;
+    }
+
+    return {
+        multiply: multiply,
+        factor: factor
+    };
+}
+
+module.exports = {
+    multiplyModuleFactor: multiplyModuleFactor,
+    createCalculator: createCalculator
+};

--- a/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Export_ObjectWithClosure_Main.js
+++ b/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Export_ObjectWithClosure_Main.js
@@ -1,0 +1,9 @@
+// Issue #167 repro main: import and invoke exported escaping closures.
+
+const lib = require('./CommonJS_Export_ObjectWithClosure_Lib');
+
+console.log('lib.multiplyModuleFactor(3):', lib.multiplyModuleFactor(3));
+
+const calc = lib.createCalculator(10);
+console.log('calc.factor:', calc.factor);
+console.log('calc.multiply(5):', calc.multiply(5));

--- a/Js2IL.Tests/CommonJS/Snapshots/ExecutionTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/ExecutionTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -1,0 +1,3 @@
+lib.multiplyModuleFactor(3): 21
+calc.factor: 10
+calc.multiply(5): 50

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -1,0 +1,469 @@
+﻿// IL code: CommonJS_Export_ObjectWithClosure_Main
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.CommonJS_Export_ObjectWithClosure_Main
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method CommonJS_Export_ObjectWithClosure_Main::.ctor
+
+} // end of class Scopes.CommonJS_Export_ObjectWithClosure_Main
+
+.class public auto ansi beforefieldinit Scopes.CommonJS_Export_ObjectWithClosure_Lib
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit multiplyModuleFactor
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method multiplyModuleFactor::.ctor
+
+	} // end of class multiplyModuleFactor
+
+	.class nested public auto ansi beforefieldinit createCalculator
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit multiply
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2074
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method multiply::.ctor
+
+		} // end of class multiply
+
+
+		// Fields
+		.field public object factor
+		.field public object multiply
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method createCalculator::.ctor
+
+	} // end of class createCalculator
+
+
+	// Fields
+	.field public object moduleFactor
+	.field public object multiplyModuleFactor
+	.field public object createCalculator
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2059
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method CommonJS_Export_ObjectWithClosure_Lib::.ctor
+
+} // end of class Scopes.CommonJS_Export_ObjectWithClosure_Lib
+
+.class public auto ansi beforefieldinit Scripts.CommonJS_Export_ObjectWithClosure_Main
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2080
+		// Header size: 12
+		// Code size: 246 (0xf6)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.CommonJS_Export_ObjectWithClosure_Main,
+			[1] object,
+			[2] object,
+			[3] object[],
+			[4] object
+		)
+
+		IL_0000: newobj instance void Scopes.CommonJS_Export_ObjectWithClosure_Main::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldstr "./CommonJS_Export_ObjectWithClosure_Lib"
+		IL_0013: stelem.ref
+		IL_0014: stloc.3
+		IL_0015: ldarg.1
+		IL_0016: ldc.i4.1
+		IL_0017: newarr [System.Runtime]System.Object
+		IL_001c: dup
+		IL_001d: ldc.i4.0
+		IL_001e: ldnull
+		IL_001f: stelem.ref
+		IL_0020: ldloc.3
+		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0026: stloc.1
+		IL_0027: ldloc.1
+		IL_0028: ldstr "multiplyModuleFactor"
+		IL_002d: ldc.i4.1
+		IL_002e: newarr [System.Runtime]System.Object
+		IL_0033: dup
+		IL_0034: ldc.i4.0
+		IL_0035: ldc.r8 3
+		IL_003e: box [System.Runtime]System.Double
+		IL_0043: stelem.ref
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0049: stloc.s 4
+		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0050: ldc.i4.2
+		IL_0051: newarr [System.Runtime]System.Object
+		IL_0056: dup
+		IL_0057: ldc.i4.0
+		IL_0058: ldstr "lib.multiplyModuleFactor(3):"
+		IL_005d: stelem.ref
+		IL_005e: dup
+		IL_005f: ldc.i4.1
+		IL_0060: ldloc.s 4
+		IL_0062: stelem.ref
+		IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0068: pop
+		IL_0069: ldloc.1
+		IL_006a: ldstr "createCalculator"
+		IL_006f: ldc.i4.1
+		IL_0070: newarr [System.Runtime]System.Object
+		IL_0075: dup
+		IL_0076: ldc.i4.0
+		IL_0077: ldc.r8 10
+		IL_0080: box [System.Runtime]System.Double
+		IL_0085: stelem.ref
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_008b: stloc.2
+		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0091: ldc.i4.2
+		IL_0092: newarr [System.Runtime]System.Object
+		IL_0097: dup
+		IL_0098: ldc.i4.0
+		IL_0099: ldstr "calc.factor:"
+		IL_009e: stelem.ref
+		IL_009f: dup
+		IL_00a0: ldc.i4.1
+		IL_00a1: ldloc.2
+		IL_00a2: ldstr "factor"
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00ac: stelem.ref
+		IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00b2: pop
+		IL_00b3: ldloc.2
+		IL_00b4: ldstr "multiply"
+		IL_00b9: ldc.i4.1
+		IL_00ba: newarr [System.Runtime]System.Object
+		IL_00bf: dup
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldc.r8 5
+		IL_00ca: box [System.Runtime]System.Double
+		IL_00cf: stelem.ref
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00d5: stloc.s 4
+		IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dc: ldc.i4.2
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldstr "calc.multiply(5):"
+		IL_00e9: stelem.ref
+		IL_00ea: dup
+		IL_00eb: ldc.i4.1
+		IL_00ec: ldloc.s 4
+		IL_00ee: stelem.ref
+		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f4: pop
+		IL_00f5: ret
+	} // end of method CommonJS_Export_ObjectWithClosure_Main::Main
+
+} // end of class Scripts.CommonJS_Export_ObjectWithClosure_Main
+
+.class public auto ansi abstract sealed beforefieldinit Functions.CommonJS_Export_ObjectWithClosure_Lib
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object multiplyModuleFactor (
+			object[] scopes,
+			object x
+		) cil managed 
+	{
+		// Method begins at RVA 0x21e4
+		// Header size: 12
+		// Code size: 39 (0x27)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] float64,
+			[2] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.CommonJS_Export_ObjectWithClosure_Lib
+		IL_0008: ldfld object Scopes.CommonJS_Export_ObjectWithClosure_Lib::moduleFactor
+		IL_000d: stloc.0
+		IL_000e: ldarg.1
+		IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0014: stloc.1
+		IL_0015: ldloc.1
+		IL_0016: ldloc.0
+		IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_001c: mul
+		IL_001d: stloc.1
+		IL_001e: ldloc.1
+		IL_001f: box [System.Runtime]System.Double
+		IL_0024: stloc.2
+		IL_0025: ldloc.2
+		IL_0026: ret
+	} // end of method CommonJS_Export_ObjectWithClosure_Lib::multiplyModuleFactor
+
+	.method public hidebysig static 
+		object createCalculator (
+			object[] scopes,
+			object factor
+		) cil managed 
+	{
+		// Method begins at RVA 0x2184
+		// Header size: 12
+		// Code size: 84 (0x54)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.CommonJS_Export_ObjectWithClosure_Lib/createCalculator,
+			[1] object,
+			[2] class [System.Linq.Expressions]System.Dynamic.ExpandoObject
+		)
+
+		IL_0000: newobj instance void Scopes.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld object Scopes.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::factor
+		IL_000d: ldnull
+		IL_000e: ldftn object Functions.CommonJS_Export_ObjectWithClosure_Lib::multiply(object[], object)
+		IL_0014: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0019: ldc.i4.2
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldarg.0
+		IL_0022: ldc.i4.0
+		IL_0023: ldelem.ref
+		IL_0024: stelem.ref
+		IL_0025: dup
+		IL_0026: ldc.i4.1
+		IL_0027: ldloc.0
+		IL_0028: stelem.ref
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_002e: stloc.1
+		IL_002f: newobj instance void [System.Linq.Expressions]System.Dynamic.ExpandoObject::.ctor()
+		IL_0034: dup
+		IL_0035: ldstr "multiply"
+		IL_003a: ldloc.1
+		IL_003b: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_0040: dup
+		IL_0041: ldstr "factor"
+		IL_0046: ldloc.0
+		IL_0047: ldfld object Scopes.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::factor
+		IL_004c: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_0051: stloc.2
+		IL_0052: ldloc.2
+		IL_0053: ret
+	} // end of method CommonJS_Export_ObjectWithClosure_Lib::createCalculator
+
+	.method public hidebysig static 
+		object multiply (
+			object[] scopes,
+			object x
+		) cil managed 
+	{
+		// Method begins at RVA 0x2218
+		// Header size: 12
+		// Code size: 39 (0x27)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] float64,
+			[2] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.1
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.CommonJS_Export_ObjectWithClosure_Lib/createCalculator
+		IL_0008: ldfld object Scopes.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::factor
+		IL_000d: stloc.0
+		IL_000e: ldarg.1
+		IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0014: stloc.1
+		IL_0015: ldloc.1
+		IL_0016: ldloc.0
+		IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_001c: mul
+		IL_001d: stloc.1
+		IL_001e: ldloc.1
+		IL_001f: box [System.Runtime]System.Double
+		IL_0024: stloc.2
+		IL_0025: ldloc.2
+		IL_0026: ret
+	} // end of method CommonJS_Export_ObjectWithClosure_Lib::multiply
+
+} // end of class Functions.CommonJS_Export_ObjectWithClosure_Lib
+
+.class public auto ansi beforefieldinit Scripts.CommonJS_Export_ObjectWithClosure_Lib
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x224c
+		// Header size: 12
+		// Code size: 126 (0x7e)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.CommonJS_Export_ObjectWithClosure_Lib,
+			[1] object,
+			[2] object,
+			[3] class [System.Linq.Expressions]System.Dynamic.ExpandoObject
+		)
+
+		IL_0000: newobj instance void Scopes.CommonJS_Export_ObjectWithClosure_Lib::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldc.r8 7
+		IL_0010: box [System.Runtime]System.Double
+		IL_0015: stfld object Scopes.CommonJS_Export_ObjectWithClosure_Lib::moduleFactor
+		IL_001a: ldnull
+		IL_001b: ldftn object Functions.CommonJS_Export_ObjectWithClosure_Lib::multiplyModuleFactor(object[], object)
+		IL_0021: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0026: ldc.i4.1
+		IL_0027: newarr [System.Runtime]System.Object
+		IL_002c: dup
+		IL_002d: ldc.i4.0
+		IL_002e: ldloc.0
+		IL_002f: stelem.ref
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0035: stloc.1
+		IL_0036: ldnull
+		IL_0037: ldftn object Functions.CommonJS_Export_ObjectWithClosure_Lib::createCalculator(object[], object)
+		IL_003d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0042: ldc.i4.1
+		IL_0043: newarr [System.Runtime]System.Object
+		IL_0048: dup
+		IL_0049: ldc.i4.0
+		IL_004a: ldloc.0
+		IL_004b: stelem.ref
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0051: stloc.2
+		IL_0052: newobj instance void [System.Linq.Expressions]System.Dynamic.ExpandoObject::.ctor()
+		IL_0057: dup
+		IL_0058: ldstr "multiplyModuleFactor"
+		IL_005d: ldloc.1
+		IL_005e: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_0063: dup
+		IL_0064: ldstr "createCalculator"
+		IL_0069: ldloc.2
+		IL_006a: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_006f: stloc.3
+		IL_0070: ldarg.2
+		IL_0071: ldstr "exports"
+		IL_0076: ldloc.3
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_007c: pop
+		IL_007d: ret
+	} // end of method CommonJS_Export_ObjectWithClosure_Lib::Main
+
+} // end of class Scripts.CommonJS_Export_ObjectWithClosure_Lib
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x22d6
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.CommonJS_Export_ObjectWithClosure_Main::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Function/ExecutionTests.cs
+++ b/Js2IL.Tests/Function/ExecutionTests.cs
@@ -62,8 +62,11 @@ namespace Js2IL.Tests.Function
         [Fact]
         public Task Function_ReturnsStaticValueAndLogs() { var testName = nameof(Function_ReturnsStaticValueAndLogs); return ExecutionTest(testName); }
 
-        [Fact(Skip = "Closures not bound when function escapes scope via object literal - see issue #167")]
+        [Fact]
         public Task Function_ReturnObjectWithClosure() { var testName = nameof(Function_ReturnObjectWithClosure); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Function_ClosureEscapesScope_ObjectLiteralProperty() { var testName = nameof(Function_ClosureEscapesScope_ObjectLiteralProperty); return ExecutionTest(testName); }
 
         [Fact]
         public Task Function_ClosureMutatesOuterVariable() { var testName = nameof(Function_ClosureMutatesOuterVariable); return ExecutionTest(testName); }

--- a/Js2IL.Tests/Function/GeneratorTests.cs
+++ b/Js2IL.Tests/Function/GeneratorTests.cs
@@ -69,6 +69,9 @@ namespace Js2IL.Tests.Function
         public Task Function_ReturnsStaticValueAndLogs() { var testName = nameof(Function_ReturnsStaticValueAndLogs); return GenerateTest(testName); }
 
         [Fact]
+        public Task Function_ReturnObjectWithClosure() { var testName = nameof(Function_ReturnObjectWithClosure); return GenerateTest(testName); }
+
+        [Fact]
         public Task Function_ClosureMutatesOuterVariable() { var testName = nameof(Function_ClosureMutatesOuterVariable); return GenerateTest(testName); }
 
         [Fact]
@@ -76,5 +79,8 @@ namespace Js2IL.Tests.Function
 
         [Fact]
         public Task Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter() { var testName = nameof(Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter); return GenerateTest(testName); }
+
+        [Fact]
+        public Task Function_ClosureEscapesScope_ObjectLiteralProperty() { var testName = nameof(Function_ClosureEscapesScope_ObjectLiteralProperty); return GenerateTest(testName); }
     }
 }

--- a/Js2IL.Tests/Function/JavaScript/Function_ClosureEscapesScope_ObjectLiteralProperty.js
+++ b/Js2IL.Tests/Function/JavaScript/Function_ClosureEscapesScope_ObjectLiteralProperty.js
@@ -1,0 +1,17 @@
+// Issue #167 repro: a capturing function escapes its scope via object literal property.
+
+function createCalculator(factor) {
+    function multiply(x) {
+        return x * factor;
+    }
+
+    return {
+        multiply: multiply
+    };
+}
+
+const a = createCalculator(10);
+console.log("a.multiply(5):", a.multiply(5));
+
+const b = createCalculator(3);
+console.log("b.multiply(7):", b.multiply(7));

--- a/Js2IL.Tests/Function/Snapshots/ExecutionTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/Js2IL.Tests/Function/Snapshots/ExecutionTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -1,0 +1,2 @@
+a.multiply(5): 50
+b.multiply(7): 21

--- a/Js2IL.Tests/Function/Snapshots/ExecutionTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/Js2IL.Tests/Function/Snapshots/ExecutionTests.Function_ReturnObjectWithClosure.verified.txt
@@ -1,0 +1,3 @@
+multiply(5): 50
+factor: 10
+calc2.multiply(7): 21

--- a/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -1,0 +1,295 @@
+﻿// IL code: Function_ClosureEscapesScope_ObjectLiteralProperty
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit createCalculator
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit multiply
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2062
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method multiply::.ctor
+
+		} // end of class multiply
+
+
+		// Fields
+		.field public object factor
+		.field public object multiply
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method createCalculator::.ctor
+
+	} // end of class createCalculator
+
+
+	// Fields
+	.field public object createCalculator
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::.ctor
+
+} // end of class Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty
+
+.class public auto ansi abstract sealed beforefieldinit Functions.Function_ClosureEscapesScope_ObjectLiteralProperty
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object createCalculator (
+			object[] scopes,
+			object factor
+		) cil managed 
+	{
+		// Method begins at RVA 0x206c
+		// Header size: 12
+		// Code size: 67 (0x43)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator,
+			[1] object,
+			[2] class [System.Linq.Expressions]System.Dynamic.ExpandoObject
+		)
+
+		IL_0000: newobj instance void Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld object Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::factor
+		IL_000d: ldnull
+		IL_000e: ldftn object Functions.Function_ClosureEscapesScope_ObjectLiteralProperty::multiply(object[], object)
+		IL_0014: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0019: ldc.i4.2
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldarg.0
+		IL_0022: ldc.i4.0
+		IL_0023: ldelem.ref
+		IL_0024: stelem.ref
+		IL_0025: dup
+		IL_0026: ldc.i4.1
+		IL_0027: ldloc.0
+		IL_0028: stelem.ref
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_002e: stloc.1
+		IL_002f: newobj instance void [System.Linq.Expressions]System.Dynamic.ExpandoObject::.ctor()
+		IL_0034: dup
+		IL_0035: ldstr "multiply"
+		IL_003a: ldloc.1
+		IL_003b: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_0040: stloc.2
+		IL_0041: ldloc.2
+		IL_0042: ret
+	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::createCalculator
+
+	.method public hidebysig static 
+		object multiply (
+			object[] scopes,
+			object x
+		) cil managed 
+	{
+		// Method begins at RVA 0x20bc
+		// Header size: 12
+		// Code size: 39 (0x27)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] float64,
+			[2] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.1
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator
+		IL_0008: ldfld object Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::factor
+		IL_000d: stloc.0
+		IL_000e: ldarg.1
+		IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0014: stloc.1
+		IL_0015: ldloc.1
+		IL_0016: ldloc.0
+		IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_001c: mul
+		IL_001d: stloc.1
+		IL_001e: ldloc.1
+		IL_001f: box [System.Runtime]System.Double
+		IL_0024: stloc.2
+		IL_0025: ldloc.2
+		IL_0026: ret
+	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::multiply
+
+} // end of class Functions.Function_ClosureEscapesScope_ObjectLiteralProperty
+
+.class public auto ansi beforefieldinit Scripts.Function_ClosureEscapesScope_ObjectLiteralProperty
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x20f0
+		// Header size: 12
+		// Code size: 219 (0xdb)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty,
+			[1] object,
+			[2] object,
+			[3] object
+		)
+
+		IL_0000: newobj instance void Scopes.Function_ClosureEscapesScope_ObjectLiteralProperty::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.Function_ClosureEscapesScope_ObjectLiteralProperty::createCalculator(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldc.r8 10
+		IL_0025: box [System.Runtime]System.Double
+		IL_002a: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_002f: stloc.1
+		IL_0030: ldloc.1
+		IL_0031: ldstr "multiply"
+		IL_0036: ldc.i4.1
+		IL_0037: newarr [System.Runtime]System.Object
+		IL_003c: dup
+		IL_003d: ldc.i4.0
+		IL_003e: ldc.r8 5
+		IL_0047: box [System.Runtime]System.Double
+		IL_004c: stelem.ref
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0052: stloc.3
+		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0058: ldc.i4.2
+		IL_0059: newarr [System.Runtime]System.Object
+		IL_005e: dup
+		IL_005f: ldc.i4.0
+		IL_0060: ldstr "a.multiply(5):"
+		IL_0065: stelem.ref
+		IL_0066: dup
+		IL_0067: ldc.i4.1
+		IL_0068: ldloc.3
+		IL_0069: stelem.ref
+		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_006f: pop
+		IL_0070: ldnull
+		IL_0071: ldftn object Functions.Function_ClosureEscapesScope_ObjectLiteralProperty::createCalculator(object[], object)
+		IL_0077: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_007c: ldc.i4.1
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: dup
+		IL_0083: ldc.i4.0
+		IL_0084: ldloc.0
+		IL_0085: stelem.ref
+		IL_0086: ldc.r8 3
+		IL_008f: box [System.Runtime]System.Double
+		IL_0094: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0099: stloc.2
+		IL_009a: ldloc.2
+		IL_009b: ldstr "multiply"
+		IL_00a0: ldc.i4.1
+		IL_00a1: newarr [System.Runtime]System.Object
+		IL_00a6: dup
+		IL_00a7: ldc.i4.0
+		IL_00a8: ldc.r8 7
+		IL_00b1: box [System.Runtime]System.Double
+		IL_00b6: stelem.ref
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00bc: stloc.3
+		IL_00bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c2: ldc.i4.2
+		IL_00c3: newarr [System.Runtime]System.Object
+		IL_00c8: dup
+		IL_00c9: ldc.i4.0
+		IL_00ca: ldstr "b.multiply(7):"
+		IL_00cf: stelem.ref
+		IL_00d0: dup
+		IL_00d1: ldc.i4.1
+		IL_00d2: ldloc.3
+		IL_00d3: stelem.ref
+		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00d9: pop
+		IL_00da: ret
+	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::Main
+
+} // end of class Scripts.Function_ClosureEscapesScope_ObjectLiteralProperty
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21d7
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.Function_ClosureEscapesScope_ObjectLiteralProperty::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
@@ -1,0 +1,315 @@
+﻿// IL code: Function_ReturnObjectWithClosure
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Function_ReturnObjectWithClosure
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit createCalculator
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit multiply
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2062
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method multiply::.ctor
+
+		} // end of class multiply
+
+
+		// Fields
+		.field public object factor
+		.field public object multiply
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method createCalculator::.ctor
+
+	} // end of class createCalculator
+
+
+	// Fields
+	.field public object createCalculator
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Function_ReturnObjectWithClosure::.ctor
+
+} // end of class Scopes.Function_ReturnObjectWithClosure
+
+.class public auto ansi abstract sealed beforefieldinit Functions.Function_ReturnObjectWithClosure
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object createCalculator (
+			object[] scopes,
+			object factor
+		) cil managed 
+	{
+		// Method begins at RVA 0x206c
+		// Header size: 12
+		// Code size: 84 (0x54)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.Function_ReturnObjectWithClosure/createCalculator,
+			[1] object,
+			[2] class [System.Linq.Expressions]System.Dynamic.ExpandoObject
+		)
+
+		IL_0000: newobj instance void Scopes.Function_ReturnObjectWithClosure/createCalculator::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld object Scopes.Function_ReturnObjectWithClosure/createCalculator::factor
+		IL_000d: ldnull
+		IL_000e: ldftn object Functions.Function_ReturnObjectWithClosure::multiply(object[], object)
+		IL_0014: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0019: ldc.i4.2
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldarg.0
+		IL_0022: ldc.i4.0
+		IL_0023: ldelem.ref
+		IL_0024: stelem.ref
+		IL_0025: dup
+		IL_0026: ldc.i4.1
+		IL_0027: ldloc.0
+		IL_0028: stelem.ref
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_002e: stloc.1
+		IL_002f: newobj instance void [System.Linq.Expressions]System.Dynamic.ExpandoObject::.ctor()
+		IL_0034: dup
+		IL_0035: ldstr "multiply"
+		IL_003a: ldloc.1
+		IL_003b: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_0040: dup
+		IL_0041: ldstr "factor"
+		IL_0046: ldloc.0
+		IL_0047: ldfld object Scopes.Function_ReturnObjectWithClosure/createCalculator::factor
+		IL_004c: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_0051: stloc.2
+		IL_0052: ldloc.2
+		IL_0053: ret
+	} // end of method Function_ReturnObjectWithClosure::createCalculator
+
+	.method public hidebysig static 
+		object multiply (
+			object[] scopes,
+			object x
+		) cil managed 
+	{
+		// Method begins at RVA 0x20cc
+		// Header size: 12
+		// Code size: 39 (0x27)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] float64,
+			[2] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.1
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.Function_ReturnObjectWithClosure/createCalculator
+		IL_0008: ldfld object Scopes.Function_ReturnObjectWithClosure/createCalculator::factor
+		IL_000d: stloc.0
+		IL_000e: ldarg.1
+		IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0014: stloc.1
+		IL_0015: ldloc.1
+		IL_0016: ldloc.0
+		IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_001c: mul
+		IL_001d: stloc.1
+		IL_001e: ldloc.1
+		IL_001f: box [System.Runtime]System.Double
+		IL_0024: stloc.2
+		IL_0025: ldloc.2
+		IL_0026: ret
+	} // end of method Function_ReturnObjectWithClosure::multiply
+
+} // end of class Functions.Function_ReturnObjectWithClosure
+
+.class public auto ansi beforefieldinit Scripts.Function_ReturnObjectWithClosure
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2100
+		// Header size: 12
+		// Code size: 258 (0x102)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.Function_ReturnObjectWithClosure,
+			[1] object,
+			[2] object,
+			[3] object
+		)
+
+		IL_0000: newobj instance void Scopes.Function_ReturnObjectWithClosure::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.Function_ReturnObjectWithClosure::createCalculator(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldc.r8 10
+		IL_0025: box [System.Runtime]System.Double
+		IL_002a: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_002f: stloc.1
+		IL_0030: ldloc.1
+		IL_0031: ldstr "multiply"
+		IL_0036: ldc.i4.1
+		IL_0037: newarr [System.Runtime]System.Object
+		IL_003c: dup
+		IL_003d: ldc.i4.0
+		IL_003e: ldc.r8 5
+		IL_0047: box [System.Runtime]System.Double
+		IL_004c: stelem.ref
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0052: stloc.3
+		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0058: ldc.i4.2
+		IL_0059: newarr [System.Runtime]System.Object
+		IL_005e: dup
+		IL_005f: ldc.i4.0
+		IL_0060: ldstr "multiply(5):"
+		IL_0065: stelem.ref
+		IL_0066: dup
+		IL_0067: ldc.i4.1
+		IL_0068: ldloc.3
+		IL_0069: stelem.ref
+		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_006f: pop
+		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0075: ldc.i4.2
+		IL_0076: newarr [System.Runtime]System.Object
+		IL_007b: dup
+		IL_007c: ldc.i4.0
+		IL_007d: ldstr "factor:"
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.1
+		IL_0085: ldloc.1
+		IL_0086: ldstr "factor"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0090: stelem.ref
+		IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0096: pop
+		IL_0097: ldnull
+		IL_0098: ldftn object Functions.Function_ReturnObjectWithClosure::createCalculator(object[], object)
+		IL_009e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_00a3: ldc.i4.1
+		IL_00a4: newarr [System.Runtime]System.Object
+		IL_00a9: dup
+		IL_00aa: ldc.i4.0
+		IL_00ab: ldloc.0
+		IL_00ac: stelem.ref
+		IL_00ad: ldc.r8 3
+		IL_00b6: box [System.Runtime]System.Double
+		IL_00bb: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00c0: stloc.2
+		IL_00c1: ldloc.2
+		IL_00c2: ldstr "multiply"
+		IL_00c7: ldc.i4.1
+		IL_00c8: newarr [System.Runtime]System.Object
+		IL_00cd: dup
+		IL_00ce: ldc.i4.0
+		IL_00cf: ldc.r8 7
+		IL_00d8: box [System.Runtime]System.Double
+		IL_00dd: stelem.ref
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00e3: stloc.3
+		IL_00e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e9: ldc.i4.2
+		IL_00ea: newarr [System.Runtime]System.Object
+		IL_00ef: dup
+		IL_00f0: ldc.i4.0
+		IL_00f1: ldstr "calc2.multiply(7):"
+		IL_00f6: stelem.ref
+		IL_00f7: dup
+		IL_00f8: ldc.i4.1
+		IL_00f9: ldloc.3
+		IL_00fa: stelem.ref
+		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0100: pop
+		IL_0101: ret
+	} // end of method Function_ReturnObjectWithClosure::Main
+
+} // end of class Scripts.Function_ReturnObjectWithClosure
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x220e
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.Function_ReturnObjectWithClosure::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
Refs #167.

Adds Function + CommonJS execution/generator tests for closures escaping scope via object literals and exported objects, and updates CHANGELOG.md.