### PR TITLE
docs(release): clarify automated release behavior

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,7 +99,8 @@ npm run release:cut -- patch --merge
 Notes:
 - Requires `gh auth status` to be OK (GitHub CLI authenticated)
 - Without `--merge`, it stops after creating the PR
-- With `--merge`, it waits for checks (`gh pr checks --watch`), merges, then creates the GitHub release using the relevant `CHANGELOG.md` section
+- With `--merge`, it waits for checks (if any are configured), merges, then creates the GitHub release using the relevant `CHANGELOG.md` section
+- Optional flags: `--skip-empty`, `--dry-run`, `--repo owner/name`, `--base master`, `--verbose`
 
 **Fallback (Manual):**
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ What it does:
 - Creates `release/<version>` branch
 - Runs the existing `scripts/bumpVersion.js` to update `CHANGELOG.md` + project versions
 - Commits, pushes, and opens a PR
-- With `--merge`: waits for CI checks, merges the PR, then creates the GitHub release/tag using the `CHANGELOG.md` section
+- With `--merge`: waits for CI checks (if configured), merges the PR, then creates the GitHub release/tag using the `CHANGELOG.md` section
 
 Requirements: `git`, `gh` (authenticated), `node`/`npm`.
 
@@ -214,8 +214,6 @@ git checkout master
 git pull
 gh release create v0.x.y --title "v0.x.y" --notes "See CHANGELOG.md for details" --target master
 ```
-
-This creates the tag and triggers the GitHub Actions workflow (`.github/workflows/release.yml`) which builds and publishes to NuGet.
 
 This creates the tag and triggers the GitHub Actions workflow (`.github/workflows/release.yml`) which builds and publishes to NuGet.
 


### PR DESCRIPTION
Update release docs to match current release automation behavior.

- Clarify that --merge waits for checks if configured (continues when no checks are reported).
- Mention optional flags supported by scripts/release.js.
- Remove a duplicate sentence in README.