### PR TITLE
feat: support node: module specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+### Added
+- `NodeModuleRegistry` to normalize module specifiers and resolve `[NodeModule]` types for `require()`.
+- Validator coverage for `require('node:path')`.
+- Internal punch list for missing Node module APIs needed by scripts.
 
 ## v0.7.0 - 2026-01-15
 

--- a/JavaScriptRuntime/CommonJS/Require.cs
+++ b/JavaScriptRuntime/CommonJS/Require.cs
@@ -1,5 +1,7 @@
-using System.Reflection;
+using System;
+using System.Collections.Generic;
 using System.Dynamic;
+using System.Reflection;
 
 namespace JavaScriptRuntime.CommonJS
 {
@@ -36,19 +38,9 @@ namespace JavaScriptRuntime.CommonJS
         internal Module? GetModule(string key) => _modules.TryGetValue(key, out var m) ? m : null;
 
         // Deferred type lookup to avoid startup cost; scans assembly only on demand.
-        private Type? FindModuleType(string name)
+        private static Type? FindModuleType(string name)
         {
-            var asm = typeof(Require).Assembly;
-            foreach (var t in asm.GetTypes())
-            {
-                if (!t.IsClass || t.IsAbstract) continue;
-                if (!string.Equals(t.Namespace, "JavaScriptRuntime.Node", StringComparison.Ordinal)) continue;
-                var attr = t.GetCustomAttribute<Node.NodeModuleAttribute>();
-                if (attr == null) continue;
-                if (string.Equals(attr.Name, name, StringComparison.OrdinalIgnoreCase))
-                    return t;
-            }
-            return null;
+            return Node.NodeModuleRegistry.TryGetModuleType(name, out var type) ? type : null;
         }
 
         // require("module") returns a Node core module instance; modules are singletons.

--- a/JavaScriptRuntime/Node/NodeModuleRegistry.cs
+++ b/JavaScriptRuntime/Node/NodeModuleRegistry.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace JavaScriptRuntime.Node
+{
+    public static class NodeModuleRegistry
+    {
+        private static readonly Lazy<Dictionary<string, Type>> ModulesByName = new(() =>
+        {
+            var asm = typeof(NodeModuleAttribute).Assembly;
+            var modules = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var t in asm.GetTypes())
+            {
+                if (!t.IsClass || t.IsAbstract) continue;
+                if (!string.Equals(t.Namespace, "JavaScriptRuntime.Node", StringComparison.Ordinal)) continue;
+
+                var attr = t.GetCustomAttribute<NodeModuleAttribute>(false);
+                if (attr == null || string.IsNullOrWhiteSpace(attr.Name)) continue;
+
+                var name = NormalizeModuleName(attr.Name);
+                if (string.IsNullOrWhiteSpace(name)) continue;
+
+                if (!modules.ContainsKey(name))
+                {
+                    modules.Add(name, t);
+                }
+            }
+
+            return modules;
+        });
+
+        public static string NormalizeModuleName(string specifier)
+        {
+            if (specifier == null)
+            {
+                return string.Empty;
+            }
+
+            var trimmed = specifier.Trim();
+            if (trimmed.StartsWith("node:", StringComparison.OrdinalIgnoreCase))
+            {
+                trimmed = trimmed.Substring("node:".Length);
+            }
+
+            return trimmed;
+        }
+
+        public static IReadOnlyCollection<string> GetSupportedModuleNames()
+        {
+            return ModulesByName.Value.Keys.ToArray();
+        }
+
+        public static bool TryGetModuleType(string specifier, out Type? type)
+        {
+            var key = NormalizeModuleName(specifier);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                type = null;
+                return false;
+            }
+
+            return ModulesByName.Value.TryGetValue(key, out type);
+        }
+    }
+}

--- a/Js2IL.Tests/ValidatorTests.cs
+++ b/Js2IL.Tests/ValidatorTests.cs
@@ -84,6 +84,16 @@ public class ValidatorTests
     }
 
     [Fact]
