### PR TITLE
fix: update expression lowering and unary operator coverage

### DIFF
--- a/JavaScriptRuntime/Array.cs
+++ b/JavaScriptRuntime/Array.cs
@@ -267,6 +267,52 @@ namespace JavaScriptRuntime
         }
 
         /// <summary>
+        /// JavaScript Array.some(callback[, thisArg])
+        /// Minimal implementation: invokes the callback with (value, index, array) and returns true if any call is truthy.
+        /// </summary>
+        public object some(object[] args)
+        {
+            var cb = (args != null && args.Length > 0) ? args[0] : null;
+
+            for (int i = 0; i < this.Count; i++)
+            {
+                var value = this[i];
+                object? result;
+
+                if (cb is Func<object?[], object?, object?, object?, object?> f3)
+                {
+                    // (scopes, value, index, array)
+                    result = f3(System.Array.Empty<object?>(), value, (double)i, this);
+                }
+                else if (cb is Func<object?[], object?, object?, object?> f2)
+                {
+                    // (scopes, value, index)
+                    result = f2(System.Array.Empty<object?>(), value, (double)i);
+                }
+                else if (cb is Func<object?[], object?, object?> f1)
+                {
+                    // (scopes, value)
+                    result = f1(System.Array.Empty<object?>(), value);
+                }
+                else if (cb is Func<object?[], object?> f0)
+                {
+                    result = f0(System.Array.Empty<object?>());
+                }
+                else
+                {
+                    throw new InvalidOperationException("some callback is not a supported function type");
+                }
+
+                if (Operators.IsTruthy(result))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// JavaScript Array.join([separator]) implementation.
         /// Joins elements by the given separator (default ',') and returns a string.
         /// Each element is converted using DotNet2JSConversions.ToString to approximate JS semantics.

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
@@ -113,7 +113,7 @@
 	{
 		// Method begins at RVA 0x2088
 		// Header size: 12
-		// Code size: 56 (0x38)
+		// Code size: 63 (0x3f)
 		.maxstack 32
 		.locals init (
 			[0] float64
@@ -124,23 +124,26 @@
 			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0006: ldc.r8 3
 			IL_000f: clt
-			IL_0011: brfalse IL_0036
+			IL_0011: brfalse IL_003d
 
 			IL_0016: ldarg.1
-			IL_0017: pop
-			IL_0018: ldarg.1
-			IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001e: ldc.r8 1
-			IL_0027: add
-			IL_0028: stloc.0
-			IL_0029: ldloc.0
-			IL_002a: box [System.Runtime]System.Double
-			IL_002f: starg.s n
-			IL_0031: br IL_0000
+			IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: box [System.Runtime]System.Double
+			IL_0023: pop
+			IL_0024: ldloc.0
+			IL_0025: ldc.r8 1
+			IL_002e: add
+			IL_002f: stloc.0
+			IL_0030: ldloc.0
+			IL_0031: box [System.Runtime]System.Double
+			IL_0036: starg.s n
+			IL_0038: br IL_0000
 		// end loop
 
-		IL_0036: ldnull
-		IL_0037: ret
+		IL_003d: ldnull
+		IL_003e: ret
 	} // end of method Counter::run
 
 } // end of class Classes.Classes_ClassMethod_While_Increment_Param_Postfix.Counter
@@ -158,7 +161,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20cc
+		// Method begins at RVA 0x20d4
 		// Header size: 12
 		// Code size: 102 (0x66)
 		.maxstack 32
@@ -220,7 +223,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213e
+		// Method begins at RVA 0x2146
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Integration/GeneratorTests.cs
+++ b/Js2IL.Tests/Integration/GeneratorTests.cs
@@ -13,6 +13,9 @@ namespace Js2IL.Tests.Integration
         public Task Compile_Scripts_GenerateNodeSupportMd() => GenerateTest(nameof(Compile_Scripts_GenerateNodeSupportMd));
 
         [Fact]
+        public Task Compile_Scripts_BumpVersion() => GenerateTest(nameof(Compile_Scripts_BumpVersion));
+
+        [Fact]
         public Task Compile_Performance_PrimeJavaScript() => GenerateTest(nameof(Compile_Performance_PrimeJavaScript));
     }
 }

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -1,0 +1,2638 @@
+﻿// IL code: Compile_Scripts_BumpVersion
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.Compile_Scripts_BumpVersion
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit readFile
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method readFile::.ctor
+
+	} // end of class readFile
+
+	.class nested public auto ansi beforefieldinit writeFile
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method writeFile::.ctor
+
+	} // end of class writeFile
+
+	.class nested public auto ansi beforefieldinit parseCurrentVersion
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method parseCurrentVersion::.ctor
+
+	} // end of class parseCurrentVersion
+
+	.class nested public auto ansi beforefieldinit incVersion
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit ArrowFunction_L42C45
+			extends [System.Runtime]System.Object
+		{
+			// Fields
+			.field public object n
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x207d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method ArrowFunction_L42C45::.ctor
+
+		} // end of class ArrowFunction_L42C45
+
+		.class nested public auto ansi beforefieldinit ArrowFunction_L43C26
+			extends [System.Runtime]System.Object
+		{
+			// Fields
+			.field public object n
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2086
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method ArrowFunction_L43C26::.ctor
+
+		} // end of class ArrowFunction_L43C26
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method incVersion::.ctor
+
+	} // end of class incVersion
+
+	.class nested public auto ansi beforefieldinit resolveTargetVersion
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x208f
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method resolveTargetVersion::.ctor
+
+	} // end of class resolveTargetVersion
+
+	.class nested public auto ansi beforefieldinit updateCsprojVersion
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L63C34
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20a1
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L63C34::.ctor
+
+		} // end of class Block_L63C34
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2098
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method updateCsprojVersion::.ctor
+
+	} // end of class updateCsprojVersion
+
+	.class nested public auto ansi beforefieldinit extractUnreleased
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L81C23
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20b3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L81C23::.ctor
+
+		} // end of class Block_L81C23
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20aa
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method extractUnreleased::.ctor
+
+	} // end of class extractUnreleased
+
+	.class nested public auto ansi beforefieldinit isPlaceholder
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20bc
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method isPlaceholder::.ctor
+
+	} // end of class isPlaceholder
+
+	.class nested public auto ansi beforefieldinit generateReleaseSection
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit ArrowFunction_cleaned
+			extends [System.Runtime]System.Object
+		{
+			// Fields
+			.field public object l
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20ce
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method ArrowFunction_cleaned::.ctor
+
+		} // end of class ArrowFunction_cleaned
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20c5
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method generateReleaseSection::.ctor
+
+	} // end of class generateReleaseSection
+
+	.class nested public auto ansi beforefieldinit perform
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L109C36
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20e0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L109C36::.ctor
+
+		} // end of class Block_L109C36
+
+		.class nested public auto ansi beforefieldinit ArrowFunction_hasRealContent
+			extends [System.Runtime]System.Object
+		{
+			// Fields
+			.field public object l
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20e9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method ArrowFunction_hasRealContent::.ctor
+
+		} // end of class ArrowFunction_hasRealContent
+
+		.class nested public auto ansi beforefieldinit Block_L116C35
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20f2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L116C35::.ctor
+
+		} // end of class Block_L116C35
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20d7
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method perform::.ctor
+
+	} // end of class perform
+
+	.class nested public auto ansi beforefieldinit Block_L147C4
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20fb
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L147C4::.ctor
+
+	} // end of class Block_L147C4
+
+	.class nested public auto ansi beforefieldinit Block_L147C29
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2104
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Block_L147C29::.ctor
+
+	} // end of class Block_L147C29
+
+
+	// Fields
+	.field public object fs
+	.field public object CSPROJ_PATH
+	.field public object RUNTIME_CSPROJ_PATH
+	.field public object CHANGELOG_PATH
+	.field public object readFile
+	.field public object writeFile
+	.field public object parseCurrentVersion
+	.field public object incVersion
+	.field public object resolveTargetVersion
+	.field public object updateCsprojVersion
+	.field public object extractUnreleased
+	.field public object isPlaceholder
+	.field public object generateReleaseSection
+	.field public object perform
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Compile_Scripts_BumpVersion::.ctor
+
+} // end of class Scopes.Compile_Scripts_BumpVersion
+
+.class public auto ansi abstract sealed beforefieldinit Functions.Compile_Scripts_BumpVersion
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object readFile (
+			object[] scopes,
+			object p
+		) cil managed 
+	{
+		// Method begins at RVA 0x2b58
+		// Header size: 12
+		// Code size: 46 (0x2e)
+		.maxstack 32
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_0008: ldfld object Scopes.Compile_Scripts_BumpVersion::fs
+		IL_000d: stloc.0
+		IL_000e: ldloc.0
+		IL_000f: ldstr "readFileSync"
+		IL_0014: ldc.i4.2
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: dup
+		IL_001b: ldc.i4.0
+		IL_001c: ldarg.1
+		IL_001d: stelem.ref
+		IL_001e: dup
+		IL_001f: ldc.i4.1
+		IL_0020: ldstr "utf8"
+		IL_0025: stelem.ref
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_002b: stloc.0
+		IL_002c: ldloc.0
+		IL_002d: ret
+	} // end of method Compile_Scripts_BumpVersion::readFile
+
+	.method public hidebysig static 
+		object writeFile (
+			object[] scopes,
+			object p,
+			object c
+		) cil managed 
+	{
+		// Method begins at RVA 0x302c
+		// Header size: 12
+		// Code size: 50 (0x32)
+		.maxstack 32
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_0008: ldfld object Scopes.Compile_Scripts_BumpVersion::fs
+		IL_000d: stloc.0
+		IL_000e: ldloc.0
+		IL_000f: ldstr "writeFileSync"
+		IL_0014: ldc.i4.3
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: dup
+		IL_001b: ldc.i4.0
+		IL_001c: ldarg.1
+		IL_001d: stelem.ref
+		IL_001e: dup
+		IL_001f: ldc.i4.1
+		IL_0020: ldarg.2
+		IL_0021: stelem.ref
+		IL_0022: dup
+		IL_0023: ldc.i4.2
+		IL_0024: ldstr "utf8"
+		IL_0029: stelem.ref
+		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_002f: pop
+		IL_0030: ldnull
+		IL_0031: ret
+	} // end of method Compile_Scripts_BumpVersion::writeFile
+
+	.method public hidebysig static 
+		object parseCurrentVersion (
+			object[] scopes,
+			object csprojText
+		) cil managed 
+	{
+		// Method begins at RVA 0x2acc
+		// Header size: 12
+		// Code size: 126 (0x7e)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object[],
+			[3] bool
+		)
+
+		IL_0000: ldstr "<Version>([^<]+)<\\/Version>"
+		IL_0005: ldstr ""
+		IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_000f: stloc.1
+		IL_0010: ldc.i4.1
+		IL_0011: newarr [System.Runtime]System.Object
+		IL_0016: dup
+		IL_0017: ldc.i4.0
+		IL_0018: ldloc.1
+		IL_0019: stelem.ref
+		IL_001a: stloc.2
+		IL_001b: ldarg.1
+		IL_001c: ldstr "match"
+		IL_0021: ldloc.2
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0027: stloc.0
+		IL_0028: ldloc.0
+		IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_002e: ldc.i4.0
+		IL_002f: ceq
+		IL_0031: stloc.3
+		IL_0032: ldloc.3
+		IL_0033: brfalse IL_005c
+
+		IL_0038: ldstr "Could not find <Version> in Js2IL.csproj"
+		IL_003d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_0047: dup
+		IL_0048: isinst [System.Runtime]System.Exception
+		IL_004d: dup
+		IL_004e: brtrue IL_005a
+
+		IL_0053: pop
+		IL_0054: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+		IL_0059: throw
+
+		IL_005a: pop
+		IL_005b: throw
+
+		IL_005c: ldloc.0
+		IL_005d: ldc.r8 1
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_006b: ldstr "trim"
+		IL_0070: ldc.i4.0
+		IL_0071: newarr [System.Runtime]System.Object
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_007b: stloc.1
+		IL_007c: ldloc.1
+		IL_007d: ret
+	} // end of method Compile_Scripts_BumpVersion::parseCurrentVersion
+
+	.method public hidebysig static 
+		object incVersion (
+			object[] scopes,
+			object version,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2c88
+		// Header size: 12
+		// Code size: 710 (0x2c6)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.Compile_Scripts_BumpVersion/incVersion,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] object,
+			[7] object,
+			[8] object,
+			[9] object,
+			[10] object[],
+			[11] bool,
+			[12] object,
+			[13] float64,
+			[14] string,
+			[15] string
+		)
+
+		IL_0000: newobj instance void Scopes.Compile_Scripts_BumpVersion/incVersion::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.1
+		IL_0007: ldstr "split"
+		IL_000c: ldc.i4.1
+		IL_000d: newarr [System.Runtime]System.Object
+		IL_0012: dup
+		IL_0013: ldc.i4.0
+		IL_0014: ldstr "-"
+		IL_0019: stelem.ref
+		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_001f: stloc.s 8
+		IL_0021: ldloc.s 8
+		IL_0023: ldc.r8 0.0
+		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_0031: stloc.1
+		IL_0032: ldloc.1
+		IL_0033: ldstr "split"
+		IL_0038: ldc.i4.1
+		IL_0039: newarr [System.Runtime]System.Object
+		IL_003e: dup
+		IL_003f: ldc.i4.0
+		IL_0040: ldstr "."
+		IL_0045: stelem.ref
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_004b: stloc.s 8
+		IL_004d: ldnull
+		IL_004e: ldftn object Functions.ArrowFunction_L42C46::ArrowFunction_L42C46(object[], object)
+		IL_0054: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0059: ldc.i4.1
+		IL_005a: newarr [System.Runtime]System.Object
+		IL_005f: dup
+		IL_0060: ldc.i4.0
+		IL_0061: ldarg.0
+		IL_0062: ldc.i4.0
+		IL_0063: ldelem.ref
+		IL_0064: stelem.ref
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_006a: stloc.s 9
+		IL_006c: ldc.i4.1
+		IL_006d: newarr [System.Runtime]System.Object
+		IL_0072: dup
+		IL_0073: ldc.i4.0
+		IL_0074: ldloc.s 9
+		IL_0076: stelem.ref
+		IL_0077: stloc.s 10
+		IL_0079: ldloc.s 8
+		IL_007b: ldstr "map"
+		IL_0080: ldloc.s 10
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0087: stloc.s 8
+		IL_0089: ldloc.s 8
+		IL_008b: brfalse IL_00a0
+
+		IL_0090: ldloc.s 8
+		IL_0092: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0097: stloc.s 9
+		IL_0099: ldloc.s 9
+		IL_009b: brfalse IL_00b1
+
+		IL_00a0: ldloc.s 8
+		IL_00a2: ldstr ""
+		IL_00a7: ldstr "0"
+		IL_00ac: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+
+		IL_00b1: ldloc.s 8
+		IL_00b3: ldc.r8 0.0
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_00c1: stloc.s 5
+		IL_00c3: ldloc.s 8
+		IL_00c5: ldc.r8 1
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_00d3: stloc.s 6
+		IL_00d5: ldloc.s 8
+		IL_00d7: ldc.r8 2
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_00e5: stloc.s 7
+		IL_00e7: ldnull
+		IL_00e8: ldftn object Functions.ArrowFunction_L43C27::ArrowFunction_L43C27(object[], object)
+		IL_00ee: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_00f3: ldc.i4.1
+		IL_00f4: newarr [System.Runtime]System.Object
+		IL_00f9: dup
+		IL_00fa: ldc.i4.0
+		IL_00fb: ldarg.0
+		IL_00fc: ldc.i4.0
+		IL_00fd: ldelem.ref
+		IL_00fe: stelem.ref
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0104: stloc.s 8
+		IL_0106: ldc.i4.3
+		IL_0107: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_010c: dup
+		IL_010d: ldloc.s 5
+		IL_010f: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0114: dup
+		IL_0115: ldloc.s 6
+		IL_0117: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_011c: dup
+		IL_011d: ldloc.s 7
+		IL_011f: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0124: ldc.i4.1
+		IL_0125: newarr [System.Runtime]System.Object
+		IL_012a: dup
+		IL_012b: ldc.i4.0
+		IL_012c: ldloc.s 8
+		IL_012e: stelem.ref
+		IL_012f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::some(object[])
+		IL_0134: stloc.s 8
+		IL_0136: ldloc.s 8
+		IL_0138: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_013d: stloc.s 11
+		IL_013f: ldloc.s 11
+		IL_0141: brfalse IL_0174
+
+		IL_0146: ldstr "Invalid current version: "
+		IL_014b: ldarg.1
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0151: stloc.s 12
+		IL_0153: ldloc.s 12
+		IL_0155: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_015f: dup
+		IL_0160: isinst [System.Runtime]System.Exception
+		IL_0165: dup
+		IL_0166: brtrue IL_0172
+
+		IL_016b: pop
+		IL_016c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+		IL_0171: throw
+
+		IL_0172: pop
+		IL_0173: throw
+
+		IL_0174: ldarg.2
+		IL_0175: ldstr "major"
+		IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_017f: stloc.s 11
+		IL_0181: ldloc.s 11
+		IL_0183: brtrue IL_01b5
+
+		IL_0188: ldarg.2
+		IL_0189: ldstr "minor"
+		IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0193: stloc.s 11
+		IL_0195: ldloc.s 11
+		IL_0197: brtrue IL_01fa
+
+		IL_019c: ldarg.2
+		IL_019d: ldstr "patch"
+		IL_01a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01a7: stloc.s 11
+		IL_01a9: ldloc.s 11
+		IL_01ab: brtrue IL_021d
+
+		IL_01b0: br IL_0230
+
+		IL_01b5: ldloc.s 5
+		IL_01b7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01bc: stloc.s 13
+		IL_01be: ldloc.s 13
+		IL_01c0: ldc.r8 1
+		IL_01c9: add
+		IL_01ca: stloc.s 13
+		IL_01cc: ldloc.s 13
+		IL_01ce: box [System.Runtime]System.Double
+		IL_01d3: stloc.s 5
+		IL_01d5: ldc.r8 0.0
+		IL_01de: box [System.Runtime]System.Double
+		IL_01e3: stloc.s 6
+		IL_01e5: ldc.r8 0.0
+		IL_01ee: box [System.Runtime]System.Double
+		IL_01f3: stloc.s 7
+		IL_01f5: br IL_025e
+
+		IL_01fa: ldloc.s 6
+		IL_01fc: ldc.r8 1
+		IL_0205: add
+		IL_0206: stloc.s 6
+		IL_0208: ldc.r8 0.0
+		IL_0211: box [System.Runtime]System.Double
+		IL_0216: stloc.s 7
+		IL_0218: br IL_025e
+
+		IL_021d: ldloc.s 7
+		IL_021f: ldc.r8 1
+		IL_0228: add
+		IL_0229: stloc.s 7
+		IL_022b: br IL_025e
+
+		IL_0230: ldstr "Unknown bump kind: "
+		IL_0235: ldarg.2
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_023b: stloc.s 12
+		IL_023d: ldloc.s 12
+		IL_023f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0244: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_0249: dup
+		IL_024a: isinst [System.Runtime]System.Exception
+		IL_024f: dup
+		IL_0250: brtrue IL_025c
+
+		IL_0255: pop
+		IL_0256: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+		IL_025b: throw
+
+		IL_025c: pop
+		IL_025d: throw
+
+		IL_025e: ldloc.s 5
+		IL_0260: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0265: stloc.s 14
+		IL_0267: ldstr ""
+		IL_026c: ldloc.s 14
+		IL_026e: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0273: stloc.s 14
+		IL_0275: ldloc.s 14
+		IL_0277: ldstr "."
+		IL_027c: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0281: stloc.s 14
+		IL_0283: ldloc.s 6
+		IL_0285: box [System.Runtime]System.Double
+		IL_028a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_028f: stloc.s 15
+		IL_0291: ldloc.s 14
+		IL_0293: ldloc.s 15
+		IL_0295: call string [System.Runtime]System.String::Concat(string, string)
+		IL_029a: stloc.s 15
+		IL_029c: ldloc.s 15
+		IL_029e: ldstr "."
+		IL_02a3: call string [System.Runtime]System.String::Concat(string, string)
+		IL_02a8: stloc.s 15
+		IL_02aa: ldloc.s 7
+		IL_02ac: box [System.Runtime]System.Double
+		IL_02b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_02b6: stloc.s 14
+		IL_02b8: ldloc.s 15
+		IL_02ba: ldloc.s 14
+		IL_02bc: call string [System.Runtime]System.String::Concat(string, string)
+		IL_02c1: stloc.s 14
+		IL_02c3: ldloc.s 14
+		IL_02c5: ret
+	} // end of method Compile_Scripts_BumpVersion::incVersion
+
+	.method public hidebysig static 
+		object resolveTargetVersion (
+			object[] scopes,
+			object argVersion,
+			object current
+		) cil managed 
+	{
+		// Method begins at RVA 0x2b94
+		// Header size: 12
+		// Code size: 229 (0xe5)
+		.maxstack 32
+		.locals init (
+			[0] bool,
+			[1] object
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_0006: ldc.i4.0
+		IL_0007: ceq
+		IL_0009: stloc.0
+		IL_000a: ldloc.0
+		IL_000b: brfalse IL_0034
+
+		IL_0010: ldstr "Provide a bump type (major|minor|patch) or explicit version"
+		IL_0015: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_001a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_001f: dup
+		IL_0020: isinst [System.Runtime]System.Exception
+		IL_0025: dup
+		IL_0026: brtrue IL_0032
+
+		IL_002b: pop
+		IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+		IL_0031: throw
+
+		IL_0032: pop
+		IL_0033: throw
+
+		IL_0034: ldstr "^major|minor|patch$"
+		IL_0039: ldstr ""
+		IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0043: stloc.1
+		IL_0044: ldloc.1
+		IL_0045: ldstr "test"
+		IL_004a: ldc.i4.1
+		IL_004b: newarr [System.Runtime]System.Object
+		IL_0050: dup
+		IL_0051: ldc.i4.0
+		IL_0052: ldarg.1
+		IL_0053: stelem.ref
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0059: stloc.1
+		IL_005a: ldloc.1
+		IL_005b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0060: stloc.0
+		IL_0061: ldloc.0
+		IL_0062: brfalse IL_0089
+
+		IL_0067: ldnull
+		IL_0068: ldftn object Functions.Compile_Scripts_BumpVersion::incVersion(object[], object, object)
+		IL_006e: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_0073: ldc.i4.1
+		IL_0074: newarr [System.Runtime]System.Object
+		IL_0079: dup
+		IL_007a: ldc.i4.0
+		IL_007b: ldarg.0
+		IL_007c: ldc.i4.0
+		IL_007d: ldelem.ref
+		IL_007e: stelem.ref
+		IL_007f: ldarg.2
+		IL_0080: ldarg.1
+		IL_0081: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_0086: stloc.1
+		IL_0087: ldloc.1
+		IL_0088: ret
+
+		IL_0089: ldstr "^\\d+\\.\\d+\\.\\d+$"
+		IL_008e: ldstr ""
+		IL_0093: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0098: stloc.1
+		IL_0099: ldloc.1
+		IL_009a: ldstr "test"
+		IL_009f: ldc.i4.1
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldarg.1
+		IL_00a8: stelem.ref
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00ae: stloc.1
+		IL_00af: ldloc.1
+		IL_00b0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_00b5: ldc.i4.0
+		IL_00b6: ceq
+		IL_00b8: stloc.0
+		IL_00b9: ldloc.0
+		IL_00ba: brfalse IL_00e3
+
+		IL_00bf: ldstr "Explicit version must be major.minor.patch"
+		IL_00c4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_00ce: dup
+		IL_00cf: isinst [System.Runtime]System.Exception
+		IL_00d4: dup
+		IL_00d5: brtrue IL_00e1
+
+		IL_00da: pop
+		IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+		IL_00e0: throw
+
+		IL_00e1: pop
+		IL_00e2: throw
+
+		IL_00e3: ldarg.1
+		IL_00e4: ret
+	} // end of method Compile_Scripts_BumpVersion::resolveTargetVersion
+
+	.method public hidebysig static 
+		object updateCsprojVersion (
+			object[] scopes,
+			object text,
+			object newVersion
+		) cil managed 
+	{
+		// Method begins at RVA 0x2f5c
+		// Header size: 12
+		// Code size: 193 (0xc1)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] bool,
+			[2] string,
+			[3] object[]
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: ldstr "includes"
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldstr "<Version>"
+		IL_0013: stelem.ref
+		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0019: stloc.0
+		IL_001a: ldloc.0
+		IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0020: stloc.1
+		IL_0021: ldloc.1
+		IL_0022: brfalse IL_0074
+
+		IL_0027: ldstr "<Version>[^<]+<\\/Version>"
+		IL_002c: ldstr ""
+		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0036: stloc.0
+		IL_0037: ldarg.2
+		IL_0038: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_003d: stloc.2
+		IL_003e: ldstr "<Version>"
+		IL_0043: ldloc.2
+		IL_0044: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0049: stloc.2
+		IL_004a: ldloc.2
+		IL_004b: ldstr "</Version>"
+		IL_0050: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0055: stloc.2
+		IL_0056: ldc.i4.2
+		IL_0057: newarr [System.Runtime]System.Object
+		IL_005c: dup
+		IL_005d: ldc.i4.0
+		IL_005e: ldloc.0
+		IL_005f: stelem.ref
+		IL_0060: dup
+		IL_0061: ldc.i4.1
+		IL_0062: ldloc.2
+		IL_0063: stelem.ref
+		IL_0064: stloc.3
+		IL_0065: ldarg.1
+		IL_0066: ldstr "replace"
+		IL_006b: ldloc.3
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0071: stloc.0
+		IL_0072: ldloc.0
+		IL_0073: ret
+
+		IL_0074: ldstr "(<PropertyGroup>\\s*\\n)"
+		IL_0079: ldstr ""
+		IL_007e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0083: stloc.0
+		IL_0084: ldarg.2
+		IL_0085: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_008a: stloc.2
+		IL_008b: ldstr "$1    <Version>"
+		IL_0090: ldloc.2
+		IL_0091: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0096: stloc.2
+		IL_0097: ldloc.2
+		IL_0098: ldstr "</Version>\n"
+		IL_009d: call string [System.Runtime]System.String::Concat(string, string)
+		IL_00a2: stloc.2
+		IL_00a3: ldc.i4.2
+		IL_00a4: newarr [System.Runtime]System.Object
+		IL_00a9: dup
+		IL_00aa: ldc.i4.0
+		IL_00ab: ldloc.0
+		IL_00ac: stelem.ref
+		IL_00ad: dup
+		IL_00ae: ldc.i4.1
+		IL_00af: ldloc.2
+		IL_00b0: stelem.ref
+		IL_00b1: stloc.3
+		IL_00b2: ldarg.1
+		IL_00b3: ldstr "replace"
+		IL_00b8: ldloc.3
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00be: stloc.0
+		IL_00bf: ldloc.0
+		IL_00c0: ret
+	} // end of method Compile_Scripts_BumpVersion::updateCsprojVersion
+
+	.method public hidebysig static 
+		object extractUnreleased (
+			object[] scopes,
+			object changelog
+		) cil managed 
+	{
+		// Method begins at RVA 0x274c
+		// Header size: 12
+		// Code size: 528 (0x210)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64,
+			[4] object,
+			[5] object,
+			[6] bool,
+			[7] object[],
+			[8] object,
+			[9] object,
+			[10] object,
+			[11] float64,
+			[12] object,
+			[13] class [System.Linq.Expressions]System.Dynamic.ExpandoObject
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: ldstr "indexOf"
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldstr "## Unreleased"
+		IL_0013: stelem.ref
+		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0019: stloc.0
+		IL_001a: ldloc.0
+		IL_001b: ldc.r8 1
+		IL_0024: neg
+		IL_0025: box [System.Runtime]System.Double
+		IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_002f: stloc.s 6
+		IL_0031: ldloc.s 6
+		IL_0033: brfalse IL_005c
+
+		IL_0038: ldstr "CHANGELOG.md missing \"## Unreleased\" section"
+		IL_003d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_0047: dup
+		IL_0048: isinst [System.Runtime]System.Exception
+		IL_004d: dup
+		IL_004e: brtrue IL_005a
+
+		IL_0053: pop
+		IL_0054: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+		IL_0059: throw
+
+		IL_005a: pop
+		IL_005b: throw
+
+		IL_005c: ldc.i4.2
+		IL_005d: newarr [System.Runtime]System.Object
+		IL_0062: dup
+		IL_0063: ldc.i4.0
+		IL_0064: ldstr "\n"
+		IL_0069: stelem.ref
+		IL_006a: dup
+		IL_006b: ldc.i4.1
+		IL_006c: ldloc.0
+		IL_006d: stelem.ref
+		IL_006e: stloc.s 7
+		IL_0070: ldarg.1
+		IL_0071: ldstr "indexOf"
+		IL_0076: ldloc.s 7
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_007d: stloc.1
+		IL_007e: ldloc.1
+		IL_007f: ldc.r8 1
+		IL_0088: box [System.Runtime]System.Double
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0092: stloc.s 8
+		IL_0094: ldc.i4.1
+		IL_0095: newarr [System.Runtime]System.Object
+		IL_009a: dup
+		IL_009b: ldc.i4.0
+		IL_009c: ldloc.s 8
+		IL_009e: stelem.ref
+		IL_009f: stloc.s 7
+		IL_00a1: ldarg.1
+		IL_00a2: ldstr "slice"
+		IL_00a7: ldloc.s 7
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00ae: stloc.s 9
+		IL_00b0: ldstr "\\n## v?\\d+\\.\\d+\\.\\d+ "
+		IL_00b5: ldstr ""
+		IL_00ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00bf: stloc.s 10
+		IL_00c1: ldc.i4.1
+		IL_00c2: newarr [System.Runtime]System.Object
+		IL_00c7: dup
+		IL_00c8: ldc.i4.0
+		IL_00c9: ldloc.s 10
+		IL_00cb: stelem.ref
+		IL_00cc: stloc.s 7
+		IL_00ce: ldloc.s 9
+		IL_00d0: ldstr "match"
+		IL_00d5: ldloc.s 7
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00dc: stloc.2
+		IL_00dd: ldc.r8 1
+		IL_00e6: neg
+		IL_00e7: stloc.3
+		IL_00e8: ldloc.2
+		IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_00ee: stloc.s 6
+		IL_00f0: ldloc.s 6
+		IL_00f2: brfalse IL_0140
+
+		IL_00f7: ldloc.1
+		IL_00f8: ldc.r8 1
+		IL_0101: box [System.Runtime]System.Double
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_010b: stloc.s 8
+		IL_010d: ldloc.s 8
+		IL_010f: ldloc.2
+		IL_0110: ldstr "index"
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_011f: stloc.s 8
+		IL_0121: ldloc.s 8
+		IL_0123: ldc.r8 1
+		IL_012c: box [System.Runtime]System.Double
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0136: stloc.s 8
+		IL_0138: ldloc.s 8
+		IL_013a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_013f: stloc.3
+
+		IL_0140: ldloc.3
+		IL_0141: ldc.r8 1
+		IL_014a: neg
+		IL_014b: ceq
+		IL_014d: brfalse IL_0164
+
+		IL_0152: ldarg.1
+		IL_0153: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0158: box [System.Runtime]System.Double
+		IL_015d: stloc.s 4
+		IL_015f: br IL_017e
+
+		IL_0164: ldloc.3
+		IL_0165: ldc.r8 1
+		IL_016e: sub
+		IL_016f: stloc.s 11
+		IL_0171: ldloc.s 11
+		IL_0173: box [System.Runtime]System.Double
+		IL_0178: stloc.s 12
+		IL_017a: ldloc.s 12
+		IL_017c: stloc.s 4
+
+		IL_017e: ldloc.1
+		IL_017f: ldc.r8 1
+		IL_0188: box [System.Runtime]System.Double
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0192: stloc.s 8
+		IL_0194: ldc.i4.2
+		IL_0195: newarr [System.Runtime]System.Object
+		IL_019a: dup
+		IL_019b: ldc.i4.0
+		IL_019c: ldloc.s 8
+		IL_019e: stelem.ref
+		IL_019f: dup
+		IL_01a0: ldc.i4.1
+		IL_01a1: ldloc.s 4
+		IL_01a3: stelem.ref
+		IL_01a4: stloc.s 7
+		IL_01a6: ldarg.1
+		IL_01a7: ldstr "slice"
+		IL_01ac: ldloc.s 7
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_01b3: stloc.s 9
+		IL_01b5: ldloc.s 9
+		IL_01b7: ldstr "trim"
+		IL_01bc: ldc.i4.0
+		IL_01bd: newarr [System.Runtime]System.Object
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_01c7: stloc.s 5
+		IL_01c9: ldloc.1
+		IL_01ca: ldc.r8 1
+		IL_01d3: box [System.Runtime]System.Double
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01dd: stloc.s 8
+		IL_01df: newobj instance void [System.Linq.Expressions]System.Dynamic.ExpandoObject::.ctor()
+		IL_01e4: dup
+		IL_01e5: ldstr "body"
+		IL_01ea: ldloc.s 5
+		IL_01ec: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_01f1: dup
+		IL_01f2: ldstr "start"
+		IL_01f7: ldloc.s 8
+		IL_01f9: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_01fe: dup
+		IL_01ff: ldstr "end"
+		IL_0204: ldloc.s 4
+		IL_0206: callvirt instance void class [System.Runtime]System.Collections.Generic.IDictionary`2<string, object>::set_Item(!0, !1)
+		IL_020b: stloc.s 13
+		IL_020d: ldloc.s 13
+		IL_020f: ret
+	} // end of method Compile_Scripts_BumpVersion::extractUnreleased
+
+	.method public hidebysig static 
+		object isPlaceholder (
+			object[] scopes,
+			object line
+		) cil managed 
+	{
+		// Method begins at RVA 0x306c
+		// Header size: 12
+		// Code size: 60 (0x3c)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object[]
+		)
+
+		IL_0000: ldstr "^_Nothing yet\\._"
+		IL_0005: ldstr "i"
+		IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_000f: stloc.0
+		IL_0010: ldarg.1
+		IL_0011: ldstr "trim"
+		IL_0016: ldc.i4.0
+		IL_0017: newarr [System.Runtime]System.Object
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0021: stloc.1
+		IL_0022: ldc.i4.1
+		IL_0023: newarr [System.Runtime]System.Object
+		IL_0028: dup
+		IL_0029: ldc.i4.0
+		IL_002a: ldloc.1
+		IL_002b: stelem.ref
+		IL_002c: stloc.2
+		IL_002d: ldloc.0
+		IL_002e: ldstr "test"
+		IL_0033: ldloc.2
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0039: stloc.0
+		IL_003a: ldloc.0
+		IL_003b: ret
+	} // end of method Compile_Scripts_BumpVersion::isPlaceholder
+
+	.method public hidebysig static 
+		object generateReleaseSection (
+			object[] scopes,
+			object newVersion,
+			object body
+		) cil managed 
+	{
+		// Method begins at RVA 0x2968
+		// Header size: 12
+		// Code size: 341 (0x155)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.Compile_Scripts_BumpVersion/generateReleaseSection,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] object[],
+			[5] object,
+			[6] bool,
+			[7] string,
+			[8] string
+		)
+
+		IL_0000: newobj instance void Scopes.Compile_Scripts_BumpVersion/generateReleaseSection::.ctor()
+		IL_0005: stloc.0
+		IL_0006: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Date::.ctor()
+		IL_000b: stloc.3
+		IL_000c: ldloc.3
+		IL_000d: ldstr "toISOString"
+		IL_0012: ldc.i4.0
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_001d: stloc.3
+		IL_001e: ldloc.3
+		IL_001f: ldstr "slice"
+		IL_0024: ldc.i4.2
+		IL_0025: newarr [System.Runtime]System.Object
+		IL_002a: dup
+		IL_002b: ldc.i4.0
+		IL_002c: ldc.r8 0.0
+		IL_0035: box [System.Runtime]System.Double
+		IL_003a: stelem.ref
+		IL_003b: dup
+		IL_003c: ldc.i4.1
+		IL_003d: ldc.r8 10
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: stelem.ref
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0051: stloc.1
+		IL_0052: ldstr "\\r?\\n"
+		IL_0057: ldstr ""
+		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0061: stloc.3
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.3
+		IL_006b: stelem.ref
+		IL_006c: stloc.s 4
+		IL_006e: ldarg.2
+		IL_006f: ldstr "split"
+		IL_0074: ldloc.s 4
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_007b: stloc.3
+		IL_007c: ldnull
+		IL_007d: ldftn object Functions.ArrowFunction_L95C44::ArrowFunction_L95C44(object[], object)
+		IL_0083: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0088: ldc.i4.2
+		IL_0089: newarr [System.Runtime]System.Object
+		IL_008e: dup
+		IL_008f: ldc.i4.0
+		IL_0090: ldarg.0
+		IL_0091: ldc.i4.0
+		IL_0092: ldelem.ref
+		IL_0093: stelem.ref
+		IL_0094: dup
+		IL_0095: ldc.i4.1
+		IL_0096: ldloc.0
+		IL_0097: stelem.ref
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_009d: stloc.s 5
+		IL_009f: ldc.i4.1
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldloc.s 5
+		IL_00a9: stelem.ref
+		IL_00aa: stloc.s 4
+		IL_00ac: ldloc.3
+		IL_00ad: ldstr "filter"
+		IL_00b2: ldloc.s 4
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00b9: stloc.3
+		IL_00ba: ldloc.3
+		IL_00bb: ldstr "join"
+		IL_00c0: ldc.i4.1
+		IL_00c1: newarr [System.Runtime]System.Object
+		IL_00c6: dup
+		IL_00c7: ldc.i4.0
+		IL_00c8: ldstr "\n"
+		IL_00cd: stelem.ref
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00d3: stloc.2
+		IL_00d4: ldloc.2
+		IL_00d5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_00da: ldc.i4.0
+		IL_00db: ceq
+		IL_00dd: stloc.s 6
+		IL_00df: ldloc.s 6
+		IL_00e1: brfalse IL_00ec
+
+		IL_00e6: ldstr "\n"
+		IL_00eb: stloc.2
+
+		IL_00ec: ldarg.1
+		IL_00ed: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_00f2: stloc.s 7
+		IL_00f4: ldstr "## v"
+		IL_00f9: ldloc.s 7
+		IL_00fb: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0100: stloc.s 7
+		IL_0102: ldloc.s 7
+		IL_0104: ldstr " - "
+		IL_0109: call string [System.Runtime]System.String::Concat(string, string)
+		IL_010e: stloc.s 7
+		IL_0110: ldloc.1
+		IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0116: stloc.s 8
+		IL_0118: ldloc.s 7
+		IL_011a: ldloc.s 8
+		IL_011c: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0121: stloc.s 8
+		IL_0123: ldloc.s 8
+		IL_0125: ldstr "\n\n"
+		IL_012a: call string [System.Runtime]System.String::Concat(string, string)
+		IL_012f: stloc.s 8
+		IL_0131: ldloc.2
+		IL_0132: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0137: stloc.s 7
+		IL_0139: ldloc.s 8
+		IL_013b: ldloc.s 7
+		IL_013d: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0142: stloc.s 7
+		IL_0144: ldloc.s 7
+		IL_0146: ldstr "\n"
+		IL_014b: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0150: stloc.s 7
+		IL_0152: ldloc.s 7
+		IL_0154: ret
+	} // end of method Compile_Scripts_BumpVersion::generateReleaseSection
+
+	.method public hidebysig static 
+		object perform (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x2110
+		// Header size: 12
+		// Code size: 1584 (0x630)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.Compile_Scripts_BumpVersion/perform,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] object,
+			[7] object,
+			[8] object,
+			[9] object,
+			[10] object,
+			[11] object,
+			[12] object,
+			[13] object,
+			[14] object,
+			[15] object,
+			[16] object,
+			[17] string,
+			[18] object,
+			[19] object,
+			[20] object,
+			[21] object,
+			[22] bool,
+			[23] string,
+			[24] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process,
+			[25] object,
+			[26] object[],
+			[27] object,
+			[28] object,
+			[29] object,
+			[30] string
+		)
+
+		IL_0000: newobj instance void Scopes.Compile_Scripts_BumpVersion/perform::.ctor()
+		IL_0005: stloc.0
+		IL_0006: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_000b: ldstr "argv"
+		IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0015: ldc.r8 2
+		IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_0023: stloc.1
+		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_0029: ldstr "argv"
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0033: stloc.s 21
+		IL_0035: ldloc.s 21
+		IL_0037: ldstr "includes"
+		IL_003c: ldc.i4.1
+		IL_003d: newarr [System.Runtime]System.Object
+		IL_0042: dup
+		IL_0043: ldc.i4.0
+		IL_0044: ldstr "--skip-empty"
+		IL_0049: stelem.ref
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_004f: stloc.2
+		IL_0050: ldarg.0
+		IL_0051: ldc.i4.0
+		IL_0052: ldelem.ref
+		IL_0053: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_0058: ldfld object Scopes.Compile_Scripts_BumpVersion::CSPROJ_PATH
+		IL_005d: stloc.s 21
+		IL_005f: ldnull
+		IL_0060: ldftn object Functions.Compile_Scripts_BumpVersion::readFile(object[], object)
+		IL_0066: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_006b: ldc.i4.1
+		IL_006c: newarr [System.Runtime]System.Object
+		IL_0071: dup
+		IL_0072: ldc.i4.0
+		IL_0073: ldarg.0
+		IL_0074: ldc.i4.0
+		IL_0075: ldelem.ref
+		IL_0076: stelem.ref
+		IL_0077: ldloc.s 21
+		IL_0079: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_007e: stloc.3
+		IL_007f: ldarg.0
+		IL_0080: ldc.i4.0
+		IL_0081: ldelem.ref
+		IL_0082: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_0087: ldfld object Scopes.Compile_Scripts_BumpVersion::RUNTIME_CSPROJ_PATH
+		IL_008c: stloc.s 21
+		IL_008e: ldnull
+		IL_008f: ldftn object Functions.Compile_Scripts_BumpVersion::readFile(object[], object)
+		IL_0095: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_009a: ldc.i4.1
+		IL_009b: newarr [System.Runtime]System.Object
+		IL_00a0: dup
+		IL_00a1: ldc.i4.0
+		IL_00a2: ldarg.0
+		IL_00a3: ldc.i4.0
+		IL_00a4: ldelem.ref
+		IL_00a5: stelem.ref
+		IL_00a6: ldloc.s 21
+		IL_00a8: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00ad: stloc.s 4
+		IL_00af: ldarg.0
+		IL_00b0: ldc.i4.0
+		IL_00b1: ldelem.ref
+		IL_00b2: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_00b7: ldfld object Scopes.Compile_Scripts_BumpVersion::CHANGELOG_PATH
+		IL_00bc: stloc.s 21
+		IL_00be: ldnull
+		IL_00bf: ldftn object Functions.Compile_Scripts_BumpVersion::readFile(object[], object)
+		IL_00c5: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_00ca: ldc.i4.1
+		IL_00cb: newarr [System.Runtime]System.Object
+		IL_00d0: dup
+		IL_00d1: ldc.i4.0
+		IL_00d2: ldarg.0
+		IL_00d3: ldc.i4.0
+		IL_00d4: ldelem.ref
+		IL_00d5: stelem.ref
+		IL_00d6: ldloc.s 21
+		IL_00d8: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00dd: stloc.s 5
+		IL_00df: ldnull
+		IL_00e0: ldftn object Functions.Compile_Scripts_BumpVersion::parseCurrentVersion(object[], object)
+		IL_00e6: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_00eb: ldc.i4.1
+		IL_00ec: newarr [System.Runtime]System.Object
+		IL_00f1: dup
+		IL_00f2: ldc.i4.0
+		IL_00f3: ldarg.0
+		IL_00f4: ldc.i4.0
+		IL_00f5: ldelem.ref
+		IL_00f6: stelem.ref
+		IL_00f7: ldloc.3
+		IL_00f8: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00fd: stloc.s 6
+		IL_00ff: ldnull
+		IL_0100: ldftn object Functions.Compile_Scripts_BumpVersion::resolveTargetVersion(object[], object, object)
+		IL_0106: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_010b: ldc.i4.1
+		IL_010c: newarr [System.Runtime]System.Object
+		IL_0111: dup
+		IL_0112: ldc.i4.0
+		IL_0113: ldarg.0
+		IL_0114: ldc.i4.0
+		IL_0115: ldelem.ref
+		IL_0116: stelem.ref
+		IL_0117: ldloc.1
+		IL_0118: ldloc.s 6
+		IL_011a: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_011f: stloc.s 7
+		IL_0121: ldloc.s 6
+		IL_0123: ldloc.s 7
+		IL_0125: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_012a: stloc.s 22
+		IL_012c: ldloc.s 22
+		IL_012e: brfalse IL_0199
+
+		IL_0133: ldloc.s 6
+		IL_0135: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_013a: stloc.s 23
+		IL_013c: ldstr "Version unchanged ("
+		IL_0141: ldloc.s 23
+		IL_0143: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0148: stloc.s 23
+		IL_014a: ldloc.s 23
+		IL_014c: ldstr "); aborting."
+		IL_0151: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0156: stloc.s 23
+		IL_0158: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015d: ldc.i4.1
+		IL_015e: newarr [System.Runtime]System.Object
+		IL_0163: dup
+		IL_0164: ldc.i4.0
+		IL_0165: ldloc.s 23
+		IL_0167: stelem.ref
+		IL_0168: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object[])
+		IL_016d: pop
+		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_0173: stloc.s 24
+		IL_0175: ldloc.s 24
+		IL_0177: ldstr "exit"
+		IL_017c: ldc.i4.1
+		IL_017d: newarr [System.Runtime]System.Object
+		IL_0182: dup
+		IL_0183: ldc.i4.0
+		IL_0184: ldc.r8 1
+		IL_018d: box [System.Runtime]System.Double
+		IL_0192: stelem.ref
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0198: pop
+
+		IL_0199: ldnull
+		IL_019a: ldftn object Functions.Compile_Scripts_BumpVersion::extractUnreleased(object[], object)
+		IL_01a0: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_01a5: ldc.i4.1
+		IL_01a6: newarr [System.Runtime]System.Object
+		IL_01ab: dup
+		IL_01ac: ldc.i4.0
+		IL_01ad: ldarg.0
+		IL_01ae: ldc.i4.0
+		IL_01af: ldelem.ref
+		IL_01b0: stelem.ref
+		IL_01b1: ldloc.s 5
+		IL_01b3: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_01b8: stloc.s 21
+		IL_01ba: ldloc.s 21
+		IL_01bc: brfalse IL_01d1
+
+		IL_01c1: ldloc.s 21
+		IL_01c3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_01c8: stloc.s 25
+		IL_01ca: ldloc.s 25
+		IL_01cc: brfalse IL_01e2
+
+		IL_01d1: ldloc.s 21
+		IL_01d3: ldstr ""
+		IL_01d8: ldstr "body"
+		IL_01dd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+
+		IL_01e2: ldloc.s 21
+		IL_01e4: ldstr "body"
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_01ee: stloc.s 8
+		IL_01f0: ldloc.s 21
+		IL_01f2: ldstr "start"
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_01fc: stloc.s 9
+		IL_01fe: ldloc.s 21
+		IL_0200: ldstr "end"
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_020a: stloc.s 10
+		IL_020c: ldstr "\\r?\\n"
+		IL_0211: ldstr ""
+		IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_021b: stloc.s 21
+		IL_021d: ldc.i4.1
+		IL_021e: newarr [System.Runtime]System.Object
+		IL_0223: dup
+		IL_0224: ldc.i4.0
+		IL_0225: ldloc.s 21
+		IL_0227: stelem.ref
+		IL_0228: stloc.s 26
+		IL_022a: ldloc.s 8
+		IL_022c: ldstr "split"
+		IL_0231: ldloc.s 26
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0238: stloc.s 21
+		IL_023a: ldnull
+		IL_023b: ldftn object Functions.ArrowFunction_L115C51::ArrowFunction_L115C51(object[], object)
+		IL_0241: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0246: ldc.i4.2
+		IL_0247: newarr [System.Runtime]System.Object
+		IL_024c: dup
+		IL_024d: ldc.i4.0
+		IL_024e: ldarg.0
+		IL_024f: ldc.i4.0
+		IL_0250: ldelem.ref
+		IL_0251: stelem.ref
+		IL_0252: dup
+		IL_0253: ldc.i4.1
+		IL_0254: ldloc.0
+		IL_0255: stelem.ref
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_025b: stloc.s 25
+		IL_025d: ldc.i4.1
+		IL_025e: newarr [System.Runtime]System.Object
+		IL_0263: dup
+		IL_0264: ldc.i4.0
+		IL_0265: ldloc.s 25
+		IL_0267: stelem.ref
+		IL_0268: stloc.s 26
+		IL_026a: ldloc.s 21
+		IL_026c: ldstr "some"
+		IL_0271: ldloc.s 26
+		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0278: stloc.s 11
+		IL_027a: ldloc.s 11
+		IL_027c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_0281: ldc.i4.0
+		IL_0282: ceq
+		IL_0284: stloc.s 22
+		IL_0286: ldloc.s 22
+		IL_0288: box [System.Runtime]System.Boolean
+		IL_028d: stloc.s 27
+		IL_028f: ldloc.s 27
+		IL_0291: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0296: stloc.s 22
+		IL_0298: ldloc.s 22
+		IL_029a: brfalse IL_02a7
+
+		IL_029f: ldloc.2
+		IL_02a0: stloc.s 29
+		IL_02a2: br IL_02ab
+
+		IL_02a7: ldloc.s 27
+		IL_02a9: stloc.s 29
+
+		IL_02ab: ldloc.s 29
+		IL_02ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_02b2: stloc.s 22
+		IL_02b4: ldloc.s 22
+		IL_02b6: brfalse IL_037d
+
+		IL_02bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c0: ldc.i4.1
+		IL_02c1: newarr [System.Runtime]System.Object
+		IL_02c6: dup
+		IL_02c7: ldc.i4.0
+		IL_02c8: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj version."
+		IL_02cd: stelem.ref
+		IL_02ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_02d3: pop
+		IL_02d4: ldnull
+		IL_02d5: ldftn object Functions.Compile_Scripts_BumpVersion::updateCsprojVersion(object[], object, object)
+		IL_02db: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_02e0: ldc.i4.1
+		IL_02e1: newarr [System.Runtime]System.Object
+		IL_02e6: dup
+		IL_02e7: ldc.i4.0
+		IL_02e8: ldarg.0
+		IL_02e9: ldc.i4.0
+		IL_02ea: ldelem.ref
+		IL_02eb: stelem.ref
+		IL_02ec: ldloc.3
+		IL_02ed: ldloc.s 7
+		IL_02ef: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_02f4: stloc.s 12
+		IL_02f6: ldnull
+		IL_02f7: ldftn object Functions.Compile_Scripts_BumpVersion::updateCsprojVersion(object[], object, object)
+		IL_02fd: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_0302: ldc.i4.1
+		IL_0303: newarr [System.Runtime]System.Object
+		IL_0308: dup
+		IL_0309: ldc.i4.0
+		IL_030a: ldarg.0
+		IL_030b: ldc.i4.0
+		IL_030c: ldelem.ref
+		IL_030d: stelem.ref
+		IL_030e: ldloc.s 4
+		IL_0310: ldloc.s 7
+		IL_0312: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_0317: stloc.s 13
+		IL_0319: ldarg.0
+		IL_031a: ldc.i4.0
+		IL_031b: ldelem.ref
+		IL_031c: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_0321: ldfld object Scopes.Compile_Scripts_BumpVersion::CSPROJ_PATH
+		IL_0326: stloc.s 21
+		IL_0328: ldnull
+		IL_0329: ldftn object Functions.Compile_Scripts_BumpVersion::writeFile(object[], object, object)
+		IL_032f: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_0334: ldc.i4.1
+		IL_0335: newarr [System.Runtime]System.Object
+		IL_033a: dup
+		IL_033b: ldc.i4.0
+		IL_033c: ldarg.0
+		IL_033d: ldc.i4.0
+		IL_033e: ldelem.ref
+		IL_033f: stelem.ref
+		IL_0340: ldloc.s 21
+		IL_0342: ldloc.s 12
+		IL_0344: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_0349: pop
+		IL_034a: ldarg.0
+		IL_034b: ldc.i4.0
+		IL_034c: ldelem.ref
+		IL_034d: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_0352: ldfld object Scopes.Compile_Scripts_BumpVersion::RUNTIME_CSPROJ_PATH
+		IL_0357: stloc.s 21
+		IL_0359: ldnull
+		IL_035a: ldftn object Functions.Compile_Scripts_BumpVersion::writeFile(object[], object, object)
+		IL_0360: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_0365: ldc.i4.1
+		IL_0366: newarr [System.Runtime]System.Object
+		IL_036b: dup
+		IL_036c: ldc.i4.0
+		IL_036d: ldarg.0
+		IL_036e: ldc.i4.0
+		IL_036f: ldelem.ref
+		IL_0370: stelem.ref
+		IL_0371: ldloc.s 21
+		IL_0373: ldloc.s 13
+		IL_0375: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_037a: pop
+		IL_037b: ldnull
+		IL_037c: ret
+
+		IL_037d: ldnull
+		IL_037e: ldftn object Functions.Compile_Scripts_BumpVersion::generateReleaseSection(object[], object, object)
+		IL_0384: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_0389: ldc.i4.1
+		IL_038a: newarr [System.Runtime]System.Object
+		IL_038f: dup
+		IL_0390: ldc.i4.0
+		IL_0391: ldarg.0
+		IL_0392: ldc.i4.0
+		IL_0393: ldelem.ref
+		IL_0394: stelem.ref
+		IL_0395: ldloc.s 7
+		IL_0397: ldloc.s 8
+		IL_0399: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_039e: stloc.s 14
+		IL_03a0: ldloc.s 5
+		IL_03a2: ldstr "slice"
+		IL_03a7: ldc.i4.2
+		IL_03a8: newarr [System.Runtime]System.Object
+		IL_03ad: dup
+		IL_03ae: ldc.i4.0
+		IL_03af: ldc.r8 0.0
+		IL_03b8: box [System.Runtime]System.Double
+		IL_03bd: stelem.ref
+		IL_03be: dup
+		IL_03bf: ldc.i4.1
+		IL_03c0: ldloc.s 9
+		IL_03c2: stelem.ref
+		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_03c8: stloc.s 15
+		IL_03ca: ldloc.s 5
+		IL_03cc: ldstr "slice"
+		IL_03d1: ldc.i4.1
+		IL_03d2: newarr [System.Runtime]System.Object
+		IL_03d7: dup
+		IL_03d8: ldc.i4.0
+		IL_03d9: ldloc.s 10
+		IL_03db: stelem.ref
+		IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_03e1: stloc.s 16
+		IL_03e3: ldstr "\n_Nothing yet._\n\n"
+		IL_03e8: stloc.s 17
+		IL_03ea: ldloc.s 15
+		IL_03ec: ldloc.s 17
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03f3: stloc.s 29
+		IL_03f5: ldloc.s 29
+		IL_03f7: ldloc.s 14
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03fe: stloc.s 29
+		IL_0400: ldloc.s 29
+		IL_0402: ldloc.s 16
+		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0409: stloc.s 18
+		IL_040b: ldnull
+		IL_040c: ldftn object Functions.Compile_Scripts_BumpVersion::updateCsprojVersion(object[], object, object)
+		IL_0412: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_0417: ldc.i4.1
+		IL_0418: newarr [System.Runtime]System.Object
+		IL_041d: dup
+		IL_041e: ldc.i4.0
+		IL_041f: ldarg.0
+		IL_0420: ldc.i4.0
+		IL_0421: ldelem.ref
+		IL_0422: stelem.ref
+		IL_0423: ldloc.3
+		IL_0424: ldloc.s 7
+		IL_0426: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_042b: stloc.s 19
+		IL_042d: ldnull
+		IL_042e: ldftn object Functions.Compile_Scripts_BumpVersion::updateCsprojVersion(object[], object, object)
+		IL_0434: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_0439: ldc.i4.1
+		IL_043a: newarr [System.Runtime]System.Object
+		IL_043f: dup
+		IL_0440: ldc.i4.0
+		IL_0441: ldarg.0
+		IL_0442: ldc.i4.0
+		IL_0443: ldelem.ref
+		IL_0444: stelem.ref
+		IL_0445: ldloc.s 4
+		IL_0447: ldloc.s 7
+		IL_0449: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_044e: stloc.s 20
+		IL_0450: ldarg.0
+		IL_0451: ldc.i4.0
+		IL_0452: ldelem.ref
+		IL_0453: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_0458: ldfld object Scopes.Compile_Scripts_BumpVersion::CHANGELOG_PATH
+		IL_045d: stloc.s 21
+		IL_045f: ldnull
+		IL_0460: ldftn object Functions.Compile_Scripts_BumpVersion::writeFile(object[], object, object)
+		IL_0466: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_046b: ldc.i4.1
+		IL_046c: newarr [System.Runtime]System.Object
+		IL_0471: dup
+		IL_0472: ldc.i4.0
+		IL_0473: ldarg.0
+		IL_0474: ldc.i4.0
+		IL_0475: ldelem.ref
+		IL_0476: stelem.ref
+		IL_0477: ldloc.s 21
+		IL_0479: ldloc.s 18
+		IL_047b: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_0480: pop
+		IL_0481: ldarg.0
+		IL_0482: ldc.i4.0
+		IL_0483: ldelem.ref
+		IL_0484: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_0489: ldfld object Scopes.Compile_Scripts_BumpVersion::CSPROJ_PATH
+		IL_048e: stloc.s 21
+		IL_0490: ldnull
+		IL_0491: ldftn object Functions.Compile_Scripts_BumpVersion::writeFile(object[], object, object)
+		IL_0497: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_049c: ldc.i4.1
+		IL_049d: newarr [System.Runtime]System.Object
+		IL_04a2: dup
+		IL_04a3: ldc.i4.0
+		IL_04a4: ldarg.0
+		IL_04a5: ldc.i4.0
+		IL_04a6: ldelem.ref
+		IL_04a7: stelem.ref
+		IL_04a8: ldloc.s 21
+		IL_04aa: ldloc.s 19
+		IL_04ac: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_04b1: pop
+		IL_04b2: ldarg.0
+		IL_04b3: ldc.i4.0
+		IL_04b4: ldelem.ref
+		IL_04b5: castclass Scopes.Compile_Scripts_BumpVersion
+		IL_04ba: ldfld object Scopes.Compile_Scripts_BumpVersion::RUNTIME_CSPROJ_PATH
+		IL_04bf: stloc.s 21
+		IL_04c1: ldnull
+		IL_04c2: ldftn object Functions.Compile_Scripts_BumpVersion::writeFile(object[], object, object)
+		IL_04c8: newobj instance void class [System.Runtime]System.Func`4<object[], object, object, object>::.ctor(object, native int)
+		IL_04cd: ldc.i4.1
+		IL_04ce: newarr [System.Runtime]System.Object
+		IL_04d3: dup
+		IL_04d4: ldc.i4.0
+		IL_04d5: ldarg.0
+		IL_04d6: ldc.i4.0
+		IL_04d7: ldelem.ref
+		IL_04d8: stelem.ref
+		IL_04d9: ldloc.s 21
+		IL_04db: ldloc.s 20
+		IL_04dd: callvirt instance !3 class [System.Runtime]System.Func`4<object[], object, object, object>::Invoke(!0, !1, !2)
+		IL_04e2: pop
+		IL_04e3: ldloc.s 6
+		IL_04e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_04ea: stloc.s 23
+		IL_04ec: ldstr "Bumped version: "
+		IL_04f1: ldloc.s 23
+		IL_04f3: call string [System.Runtime]System.String::Concat(string, string)
+		IL_04f8: stloc.s 23
+		IL_04fa: ldloc.s 23
+		IL_04fc: ldstr " -> "
+		IL_0501: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0506: stloc.s 23
+		IL_0508: ldloc.s 7
+		IL_050a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_050f: stloc.s 30
+		IL_0511: ldloc.s 23
+		IL_0513: ldloc.s 30
+		IL_0515: call string [System.Runtime]System.String::Concat(string, string)
+		IL_051a: stloc.s 30
+		IL_051c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0521: ldc.i4.1
+		IL_0522: newarr [System.Runtime]System.Object
+		IL_0527: dup
+		IL_0528: ldc.i4.0
+		IL_0529: ldloc.s 30
+		IL_052b: stelem.ref
+		IL_052c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0531: pop
+		IL_0532: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0537: ldc.i4.1
+		IL_0538: newarr [System.Runtime]System.Object
+		IL_053d: dup
+		IL_053e: ldc.i4.0
+		IL_053f: ldstr "Updated CHANGELOG.md, Js2IL.csproj, and JavaScriptRuntime.csproj"
+		IL_0544: stelem.ref
+		IL_0545: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_054a: pop
+		IL_054b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0550: ldc.i4.1
+		IL_0551: newarr [System.Runtime]System.Object
+		IL_0556: dup
+		IL_0557: ldc.i4.0
+		IL_0558: ldstr "\nNext steps:"
+		IL_055d: stelem.ref
+		IL_055e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0563: pop
+		IL_0564: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0569: ldc.i4.1
+		IL_056a: newarr [System.Runtime]System.Object
+		IL_056f: dup
+		IL_0570: ldc.i4.0
+		IL_0571: ldstr "  git add CHANGELOG.md Js2IL/Js2IL.csproj JavaScriptRuntime/JavaScriptRuntime.csproj"
+		IL_0576: stelem.ref
+		IL_0577: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_057c: pop
+		IL_057d: ldloc.s 7
+		IL_057f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0584: stloc.s 30
+		IL_0586: ldstr "  git commit -m \"chore(release): cut "
+		IL_058b: ldloc.s 30
+		IL_058d: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0592: stloc.s 30
+		IL_0594: ldloc.s 30
+		IL_0596: ldstr "\""
+		IL_059b: call string [System.Runtime]System.String::Concat(string, string)
+		IL_05a0: stloc.s 30
+		IL_05a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05a7: ldc.i4.1
+		IL_05a8: newarr [System.Runtime]System.Object
+		IL_05ad: dup
+		IL_05ae: ldc.i4.0
+		IL_05af: ldloc.s 30
+		IL_05b1: stelem.ref
+		IL_05b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_05b7: pop
+		IL_05b8: ldloc.s 7
+		IL_05ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_05bf: stloc.s 30
+		IL_05c1: ldstr "  git tag -a v"
+		IL_05c6: ldloc.s 30
+		IL_05c8: call string [System.Runtime]System.String::Concat(string, string)
+		IL_05cd: stloc.s 30
+		IL_05cf: ldloc.s 30
+		IL_05d1: ldstr " -m \"Release "
+		IL_05d6: call string [System.Runtime]System.String::Concat(string, string)
+		IL_05db: stloc.s 30
+		IL_05dd: ldloc.s 7
+		IL_05df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_05e4: stloc.s 23
+		IL_05e6: ldloc.s 30
+		IL_05e8: ldloc.s 23
+		IL_05ea: call string [System.Runtime]System.String::Concat(string, string)
+		IL_05ef: stloc.s 23
+		IL_05f1: ldloc.s 23
+		IL_05f3: ldstr "\""
+		IL_05f8: call string [System.Runtime]System.String::Concat(string, string)
+		IL_05fd: stloc.s 23
+		IL_05ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0604: ldc.i4.1
+		IL_0605: newarr [System.Runtime]System.Object
+		IL_060a: dup
+		IL_060b: ldc.i4.0
+		IL_060c: ldloc.s 23
+		IL_060e: stelem.ref
+		IL_060f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0614: pop
+		IL_0615: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_061a: ldc.i4.1
+		IL_061b: newarr [System.Runtime]System.Object
+		IL_0620: dup
+		IL_0621: ldc.i4.0
+		IL_0622: ldstr "  git push && git push --tags"
+		IL_0627: stelem.ref
+		IL_0628: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_062d: pop
+		IL_062e: ldnull
+		IL_062f: ret
+	} // end of method Compile_Scripts_BumpVersion::perform
+
+} // end of class Functions.Compile_Scripts_BumpVersion
+
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L95C44
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object ArrowFunction_L95C44 (
+			object[] scopes,
+			object l
+		) cil managed 
+	{
+		// Method begins at RVA 0x30b4
+		// Header size: 12
+		// Code size: 118 (0x76)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] bool,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] object
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: ldstr "trim"
+		IL_0006: ldc.i4.0
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0011: stloc.0
+		IL_0012: ldloc.0
+		IL_0013: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0018: ldc.r8 0.0
+		IL_0021: cgt
+		IL_0023: stloc.1
+		IL_0024: ldloc.1
+		IL_0025: box [System.Runtime]System.Boolean
+		IL_002a: stloc.2
+		IL_002b: ldloc.2
+		IL_002c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0031: stloc.1
+		IL_0032: ldloc.1
+		IL_0033: brfalse IL_0070
+
+		IL_0038: ldnull
+		IL_0039: ldftn object Functions.Compile_Scripts_BumpVersion::isPlaceholder(object[], object)
+		IL_003f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0044: ldc.i4.1
+		IL_0045: newarr [System.Runtime]System.Object
+		IL_004a: dup
+		IL_004b: ldc.i4.0
+		IL_004c: ldarg.0
+		IL_004d: ldc.i4.0
+		IL_004e: ldelem.ref
+		IL_004f: stelem.ref
+		IL_0050: ldarg.1
+		IL_0051: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0056: stloc.0
+		IL_0057: ldloc.0
+		IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_005d: ldc.i4.0
+		IL_005e: ceq
+		IL_0060: stloc.1
+		IL_0061: ldloc.1
+		IL_0062: box [System.Runtime]System.Boolean
+		IL_0067: stloc.3
+		IL_0068: ldloc.3
+		IL_0069: stloc.s 5
+		IL_006b: br IL_0073
+
+		IL_0070: ldloc.2
+		IL_0071: stloc.s 5
+
+		IL_0073: ldloc.s 5
+		IL_0075: ret
+	} // end of method ArrowFunction_L95C44::ArrowFunction_L95C44
+
+} // end of class Functions.ArrowFunction_L95C44
+
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L42C46
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object ArrowFunction_L42C46 (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x3138
+		// Header size: 12
+		// Code size: 23 (0x17)
+		.maxstack 32
+		.locals init (
+			[0] object
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: ldc.r8 10
+		IL_000a: box [System.Runtime]System.Double
+		IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::parseInt(object, object)
+		IL_0014: stloc.0
+		IL_0015: ldloc.0
+		IL_0016: ret
+	} // end of method ArrowFunction_L42C46::ArrowFunction_L42C46
+
+} // end of class Functions.ArrowFunction_L42C46
+
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L43C27
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object ArrowFunction_L43C27 (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x315c
+		// Header size: 12
+		// Code size: 16 (0x10)
+		.maxstack 32
+		.locals init (
+			[0] bool,
+			[1] object
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.Number::isNaN(object)
+		IL_0006: stloc.0
+		IL_0007: ldloc.0
+		IL_0008: box [System.Runtime]System.Boolean
+		IL_000d: stloc.1
+		IL_000e: ldloc.1
+		IL_000f: ret
+	} // end of method ArrowFunction_L43C27::ArrowFunction_L43C27
+
+} // end of class Functions.ArrowFunction_L43C27
+
+.class public auto ansi abstract sealed beforefieldinit Functions.ArrowFunction_L115C51
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object ArrowFunction_L115C51 (
+			object[] scopes,
+			object l
+		) cil managed 
+	{
+		// Method begins at RVA 0x3178
+		// Header size: 12
+		// Code size: 105 (0x69)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] bool,
+			[3] object,
+			[4] object,
+			[5] object
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: ldstr "trim"
+		IL_0006: ldc.i4.0
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0011: stloc.0
+		IL_0012: ldloc.0
+		IL_0013: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0018: box [System.Runtime]System.Double
+		IL_001d: stloc.1
+		IL_001e: ldloc.1
+		IL_001f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0024: stloc.2
+		IL_0025: ldloc.2
+		IL_0026: brfalse IL_0063
+
+		IL_002b: ldnull
+		IL_002c: ldftn object Functions.Compile_Scripts_BumpVersion::isPlaceholder(object[], object)
+		IL_0032: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0037: ldc.i4.1
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: dup
+		IL_003e: ldc.i4.0
+		IL_003f: ldarg.0
+		IL_0040: ldc.i4.0
+		IL_0041: ldelem.ref
+		IL_0042: stelem.ref
+		IL_0043: ldarg.1
+		IL_0044: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0049: stloc.0
+		IL_004a: ldloc.0
+		IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_0050: ldc.i4.0
+		IL_0051: ceq
+		IL_0053: stloc.2
+		IL_0054: ldloc.2
+		IL_0055: box [System.Runtime]System.Boolean
+		IL_005a: stloc.3
+		IL_005b: ldloc.3
+		IL_005c: stloc.s 5
+		IL_005e: br IL_0066
+
+		IL_0063: ldloc.1
+		IL_0064: stloc.s 5
+
+		IL_0066: ldloc.s 5
+		IL_0068: ret
+	} // end of method ArrowFunction_L115C51::ArrowFunction_L115C51
+
+} // end of class Functions.ArrowFunction_L115C51
+
+.class public auto ansi beforefieldinit Scripts.Compile_Scripts_BumpVersion
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x31f0
+		// Header size: 12
+		// Code size: 434 (0x1b2)
+		.maxstack 32
+		.locals init (
+			[0] class Scopes.Compile_Scripts_BumpVersion,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] object[],
+			[7] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process
+		)
+
+		IL_0000: newobj instance void Scopes.Compile_Scripts_BumpVersion::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldstr "fs"
+		IL_0013: stelem.ref
+		IL_0014: stloc.s 6
+		IL_0016: ldarg.1
+		IL_0017: ldc.i4.1
+		IL_0018: newarr [System.Runtime]System.Object
+		IL_001d: dup
+		IL_001e: ldc.i4.0
+		IL_001f: ldnull
+		IL_0020: stelem.ref
+		IL_0021: ldloc.s 6
+		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0028: stloc.s 7
+		IL_002a: ldloc.0
+		IL_002b: ldloc.s 7
+		IL_002d: stfld object Scopes.Compile_Scripts_BumpVersion::fs
+		IL_0032: ldc.i4.1
+		IL_0033: newarr [System.Runtime]System.Object
+		IL_0038: dup
+		IL_0039: ldc.i4.0
+		IL_003a: ldstr "path"
+		IL_003f: stelem.ref
+		IL_0040: stloc.s 6
+		IL_0042: ldarg.1
+		IL_0043: ldc.i4.1
+		IL_0044: newarr [System.Runtime]System.Object
+		IL_0049: dup
+		IL_004a: ldc.i4.0
+		IL_004b: ldnull
+		IL_004c: stelem.ref
+		IL_004d: ldloc.s 6
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0054: stloc.1
+		IL_0055: ldloc.1
+		IL_0056: ldstr "resolve"
+		IL_005b: ldc.i4.2
+		IL_005c: newarr [System.Runtime]System.Object
+		IL_0061: dup
+		IL_0062: ldc.i4.0
+		IL_0063: ldarg.s __dirname
+		IL_0065: stelem.ref
+		IL_0066: dup
+		IL_0067: ldc.i4.1
+		IL_0068: ldstr ".."
+		IL_006d: stelem.ref
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0073: stloc.2
+		IL_0074: ldc.i4.3
+		IL_0075: newarr [System.Runtime]System.Object
+		IL_007a: dup
+		IL_007b: ldc.i4.0
+		IL_007c: ldloc.2
+		IL_007d: stelem.ref
+		IL_007e: dup
+		IL_007f: ldc.i4.1
+		IL_0080: ldstr "Js2IL"
+		IL_0085: stelem.ref
+		IL_0086: dup
+		IL_0087: ldc.i4.2
+		IL_0088: ldstr "Js2IL.csproj"
+		IL_008d: stelem.ref
+		IL_008e: stloc.s 6
+		IL_0090: ldloc.1
+		IL_0091: ldstr "join"
+		IL_0096: ldloc.s 6
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_009d: stloc.s 7
+		IL_009f: ldloc.0
+		IL_00a0: ldloc.s 7
+		IL_00a2: stfld object Scopes.Compile_Scripts_BumpVersion::CSPROJ_PATH
+		IL_00a7: ldc.i4.3
+		IL_00a8: newarr [System.Runtime]System.Object
+		IL_00ad: dup
+		IL_00ae: ldc.i4.0
+		IL_00af: ldloc.2
+		IL_00b0: stelem.ref
+		IL_00b1: dup
+		IL_00b2: ldc.i4.1
+		IL_00b3: ldstr "JavaScriptRuntime"
+		IL_00b8: stelem.ref
+		IL_00b9: dup
+		IL_00ba: ldc.i4.2
+		IL_00bb: ldstr "JavaScriptRuntime.csproj"
+		IL_00c0: stelem.ref
+		IL_00c1: stloc.s 6
+		IL_00c3: ldloc.1
+		IL_00c4: ldstr "join"
+		IL_00c9: ldloc.s 6
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00d0: stloc.s 7
+		IL_00d2: ldloc.0
+		IL_00d3: ldloc.s 7
+		IL_00d5: stfld object Scopes.Compile_Scripts_BumpVersion::RUNTIME_CSPROJ_PATH
+		IL_00da: ldc.i4.2
+		IL_00db: newarr [System.Runtime]System.Object
+		IL_00e0: dup
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldloc.2
+		IL_00e3: stelem.ref
+		IL_00e4: dup
+		IL_00e5: ldc.i4.1
+		IL_00e6: ldstr "CHANGELOG.md"
+		IL_00eb: stelem.ref
+		IL_00ec: stloc.s 6
+		IL_00ee: ldloc.1
+		IL_00ef: ldstr "join"
+		IL_00f4: ldloc.s 6
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_00fb: stloc.s 7
+		IL_00fd: ldloc.0
+		IL_00fe: ldloc.s 7
+		IL_0100: stfld object Scopes.Compile_Scripts_BumpVersion::CHANGELOG_PATH
+		.try
+		{
+			IL_0105: ldnull
+			IL_0106: ldftn object Functions.Compile_Scripts_BumpVersion::perform(object[])
+			IL_010c: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+			IL_0111: ldc.i4.1
+			IL_0112: newarr [System.Runtime]System.Object
+			IL_0117: dup
+			IL_0118: ldc.i4.0
+			IL_0119: ldloc.0
+			IL_011a: stelem.ref
+			IL_011b: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+			IL_0120: pop
+			IL_0121: leave IL_01b1
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_0126: stloc.3
+			IL_0127: ldloc.3
+			IL_0128: dup
+			IL_0129: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_012e: dup
+			IL_012f: brtrue IL_0145
+
+			IL_0134: pop
+			IL_0135: dup
+			IL_0136: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_013b: dup
+			IL_013c: brtrue IL_0152
+
+			IL_0141: pop
+			IL_0142: pop
+			IL_0143: rethrow
+
+			IL_0145: pop
+			IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_014b: stloc.s 4
+			IL_014d: br IL_0155
+
+			IL_0152: pop
+			IL_0153: stloc.s 4
+
+			IL_0155: ldloc.s 4
+			IL_0157: stloc.s 5
+			IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_015e: ldc.i4.2
+			IL_015f: newarr [System.Runtime]System.Object
+			IL_0164: dup
+			IL_0165: ldc.i4.0
+			IL_0166: ldstr "ERROR:"
+			IL_016b: stelem.ref
+			IL_016c: dup
+			IL_016d: ldc.i4.1
+			IL_016e: ldloc.s 5
+			IL_0170: ldstr "message"
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+			IL_017a: stelem.ref
+			IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object[])
+			IL_0180: pop
+			IL_0181: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0186: stloc.s 8
+			IL_0188: ldloc.s 8
+			IL_018a: ldstr "exit"
+			IL_018f: ldc.i4.1
+			IL_0190: newarr [System.Runtime]System.Object
+			IL_0195: dup
+			IL_0196: ldc.i4.0
+			IL_0197: ldc.r8 1
+			IL_01a0: box [System.Runtime]System.Double
+			IL_01a5: stelem.ref
+			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_01ab: pop
+			IL_01ac: leave IL_01b1
+		} // end handler
+
+		IL_01b1: ret
+	} // end of method Compile_Scripts_BumpVersion::Main
+
+} // end of class Scripts.Compile_Scripts_BumpVersion
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x33c0
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.Compile_Scripts_BumpVersion::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Js2IL.Tests.csproj
+++ b/Js2IL.Tests/Js2IL.Tests.csproj
@@ -28,6 +28,9 @@
     <EmbeddedResource Include="..\scripts\generateNodeSupportMd.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_GenerateNodeSupportMd.js</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\scripts\bumpVersion.js">
+      <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_BumpVersion.js</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\tests\performance\PrimeJavaScript.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Performance_PrimeJavaScript.js</LogicalName>
     </EmbeddedResource>

--- a/Js2IL.Tests/UnaryOperator/ExecutionTests.cs
+++ b/Js2IL.Tests/UnaryOperator/ExecutionTests.cs
@@ -11,13 +11,37 @@ namespace Js2IL.Tests.UnaryOperator
         public Task UnaryOperator_MinusMinusPostfix() => ExecutionTest(nameof(UnaryOperator_MinusMinusPostfix));
 
         [Fact]
+        public Task UnaryOperator_MinusMinusPostfix_InFunctionSwitch() => ExecutionTest(nameof(UnaryOperator_MinusMinusPostfix_InFunctionSwitch));
+
+        [Fact]
+        public Task UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal() => ExecutionTest(nameof(UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal));
+
+        [Fact]
         public Task UnaryOperator_MinusMinusPrefix() => ExecutionTest(nameof(UnaryOperator_MinusMinusPrefix));
+
+        [Fact]
+        public Task UnaryOperator_MinusMinusPrefix_InFunctionSwitch() => ExecutionTest(nameof(UnaryOperator_MinusMinusPrefix_InFunctionSwitch));
+
+        [Fact]
+        public Task UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal() => ExecutionTest(nameof(UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal));
 
         [Fact]
         public Task UnaryOperator_PlusPlusPostfix() => ExecutionTest(nameof(UnaryOperator_PlusPlusPostfix));
 
         [Fact]
+        public Task UnaryOperator_PlusPlusPostfix_InFunctionSwitch() => ExecutionTest(nameof(UnaryOperator_PlusPlusPostfix_InFunctionSwitch));
+
+        [Fact]
+        public Task UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal() => ExecutionTest(nameof(UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal));
+
+        [Fact]
         public Task UnaryOperator_PlusPlusPrefix() => ExecutionTest(nameof(UnaryOperator_PlusPlusPrefix));
+
+        [Fact]
+        public Task UnaryOperator_PlusPlusPrefix_InFunctionSwitch() => ExecutionTest(nameof(UnaryOperator_PlusPlusPrefix_InFunctionSwitch));
+
+        [Fact]
+        public Task UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal() => ExecutionTest(nameof(UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal));
 
         [Fact]
         public Task UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction() => ExecutionTest(nameof(UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction));

--- a/Js2IL.Tests/UnaryOperator/GeneratorTests.cs
+++ b/Js2IL.Tests/UnaryOperator/GeneratorTests.cs
@@ -11,13 +11,37 @@ namespace Js2IL.Tests.UnaryOperator
         public Task UnaryOperator_MinusMinusPostfix() => GenerateTest(nameof(UnaryOperator_MinusMinusPostfix));
 
         [Fact]
+        public Task UnaryOperator_MinusMinusPostfix_InFunctionSwitch() => GenerateTest(nameof(UnaryOperator_MinusMinusPostfix_InFunctionSwitch));
+
+        [Fact]
+        public Task UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal() => GenerateTest(nameof(UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal));
+
+        [Fact]
         public Task UnaryOperator_MinusMinusPrefix() => GenerateTest(nameof(UnaryOperator_MinusMinusPrefix));
+
+        [Fact]
+        public Task UnaryOperator_MinusMinusPrefix_InFunctionSwitch() => GenerateTest(nameof(UnaryOperator_MinusMinusPrefix_InFunctionSwitch));
+
+        [Fact]
+        public Task UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal() => GenerateTest(nameof(UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal));
 
         [Fact]
         public Task UnaryOperator_PlusPlusPostfix() => GenerateTest(nameof(UnaryOperator_PlusPlusPostfix));
 
         [Fact]
+        public Task UnaryOperator_PlusPlusPostfix_InFunctionSwitch() => GenerateTest(nameof(UnaryOperator_PlusPlusPostfix_InFunctionSwitch));
+
+        [Fact]
+        public Task UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal() => GenerateTest(nameof(UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal));
+
+        [Fact]
         public Task UnaryOperator_PlusPlusPrefix() => GenerateTest(nameof(UnaryOperator_PlusPlusPrefix));
+
+        [Fact]
+        public Task UnaryOperator_PlusPlusPrefix_InFunctionSwitch() => GenerateTest(nameof(UnaryOperator_PlusPlusPrefix_InFunctionSwitch));
+
+        [Fact]
+        public Task UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal() => GenerateTest(nameof(UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal));
 
         [Fact]
         public Task UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction() => GenerateTest(nameof(UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction));

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPostfix.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPostfix.js
@@ -1,3 +1,55 @@
-let x = 3;
-console.log(x--);
-console.log(x);
+function logCase(label, before, result, after) {
+	console.log(label, before, result, after);
+}
+
+// uncaptured global variable (typed as double)
+let g = 3;
+let before = g;
+let result = g--;
+let after = g;
+logCase('global-double', before, result, after);
+
+// captured variable in a function (typed as double)
+let capturedGlobalDouble = 3;
+function capturedDouble() {
+	let before = capturedGlobalDouble;
+	let result = capturedGlobalDouble--;
+	let after = capturedGlobalDouble;
+	logCase('captured-double', before, result, after);
+}
+capturedDouble();
+
+// argument passed in as double
+function argDouble(n) {
+	let before = n;
+	let result = n--;
+	let after = n;
+	logCase('arg-double', before, result, after);
+}
+argDouble(3);
+
+// uncaptured global variable (typed as string)
+let gs = '3';
+before = gs;
+result = gs--;
+after = gs;
+logCase('global-string', before, result, after);
+
+// captured variable in a function (typed as string)
+let capturedGlobalString = '3';
+function capturedString() {
+	let before = capturedGlobalString;
+	let result = capturedGlobalString--;
+	let after = capturedGlobalString;
+	logCase('captured-string', before, result, after);
+}
+capturedString();
+
+// argument passed in as string
+function argString(n) {
+	let before = n;
+	let result = n--;
+	let after = n;
+	logCase('arg-string', before, result, after);
+}
+argString('3');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPostfix_InFunctionSwitch.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPostfix_InFunctionSwitch.js
@@ -1,0 +1,30 @@
+function bump(kind) {
+  let maj = 3;
+  let min = 2;
+  let pat = 1;
+
+  let M = maj;
+  let m = min;
+  let p = pat;
+
+  switch (kind) {
+    case 'major':
+      M--;
+      m = 0;
+      p = 0;
+      break;
+    case 'minor':
+      m--;
+      p = 0;
+      break;
+    case 'patch':
+      p--;
+      break;
+  }
+
+  console.log(kind, M, m, p);
+}
+
+bump('major');
+bump('minor');
+bump('patch');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.js
@@ -1,0 +1,30 @@
+function bump(kind) {
+  let maj = '3';
+  let min = '2';
+  let pat = '1';
+
+  let M = maj;
+  let m = min;
+  let p = pat;
+
+  switch (kind) {
+    case 'major':
+      M--;
+      m = '0';
+      p = '0';
+      break;
+    case 'minor':
+      m--;
+      p = '0';
+      break;
+    case 'patch':
+      p--;
+      break;
+  }
+
+  console.log(kind, M, m, p);
+}
+
+bump('major');
+bump('minor');
+bump('patch');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPrefix.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPrefix.js
@@ -1,3 +1,55 @@
-let x = 3;
-console.log(--x);
-console.log(x);
+function logCase(label, before, result, after) {
+	console.log(label, before, result, after);
+}
+
+// uncaptured global variable (typed as double)
+let g = 3;
+let before = g;
+let result = --g;
+let after = g;
+logCase('global-double', before, result, after);
+
+// captured variable in a function (typed as double)
+let capturedGlobalDouble = 3;
+function capturedDouble() {
+	let before = capturedGlobalDouble;
+	let result = --capturedGlobalDouble;
+	let after = capturedGlobalDouble;
+	logCase('captured-double', before, result, after);
+}
+capturedDouble();
+
+// argument passed in as double
+function argDouble(n) {
+	let before = n;
+	let result = --n;
+	let after = n;
+	logCase('arg-double', before, result, after);
+}
+argDouble(3);
+
+// uncaptured global variable (typed as string)
+let gs = '3';
+before = gs;
+result = --gs;
+after = gs;
+logCase('global-string', before, result, after);
+
+// captured variable in a function (typed as string)
+let capturedGlobalString = '3';
+function capturedString() {
+	let before = capturedGlobalString;
+	let result = --capturedGlobalString;
+	let after = capturedGlobalString;
+	logCase('captured-string', before, result, after);
+}
+capturedString();
+
+// argument passed in as string
+function argString(n) {
+	let before = n;
+	let result = --n;
+	let after = n;
+	logCase('arg-string', before, result, after);
+}
+argString('3');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPrefix_InFunctionSwitch.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPrefix_InFunctionSwitch.js
@@ -1,0 +1,30 @@
+function bump(kind) {
+  let maj = 3;
+  let min = 2;
+  let pat = 1;
+
+  let M = maj;
+  let m = min;
+  let p = pat;
+
+  switch (kind) {
+    case 'major':
+      --M;
+      m = 0;
+      p = 0;
+      break;
+    case 'minor':
+      --m;
+      p = 0;
+      break;
+    case 'patch':
+      --p;
+      break;
+  }
+
+  console.log(kind, M, m, p);
+}
+
+bump('major');
+bump('minor');
+bump('patch');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.js
@@ -1,0 +1,30 @@
+function bump(kind) {
+  let maj = '3';
+  let min = '2';
+  let pat = '1';
+
+  let M = maj;
+  let m = min;
+  let p = pat;
+
+  switch (kind) {
+    case 'major':
+      --M;
+      m = '0';
+      p = '0';
+      break;
+    case 'minor':
+      --m;
+      p = '0';
+      break;
+    case 'patch':
+      --p;
+      break;
+  }
+
+  console.log(kind, M, m, p);
+}
+
+bump('major');
+bump('minor');
+bump('patch');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPostfix.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPostfix.js
@@ -1,3 +1,55 @@
-let x = 3;
-console.log(x++);
-console.log(x);
+function logCase(label, before, result, after) {
+	console.log(label, before, result, after);
+}
+
+// uncaptured global variable (typed as double)
+let g = 3;
+let before = g;
+let result = g++;
+let after = g;
+logCase('global-double', before, result, after);
+
+// captured variable in a function (typed as double)
+let capturedGlobalDouble = 3;
+function capturedDouble() {
+	let before = capturedGlobalDouble;
+	let result = capturedGlobalDouble++;
+	let after = capturedGlobalDouble;
+	logCase('captured-double', before, result, after);
+}
+capturedDouble();
+
+// argument passed in as double
+function argDouble(n) {
+	let before = n;
+	let result = n++;
+	let after = n;
+	logCase('arg-double', before, result, after);
+}
+argDouble(3);
+
+// uncaptured global variable (typed as string)
+let gs = '3';
+before = gs;
+result = gs++;
+after = gs;
+logCase('global-string', before, result, after);
+
+// captured variable in a function (typed as string)
+let capturedGlobalString = '3';
+function capturedString() {
+	let before = capturedGlobalString;
+	let result = capturedGlobalString++;
+	let after = capturedGlobalString;
+	logCase('captured-string', before, result, after);
+}
+capturedString();
+
+// argument passed in as string
+function argString(n) {
+	let before = n;
+	let result = n++;
+	let after = n;
+	logCase('arg-string', before, result, after);
+}
+argString('3');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPostfix_InFunctionSwitch.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPostfix_InFunctionSwitch.js
@@ -1,0 +1,30 @@
+function bump(kind) {
+  let maj = 1;
+  let min = 2;
+  let pat = 3;
+
+  let M = maj;
+  let m = min;
+  let p = pat;
+
+  switch (kind) {
+    case 'major':
+      M++;
+      m = 0;
+      p = 0;
+      break;
+    case 'minor':
+      m++;
+      p = 0;
+      break;
+    case 'patch':
+      p++;
+      break;
+  }
+
+  console.log(kind, M, m, p);
+}
+
+bump('major');
+bump('minor');
+bump('patch');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.js
@@ -1,0 +1,30 @@
+function bump(kind) {
+  let maj = '1';
+  let min = '2';
+  let pat = '3';
+
+  let M = maj;
+  let m = min;
+  let p = pat;
+
+  switch (kind) {
+    case 'major':
+      M++;
+      m = '0';
+      p = '0';
+      break;
+    case 'minor':
+      m++;
+      p = '0';
+      break;
+    case 'patch':
+      p++;
+      break;
+  }
+
+  console.log(kind, M, m, p);
+}
+
+bump('major');
+bump('minor');
+bump('patch');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPrefix.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPrefix.js
@@ -1,3 +1,55 @@
-let x = 3;
-console.log(++x);
-console.log(x);
+function logCase(label, before, result, after) {
+	console.log(label, before, result, after);
+}
+
+// uncaptured global variable (typed as double)
+let g = 3;
+let before = g;
+let result = ++g;
+let after = g;
+logCase('global-double', before, result, after);
+
+// captured variable in a function (typed as double)
+let capturedGlobalDouble = 3;
+function capturedDouble() {
+	let before = capturedGlobalDouble;
+	let result = ++capturedGlobalDouble;
+	let after = capturedGlobalDouble;
+	logCase('captured-double', before, result, after);
+}
+capturedDouble();
+
+// argument passed in as double
+function argDouble(n) {
+	let before = n;
+	let result = ++n;
+	let after = n;
+	logCase('arg-double', before, result, after);
+}
+argDouble(3);
+
+// uncaptured global variable (typed as string)
+let gs = '3';
+before = gs;
+result = ++gs;
+after = gs;
+logCase('global-string', before, result, after);
+
+// captured variable in a function (typed as string)
+let capturedGlobalString = '3';
+function capturedString() {
+	let before = capturedGlobalString;
+	let result = ++capturedGlobalString;
+	let after = capturedGlobalString;
+	logCase('captured-string', before, result, after);
+}
+capturedString();
+
+// argument passed in as string
+function argString(n) {
+	let before = n;
+	let result = ++n;
+	let after = n;
+	logCase('arg-string', before, result, after);
+}
+argString('3');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPrefix_InFunctionSwitch.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPrefix_InFunctionSwitch.js
@@ -1,0 +1,30 @@
+function bump(kind) {
+  let maj = 1;
+  let min = 2;
+  let pat = 3;
+
+  let M = maj;
+  let m = min;
+  let p = pat;
+
+  switch (kind) {
+    case 'major':
+      ++M;
+      m = 0;
+      p = 0;
+      break;
+    case 'minor':
+      ++m;
+      p = 0;
+      break;
+    case 'patch':
+      ++p;
+      break;
+  }
+
+  console.log(kind, M, m, p);
+}
+
+bump('major');
+bump('minor');
+bump('patch');

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.js
@@ -1,0 +1,30 @@
+function bump(kind) {
+  let maj = '1';
+  let min = '2';
+  let pat = '3';
+
+  let M = maj;
+  let m = min;
+  let p = pat;
+
+  switch (kind) {
+    case 'major':
+      ++M;
+      m = '0';
+      p = '0';
+      break;
+    case 'minor':
+      ++m;
+      p = '0';
+      break;
+    case 'patch':
+      ++p;
+      break;
+  }
+
+  console.log(kind, M, m, p);
+}
+
+bump('major');
+bump('minor');
+bump('patch');

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -1,2 +1,6 @@
-3
-2
+﻿global-double 3 3 2
+captured-double 3 3 2
+arg-double 3 3 2
+global-string 3 3 2
+captured-string 3 3 2
+arg-string 3 3 2

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
@@ -1,0 +1,3 @@
+﻿major 2 0 0
+minor 3 1 0
+patch 3 2 0

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -1,0 +1,3 @@
+﻿major 2 0 0
+minor 3 1 0
+patch 3 2 0

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -1,2 +1,6 @@
-2
-2
+﻿global-double 3 2 2
+captured-double 3 2 2
+arg-double 3 2 2
+global-string 3 2 2
+captured-string 3 2 2
+arg-string 3 2 2

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
@@ -1,0 +1,3 @@
+﻿major 2 0 0
+minor 3 1 0
+patch 3 2 0

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -1,0 +1,3 @@
+﻿major 2 0 0
+minor 3 1 0
+patch 3 2 0

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -1,2 +1,6 @@
-3
-4
+﻿global-double 3 3 4
+captured-double 3 3 4
+arg-double 3 3 4
+global-string 3 3 4
+captured-string 3 3 4
+arg-string 3 3 4

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
@@ -1,0 +1,3 @@
+﻿major 2 0 0
+minor 1 3 0
+patch 1 2 4

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -1,0 +1,3 @@
+﻿major 2 0 0
+minor 1 3 0
+patch 1 2 4

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -1,2 +1,6 @@
-4
-4
+﻿global-double 3 4 4
+captured-double 3 4 4
+arg-double 3 4 4
+global-string 3 4 4
+captured-string 3 4 4
+arg-string 3 4 4

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
@@ -1,0 +1,3 @@
+﻿major 2 0 0
+minor 1 3 0
+patch 1 2 4

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -1,0 +1,3 @@
+﻿major 2 0 0
+minor 1 3 0
+patch 1 2 4

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -6,6 +6,117 @@
 .class public auto ansi beforefieldinit Scopes.UnaryOperator_MinusMinusPostfix
 	extends [System.Runtime]System.Object
 {
+	// Nested Types
+	.class nested public auto ansi beforefieldinit logCase
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method logCase::.ctor
+
+	} // end of class logCase
+
+	.class nested public auto ansi beforefieldinit capturedDouble
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method capturedDouble::.ctor
+
+	} // end of class capturedDouble
+
+	.class nested public auto ansi beforefieldinit argDouble
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method argDouble::.ctor
+
+	} // end of class argDouble
+
+	.class nested public auto ansi beforefieldinit capturedString
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method capturedString::.ctor
+
+	} // end of class capturedString
+
+	.class nested public auto ansi beforefieldinit argString
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x207d
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method argString::.ctor
+
+	} // end of class argString
+
+
+	// Fields
+	.field public object logCase
+	.field public object capturedGlobalDouble
+	.field public object capturedDouble
+	.field public object argDouble
+	.field public object capturedGlobalString
+	.field public object capturedString
+	.field public object argString
+
 	// Methods
 	.method public hidebysig specialname rtspecialname 
 		instance void .ctor () cil managed 
@@ -23,6 +134,307 @@
 
 } // end of class Scopes.UnaryOperator_MinusMinusPostfix
 
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_MinusMinusPostfix
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object logCase (
+			object[] scopes,
+			object label,
+			object before,
+			object result,
+			object after
+		) cil managed 
+	{
+		// Method begins at RVA 0x2260
+		// Header size: 12
+		// Code size: 36 (0x24)
+		.maxstack 32
+
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: ldc.i4.4
+		IL_0006: newarr [System.Runtime]System.Object
+		IL_000b: dup
+		IL_000c: ldc.i4.0
+		IL_000d: ldarg.1
+		IL_000e: stelem.ref
+		IL_000f: dup
+		IL_0010: ldc.i4.1
+		IL_0011: ldarg.2
+		IL_0012: stelem.ref
+		IL_0013: dup
+		IL_0014: ldc.i4.2
+		IL_0015: ldarg.3
+		IL_0016: stelem.ref
+		IL_0017: dup
+		IL_0018: ldc.i4.3
+		IL_0019: ldarg.s after
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: pop
+		IL_0022: ldnull
+		IL_0023: ret
+	} // end of method UnaryOperator_MinusMinusPostfix::logCase
+
+	.method public hidebysig static 
+		object capturedDouble (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x2140
+		// Header size: 12
+		// Code size: 129 (0x81)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64,
+			[4] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.UnaryOperator_MinusMinusPostfix
+		IL_0008: ldfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalDouble
+		IL_000d: stloc.0
+		IL_000e: ldarg.0
+		IL_000f: ldc.i4.0
+		IL_0010: ldelem.ref
+		IL_0011: castclass Scopes.UnaryOperator_MinusMinusPostfix
+		IL_0016: ldfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalDouble
+		IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0020: stloc.3
+		IL_0021: ldloc.3
+		IL_0022: box [System.Runtime]System.Double
+		IL_0027: stloc.1
+		IL_0028: ldloc.3
+		IL_0029: ldc.r8 1
+		IL_0032: sub
+		IL_0033: stloc.3
+		IL_0034: ldloc.3
+		IL_0035: box [System.Runtime]System.Double
+		IL_003a: stloc.s 4
+		IL_003c: ldarg.0
+		IL_003d: ldc.i4.0
+		IL_003e: ldelem.ref
+		IL_003f: castclass Scopes.UnaryOperator_MinusMinusPostfix
+		IL_0044: ldloc.s 4
+		IL_0046: stfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalDouble
+		IL_004b: ldarg.0
+		IL_004c: ldc.i4.0
+		IL_004d: ldelem.ref
+		IL_004e: castclass Scopes.UnaryOperator_MinusMinusPostfix
+		IL_0053: ldfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalDouble
+		IL_0058: stloc.2
+		IL_0059: ldnull
+		IL_005a: ldftn object Functions.UnaryOperator_MinusMinusPostfix::logCase(object[], object, object, object, object)
+		IL_0060: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0065: ldc.i4.1
+		IL_0066: newarr [System.Runtime]System.Object
+		IL_006b: dup
+		IL_006c: ldc.i4.0
+		IL_006d: ldarg.0
+		IL_006e: ldc.i4.0
+		IL_006f: ldelem.ref
+		IL_0070: stelem.ref
+		IL_0071: ldstr "captured-double"
+		IL_0076: ldloc.0
+		IL_0077: ldloc.1
+		IL_0078: ldloc.2
+		IL_0079: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_007e: pop
+		IL_007f: ldnull
+		IL_0080: ret
+	} // end of method UnaryOperator_MinusMinusPostfix::capturedDouble
+
+	.method public hidebysig static 
+		object argDouble (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x2088
+		// Header size: 12
+		// Code size: 78 (0x4e)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.0
+		IL_0002: ldarg.1
+		IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0008: stloc.3
+		IL_0009: ldloc.3
+		IL_000a: box [System.Runtime]System.Double
+		IL_000f: stloc.1
+		IL_0010: ldloc.3
+		IL_0011: ldc.r8 1
+		IL_001a: sub
+		IL_001b: stloc.3
+		IL_001c: ldloc.3
+		IL_001d: box [System.Runtime]System.Double
+		IL_0022: starg.s n
+		IL_0024: ldarg.1
+		IL_0025: stloc.2
+		IL_0026: ldnull
+		IL_0027: ldftn object Functions.UnaryOperator_MinusMinusPostfix::logCase(object[], object, object, object, object)
+		IL_002d: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0032: ldc.i4.1
+		IL_0033: newarr [System.Runtime]System.Object
+		IL_0038: dup
+		IL_0039: ldc.i4.0
+		IL_003a: ldarg.0
+		IL_003b: ldc.i4.0
+		IL_003c: ldelem.ref
+		IL_003d: stelem.ref
+		IL_003e: ldstr "arg-double"
+		IL_0043: ldloc.0
+		IL_0044: ldloc.1
+		IL_0045: ldloc.2
+		IL_0046: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_004b: pop
+		IL_004c: ldnull
+		IL_004d: ret
+	} // end of method UnaryOperator_MinusMinusPostfix::argDouble
+
+	.method public hidebysig static 
+		object capturedString (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x21d0
+		// Header size: 12
+		// Code size: 129 (0x81)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64,
+			[4] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.UnaryOperator_MinusMinusPostfix
+		IL_0008: ldfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalString
+		IL_000d: stloc.0
+		IL_000e: ldarg.0
+		IL_000f: ldc.i4.0
+		IL_0010: ldelem.ref
+		IL_0011: castclass Scopes.UnaryOperator_MinusMinusPostfix
+		IL_0016: ldfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalString
+		IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0020: stloc.3
+		IL_0021: ldloc.3
+		IL_0022: box [System.Runtime]System.Double
+		IL_0027: stloc.1
+		IL_0028: ldloc.3
+		IL_0029: ldc.r8 1
+		IL_0032: sub
+		IL_0033: stloc.3
+		IL_0034: ldloc.3
+		IL_0035: box [System.Runtime]System.Double
+		IL_003a: stloc.s 4
+		IL_003c: ldarg.0
+		IL_003d: ldc.i4.0
+		IL_003e: ldelem.ref
+		IL_003f: castclass Scopes.UnaryOperator_MinusMinusPostfix
+		IL_0044: ldloc.s 4
+		IL_0046: stfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalString
+		IL_004b: ldarg.0
+		IL_004c: ldc.i4.0
+		IL_004d: ldelem.ref
+		IL_004e: castclass Scopes.UnaryOperator_MinusMinusPostfix
+		IL_0053: ldfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalString
+		IL_0058: stloc.2
+		IL_0059: ldnull
+		IL_005a: ldftn object Functions.UnaryOperator_MinusMinusPostfix::logCase(object[], object, object, object, object)
+		IL_0060: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0065: ldc.i4.1
+		IL_0066: newarr [System.Runtime]System.Object
+		IL_006b: dup
+		IL_006c: ldc.i4.0
+		IL_006d: ldarg.0
+		IL_006e: ldc.i4.0
+		IL_006f: ldelem.ref
+		IL_0070: stelem.ref
+		IL_0071: ldstr "captured-string"
+		IL_0076: ldloc.0
+		IL_0077: ldloc.1
+		IL_0078: ldloc.2
+		IL_0079: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_007e: pop
+		IL_007f: ldnull
+		IL_0080: ret
+	} // end of method UnaryOperator_MinusMinusPostfix::capturedString
+
+	.method public hidebysig static 
+		object argString (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x20e4
+		// Header size: 12
+		// Code size: 78 (0x4e)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.0
+		IL_0002: ldarg.1
+		IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0008: stloc.3
+		IL_0009: ldloc.3
+		IL_000a: box [System.Runtime]System.Double
+		IL_000f: stloc.1
+		IL_0010: ldloc.3
+		IL_0011: ldc.r8 1
+		IL_001a: sub
+		IL_001b: stloc.3
+		IL_001c: ldloc.3
+		IL_001d: box [System.Runtime]System.Double
+		IL_0022: starg.s n
+		IL_0024: ldarg.1
+		IL_0025: stloc.2
+		IL_0026: ldnull
+		IL_0027: ldftn object Functions.UnaryOperator_MinusMinusPostfix::logCase(object[], object, object, object, object)
+		IL_002d: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0032: ldc.i4.1
+		IL_0033: newarr [System.Runtime]System.Object
+		IL_0038: dup
+		IL_0039: ldc.i4.0
+		IL_003a: ldarg.0
+		IL_003b: ldc.i4.0
+		IL_003c: ldelem.ref
+		IL_003d: stelem.ref
+		IL_003e: ldstr "arg-string"
+		IL_0043: ldloc.0
+		IL_0044: ldloc.1
+		IL_0045: ldloc.2
+		IL_0046: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_004b: pop
+		IL_004c: ldnull
+		IL_004d: ret
+	} // end of method UnaryOperator_MinusMinusPostfix::argString
+
+} // end of class Functions.UnaryOperator_MinusMinusPostfix
+
 .class public auto ansi beforefieldinit Scripts.UnaryOperator_MinusMinusPostfix
 	extends [System.Runtime]System.Object
 {
@@ -36,14 +448,20 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x205c
+		// Method begins at RVA 0x2290
 		// Header size: 12
-		// Code size: 85 (0x55)
+		// Code size: 373 (0x175)
 		.maxstack 32
 		.locals init (
 			[0] class Scopes.UnaryOperator_MinusMinusPostfix,
 			[1] float64,
-			[2] object
+			[2] float64,
+			[3] object,
+			[4] float64,
+			[5] string,
+			[6] object,
+			[7] object,
+			[8] float64
 		)
 
 		IL_0000: newobj instance void Scopes.UnaryOperator_MinusMinusPostfix::.ctor()
@@ -52,33 +470,129 @@
 		IL_000f: stloc.1
 		IL_0010: ldloc.1
 		IL_0011: box [System.Runtime]System.Double
-		IL_0016: stloc.2
+		IL_0016: stloc.3
 		IL_0017: ldloc.1
 		IL_0018: ldc.r8 1
 		IL_0021: sub
-		IL_0022: stloc.1
-		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0028: ldc.i4.1
-		IL_0029: newarr [System.Runtime]System.Object
-		IL_002e: dup
-		IL_002f: ldc.i4.0
-		IL_0030: ldloc.2
-		IL_0031: stelem.ref
-		IL_0032: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0037: pop
-		IL_0038: ldloc.1
-		IL_0039: box [System.Runtime]System.Double
-		IL_003e: stloc.2
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0044: ldc.i4.1
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldloc.2
-		IL_004d: stelem.ref
-		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0053: pop
-		IL_0054: ret
+		IL_0022: stloc.s 4
+		IL_0024: ldloc.1
+		IL_0025: box [System.Runtime]System.Double
+		IL_002a: stloc.s 6
+		IL_002c: ldloc.s 4
+		IL_002e: box [System.Runtime]System.Double
+		IL_0033: stloc.s 7
+		IL_0035: ldnull
+		IL_0036: ldftn object Functions.UnaryOperator_MinusMinusPostfix::logCase(object[], object, object, object, object)
+		IL_003c: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0041: ldc.i4.1
+		IL_0042: newarr [System.Runtime]System.Object
+		IL_0047: dup
+		IL_0048: ldc.i4.0
+		IL_0049: ldloc.0
+		IL_004a: stelem.ref
+		IL_004b: ldstr "global-double"
+		IL_0050: ldloc.s 6
+		IL_0052: ldloc.3
+		IL_0053: ldloc.s 7
+		IL_0055: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_005a: pop
+		IL_005b: ldloc.0
+		IL_005c: ldc.r8 3
+		IL_0065: box [System.Runtime]System.Double
+		IL_006a: stfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalDouble
+		IL_006f: ldnull
+		IL_0070: ldftn object Functions.UnaryOperator_MinusMinusPostfix::capturedDouble(object[])
+		IL_0076: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_007b: ldc.i4.1
+		IL_007c: newarr [System.Runtime]System.Object
+		IL_0081: dup
+		IL_0082: ldc.i4.0
+		IL_0083: ldloc.0
+		IL_0084: stelem.ref
+		IL_0085: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_008a: pop
+		IL_008b: ldnull
+		IL_008c: ldftn object Functions.UnaryOperator_MinusMinusPostfix::argDouble(object[], object)
+		IL_0092: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: ldc.r8 3
+		IL_00aa: box [System.Runtime]System.Double
+		IL_00af: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00b4: pop
+		IL_00b5: ldstr "3"
+		IL_00ba: stloc.s 5
+		IL_00bc: ldloc.s 5
+		IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00c3: stloc.2
+		IL_00c4: ldloc.s 5
+		IL_00c6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00cb: stloc.s 8
+		IL_00cd: ldloc.s 8
+		IL_00cf: box [System.Runtime]System.Double
+		IL_00d4: stloc.3
+		IL_00d5: ldloc.s 8
+		IL_00d7: ldc.r8 1
+		IL_00e0: sub
+		IL_00e1: stloc.s 8
+		IL_00e3: ldloc.s 8
+		IL_00e5: box [System.Runtime]System.Double
+		IL_00ea: stloc.s 5
+		IL_00ec: ldloc.s 5
+		IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00f3: stloc.s 4
+		IL_00f5: ldloc.2
+		IL_00f6: box [System.Runtime]System.Double
+		IL_00fb: stloc.s 7
+		IL_00fd: ldloc.s 4
+		IL_00ff: box [System.Runtime]System.Double
+		IL_0104: stloc.s 6
+		IL_0106: ldnull
+		IL_0107: ldftn object Functions.UnaryOperator_MinusMinusPostfix::logCase(object[], object, object, object, object)
+		IL_010d: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0112: ldc.i4.1
+		IL_0113: newarr [System.Runtime]System.Object
+		IL_0118: dup
+		IL_0119: ldc.i4.0
+		IL_011a: ldloc.0
+		IL_011b: stelem.ref
+		IL_011c: ldstr "global-string"
+		IL_0121: ldloc.s 7
+		IL_0123: ldloc.3
+		IL_0124: ldloc.s 6
+		IL_0126: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_012b: pop
+		IL_012c: ldloc.0
+		IL_012d: ldstr "3"
+		IL_0132: stfld object Scopes.UnaryOperator_MinusMinusPostfix::capturedGlobalString
+		IL_0137: ldnull
+		IL_0138: ldftn object Functions.UnaryOperator_MinusMinusPostfix::capturedString(object[])
+		IL_013e: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_0143: ldc.i4.1
+		IL_0144: newarr [System.Runtime]System.Object
+		IL_0149: dup
+		IL_014a: ldc.i4.0
+		IL_014b: ldloc.0
+		IL_014c: stelem.ref
+		IL_014d: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_0152: pop
+		IL_0153: ldnull
+		IL_0154: ldftn object Functions.UnaryOperator_MinusMinusPostfix::argString(object[], object)
+		IL_015a: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_015f: ldc.i4.1
+		IL_0160: newarr [System.Runtime]System.Object
+		IL_0165: dup
+		IL_0166: ldc.i4.0
+		IL_0167: ldloc.0
+		IL_0168: stelem.ref
+		IL_0169: ldstr "3"
+		IL_016e: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0173: pop
+		IL_0174: ret
 	} // end of method UnaryOperator_MinusMinusPostfix::Main
 
 } // end of class Scripts.UnaryOperator_MinusMinusPostfix
@@ -90,7 +604,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20bd
+		// Method begins at RVA 0x2411
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
@@ -1,0 +1,253 @@
+﻿// IL code: UnaryOperator_MinusMinusPostfix_InFunctionSwitch
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit bump
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method bump::.ctor
+
+	} // end of class bump
+
+
+	// Fields
+	.field public object bump
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch::.ctor
+
+} // end of class Scopes.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
+
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object bump (
+			object[] scopes,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 249 (0xf9)
+		.maxstack 32
+		.locals init (
+			[0] float64,
+			[1] float64,
+			[2] float64,
+			[3] float64,
+			[4] float64,
+			[5] float64,
+			[6] bool,
+			[7] object,
+			[8] object,
+			[9] object
+		)
+
+		IL_0000: ldc.r8 3
+		IL_0009: stloc.3
+		IL_000a: ldc.r8 2
+		IL_0013: stloc.s 4
+		IL_0015: ldc.r8 1
+		IL_001e: stloc.s 5
+		IL_0020: ldarg.1
+		IL_0021: ldstr "major"
+		IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_002b: stloc.s 6
+		IL_002d: ldloc.s 6
+		IL_002f: brtrue IL_0061
+
+		IL_0034: ldarg.1
+		IL_0035: ldstr "minor"
+		IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_003f: stloc.s 6
+		IL_0041: ldloc.s 6
+		IL_0043: brtrue IL_0088
+
+		IL_0048: ldarg.1
+		IL_0049: ldstr "patch"
+		IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0053: stloc.s 6
+		IL_0055: ldloc.s 6
+		IL_0057: brtrue IL_00a6
+
+		IL_005c: br IL_00b9
+
+		IL_0061: ldloc.3
+		IL_0062: ldc.r8 1
+		IL_006b: sub
+		IL_006c: stloc.3
+		IL_006d: ldc.r8 0.0
+		IL_0076: stloc.s 4
+		IL_0078: ldc.r8 0.0
+		IL_0081: stloc.s 5
+		IL_0083: br IL_00b9
+
+		IL_0088: ldloc.s 4
+		IL_008a: ldc.r8 1
+		IL_0093: sub
+		IL_0094: stloc.s 4
+		IL_0096: ldc.r8 0.0
+		IL_009f: stloc.s 5
+		IL_00a1: br IL_00b9
+
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldc.r8 1
+		IL_00b1: sub
+		IL_00b2: stloc.s 5
+		IL_00b4: br IL_00b9
+
+		IL_00b9: ldloc.3
+		IL_00ba: box [System.Runtime]System.Double
+		IL_00bf: stloc.s 7
+		IL_00c1: ldloc.s 4
+		IL_00c3: box [System.Runtime]System.Double
+		IL_00c8: stloc.s 8
+		IL_00ca: ldloc.s 5
+		IL_00cc: box [System.Runtime]System.Double
+		IL_00d1: stloc.s 9
+		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d8: ldc.i4.4
+		IL_00d9: newarr [System.Runtime]System.Object
+		IL_00de: dup
+		IL_00df: ldc.i4.0
+		IL_00e0: ldarg.1
+		IL_00e1: stelem.ref
+		IL_00e2: dup
+		IL_00e3: ldc.i4.1
+		IL_00e4: ldloc.s 7
+		IL_00e6: stelem.ref
+		IL_00e7: dup
+		IL_00e8: ldc.i4.2
+		IL_00e9: ldloc.s 8
+		IL_00eb: stelem.ref
+		IL_00ec: dup
+		IL_00ed: ldc.i4.3
+		IL_00ee: ldloc.s 9
+		IL_00f0: stelem.ref
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f6: pop
+		IL_00f7: ldnull
+		IL_00f8: ret
+	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch::bump
+
+} // end of class Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
+
+.class public auto ansi beforefieldinit Scripts.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x216c
+		// Header size: 12
+		// Code size: 106 (0x6a)
+		.maxstack 32
+		.locals (
+			[0] class Scopes.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
+		)
+
+		IL_0000: newobj instance void Scopes.UnaryOperator_MinusMinusPostfix_InFunctionSwitch::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch::bump(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldstr "major"
+		IL_0021: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0026: pop
+		IL_0027: ldnull
+		IL_0028: ldftn object Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch::bump(object[], object)
+		IL_002e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: ldstr "minor"
+		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0047: pop
+		IL_0048: ldnull
+		IL_0049: ldftn object Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch::bump(object[], object)
+		IL_004f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.0
+		IL_005d: stelem.ref
+		IL_005e: ldstr "patch"
+		IL_0063: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0068: pop
+		IL_0069: ret
+	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch::Main
+
+} // end of class Scripts.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21e2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.UnaryOperator_MinusMinusPostfix_InFunctionSwitch::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -1,0 +1,260 @@
+﻿// IL code: UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit bump
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method bump::.ctor
+
+	} // end of class bump
+
+
+	// Fields
+	.field public object bump
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::.ctor
+
+} // end of class Scopes.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
+
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object bump (
+			object[] scopes,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 252 (0xfc)
+		.maxstack 32
+		.locals init (
+			[0] string,
+			[1] string,
+			[2] string,
+			[3] string,
+			[4] string,
+			[5] string,
+			[6] bool,
+			[7] float64
+		)
+
+		IL_0000: ldstr "3"
+		IL_0005: stloc.3
+		IL_0006: ldstr "2"
+		IL_000b: stloc.s 4
+		IL_000d: ldstr "1"
+		IL_0012: stloc.s 5
+		IL_0014: ldarg.1
+		IL_0015: ldstr "major"
+		IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_001f: stloc.s 6
+		IL_0021: ldloc.s 6
+		IL_0023: brtrue IL_0055
+
+		IL_0028: ldarg.1
+		IL_0029: ldstr "minor"
+		IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0033: stloc.s 6
+		IL_0035: ldloc.s 6
+		IL_0037: brtrue IL_0086
+
+		IL_003c: ldarg.1
+		IL_003d: ldstr "patch"
+		IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0047: stloc.s 6
+		IL_0049: ldloc.s 6
+		IL_004b: brtrue IL_00b2
+
+		IL_0050: br IL_00d7
+
+		IL_0055: ldloc.3
+		IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_005b: stloc.s 7
+		IL_005d: ldloc.s 7
+		IL_005f: ldc.r8 1
+		IL_0068: sub
+		IL_0069: stloc.s 7
+		IL_006b: ldloc.s 7
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: stloc.3
+		IL_0073: ldstr "0"
+		IL_0078: stloc.s 4
+		IL_007a: ldstr "0"
+		IL_007f: stloc.s 5
+		IL_0081: br IL_00d7
+
+		IL_0086: ldloc.s 4
+		IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_008d: stloc.s 7
+		IL_008f: ldloc.s 7
+		IL_0091: ldc.r8 1
+		IL_009a: sub
+		IL_009b: stloc.s 7
+		IL_009d: ldloc.s 7
+		IL_009f: box [System.Runtime]System.Double
+		IL_00a4: stloc.s 4
+		IL_00a6: ldstr "0"
+		IL_00ab: stloc.s 5
+		IL_00ad: br IL_00d7
+
+		IL_00b2: ldloc.s 5
+		IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00b9: stloc.s 7
+		IL_00bb: ldloc.s 7
+		IL_00bd: ldc.r8 1
+		IL_00c6: sub
+		IL_00c7: stloc.s 7
+		IL_00c9: ldloc.s 7
+		IL_00cb: box [System.Runtime]System.Double
+		IL_00d0: stloc.s 5
+		IL_00d2: br IL_00d7
+
+		IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dc: ldc.i4.4
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldarg.1
+		IL_00e5: stelem.ref
+		IL_00e6: dup
+		IL_00e7: ldc.i4.1
+		IL_00e8: ldloc.3
+		IL_00e9: stelem.ref
+		IL_00ea: dup
+		IL_00eb: ldc.i4.2
+		IL_00ec: ldloc.s 4
+		IL_00ee: stelem.ref
+		IL_00ef: dup
+		IL_00f0: ldc.i4.3
+		IL_00f1: ldloc.s 5
+		IL_00f3: stelem.ref
+		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f9: pop
+		IL_00fa: ldnull
+		IL_00fb: ret
+	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::bump
+
+} // end of class Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
+
+.class public auto ansi beforefieldinit Scripts.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x216c
+		// Header size: 12
+		// Code size: 106 (0x6a)
+		.maxstack 32
+		.locals (
+			[0] class Scopes.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
+		)
+
+		IL_0000: newobj instance void Scopes.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldstr "major"
+		IL_0021: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0026: pop
+		IL_0027: ldnull
+		IL_0028: ldftn object Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_002e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: ldstr "minor"
+		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0047: pop
+		IL_0048: ldnull
+		IL_0049: ldftn object Functions.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_004f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.0
+		IL_005d: stelem.ref
+		IL_005e: ldstr "patch"
+		IL_0063: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0068: pop
+		IL_0069: ret
+	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::Main
+
+} // end of class Scripts.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21e2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -6,6 +6,117 @@
 .class public auto ansi beforefieldinit Scopes.UnaryOperator_MinusMinusPrefix
 	extends [System.Runtime]System.Object
 {
+	// Nested Types
+	.class nested public auto ansi beforefieldinit logCase
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method logCase::.ctor
+
+	} // end of class logCase
+
+	.class nested public auto ansi beforefieldinit capturedDouble
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method capturedDouble::.ctor
+
+	} // end of class capturedDouble
+
+	.class nested public auto ansi beforefieldinit argDouble
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method argDouble::.ctor
+
+	} // end of class argDouble
+
+	.class nested public auto ansi beforefieldinit capturedString
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method capturedString::.ctor
+
+	} // end of class capturedString
+
+	.class nested public auto ansi beforefieldinit argString
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x207d
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method argString::.ctor
+
+	} // end of class argString
+
+
+	// Fields
+	.field public object logCase
+	.field public object capturedGlobalDouble
+	.field public object capturedDouble
+	.field public object argDouble
+	.field public object capturedGlobalString
+	.field public object capturedString
+	.field public object argString
+
 	// Methods
 	.method public hidebysig specialname rtspecialname 
 		instance void .ctor () cil managed 
@@ -23,6 +134,289 @@
 
 } // end of class Scopes.UnaryOperator_MinusMinusPrefix
 
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_MinusMinusPrefix
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object logCase (
+			object[] scopes,
+			object label,
+			object before,
+			object result,
+			object after
+		) cil managed 
+	{
+		// Method begins at RVA 0x2238
+		// Header size: 12
+		// Code size: 36 (0x24)
+		.maxstack 32
+
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: ldc.i4.4
+		IL_0006: newarr [System.Runtime]System.Object
+		IL_000b: dup
+		IL_000c: ldc.i4.0
+		IL_000d: ldarg.1
+		IL_000e: stelem.ref
+		IL_000f: dup
+		IL_0010: ldc.i4.1
+		IL_0011: ldarg.2
+		IL_0012: stelem.ref
+		IL_0013: dup
+		IL_0014: ldc.i4.2
+		IL_0015: ldarg.3
+		IL_0016: stelem.ref
+		IL_0017: dup
+		IL_0018: ldc.i4.3
+		IL_0019: ldarg.s after
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: pop
+		IL_0022: ldnull
+		IL_0023: ret
+	} // end of method UnaryOperator_MinusMinusPrefix::logCase
+
+	.method public hidebysig static 
+		object capturedDouble (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x2130
+		// Header size: 12
+		// Code size: 118 (0x76)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.UnaryOperator_MinusMinusPrefix
+		IL_0008: ldfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalDouble
+		IL_000d: stloc.0
+		IL_000e: ldarg.0
+		IL_000f: ldc.i4.0
+		IL_0010: ldelem.ref
+		IL_0011: castclass Scopes.UnaryOperator_MinusMinusPrefix
+		IL_0016: ldfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalDouble
+		IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0020: ldc.r8 1
+		IL_0029: sub
+		IL_002a: stloc.3
+		IL_002b: ldloc.3
+		IL_002c: box [System.Runtime]System.Double
+		IL_0031: stloc.1
+		IL_0032: ldarg.0
+		IL_0033: ldc.i4.0
+		IL_0034: ldelem.ref
+		IL_0035: castclass Scopes.UnaryOperator_MinusMinusPrefix
+		IL_003a: ldloc.1
+		IL_003b: stfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalDouble
+		IL_0040: ldarg.0
+		IL_0041: ldc.i4.0
+		IL_0042: ldelem.ref
+		IL_0043: castclass Scopes.UnaryOperator_MinusMinusPrefix
+		IL_0048: ldfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalDouble
+		IL_004d: stloc.2
+		IL_004e: ldnull
+		IL_004f: ldftn object Functions.UnaryOperator_MinusMinusPrefix::logCase(object[], object, object, object, object)
+		IL_0055: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_005a: ldc.i4.1
+		IL_005b: newarr [System.Runtime]System.Object
+		IL_0060: dup
+		IL_0061: ldc.i4.0
+		IL_0062: ldarg.0
+		IL_0063: ldc.i4.0
+		IL_0064: ldelem.ref
+		IL_0065: stelem.ref
+		IL_0066: ldstr "captured-double"
+		IL_006b: ldloc.0
+		IL_006c: ldloc.1
+		IL_006d: ldloc.2
+		IL_006e: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0073: pop
+		IL_0074: ldnull
+		IL_0075: ret
+	} // end of method UnaryOperator_MinusMinusPrefix::capturedDouble
+
+	.method public hidebysig static 
+		object argDouble (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x2088
+		// Header size: 12
+		// Code size: 71 (0x47)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.0
+		IL_0002: ldarg.1
+		IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0008: ldc.r8 1
+		IL_0011: sub
+		IL_0012: stloc.3
+		IL_0013: ldloc.3
+		IL_0014: box [System.Runtime]System.Double
+		IL_0019: stloc.1
+		IL_001a: ldloc.1
+		IL_001b: starg.s n
+		IL_001d: ldarg.1
+		IL_001e: stloc.2
+		IL_001f: ldnull
+		IL_0020: ldftn object Functions.UnaryOperator_MinusMinusPrefix::logCase(object[], object, object, object, object)
+		IL_0026: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldarg.0
+		IL_0034: ldc.i4.0
+		IL_0035: ldelem.ref
+		IL_0036: stelem.ref
+		IL_0037: ldstr "arg-double"
+		IL_003c: ldloc.0
+		IL_003d: ldloc.1
+		IL_003e: ldloc.2
+		IL_003f: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0044: pop
+		IL_0045: ldnull
+		IL_0046: ret
+	} // end of method UnaryOperator_MinusMinusPrefix::argDouble
+
+	.method public hidebysig static 
+		object capturedString (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x21b4
+		// Header size: 12
+		// Code size: 118 (0x76)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.UnaryOperator_MinusMinusPrefix
+		IL_0008: ldfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalString
+		IL_000d: stloc.0
+		IL_000e: ldarg.0
+		IL_000f: ldc.i4.0
+		IL_0010: ldelem.ref
+		IL_0011: castclass Scopes.UnaryOperator_MinusMinusPrefix
+		IL_0016: ldfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalString
+		IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0020: ldc.r8 1
+		IL_0029: sub
+		IL_002a: stloc.3
+		IL_002b: ldloc.3
+		IL_002c: box [System.Runtime]System.Double
+		IL_0031: stloc.1
+		IL_0032: ldarg.0
+		IL_0033: ldc.i4.0
+		IL_0034: ldelem.ref
+		IL_0035: castclass Scopes.UnaryOperator_MinusMinusPrefix
+		IL_003a: ldloc.1
+		IL_003b: stfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalString
+		IL_0040: ldarg.0
+		IL_0041: ldc.i4.0
+		IL_0042: ldelem.ref
+		IL_0043: castclass Scopes.UnaryOperator_MinusMinusPrefix
+		IL_0048: ldfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalString
+		IL_004d: stloc.2
+		IL_004e: ldnull
+		IL_004f: ldftn object Functions.UnaryOperator_MinusMinusPrefix::logCase(object[], object, object, object, object)
+		IL_0055: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_005a: ldc.i4.1
+		IL_005b: newarr [System.Runtime]System.Object
+		IL_0060: dup
+		IL_0061: ldc.i4.0
+		IL_0062: ldarg.0
+		IL_0063: ldc.i4.0
+		IL_0064: ldelem.ref
+		IL_0065: stelem.ref
+		IL_0066: ldstr "captured-string"
+		IL_006b: ldloc.0
+		IL_006c: ldloc.1
+		IL_006d: ldloc.2
+		IL_006e: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0073: pop
+		IL_0074: ldnull
+		IL_0075: ret
+	} // end of method UnaryOperator_MinusMinusPrefix::capturedString
+
+	.method public hidebysig static 
+		object argString (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x20dc
+		// Header size: 12
+		// Code size: 71 (0x47)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.0
+		IL_0002: ldarg.1
+		IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0008: ldc.r8 1
+		IL_0011: sub
+		IL_0012: stloc.3
+		IL_0013: ldloc.3
+		IL_0014: box [System.Runtime]System.Double
+		IL_0019: stloc.1
+		IL_001a: ldloc.1
+		IL_001b: starg.s n
+		IL_001d: ldarg.1
+		IL_001e: stloc.2
+		IL_001f: ldnull
+		IL_0020: ldftn object Functions.UnaryOperator_MinusMinusPrefix::logCase(object[], object, object, object, object)
+		IL_0026: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldarg.0
+		IL_0034: ldc.i4.0
+		IL_0035: ldelem.ref
+		IL_0036: stelem.ref
+		IL_0037: ldstr "arg-string"
+		IL_003c: ldloc.0
+		IL_003d: ldloc.1
+		IL_003e: ldloc.2
+		IL_003f: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0044: pop
+		IL_0045: ldnull
+		IL_0046: ret
+	} // end of method UnaryOperator_MinusMinusPrefix::argString
+
+} // end of class Functions.UnaryOperator_MinusMinusPrefix
+
 .class public auto ansi beforefieldinit Scripts.UnaryOperator_MinusMinusPrefix
 	extends [System.Runtime]System.Object
 {
@@ -36,14 +430,20 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x205c
+		// Method begins at RVA 0x2268
 		// Header size: 12
-		// Code size: 85 (0x55)
+		// Code size: 369 (0x171)
 		.maxstack 32
 		.locals init (
 			[0] class Scopes.UnaryOperator_MinusMinusPrefix,
 			[1] float64,
-			[2] object
+			[2] float64,
+			[3] object,
+			[4] float64,
+			[5] string,
+			[6] object,
+			[7] object,
+			[8] float64
 		)
 
 		IL_0000: newobj instance void Scopes.UnaryOperator_MinusMinusPrefix::.ctor()
@@ -53,32 +453,127 @@
 		IL_0010: ldloc.1
 		IL_0011: ldc.r8 1
 		IL_001a: sub
-		IL_001b: stloc.1
-		IL_001c: ldloc.1
-		IL_001d: box [System.Runtime]System.Double
-		IL_0022: stloc.2
-		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0028: ldc.i4.1
-		IL_0029: newarr [System.Runtime]System.Object
-		IL_002e: dup
-		IL_002f: ldc.i4.0
-		IL_0030: ldloc.2
-		IL_0031: stelem.ref
-		IL_0032: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0037: pop
-		IL_0038: ldloc.1
-		IL_0039: box [System.Runtime]System.Double
-		IL_003e: stloc.2
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0044: ldc.i4.1
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldloc.2
-		IL_004d: stelem.ref
-		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0053: pop
-		IL_0054: ret
+		IL_001b: stloc.s 4
+		IL_001d: ldloc.s 4
+		IL_001f: box [System.Runtime]System.Double
+		IL_0024: stloc.3
+		IL_0025: ldloc.1
+		IL_0026: box [System.Runtime]System.Double
+		IL_002b: stloc.s 6
+		IL_002d: ldloc.s 4
+		IL_002f: box [System.Runtime]System.Double
+		IL_0034: stloc.s 7
+		IL_0036: ldnull
+		IL_0037: ldftn object Functions.UnaryOperator_MinusMinusPrefix::logCase(object[], object, object, object, object)
+		IL_003d: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0042: ldc.i4.1
+		IL_0043: newarr [System.Runtime]System.Object
+		IL_0048: dup
+		IL_0049: ldc.i4.0
+		IL_004a: ldloc.0
+		IL_004b: stelem.ref
+		IL_004c: ldstr "global-double"
+		IL_0051: ldloc.s 6
+		IL_0053: ldloc.3
+		IL_0054: ldloc.s 7
+		IL_0056: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_005b: pop
+		IL_005c: ldloc.0
+		IL_005d: ldc.r8 3
+		IL_0066: box [System.Runtime]System.Double
+		IL_006b: stfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalDouble
+		IL_0070: ldnull
+		IL_0071: ldftn object Functions.UnaryOperator_MinusMinusPrefix::capturedDouble(object[])
+		IL_0077: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_007c: ldc.i4.1
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: dup
+		IL_0083: ldc.i4.0
+		IL_0084: ldloc.0
+		IL_0085: stelem.ref
+		IL_0086: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_008b: pop
+		IL_008c: ldnull
+		IL_008d: ldftn object Functions.UnaryOperator_MinusMinusPrefix::argDouble(object[], object)
+		IL_0093: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldloc.0
+		IL_00a1: stelem.ref
+		IL_00a2: ldc.r8 3
+		IL_00ab: box [System.Runtime]System.Double
+		IL_00b0: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00b5: pop
+		IL_00b6: ldstr "3"
+		IL_00bb: stloc.s 5
+		IL_00bd: ldloc.s 5
+		IL_00bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00c4: stloc.2
+		IL_00c5: ldloc.s 5
+		IL_00c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00cc: stloc.s 8
+		IL_00ce: ldloc.s 8
+		IL_00d0: ldc.r8 1
+		IL_00d9: sub
+		IL_00da: stloc.s 8
+		IL_00dc: ldloc.s 8
+		IL_00de: box [System.Runtime]System.Double
+		IL_00e3: stloc.s 5
+		IL_00e5: ldloc.s 5
+		IL_00e7: stloc.3
+		IL_00e8: ldloc.s 5
+		IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00ef: stloc.s 4
+		IL_00f1: ldloc.2
+		IL_00f2: box [System.Runtime]System.Double
+		IL_00f7: stloc.s 7
+		IL_00f9: ldloc.s 4
+		IL_00fb: box [System.Runtime]System.Double
+		IL_0100: stloc.s 6
+		IL_0102: ldnull
+		IL_0103: ldftn object Functions.UnaryOperator_MinusMinusPrefix::logCase(object[], object, object, object, object)
+		IL_0109: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_010e: ldc.i4.1
+		IL_010f: newarr [System.Runtime]System.Object
+		IL_0114: dup
+		IL_0115: ldc.i4.0
+		IL_0116: ldloc.0
+		IL_0117: stelem.ref
+		IL_0118: ldstr "global-string"
+		IL_011d: ldloc.s 7
+		IL_011f: ldloc.3
+		IL_0120: ldloc.s 6
+		IL_0122: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0127: pop
+		IL_0128: ldloc.0
+		IL_0129: ldstr "3"
+		IL_012e: stfld object Scopes.UnaryOperator_MinusMinusPrefix::capturedGlobalString
+		IL_0133: ldnull
+		IL_0134: ldftn object Functions.UnaryOperator_MinusMinusPrefix::capturedString(object[])
+		IL_013a: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_013f: ldc.i4.1
+		IL_0140: newarr [System.Runtime]System.Object
+		IL_0145: dup
+		IL_0146: ldc.i4.0
+		IL_0147: ldloc.0
+		IL_0148: stelem.ref
+		IL_0149: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_014e: pop
+		IL_014f: ldnull
+		IL_0150: ldftn object Functions.UnaryOperator_MinusMinusPrefix::argString(object[], object)
+		IL_0156: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_015b: ldc.i4.1
+		IL_015c: newarr [System.Runtime]System.Object
+		IL_0161: dup
+		IL_0162: ldc.i4.0
+		IL_0163: ldloc.0
+		IL_0164: stelem.ref
+		IL_0165: ldstr "3"
+		IL_016a: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_016f: pop
+		IL_0170: ret
 	} // end of method UnaryOperator_MinusMinusPrefix::Main
 
 } // end of class Scripts.UnaryOperator_MinusMinusPrefix
@@ -90,7 +585,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20bd
+		// Method begins at RVA 0x23e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
@@ -1,0 +1,253 @@
+﻿// IL code: UnaryOperator_MinusMinusPrefix_InFunctionSwitch
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit bump
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method bump::.ctor
+
+	} // end of class bump
+
+
+	// Fields
+	.field public object bump
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch::.ctor
+
+} // end of class Scopes.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
+
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object bump (
+			object[] scopes,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 249 (0xf9)
+		.maxstack 32
+		.locals init (
+			[0] float64,
+			[1] float64,
+			[2] float64,
+			[3] float64,
+			[4] float64,
+			[5] float64,
+			[6] bool,
+			[7] object,
+			[8] object,
+			[9] object
+		)
+
+		IL_0000: ldc.r8 3
+		IL_0009: stloc.3
+		IL_000a: ldc.r8 2
+		IL_0013: stloc.s 4
+		IL_0015: ldc.r8 1
+		IL_001e: stloc.s 5
+		IL_0020: ldarg.1
+		IL_0021: ldstr "major"
+		IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_002b: stloc.s 6
+		IL_002d: ldloc.s 6
+		IL_002f: brtrue IL_0061
+
+		IL_0034: ldarg.1
+		IL_0035: ldstr "minor"
+		IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_003f: stloc.s 6
+		IL_0041: ldloc.s 6
+		IL_0043: brtrue IL_0088
+
+		IL_0048: ldarg.1
+		IL_0049: ldstr "patch"
+		IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0053: stloc.s 6
+		IL_0055: ldloc.s 6
+		IL_0057: brtrue IL_00a6
+
+		IL_005c: br IL_00b9
+
+		IL_0061: ldloc.3
+		IL_0062: ldc.r8 1
+		IL_006b: sub
+		IL_006c: stloc.3
+		IL_006d: ldc.r8 0.0
+		IL_0076: stloc.s 4
+		IL_0078: ldc.r8 0.0
+		IL_0081: stloc.s 5
+		IL_0083: br IL_00b9
+
+		IL_0088: ldloc.s 4
+		IL_008a: ldc.r8 1
+		IL_0093: sub
+		IL_0094: stloc.s 4
+		IL_0096: ldc.r8 0.0
+		IL_009f: stloc.s 5
+		IL_00a1: br IL_00b9
+
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldc.r8 1
+		IL_00b1: sub
+		IL_00b2: stloc.s 5
+		IL_00b4: br IL_00b9
+
+		IL_00b9: ldloc.3
+		IL_00ba: box [System.Runtime]System.Double
+		IL_00bf: stloc.s 7
+		IL_00c1: ldloc.s 4
+		IL_00c3: box [System.Runtime]System.Double
+		IL_00c8: stloc.s 8
+		IL_00ca: ldloc.s 5
+		IL_00cc: box [System.Runtime]System.Double
+		IL_00d1: stloc.s 9
+		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d8: ldc.i4.4
+		IL_00d9: newarr [System.Runtime]System.Object
+		IL_00de: dup
+		IL_00df: ldc.i4.0
+		IL_00e0: ldarg.1
+		IL_00e1: stelem.ref
+		IL_00e2: dup
+		IL_00e3: ldc.i4.1
+		IL_00e4: ldloc.s 7
+		IL_00e6: stelem.ref
+		IL_00e7: dup
+		IL_00e8: ldc.i4.2
+		IL_00e9: ldloc.s 8
+		IL_00eb: stelem.ref
+		IL_00ec: dup
+		IL_00ed: ldc.i4.3
+		IL_00ee: ldloc.s 9
+		IL_00f0: stelem.ref
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f6: pop
+		IL_00f7: ldnull
+		IL_00f8: ret
+	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch::bump
+
+} // end of class Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
+
+.class public auto ansi beforefieldinit Scripts.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x216c
+		// Header size: 12
+		// Code size: 106 (0x6a)
+		.maxstack 32
+		.locals (
+			[0] class Scopes.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
+		)
+
+		IL_0000: newobj instance void Scopes.UnaryOperator_MinusMinusPrefix_InFunctionSwitch::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch::bump(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldstr "major"
+		IL_0021: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0026: pop
+		IL_0027: ldnull
+		IL_0028: ldftn object Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch::bump(object[], object)
+		IL_002e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: ldstr "minor"
+		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0047: pop
+		IL_0048: ldnull
+		IL_0049: ldftn object Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch::bump(object[], object)
+		IL_004f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.0
+		IL_005d: stelem.ref
+		IL_005e: ldstr "patch"
+		IL_0063: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0068: pop
+		IL_0069: ret
+	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch::Main
+
+} // end of class Scripts.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21e2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.UnaryOperator_MinusMinusPrefix_InFunctionSwitch::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -1,0 +1,260 @@
+﻿// IL code: UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit bump
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method bump::.ctor
+
+	} // end of class bump
+
+
+	// Fields
+	.field public object bump
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::.ctor
+
+} // end of class Scopes.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
+
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object bump (
+			object[] scopes,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 252 (0xfc)
+		.maxstack 32
+		.locals init (
+			[0] string,
+			[1] string,
+			[2] string,
+			[3] string,
+			[4] string,
+			[5] string,
+			[6] bool,
+			[7] float64
+		)
+
+		IL_0000: ldstr "3"
+		IL_0005: stloc.3
+		IL_0006: ldstr "2"
+		IL_000b: stloc.s 4
+		IL_000d: ldstr "1"
+		IL_0012: stloc.s 5
+		IL_0014: ldarg.1
+		IL_0015: ldstr "major"
+		IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_001f: stloc.s 6
+		IL_0021: ldloc.s 6
+		IL_0023: brtrue IL_0055
+
+		IL_0028: ldarg.1
+		IL_0029: ldstr "minor"
+		IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0033: stloc.s 6
+		IL_0035: ldloc.s 6
+		IL_0037: brtrue IL_0086
+
+		IL_003c: ldarg.1
+		IL_003d: ldstr "patch"
+		IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0047: stloc.s 6
+		IL_0049: ldloc.s 6
+		IL_004b: brtrue IL_00b2
+
+		IL_0050: br IL_00d7
+
+		IL_0055: ldloc.3
+		IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_005b: stloc.s 7
+		IL_005d: ldloc.s 7
+		IL_005f: ldc.r8 1
+		IL_0068: sub
+		IL_0069: stloc.s 7
+		IL_006b: ldloc.s 7
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: stloc.3
+		IL_0073: ldstr "0"
+		IL_0078: stloc.s 4
+		IL_007a: ldstr "0"
+		IL_007f: stloc.s 5
+		IL_0081: br IL_00d7
+
+		IL_0086: ldloc.s 4
+		IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_008d: stloc.s 7
+		IL_008f: ldloc.s 7
+		IL_0091: ldc.r8 1
+		IL_009a: sub
+		IL_009b: stloc.s 7
+		IL_009d: ldloc.s 7
+		IL_009f: box [System.Runtime]System.Double
+		IL_00a4: stloc.s 4
+		IL_00a6: ldstr "0"
+		IL_00ab: stloc.s 5
+		IL_00ad: br IL_00d7
+
+		IL_00b2: ldloc.s 5
+		IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00b9: stloc.s 7
+		IL_00bb: ldloc.s 7
+		IL_00bd: ldc.r8 1
+		IL_00c6: sub
+		IL_00c7: stloc.s 7
+		IL_00c9: ldloc.s 7
+		IL_00cb: box [System.Runtime]System.Double
+		IL_00d0: stloc.s 5
+		IL_00d2: br IL_00d7
+
+		IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dc: ldc.i4.4
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldarg.1
+		IL_00e5: stelem.ref
+		IL_00e6: dup
+		IL_00e7: ldc.i4.1
+		IL_00e8: ldloc.3
+		IL_00e9: stelem.ref
+		IL_00ea: dup
+		IL_00eb: ldc.i4.2
+		IL_00ec: ldloc.s 4
+		IL_00ee: stelem.ref
+		IL_00ef: dup
+		IL_00f0: ldc.i4.3
+		IL_00f1: ldloc.s 5
+		IL_00f3: stelem.ref
+		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f9: pop
+		IL_00fa: ldnull
+		IL_00fb: ret
+	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::bump
+
+} // end of class Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
+
+.class public auto ansi beforefieldinit Scripts.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x216c
+		// Header size: 12
+		// Code size: 106 (0x6a)
+		.maxstack 32
+		.locals (
+			[0] class Scopes.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
+		)
+
+		IL_0000: newobj instance void Scopes.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldstr "major"
+		IL_0021: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0026: pop
+		IL_0027: ldnull
+		IL_0028: ldftn object Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_002e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: ldstr "minor"
+		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0047: pop
+		IL_0048: ldnull
+		IL_0049: ldftn object Functions.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_004f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.0
+		IL_005d: stelem.ref
+		IL_005e: ldstr "patch"
+		IL_0063: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0068: pop
+		IL_0069: ret
+	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::Main
+
+} // end of class Scripts.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21e2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
@@ -135,13 +135,12 @@
 	{
 		// Method begins at RVA 0x20d0
 		// Header size: 12
-		// Code size: 294 (0x126)
+		// Code size: 304 (0x130)
 		.maxstack 32
 		.locals init (
-			[0] object,
+			[0] float64,
 			[1] object,
-			[2] float64,
-			[3] object
+			[2] object
 		)
 
 		IL_0000: ldarg.0
@@ -149,119 +148,121 @@
 		IL_0002: ldelem.ref
 		IL_0003: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
 		IL_0008: ldfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
-		IL_000d: stloc.0
-		IL_000e: ldloc.0
-		IL_000f: stloc.1
-		IL_0010: ldloc.0
-		IL_0011: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0016: ldc.r8 1
-		IL_001f: add
-		IL_0020: stloc.2
-		IL_0021: ldloc.2
-		IL_0022: box [System.Runtime]System.Double
-		IL_0027: stloc.3
-		IL_0028: ldarg.0
-		IL_0029: ldc.i4.1
-		IL_002a: ldelem.ref
-		IL_002b: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
-		IL_0030: ldloc.3
-		IL_0031: stfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
-		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003b: ldc.i4.1
-		IL_003c: newarr [System.Runtime]System.Object
-		IL_0041: dup
-		IL_0042: ldc.i4.0
-		IL_0043: ldloc.1
-		IL_0044: stelem.ref
-		IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_004a: pop
-		IL_004b: ldarg.0
-		IL_004c: ldc.i4.1
-		IL_004d: ldelem.ref
-		IL_004e: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
-		IL_0053: ldfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
-		IL_0058: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_005d: ldc.r8 1
-		IL_0066: add
-		IL_0067: stloc.2
-		IL_0068: ldloc.2
-		IL_0069: box [System.Runtime]System.Double
-		IL_006e: stloc.3
-		IL_006f: ldarg.0
-		IL_0070: ldc.i4.1
-		IL_0071: ldelem.ref
-		IL_0072: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
-		IL_0077: ldloc.3
-		IL_0078: stfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
-		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0082: ldc.i4.1
-		IL_0083: newarr [System.Runtime]System.Object
-		IL_0088: dup
-		IL_0089: ldc.i4.0
-		IL_008a: ldloc.3
-		IL_008b: stelem.ref
-		IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0091: pop
-		IL_0092: ldarg.0
-		IL_0093: ldc.i4.1
-		IL_0094: ldelem.ref
-		IL_0095: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
-		IL_009a: ldfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
-		IL_009f: stloc.1
-		IL_00a0: ldloc.1
-		IL_00a1: stloc.0
-		IL_00a2: ldloc.1
-		IL_00a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00a8: ldc.r8 1
-		IL_00b1: sub
-		IL_00b2: stloc.2
-		IL_00b3: ldloc.2
-		IL_00b4: box [System.Runtime]System.Double
-		IL_00b9: stloc.3
-		IL_00ba: ldarg.0
-		IL_00bb: ldc.i4.1
-		IL_00bc: ldelem.ref
-		IL_00bd: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
-		IL_00c2: ldloc.3
-		IL_00c3: stfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
-		IL_00c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cd: ldc.i4.1
-		IL_00ce: newarr [System.Runtime]System.Object
-		IL_00d3: dup
-		IL_00d4: ldc.i4.0
-		IL_00d5: ldloc.0
-		IL_00d6: stelem.ref
-		IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00dc: pop
-		IL_00dd: ldarg.0
-		IL_00de: ldc.i4.1
-		IL_00df: ldelem.ref
-		IL_00e0: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
-		IL_00e5: ldfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
-		IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00ef: ldc.r8 1
-		IL_00f8: sub
-		IL_00f9: stloc.2
-		IL_00fa: ldloc.2
-		IL_00fb: box [System.Runtime]System.Double
-		IL_0100: stloc.3
-		IL_0101: ldarg.0
-		IL_0102: ldc.i4.1
-		IL_0103: ldelem.ref
-		IL_0104: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
-		IL_0109: ldloc.3
-		IL_010a: stfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
-		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0114: ldc.i4.1
-		IL_0115: newarr [System.Runtime]System.Object
-		IL_011a: dup
-		IL_011b: ldc.i4.0
-		IL_011c: ldloc.3
-		IL_011d: stelem.ref
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0123: pop
-		IL_0124: ldnull
-		IL_0125: ret
+		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0012: stloc.0
+		IL_0013: ldloc.0
+		IL_0014: box [System.Runtime]System.Double
+		IL_0019: stloc.1
+		IL_001a: ldloc.0
+		IL_001b: ldc.r8 1
+		IL_0024: add
+		IL_0025: stloc.0
+		IL_0026: ldloc.0
+		IL_0027: box [System.Runtime]System.Double
+		IL_002c: stloc.2
+		IL_002d: ldarg.0
+		IL_002e: ldc.i4.1
+		IL_002f: ldelem.ref
+		IL_0030: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
+		IL_0035: ldloc.2
+		IL_0036: stfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
+		IL_003b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0040: ldc.i4.1
+		IL_0041: newarr [System.Runtime]System.Object
+		IL_0046: dup
+		IL_0047: ldc.i4.0
+		IL_0048: ldloc.1
+		IL_0049: stelem.ref
+		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_004f: pop
+		IL_0050: ldarg.0
+		IL_0051: ldc.i4.1
+		IL_0052: ldelem.ref
+		IL_0053: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
+		IL_0058: ldfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
+		IL_005d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0062: ldc.r8 1
+		IL_006b: add
+		IL_006c: stloc.0
+		IL_006d: ldloc.0
+		IL_006e: box [System.Runtime]System.Double
+		IL_0073: stloc.2
+		IL_0074: ldarg.0
+		IL_0075: ldc.i4.1
+		IL_0076: ldelem.ref
+		IL_0077: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
+		IL_007c: ldloc.2
+		IL_007d: stfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
+		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0087: ldc.i4.1
+		IL_0088: newarr [System.Runtime]System.Object
+		IL_008d: dup
+		IL_008e: ldc.i4.0
+		IL_008f: ldloc.2
+		IL_0090: stelem.ref
+		IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0096: pop
+		IL_0097: ldarg.0
+		IL_0098: ldc.i4.1
+		IL_0099: ldelem.ref
+		IL_009a: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
+		IL_009f: ldfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
+		IL_00a4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00a9: stloc.0
+		IL_00aa: ldloc.0
+		IL_00ab: box [System.Runtime]System.Double
+		IL_00b0: stloc.1
+		IL_00b1: ldloc.0
+		IL_00b2: ldc.r8 1
+		IL_00bb: sub
+		IL_00bc: stloc.0
+		IL_00bd: ldloc.0
+		IL_00be: box [System.Runtime]System.Double
+		IL_00c3: stloc.2
+		IL_00c4: ldarg.0
+		IL_00c5: ldc.i4.1
+		IL_00c6: ldelem.ref
+		IL_00c7: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
+		IL_00cc: ldloc.2
+		IL_00cd: stfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
+		IL_00d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d7: ldc.i4.1
+		IL_00d8: newarr [System.Runtime]System.Object
+		IL_00dd: dup
+		IL_00de: ldc.i4.0
+		IL_00df: ldloc.1
+		IL_00e0: stelem.ref
+		IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00e6: pop
+		IL_00e7: ldarg.0
+		IL_00e8: ldc.i4.1
+		IL_00e9: ldelem.ref
+		IL_00ea: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
+		IL_00ef: ldfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
+		IL_00f4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00f9: ldc.r8 1
+		IL_0102: sub
+		IL_0103: stloc.0
+		IL_0104: ldloc.0
+		IL_0105: box [System.Runtime]System.Double
+		IL_010a: stloc.2
+		IL_010b: ldarg.0
+		IL_010c: ldc.i4.1
+		IL_010d: ldelem.ref
+		IL_010e: castclass Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer
+		IL_0113: ldloc.2
+		IL_0114: stfld object Scopes.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::x
+		IL_0119: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011e: ldc.i4.1
+		IL_011f: newarr [System.Runtime]System.Object
+		IL_0124: dup
+		IL_0125: ldc.i4.0
+		IL_0126: ldloc.2
+		IL_0127: stelem.ref
+		IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_012d: pop
+		IL_012e: ldnull
+		IL_012f: ret
 	} // end of method UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction::inner
 
 } // end of class Functions.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
@@ -279,7 +280,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2204
+		// Method begins at RVA 0x220c
 		// Header size: 12
 		// Code size: 35 (0x23)
 		.maxstack 32
@@ -312,7 +313,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2233
+		// Method begins at RVA 0x223b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -6,6 +6,117 @@
 .class public auto ansi beforefieldinit Scopes.UnaryOperator_PlusPlusPostfix
 	extends [System.Runtime]System.Object
 {
+	// Nested Types
+	.class nested public auto ansi beforefieldinit logCase
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method logCase::.ctor
+
+	} // end of class logCase
+
+	.class nested public auto ansi beforefieldinit capturedDouble
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method capturedDouble::.ctor
+
+	} // end of class capturedDouble
+
+	.class nested public auto ansi beforefieldinit argDouble
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method argDouble::.ctor
+
+	} // end of class argDouble
+
+	.class nested public auto ansi beforefieldinit capturedString
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method capturedString::.ctor
+
+	} // end of class capturedString
+
+	.class nested public auto ansi beforefieldinit argString
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x207d
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method argString::.ctor
+
+	} // end of class argString
+
+
+	// Fields
+	.field public object logCase
+	.field public object capturedGlobalDouble
+	.field public object capturedDouble
+	.field public object argDouble
+	.field public object capturedGlobalString
+	.field public object capturedString
+	.field public object argString
+
 	// Methods
 	.method public hidebysig specialname rtspecialname 
 		instance void .ctor () cil managed 
@@ -23,6 +134,307 @@
 
 } // end of class Scopes.UnaryOperator_PlusPlusPostfix
 
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_PlusPlusPostfix
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object logCase (
+			object[] scopes,
+			object label,
+			object before,
+			object result,
+			object after
+		) cil managed 
+	{
+		// Method begins at RVA 0x2260
+		// Header size: 12
+		// Code size: 36 (0x24)
+		.maxstack 32
+
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: ldc.i4.4
+		IL_0006: newarr [System.Runtime]System.Object
+		IL_000b: dup
+		IL_000c: ldc.i4.0
+		IL_000d: ldarg.1
+		IL_000e: stelem.ref
+		IL_000f: dup
+		IL_0010: ldc.i4.1
+		IL_0011: ldarg.2
+		IL_0012: stelem.ref
+		IL_0013: dup
+		IL_0014: ldc.i4.2
+		IL_0015: ldarg.3
+		IL_0016: stelem.ref
+		IL_0017: dup
+		IL_0018: ldc.i4.3
+		IL_0019: ldarg.s after
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: pop
+		IL_0022: ldnull
+		IL_0023: ret
+	} // end of method UnaryOperator_PlusPlusPostfix::logCase
+
+	.method public hidebysig static 
+		object capturedDouble (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x2140
+		// Header size: 12
+		// Code size: 129 (0x81)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64,
+			[4] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.UnaryOperator_PlusPlusPostfix
+		IL_0008: ldfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalDouble
+		IL_000d: stloc.0
+		IL_000e: ldarg.0
+		IL_000f: ldc.i4.0
+		IL_0010: ldelem.ref
+		IL_0011: castclass Scopes.UnaryOperator_PlusPlusPostfix
+		IL_0016: ldfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalDouble
+		IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0020: stloc.3
+		IL_0021: ldloc.3
+		IL_0022: box [System.Runtime]System.Double
+		IL_0027: stloc.1
+		IL_0028: ldloc.3
+		IL_0029: ldc.r8 1
+		IL_0032: add
+		IL_0033: stloc.3
+		IL_0034: ldloc.3
+		IL_0035: box [System.Runtime]System.Double
+		IL_003a: stloc.s 4
+		IL_003c: ldarg.0
+		IL_003d: ldc.i4.0
+		IL_003e: ldelem.ref
+		IL_003f: castclass Scopes.UnaryOperator_PlusPlusPostfix
+		IL_0044: ldloc.s 4
+		IL_0046: stfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalDouble
+		IL_004b: ldarg.0
+		IL_004c: ldc.i4.0
+		IL_004d: ldelem.ref
+		IL_004e: castclass Scopes.UnaryOperator_PlusPlusPostfix
+		IL_0053: ldfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalDouble
+		IL_0058: stloc.2
+		IL_0059: ldnull
+		IL_005a: ldftn object Functions.UnaryOperator_PlusPlusPostfix::logCase(object[], object, object, object, object)
+		IL_0060: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0065: ldc.i4.1
+		IL_0066: newarr [System.Runtime]System.Object
+		IL_006b: dup
+		IL_006c: ldc.i4.0
+		IL_006d: ldarg.0
+		IL_006e: ldc.i4.0
+		IL_006f: ldelem.ref
+		IL_0070: stelem.ref
+		IL_0071: ldstr "captured-double"
+		IL_0076: ldloc.0
+		IL_0077: ldloc.1
+		IL_0078: ldloc.2
+		IL_0079: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_007e: pop
+		IL_007f: ldnull
+		IL_0080: ret
+	} // end of method UnaryOperator_PlusPlusPostfix::capturedDouble
+
+	.method public hidebysig static 
+		object argDouble (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x2088
+		// Header size: 12
+		// Code size: 78 (0x4e)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.0
+		IL_0002: ldarg.1
+		IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0008: stloc.3
+		IL_0009: ldloc.3
+		IL_000a: box [System.Runtime]System.Double
+		IL_000f: stloc.1
+		IL_0010: ldloc.3
+		IL_0011: ldc.r8 1
+		IL_001a: add
+		IL_001b: stloc.3
+		IL_001c: ldloc.3
+		IL_001d: box [System.Runtime]System.Double
+		IL_0022: starg.s n
+		IL_0024: ldarg.1
+		IL_0025: stloc.2
+		IL_0026: ldnull
+		IL_0027: ldftn object Functions.UnaryOperator_PlusPlusPostfix::logCase(object[], object, object, object, object)
+		IL_002d: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0032: ldc.i4.1
+		IL_0033: newarr [System.Runtime]System.Object
+		IL_0038: dup
+		IL_0039: ldc.i4.0
+		IL_003a: ldarg.0
+		IL_003b: ldc.i4.0
+		IL_003c: ldelem.ref
+		IL_003d: stelem.ref
+		IL_003e: ldstr "arg-double"
+		IL_0043: ldloc.0
+		IL_0044: ldloc.1
+		IL_0045: ldloc.2
+		IL_0046: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_004b: pop
+		IL_004c: ldnull
+		IL_004d: ret
+	} // end of method UnaryOperator_PlusPlusPostfix::argDouble
+
+	.method public hidebysig static 
+		object capturedString (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x21d0
+		// Header size: 12
+		// Code size: 129 (0x81)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64,
+			[4] object
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.UnaryOperator_PlusPlusPostfix
+		IL_0008: ldfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalString
+		IL_000d: stloc.0
+		IL_000e: ldarg.0
+		IL_000f: ldc.i4.0
+		IL_0010: ldelem.ref
+		IL_0011: castclass Scopes.UnaryOperator_PlusPlusPostfix
+		IL_0016: ldfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalString
+		IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0020: stloc.3
+		IL_0021: ldloc.3
+		IL_0022: box [System.Runtime]System.Double
+		IL_0027: stloc.1
+		IL_0028: ldloc.3
+		IL_0029: ldc.r8 1
+		IL_0032: add
+		IL_0033: stloc.3
+		IL_0034: ldloc.3
+		IL_0035: box [System.Runtime]System.Double
+		IL_003a: stloc.s 4
+		IL_003c: ldarg.0
+		IL_003d: ldc.i4.0
+		IL_003e: ldelem.ref
+		IL_003f: castclass Scopes.UnaryOperator_PlusPlusPostfix
+		IL_0044: ldloc.s 4
+		IL_0046: stfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalString
+		IL_004b: ldarg.0
+		IL_004c: ldc.i4.0
+		IL_004d: ldelem.ref
+		IL_004e: castclass Scopes.UnaryOperator_PlusPlusPostfix
+		IL_0053: ldfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalString
+		IL_0058: stloc.2
+		IL_0059: ldnull
+		IL_005a: ldftn object Functions.UnaryOperator_PlusPlusPostfix::logCase(object[], object, object, object, object)
+		IL_0060: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0065: ldc.i4.1
+		IL_0066: newarr [System.Runtime]System.Object
+		IL_006b: dup
+		IL_006c: ldc.i4.0
+		IL_006d: ldarg.0
+		IL_006e: ldc.i4.0
+		IL_006f: ldelem.ref
+		IL_0070: stelem.ref
+		IL_0071: ldstr "captured-string"
+		IL_0076: ldloc.0
+		IL_0077: ldloc.1
+		IL_0078: ldloc.2
+		IL_0079: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_007e: pop
+		IL_007f: ldnull
+		IL_0080: ret
+	} // end of method UnaryOperator_PlusPlusPostfix::capturedString
+
+	.method public hidebysig static 
+		object argString (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x20e4
+		// Header size: 12
+		// Code size: 78 (0x4e)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.0
+		IL_0002: ldarg.1
+		IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0008: stloc.3
+		IL_0009: ldloc.3
+		IL_000a: box [System.Runtime]System.Double
+		IL_000f: stloc.1
+		IL_0010: ldloc.3
+		IL_0011: ldc.r8 1
+		IL_001a: add
+		IL_001b: stloc.3
+		IL_001c: ldloc.3
+		IL_001d: box [System.Runtime]System.Double
+		IL_0022: starg.s n
+		IL_0024: ldarg.1
+		IL_0025: stloc.2
+		IL_0026: ldnull
+		IL_0027: ldftn object Functions.UnaryOperator_PlusPlusPostfix::logCase(object[], object, object, object, object)
+		IL_002d: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0032: ldc.i4.1
+		IL_0033: newarr [System.Runtime]System.Object
+		IL_0038: dup
+		IL_0039: ldc.i4.0
+		IL_003a: ldarg.0
+		IL_003b: ldc.i4.0
+		IL_003c: ldelem.ref
+		IL_003d: stelem.ref
+		IL_003e: ldstr "arg-string"
+		IL_0043: ldloc.0
+		IL_0044: ldloc.1
+		IL_0045: ldloc.2
+		IL_0046: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_004b: pop
+		IL_004c: ldnull
+		IL_004d: ret
+	} // end of method UnaryOperator_PlusPlusPostfix::argString
+
+} // end of class Functions.UnaryOperator_PlusPlusPostfix
+
 .class public auto ansi beforefieldinit Scripts.UnaryOperator_PlusPlusPostfix
 	extends [System.Runtime]System.Object
 {
@@ -36,14 +448,20 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x205c
+		// Method begins at RVA 0x2290
 		// Header size: 12
-		// Code size: 85 (0x55)
+		// Code size: 373 (0x175)
 		.maxstack 32
 		.locals init (
 			[0] class Scopes.UnaryOperator_PlusPlusPostfix,
 			[1] float64,
-			[2] object
+			[2] float64,
+			[3] object,
+			[4] float64,
+			[5] string,
+			[6] object,
+			[7] object,
+			[8] float64
 		)
 
 		IL_0000: newobj instance void Scopes.UnaryOperator_PlusPlusPostfix::.ctor()
@@ -52,33 +470,129 @@
 		IL_000f: stloc.1
 		IL_0010: ldloc.1
 		IL_0011: box [System.Runtime]System.Double
-		IL_0016: stloc.2
+		IL_0016: stloc.3
 		IL_0017: ldloc.1
 		IL_0018: ldc.r8 1
 		IL_0021: add
-		IL_0022: stloc.1
-		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0028: ldc.i4.1
-		IL_0029: newarr [System.Runtime]System.Object
-		IL_002e: dup
-		IL_002f: ldc.i4.0
-		IL_0030: ldloc.2
-		IL_0031: stelem.ref
-		IL_0032: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0037: pop
-		IL_0038: ldloc.1
-		IL_0039: box [System.Runtime]System.Double
-		IL_003e: stloc.2
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0044: ldc.i4.1
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldloc.2
-		IL_004d: stelem.ref
-		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0053: pop
-		IL_0054: ret
+		IL_0022: stloc.s 4
+		IL_0024: ldloc.1
+		IL_0025: box [System.Runtime]System.Double
+		IL_002a: stloc.s 6
+		IL_002c: ldloc.s 4
+		IL_002e: box [System.Runtime]System.Double
+		IL_0033: stloc.s 7
+		IL_0035: ldnull
+		IL_0036: ldftn object Functions.UnaryOperator_PlusPlusPostfix::logCase(object[], object, object, object, object)
+		IL_003c: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0041: ldc.i4.1
+		IL_0042: newarr [System.Runtime]System.Object
+		IL_0047: dup
+		IL_0048: ldc.i4.0
+		IL_0049: ldloc.0
+		IL_004a: stelem.ref
+		IL_004b: ldstr "global-double"
+		IL_0050: ldloc.s 6
+		IL_0052: ldloc.3
+		IL_0053: ldloc.s 7
+		IL_0055: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_005a: pop
+		IL_005b: ldloc.0
+		IL_005c: ldc.r8 3
+		IL_0065: box [System.Runtime]System.Double
+		IL_006a: stfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalDouble
+		IL_006f: ldnull
+		IL_0070: ldftn object Functions.UnaryOperator_PlusPlusPostfix::capturedDouble(object[])
+		IL_0076: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_007b: ldc.i4.1
+		IL_007c: newarr [System.Runtime]System.Object
+		IL_0081: dup
+		IL_0082: ldc.i4.0
+		IL_0083: ldloc.0
+		IL_0084: stelem.ref
+		IL_0085: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_008a: pop
+		IL_008b: ldnull
+		IL_008c: ldftn object Functions.UnaryOperator_PlusPlusPostfix::argDouble(object[], object)
+		IL_0092: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: ldc.r8 3
+		IL_00aa: box [System.Runtime]System.Double
+		IL_00af: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00b4: pop
+		IL_00b5: ldstr "3"
+		IL_00ba: stloc.s 5
+		IL_00bc: ldloc.s 5
+		IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00c3: stloc.2
+		IL_00c4: ldloc.s 5
+		IL_00c6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00cb: stloc.s 8
+		IL_00cd: ldloc.s 8
+		IL_00cf: box [System.Runtime]System.Double
+		IL_00d4: stloc.3
+		IL_00d5: ldloc.s 8
+		IL_00d7: ldc.r8 1
+		IL_00e0: add
+		IL_00e1: stloc.s 8
+		IL_00e3: ldloc.s 8
+		IL_00e5: box [System.Runtime]System.Double
+		IL_00ea: stloc.s 5
+		IL_00ec: ldloc.s 5
+		IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00f3: stloc.s 4
+		IL_00f5: ldloc.2
+		IL_00f6: box [System.Runtime]System.Double
+		IL_00fb: stloc.s 7
+		IL_00fd: ldloc.s 4
+		IL_00ff: box [System.Runtime]System.Double
+		IL_0104: stloc.s 6
+		IL_0106: ldnull
+		IL_0107: ldftn object Functions.UnaryOperator_PlusPlusPostfix::logCase(object[], object, object, object, object)
+		IL_010d: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0112: ldc.i4.1
+		IL_0113: newarr [System.Runtime]System.Object
+		IL_0118: dup
+		IL_0119: ldc.i4.0
+		IL_011a: ldloc.0
+		IL_011b: stelem.ref
+		IL_011c: ldstr "global-string"
+		IL_0121: ldloc.s 7
+		IL_0123: ldloc.3
+		IL_0124: ldloc.s 6
+		IL_0126: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_012b: pop
+		IL_012c: ldloc.0
+		IL_012d: ldstr "3"
+		IL_0132: stfld object Scopes.UnaryOperator_PlusPlusPostfix::capturedGlobalString
+		IL_0137: ldnull
+		IL_0138: ldftn object Functions.UnaryOperator_PlusPlusPostfix::capturedString(object[])
+		IL_013e: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_0143: ldc.i4.1
+		IL_0144: newarr [System.Runtime]System.Object
+		IL_0149: dup
+		IL_014a: ldc.i4.0
+		IL_014b: ldloc.0
+		IL_014c: stelem.ref
+		IL_014d: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_0152: pop
+		IL_0153: ldnull
+		IL_0154: ldftn object Functions.UnaryOperator_PlusPlusPostfix::argString(object[], object)
+		IL_015a: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_015f: ldc.i4.1
+		IL_0160: newarr [System.Runtime]System.Object
+		IL_0165: dup
+		IL_0166: ldc.i4.0
+		IL_0167: ldloc.0
+		IL_0168: stelem.ref
+		IL_0169: ldstr "3"
+		IL_016e: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0173: pop
+		IL_0174: ret
 	} // end of method UnaryOperator_PlusPlusPostfix::Main
 
 } // end of class Scripts.UnaryOperator_PlusPlusPostfix
@@ -90,7 +604,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20bd
+		// Method begins at RVA 0x2411
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
@@ -1,0 +1,253 @@
+﻿// IL code: UnaryOperator_PlusPlusPostfix_InFunctionSwitch
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit bump
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method bump::.ctor
+
+	} // end of class bump
+
+
+	// Fields
+	.field public object bump
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch::.ctor
+
+} // end of class Scopes.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
+
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object bump (
+			object[] scopes,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 249 (0xf9)
+		.maxstack 32
+		.locals init (
+			[0] float64,
+			[1] float64,
+			[2] float64,
+			[3] float64,
+			[4] float64,
+			[5] float64,
+			[6] bool,
+			[7] object,
+			[8] object,
+			[9] object
+		)
+
+		IL_0000: ldc.r8 1
+		IL_0009: stloc.3
+		IL_000a: ldc.r8 2
+		IL_0013: stloc.s 4
+		IL_0015: ldc.r8 3
+		IL_001e: stloc.s 5
+		IL_0020: ldarg.1
+		IL_0021: ldstr "major"
+		IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_002b: stloc.s 6
+		IL_002d: ldloc.s 6
+		IL_002f: brtrue IL_0061
+
+		IL_0034: ldarg.1
+		IL_0035: ldstr "minor"
+		IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_003f: stloc.s 6
+		IL_0041: ldloc.s 6
+		IL_0043: brtrue IL_0088
+
+		IL_0048: ldarg.1
+		IL_0049: ldstr "patch"
+		IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0053: stloc.s 6
+		IL_0055: ldloc.s 6
+		IL_0057: brtrue IL_00a6
+
+		IL_005c: br IL_00b9
+
+		IL_0061: ldloc.3
+		IL_0062: ldc.r8 1
+		IL_006b: add
+		IL_006c: stloc.3
+		IL_006d: ldc.r8 0.0
+		IL_0076: stloc.s 4
+		IL_0078: ldc.r8 0.0
+		IL_0081: stloc.s 5
+		IL_0083: br IL_00b9
+
+		IL_0088: ldloc.s 4
+		IL_008a: ldc.r8 1
+		IL_0093: add
+		IL_0094: stloc.s 4
+		IL_0096: ldc.r8 0.0
+		IL_009f: stloc.s 5
+		IL_00a1: br IL_00b9
+
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldc.r8 1
+		IL_00b1: add
+		IL_00b2: stloc.s 5
+		IL_00b4: br IL_00b9
+
+		IL_00b9: ldloc.3
+		IL_00ba: box [System.Runtime]System.Double
+		IL_00bf: stloc.s 7
+		IL_00c1: ldloc.s 4
+		IL_00c3: box [System.Runtime]System.Double
+		IL_00c8: stloc.s 8
+		IL_00ca: ldloc.s 5
+		IL_00cc: box [System.Runtime]System.Double
+		IL_00d1: stloc.s 9
+		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d8: ldc.i4.4
+		IL_00d9: newarr [System.Runtime]System.Object
+		IL_00de: dup
+		IL_00df: ldc.i4.0
+		IL_00e0: ldarg.1
+		IL_00e1: stelem.ref
+		IL_00e2: dup
+		IL_00e3: ldc.i4.1
+		IL_00e4: ldloc.s 7
+		IL_00e6: stelem.ref
+		IL_00e7: dup
+		IL_00e8: ldc.i4.2
+		IL_00e9: ldloc.s 8
+		IL_00eb: stelem.ref
+		IL_00ec: dup
+		IL_00ed: ldc.i4.3
+		IL_00ee: ldloc.s 9
+		IL_00f0: stelem.ref
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f6: pop
+		IL_00f7: ldnull
+		IL_00f8: ret
+	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch::bump
+
+} // end of class Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
+
+.class public auto ansi beforefieldinit Scripts.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x216c
+		// Header size: 12
+		// Code size: 106 (0x6a)
+		.maxstack 32
+		.locals (
+			[0] class Scopes.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
+		)
+
+		IL_0000: newobj instance void Scopes.UnaryOperator_PlusPlusPostfix_InFunctionSwitch::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch::bump(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldstr "major"
+		IL_0021: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0026: pop
+		IL_0027: ldnull
+		IL_0028: ldftn object Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch::bump(object[], object)
+		IL_002e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: ldstr "minor"
+		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0047: pop
+		IL_0048: ldnull
+		IL_0049: ldftn object Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch::bump(object[], object)
+		IL_004f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.0
+		IL_005d: stelem.ref
+		IL_005e: ldstr "patch"
+		IL_0063: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0068: pop
+		IL_0069: ret
+	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch::Main
+
+} // end of class Scripts.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21e2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.UnaryOperator_PlusPlusPostfix_InFunctionSwitch::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -1,0 +1,260 @@
+﻿// IL code: UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit bump
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method bump::.ctor
+
+	} // end of class bump
+
+
+	// Fields
+	.field public object bump
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::.ctor
+
+} // end of class Scopes.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
+
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object bump (
+			object[] scopes,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 252 (0xfc)
+		.maxstack 32
+		.locals init (
+			[0] string,
+			[1] string,
+			[2] string,
+			[3] string,
+			[4] string,
+			[5] string,
+			[6] bool,
+			[7] float64
+		)
+
+		IL_0000: ldstr "1"
+		IL_0005: stloc.3
+		IL_0006: ldstr "2"
+		IL_000b: stloc.s 4
+		IL_000d: ldstr "3"
+		IL_0012: stloc.s 5
+		IL_0014: ldarg.1
+		IL_0015: ldstr "major"
+		IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_001f: stloc.s 6
+		IL_0021: ldloc.s 6
+		IL_0023: brtrue IL_0055
+
+		IL_0028: ldarg.1
+		IL_0029: ldstr "minor"
+		IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0033: stloc.s 6
+		IL_0035: ldloc.s 6
+		IL_0037: brtrue IL_0086
+
+		IL_003c: ldarg.1
+		IL_003d: ldstr "patch"
+		IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0047: stloc.s 6
+		IL_0049: ldloc.s 6
+		IL_004b: brtrue IL_00b2
+
+		IL_0050: br IL_00d7
+
+		IL_0055: ldloc.3
+		IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_005b: stloc.s 7
+		IL_005d: ldloc.s 7
+		IL_005f: ldc.r8 1
+		IL_0068: add
+		IL_0069: stloc.s 7
+		IL_006b: ldloc.s 7
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: stloc.3
+		IL_0073: ldstr "0"
+		IL_0078: stloc.s 4
+		IL_007a: ldstr "0"
+		IL_007f: stloc.s 5
+		IL_0081: br IL_00d7
+
+		IL_0086: ldloc.s 4
+		IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_008d: stloc.s 7
+		IL_008f: ldloc.s 7
+		IL_0091: ldc.r8 1
+		IL_009a: add
+		IL_009b: stloc.s 7
+		IL_009d: ldloc.s 7
+		IL_009f: box [System.Runtime]System.Double
+		IL_00a4: stloc.s 4
+		IL_00a6: ldstr "0"
+		IL_00ab: stloc.s 5
+		IL_00ad: br IL_00d7
+
+		IL_00b2: ldloc.s 5
+		IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00b9: stloc.s 7
+		IL_00bb: ldloc.s 7
+		IL_00bd: ldc.r8 1
+		IL_00c6: add
+		IL_00c7: stloc.s 7
+		IL_00c9: ldloc.s 7
+		IL_00cb: box [System.Runtime]System.Double
+		IL_00d0: stloc.s 5
+		IL_00d2: br IL_00d7
+
+		IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dc: ldc.i4.4
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldarg.1
+		IL_00e5: stelem.ref
+		IL_00e6: dup
+		IL_00e7: ldc.i4.1
+		IL_00e8: ldloc.3
+		IL_00e9: stelem.ref
+		IL_00ea: dup
+		IL_00eb: ldc.i4.2
+		IL_00ec: ldloc.s 4
+		IL_00ee: stelem.ref
+		IL_00ef: dup
+		IL_00f0: ldc.i4.3
+		IL_00f1: ldloc.s 5
+		IL_00f3: stelem.ref
+		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f9: pop
+		IL_00fa: ldnull
+		IL_00fb: ret
+	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::bump
+
+} // end of class Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
+
+.class public auto ansi beforefieldinit Scripts.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x216c
+		// Header size: 12
+		// Code size: 106 (0x6a)
+		.maxstack 32
+		.locals (
+			[0] class Scopes.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
+		)
+
+		IL_0000: newobj instance void Scopes.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldstr "major"
+		IL_0021: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0026: pop
+		IL_0027: ldnull
+		IL_0028: ldftn object Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_002e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: ldstr "minor"
+		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0047: pop
+		IL_0048: ldnull
+		IL_0049: ldftn object Functions.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_004f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.0
+		IL_005d: stelem.ref
+		IL_005e: ldstr "patch"
+		IL_0063: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0068: pop
+		IL_0069: ret
+	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::Main
+
+} // end of class Scripts.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21e2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -6,6 +6,117 @@
 .class public auto ansi beforefieldinit Scopes.UnaryOperator_PlusPlusPrefix
 	extends [System.Runtime]System.Object
 {
+	// Nested Types
+	.class nested public auto ansi beforefieldinit logCase
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method logCase::.ctor
+
+	} // end of class logCase
+
+	.class nested public auto ansi beforefieldinit capturedDouble
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2062
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method capturedDouble::.ctor
+
+	} // end of class capturedDouble
+
+	.class nested public auto ansi beforefieldinit argDouble
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x206b
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method argDouble::.ctor
+
+	} // end of class argDouble
+
+	.class nested public auto ansi beforefieldinit capturedString
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2074
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method capturedString::.ctor
+
+	} // end of class capturedString
+
+	.class nested public auto ansi beforefieldinit argString
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x207d
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method argString::.ctor
+
+	} // end of class argString
+
+
+	// Fields
+	.field public object logCase
+	.field public object capturedGlobalDouble
+	.field public object capturedDouble
+	.field public object argDouble
+	.field public object capturedGlobalString
+	.field public object capturedString
+	.field public object argString
+
 	// Methods
 	.method public hidebysig specialname rtspecialname 
 		instance void .ctor () cil managed 
@@ -23,6 +134,289 @@
 
 } // end of class Scopes.UnaryOperator_PlusPlusPrefix
 
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_PlusPlusPrefix
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object logCase (
+			object[] scopes,
+			object label,
+			object before,
+			object result,
+			object after
+		) cil managed 
+	{
+		// Method begins at RVA 0x2238
+		// Header size: 12
+		// Code size: 36 (0x24)
+		.maxstack 32
+
+		IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0005: ldc.i4.4
+		IL_0006: newarr [System.Runtime]System.Object
+		IL_000b: dup
+		IL_000c: ldc.i4.0
+		IL_000d: ldarg.1
+		IL_000e: stelem.ref
+		IL_000f: dup
+		IL_0010: ldc.i4.1
+		IL_0011: ldarg.2
+		IL_0012: stelem.ref
+		IL_0013: dup
+		IL_0014: ldc.i4.2
+		IL_0015: ldarg.3
+		IL_0016: stelem.ref
+		IL_0017: dup
+		IL_0018: ldc.i4.3
+		IL_0019: ldarg.s after
+		IL_001b: stelem.ref
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0021: pop
+		IL_0022: ldnull
+		IL_0023: ret
+	} // end of method UnaryOperator_PlusPlusPrefix::logCase
+
+	.method public hidebysig static 
+		object capturedDouble (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x2130
+		// Header size: 12
+		// Code size: 118 (0x76)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.UnaryOperator_PlusPlusPrefix
+		IL_0008: ldfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalDouble
+		IL_000d: stloc.0
+		IL_000e: ldarg.0
+		IL_000f: ldc.i4.0
+		IL_0010: ldelem.ref
+		IL_0011: castclass Scopes.UnaryOperator_PlusPlusPrefix
+		IL_0016: ldfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalDouble
+		IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0020: ldc.r8 1
+		IL_0029: add
+		IL_002a: stloc.3
+		IL_002b: ldloc.3
+		IL_002c: box [System.Runtime]System.Double
+		IL_0031: stloc.1
+		IL_0032: ldarg.0
+		IL_0033: ldc.i4.0
+		IL_0034: ldelem.ref
+		IL_0035: castclass Scopes.UnaryOperator_PlusPlusPrefix
+		IL_003a: ldloc.1
+		IL_003b: stfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalDouble
+		IL_0040: ldarg.0
+		IL_0041: ldc.i4.0
+		IL_0042: ldelem.ref
+		IL_0043: castclass Scopes.UnaryOperator_PlusPlusPrefix
+		IL_0048: ldfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalDouble
+		IL_004d: stloc.2
+		IL_004e: ldnull
+		IL_004f: ldftn object Functions.UnaryOperator_PlusPlusPrefix::logCase(object[], object, object, object, object)
+		IL_0055: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_005a: ldc.i4.1
+		IL_005b: newarr [System.Runtime]System.Object
+		IL_0060: dup
+		IL_0061: ldc.i4.0
+		IL_0062: ldarg.0
+		IL_0063: ldc.i4.0
+		IL_0064: ldelem.ref
+		IL_0065: stelem.ref
+		IL_0066: ldstr "captured-double"
+		IL_006b: ldloc.0
+		IL_006c: ldloc.1
+		IL_006d: ldloc.2
+		IL_006e: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0073: pop
+		IL_0074: ldnull
+		IL_0075: ret
+	} // end of method UnaryOperator_PlusPlusPrefix::capturedDouble
+
+	.method public hidebysig static 
+		object argDouble (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x2088
+		// Header size: 12
+		// Code size: 71 (0x47)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.0
+		IL_0002: ldarg.1
+		IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0008: ldc.r8 1
+		IL_0011: add
+		IL_0012: stloc.3
+		IL_0013: ldloc.3
+		IL_0014: box [System.Runtime]System.Double
+		IL_0019: stloc.1
+		IL_001a: ldloc.1
+		IL_001b: starg.s n
+		IL_001d: ldarg.1
+		IL_001e: stloc.2
+		IL_001f: ldnull
+		IL_0020: ldftn object Functions.UnaryOperator_PlusPlusPrefix::logCase(object[], object, object, object, object)
+		IL_0026: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldarg.0
+		IL_0034: ldc.i4.0
+		IL_0035: ldelem.ref
+		IL_0036: stelem.ref
+		IL_0037: ldstr "arg-double"
+		IL_003c: ldloc.0
+		IL_003d: ldloc.1
+		IL_003e: ldloc.2
+		IL_003f: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0044: pop
+		IL_0045: ldnull
+		IL_0046: ret
+	} // end of method UnaryOperator_PlusPlusPrefix::argDouble
+
+	.method public hidebysig static 
+		object capturedString (
+			object[] scopes
+		) cil managed 
+	{
+		// Method begins at RVA 0x21b4
+		// Header size: 12
+		// Code size: 118 (0x76)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.0
+		IL_0001: ldc.i4.0
+		IL_0002: ldelem.ref
+		IL_0003: castclass Scopes.UnaryOperator_PlusPlusPrefix
+		IL_0008: ldfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalString
+		IL_000d: stloc.0
+		IL_000e: ldarg.0
+		IL_000f: ldc.i4.0
+		IL_0010: ldelem.ref
+		IL_0011: castclass Scopes.UnaryOperator_PlusPlusPrefix
+		IL_0016: ldfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalString
+		IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0020: ldc.r8 1
+		IL_0029: add
+		IL_002a: stloc.3
+		IL_002b: ldloc.3
+		IL_002c: box [System.Runtime]System.Double
+		IL_0031: stloc.1
+		IL_0032: ldarg.0
+		IL_0033: ldc.i4.0
+		IL_0034: ldelem.ref
+		IL_0035: castclass Scopes.UnaryOperator_PlusPlusPrefix
+		IL_003a: ldloc.1
+		IL_003b: stfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalString
+		IL_0040: ldarg.0
+		IL_0041: ldc.i4.0
+		IL_0042: ldelem.ref
+		IL_0043: castclass Scopes.UnaryOperator_PlusPlusPrefix
+		IL_0048: ldfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalString
+		IL_004d: stloc.2
+		IL_004e: ldnull
+		IL_004f: ldftn object Functions.UnaryOperator_PlusPlusPrefix::logCase(object[], object, object, object, object)
+		IL_0055: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_005a: ldc.i4.1
+		IL_005b: newarr [System.Runtime]System.Object
+		IL_0060: dup
+		IL_0061: ldc.i4.0
+		IL_0062: ldarg.0
+		IL_0063: ldc.i4.0
+		IL_0064: ldelem.ref
+		IL_0065: stelem.ref
+		IL_0066: ldstr "captured-string"
+		IL_006b: ldloc.0
+		IL_006c: ldloc.1
+		IL_006d: ldloc.2
+		IL_006e: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0073: pop
+		IL_0074: ldnull
+		IL_0075: ret
+	} // end of method UnaryOperator_PlusPlusPrefix::capturedString
+
+	.method public hidebysig static 
+		object argString (
+			object[] scopes,
+			object n
+		) cil managed 
+	{
+		// Method begins at RVA 0x20dc
+		// Header size: 12
+		// Code size: 71 (0x47)
+		.maxstack 32
+		.locals init (
+			[0] object,
+			[1] object,
+			[2] object,
+			[3] float64
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.0
+		IL_0002: ldarg.1
+		IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0008: ldc.r8 1
+		IL_0011: add
+		IL_0012: stloc.3
+		IL_0013: ldloc.3
+		IL_0014: box [System.Runtime]System.Double
+		IL_0019: stloc.1
+		IL_001a: ldloc.1
+		IL_001b: starg.s n
+		IL_001d: ldarg.1
+		IL_001e: stloc.2
+		IL_001f: ldnull
+		IL_0020: ldftn object Functions.UnaryOperator_PlusPlusPrefix::logCase(object[], object, object, object, object)
+		IL_0026: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldarg.0
+		IL_0034: ldc.i4.0
+		IL_0035: ldelem.ref
+		IL_0036: stelem.ref
+		IL_0037: ldstr "arg-string"
+		IL_003c: ldloc.0
+		IL_003d: ldloc.1
+		IL_003e: ldloc.2
+		IL_003f: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0044: pop
+		IL_0045: ldnull
+		IL_0046: ret
+	} // end of method UnaryOperator_PlusPlusPrefix::argString
+
+} // end of class Functions.UnaryOperator_PlusPlusPrefix
+
 .class public auto ansi beforefieldinit Scripts.UnaryOperator_PlusPlusPrefix
 	extends [System.Runtime]System.Object
 {
@@ -36,14 +430,20 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x205c
+		// Method begins at RVA 0x2268
 		// Header size: 12
-		// Code size: 85 (0x55)
+		// Code size: 369 (0x171)
 		.maxstack 32
 		.locals init (
 			[0] class Scopes.UnaryOperator_PlusPlusPrefix,
 			[1] float64,
-			[2] object
+			[2] float64,
+			[3] object,
+			[4] float64,
+			[5] string,
+			[6] object,
+			[7] object,
+			[8] float64
 		)
 
 		IL_0000: newobj instance void Scopes.UnaryOperator_PlusPlusPrefix::.ctor()
@@ -53,32 +453,127 @@
 		IL_0010: ldloc.1
 		IL_0011: ldc.r8 1
 		IL_001a: add
-		IL_001b: stloc.1
-		IL_001c: ldloc.1
-		IL_001d: box [System.Runtime]System.Double
-		IL_0022: stloc.2
-		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0028: ldc.i4.1
-		IL_0029: newarr [System.Runtime]System.Object
-		IL_002e: dup
-		IL_002f: ldc.i4.0
-		IL_0030: ldloc.2
-		IL_0031: stelem.ref
-		IL_0032: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0037: pop
-		IL_0038: ldloc.1
-		IL_0039: box [System.Runtime]System.Double
-		IL_003e: stloc.2
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0044: ldc.i4.1
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldloc.2
-		IL_004d: stelem.ref
-		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0053: pop
-		IL_0054: ret
+		IL_001b: stloc.s 4
+		IL_001d: ldloc.s 4
+		IL_001f: box [System.Runtime]System.Double
+		IL_0024: stloc.3
+		IL_0025: ldloc.1
+		IL_0026: box [System.Runtime]System.Double
+		IL_002b: stloc.s 6
+		IL_002d: ldloc.s 4
+		IL_002f: box [System.Runtime]System.Double
+		IL_0034: stloc.s 7
+		IL_0036: ldnull
+		IL_0037: ldftn object Functions.UnaryOperator_PlusPlusPrefix::logCase(object[], object, object, object, object)
+		IL_003d: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_0042: ldc.i4.1
+		IL_0043: newarr [System.Runtime]System.Object
+		IL_0048: dup
+		IL_0049: ldc.i4.0
+		IL_004a: ldloc.0
+		IL_004b: stelem.ref
+		IL_004c: ldstr "global-double"
+		IL_0051: ldloc.s 6
+		IL_0053: ldloc.3
+		IL_0054: ldloc.s 7
+		IL_0056: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_005b: pop
+		IL_005c: ldloc.0
+		IL_005d: ldc.r8 3
+		IL_0066: box [System.Runtime]System.Double
+		IL_006b: stfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalDouble
+		IL_0070: ldnull
+		IL_0071: ldftn object Functions.UnaryOperator_PlusPlusPrefix::capturedDouble(object[])
+		IL_0077: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_007c: ldc.i4.1
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: dup
+		IL_0083: ldc.i4.0
+		IL_0084: ldloc.0
+		IL_0085: stelem.ref
+		IL_0086: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_008b: pop
+		IL_008c: ldnull
+		IL_008d: ldftn object Functions.UnaryOperator_PlusPlusPrefix::argDouble(object[], object)
+		IL_0093: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldloc.0
+		IL_00a1: stelem.ref
+		IL_00a2: ldc.r8 3
+		IL_00ab: box [System.Runtime]System.Double
+		IL_00b0: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_00b5: pop
+		IL_00b6: ldstr "3"
+		IL_00bb: stloc.s 5
+		IL_00bd: ldloc.s 5
+		IL_00bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00c4: stloc.2
+		IL_00c5: ldloc.s 5
+		IL_00c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00cc: stloc.s 8
+		IL_00ce: ldloc.s 8
+		IL_00d0: ldc.r8 1
+		IL_00d9: add
+		IL_00da: stloc.s 8
+		IL_00dc: ldloc.s 8
+		IL_00de: box [System.Runtime]System.Double
+		IL_00e3: stloc.s 5
+		IL_00e5: ldloc.s 5
+		IL_00e7: stloc.3
+		IL_00e8: ldloc.s 5
+		IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00ef: stloc.s 4
+		IL_00f1: ldloc.2
+		IL_00f2: box [System.Runtime]System.Double
+		IL_00f7: stloc.s 7
+		IL_00f9: ldloc.s 4
+		IL_00fb: box [System.Runtime]System.Double
+		IL_0100: stloc.s 6
+		IL_0102: ldnull
+		IL_0103: ldftn object Functions.UnaryOperator_PlusPlusPrefix::logCase(object[], object, object, object, object)
+		IL_0109: newobj instance void class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::.ctor(object, native int)
+		IL_010e: ldc.i4.1
+		IL_010f: newarr [System.Runtime]System.Object
+		IL_0114: dup
+		IL_0115: ldc.i4.0
+		IL_0116: ldloc.0
+		IL_0117: stelem.ref
+		IL_0118: ldstr "global-string"
+		IL_011d: ldloc.s 7
+		IL_011f: ldloc.3
+		IL_0120: ldloc.s 6
+		IL_0122: callvirt instance !5 class [System.Runtime]System.Func`6<object[], object, object, object, object, object>::Invoke(!0, !1, !2, !3, !4)
+		IL_0127: pop
+		IL_0128: ldloc.0
+		IL_0129: ldstr "3"
+		IL_012e: stfld object Scopes.UnaryOperator_PlusPlusPrefix::capturedGlobalString
+		IL_0133: ldnull
+		IL_0134: ldftn object Functions.UnaryOperator_PlusPlusPrefix::capturedString(object[])
+		IL_013a: newobj instance void class [System.Runtime]System.Func`2<object[], object>::.ctor(object, native int)
+		IL_013f: ldc.i4.1
+		IL_0140: newarr [System.Runtime]System.Object
+		IL_0145: dup
+		IL_0146: ldc.i4.0
+		IL_0147: ldloc.0
+		IL_0148: stelem.ref
+		IL_0149: callvirt instance !1 class [System.Runtime]System.Func`2<object[], object>::Invoke(!0)
+		IL_014e: pop
+		IL_014f: ldnull
+		IL_0150: ldftn object Functions.UnaryOperator_PlusPlusPrefix::argString(object[], object)
+		IL_0156: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_015b: ldc.i4.1
+		IL_015c: newarr [System.Runtime]System.Object
+		IL_0161: dup
+		IL_0162: ldc.i4.0
+		IL_0163: ldloc.0
+		IL_0164: stelem.ref
+		IL_0165: ldstr "3"
+		IL_016a: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_016f: pop
+		IL_0170: ret
 	} // end of method UnaryOperator_PlusPlusPrefix::Main
 
 } // end of class Scripts.UnaryOperator_PlusPlusPrefix
@@ -90,7 +585,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20bd
+		// Method begins at RVA 0x23e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
@@ -1,0 +1,253 @@
+﻿// IL code: UnaryOperator_PlusPlusPrefix_InFunctionSwitch
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit bump
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method bump::.ctor
+
+	} // end of class bump
+
+
+	// Fields
+	.field public object bump
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch::.ctor
+
+} // end of class Scopes.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
+
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object bump (
+			object[] scopes,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 249 (0xf9)
+		.maxstack 32
+		.locals init (
+			[0] float64,
+			[1] float64,
+			[2] float64,
+			[3] float64,
+			[4] float64,
+			[5] float64,
+			[6] bool,
+			[7] object,
+			[8] object,
+			[9] object
+		)
+
+		IL_0000: ldc.r8 1
+		IL_0009: stloc.3
+		IL_000a: ldc.r8 2
+		IL_0013: stloc.s 4
+		IL_0015: ldc.r8 3
+		IL_001e: stloc.s 5
+		IL_0020: ldarg.1
+		IL_0021: ldstr "major"
+		IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_002b: stloc.s 6
+		IL_002d: ldloc.s 6
+		IL_002f: brtrue IL_0061
+
+		IL_0034: ldarg.1
+		IL_0035: ldstr "minor"
+		IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_003f: stloc.s 6
+		IL_0041: ldloc.s 6
+		IL_0043: brtrue IL_0088
+
+		IL_0048: ldarg.1
+		IL_0049: ldstr "patch"
+		IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0053: stloc.s 6
+		IL_0055: ldloc.s 6
+		IL_0057: brtrue IL_00a6
+
+		IL_005c: br IL_00b9
+
+		IL_0061: ldloc.3
+		IL_0062: ldc.r8 1
+		IL_006b: add
+		IL_006c: stloc.3
+		IL_006d: ldc.r8 0.0
+		IL_0076: stloc.s 4
+		IL_0078: ldc.r8 0.0
+		IL_0081: stloc.s 5
+		IL_0083: br IL_00b9
+
+		IL_0088: ldloc.s 4
+		IL_008a: ldc.r8 1
+		IL_0093: add
+		IL_0094: stloc.s 4
+		IL_0096: ldc.r8 0.0
+		IL_009f: stloc.s 5
+		IL_00a1: br IL_00b9
+
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldc.r8 1
+		IL_00b1: add
+		IL_00b2: stloc.s 5
+		IL_00b4: br IL_00b9
+
+		IL_00b9: ldloc.3
+		IL_00ba: box [System.Runtime]System.Double
+		IL_00bf: stloc.s 7
+		IL_00c1: ldloc.s 4
+		IL_00c3: box [System.Runtime]System.Double
+		IL_00c8: stloc.s 8
+		IL_00ca: ldloc.s 5
+		IL_00cc: box [System.Runtime]System.Double
+		IL_00d1: stloc.s 9
+		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d8: ldc.i4.4
+		IL_00d9: newarr [System.Runtime]System.Object
+		IL_00de: dup
+		IL_00df: ldc.i4.0
+		IL_00e0: ldarg.1
+		IL_00e1: stelem.ref
+		IL_00e2: dup
+		IL_00e3: ldc.i4.1
+		IL_00e4: ldloc.s 7
+		IL_00e6: stelem.ref
+		IL_00e7: dup
+		IL_00e8: ldc.i4.2
+		IL_00e9: ldloc.s 8
+		IL_00eb: stelem.ref
+		IL_00ec: dup
+		IL_00ed: ldc.i4.3
+		IL_00ee: ldloc.s 9
+		IL_00f0: stelem.ref
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f6: pop
+		IL_00f7: ldnull
+		IL_00f8: ret
+	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch::bump
+
+} // end of class Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
+
+.class public auto ansi beforefieldinit Scripts.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x216c
+		// Header size: 12
+		// Code size: 106 (0x6a)
+		.maxstack 32
+		.locals (
+			[0] class Scopes.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
+		)
+
+		IL_0000: newobj instance void Scopes.UnaryOperator_PlusPlusPrefix_InFunctionSwitch::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch::bump(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldstr "major"
+		IL_0021: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0026: pop
+		IL_0027: ldnull
+		IL_0028: ldftn object Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch::bump(object[], object)
+		IL_002e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: ldstr "minor"
+		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0047: pop
+		IL_0048: ldnull
+		IL_0049: ldftn object Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch::bump(object[], object)
+		IL_004f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.0
+		IL_005d: stelem.ref
+		IL_005e: ldstr "patch"
+		IL_0063: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0068: pop
+		IL_0069: ret
+	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch::Main
+
+} // end of class Scripts.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21e2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.UnaryOperator_PlusPlusPrefix_InFunctionSwitch::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -1,0 +1,260 @@
+﻿// IL code: UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit Scopes.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit bump
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2059
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method bump::.ctor
+
+	} // end of class bump
+
+
+	// Fields
+	.field public object bump
+
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::.ctor
+
+} // end of class Scopes.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
+
+.class public auto ansi abstract sealed beforefieldinit Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		object bump (
+			object[] scopes,
+			object kind
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Header size: 12
+		// Code size: 252 (0xfc)
+		.maxstack 32
+		.locals init (
+			[0] string,
+			[1] string,
+			[2] string,
+			[3] string,
+			[4] string,
+			[5] string,
+			[6] bool,
+			[7] float64
+		)
+
+		IL_0000: ldstr "1"
+		IL_0005: stloc.3
+		IL_0006: ldstr "2"
+		IL_000b: stloc.s 4
+		IL_000d: ldstr "3"
+		IL_0012: stloc.s 5
+		IL_0014: ldarg.1
+		IL_0015: ldstr "major"
+		IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_001f: stloc.s 6
+		IL_0021: ldloc.s 6
+		IL_0023: brtrue IL_0055
+
+		IL_0028: ldarg.1
+		IL_0029: ldstr "minor"
+		IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0033: stloc.s 6
+		IL_0035: ldloc.s 6
+		IL_0037: brtrue IL_0086
+
+		IL_003c: ldarg.1
+		IL_003d: ldstr "patch"
+		IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0047: stloc.s 6
+		IL_0049: ldloc.s 6
+		IL_004b: brtrue IL_00b2
+
+		IL_0050: br IL_00d7
+
+		IL_0055: ldloc.3
+		IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_005b: stloc.s 7
+		IL_005d: ldloc.s 7
+		IL_005f: ldc.r8 1
+		IL_0068: add
+		IL_0069: stloc.s 7
+		IL_006b: ldloc.s 7
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: stloc.3
+		IL_0073: ldstr "0"
+		IL_0078: stloc.s 4
+		IL_007a: ldstr "0"
+		IL_007f: stloc.s 5
+		IL_0081: br IL_00d7
+
+		IL_0086: ldloc.s 4
+		IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_008d: stloc.s 7
+		IL_008f: ldloc.s 7
+		IL_0091: ldc.r8 1
+		IL_009a: add
+		IL_009b: stloc.s 7
+		IL_009d: ldloc.s 7
+		IL_009f: box [System.Runtime]System.Double
+		IL_00a4: stloc.s 4
+		IL_00a6: ldstr "0"
+		IL_00ab: stloc.s 5
+		IL_00ad: br IL_00d7
+
+		IL_00b2: ldloc.s 5
+		IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00b9: stloc.s 7
+		IL_00bb: ldloc.s 7
+		IL_00bd: ldc.r8 1
+		IL_00c6: add
+		IL_00c7: stloc.s 7
+		IL_00c9: ldloc.s 7
+		IL_00cb: box [System.Runtime]System.Double
+		IL_00d0: stloc.s 5
+		IL_00d2: br IL_00d7
+
+		IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dc: ldc.i4.4
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldarg.1
+		IL_00e5: stelem.ref
+		IL_00e6: dup
+		IL_00e7: ldc.i4.1
+		IL_00e8: ldloc.3
+		IL_00e9: stelem.ref
+		IL_00ea: dup
+		IL_00eb: ldc.i4.2
+		IL_00ec: ldloc.s 4
+		IL_00ee: stelem.ref
+		IL_00ef: dup
+		IL_00f0: ldc.i4.3
+		IL_00f1: ldloc.s 5
+		IL_00f3: stelem.ref
+		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f9: pop
+		IL_00fa: ldnull
+		IL_00fb: ret
+	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::bump
+
+} // end of class Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
+
+.class public auto ansi beforefieldinit Scripts.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		void Main (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x216c
+		// Header size: 12
+		// Code size: 106 (0x6a)
+		.maxstack 32
+		.locals (
+			[0] class Scopes.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
+		)
+
+		IL_0000: newobj instance void Scopes.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: ldstr "major"
+		IL_0021: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0026: pop
+		IL_0027: ldnull
+		IL_0028: ldftn object Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_002e: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: ldstr "minor"
+		IL_0042: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0047: pop
+		IL_0048: ldnull
+		IL_0049: ldftn object Functions.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::bump(object[], object)
+		IL_004f: newobj instance void class [System.Runtime]System.Func`3<object[], object, object>::.ctor(object, native int)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.0
+		IL_005d: stelem.ref
+		IL_005e: ldstr "patch"
+		IL_0063: callvirt instance !2 class [System.Runtime]System.Func`3<object[], object, object>::Invoke(!0, !1)
+		IL_0068: pop
+		IL_0069: ret
+	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::Main
+
+} // end of class Scripts.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21e2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Scripts.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::Main(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary
- fix postfix ++/-- snapshot semantics for environment-stored variables (ToNumber coercion)
- add/update UpdateExpression coverage (prefix/postfix, ++/--, switch/object-local)
- expand unary operator fixtures for global/captured/argument cases (number/string) and refresh snapshots
- add bumpVersion integration compile snapshot and required runtime intrinsics (Array.some, GlobalThis.parseInt)

## Testing
- dotnet test .\\Js2IL.Tests\\Js2IL.Tests.csproj --filter FullyQualifiedName~UnaryOperator