+    public void Validate_Require_NodePath_Supported_NoError()
+    {
+        var js = "const p = require('node:path');";
+        var ast = _parser.ParseJavaScript(js, "test.js");
+        var result = _validator.Validate(ast);
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void Validate_Require_UnsupportedModule_ReportsError()
     {
         var js = "const c = require('node:crypto');";

--- a/Js2IL/SymbolTable/SymbolTableBuilder.cs
+++ b/Js2IL/SymbolTable/SymbolTableBuilder.cs
@@ -313,29 +313,12 @@ namespace Js2IL.SymbolTables
 
         private static string NormalizeModuleName(string s)
         {
-            var trimmed = (s ?? string.Empty).Trim();
-            if (trimmed.StartsWith("node:", StringComparison.OrdinalIgnoreCase))
-                trimmed = trimmed.Substring("node:".Length);
-            return trimmed;
+            return JavaScriptRuntime.Node.NodeModuleRegistry.NormalizeModuleName(s);
         }
 
         private static Type? ResolveNodeModuleType(string key)
         {
-            if (string.IsNullOrWhiteSpace(key)) return null;
-            var asm = typeof(JavaScriptRuntime.Node.NodeModuleAttribute).Assembly;
-            // Scan JavaScriptRuntime.Node namespace for [NodeModule(Name=key)]
-            foreach (var t in asm.GetTypes())
-            {
-                if (!t.IsClass || t.IsAbstract) continue;
-                if (!string.Equals(t.Namespace, "JavaScriptRuntime.Node", StringComparison.Ordinal)) continue;
-                var attr = t.GetCustomAttributes(false).FirstOrDefault(a => a.GetType().FullName == "JavaScriptRuntime.Node.NodeModuleAttribute");
-                if (attr == null) continue;
-                var nameProp = attr.GetType().GetProperty("Name");
-                var nameVal = nameProp?.GetValue(attr) as string;
-                if (string.Equals(nameVal, key, StringComparison.OrdinalIgnoreCase))
-                    return t;
-            }
-            return null;
+            return JavaScriptRuntime.Node.NodeModuleRegistry.TryGetModuleType(key, out var type) ? type : null;
         }
 
         private static string SanitizeForMetadata(string name)

--- a/docs/NodeModuleSupport_PunchList.md
+++ b/docs/NodeModuleSupport_PunchList.md
@@ -1,0 +1,40 @@
+# Node module support punch list (internal scripts)
+
+This checklist captures Node.js module APIs required so internal project scripts in scripts/ can be compiled with js2il.
+
+## child_process
+Required by:
+- scripts/decompileGeneratorTest.js
+- scripts/installLocalTool.js
+- scripts/release.js
+- scripts/runExecutionTestsAndReportFailures.js
+- scripts/runGeneratorTestsAndUpdateFailures.js
+- scripts/syncExecutionSnapshots.js
+
+APIs:
+- spawnSync(command, args, options)
+- execSync(command, options)
+
+Notes:
+- scripts use both node:child_process and child_process module specifiers.
+- spawnSync options used: cwd, stdio, shell, encoding.
+
+## fs/promises
+Required by:
+- scripts/updateVerifiedFiles.js
+
+APIs:
+- access(path, mode)
+- readdir(path, options) (withFileTypes: true)
+- mkdir(path, options) (recursive: true)
+- copyFile(src, dest)
+
+## os
+Required by:
+- scripts/decompileGeneratorTest.js
+- scripts/installLocalTool.js
+
+APIs:
+- tmpdir()
+- homedir()
+


### PR DESCRIPTION
## Summary
- normalize node module specifiers via NodeModuleRegistry
- allow node: prefixed requires in validation/type resolution
- add validator test + punch list doc and changelog update

## Testing
- not run (user reports all tests passing)