### PR TITLE
fix(release): use gh auto-merge

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -255,7 +255,7 @@ function waitForRequiredCheck(prNumber, repo, checkName, { timeoutMs = 10 * 60 *
   while (Date.now() < deadline) {
     // We rely on statusCheckRollup so we can detect when checks start existing at all.
     const q = `.statusCheckRollup[] | select(.name=="${checkName}") | .conclusion`;
-    const conclusion = run(`gh pr view ${prNumber} --repo ${repo} --json statusCheckRollup -q '${q}'`, { ...args, allowFailure: true })
+    const conclusion = run(`gh pr view ${prNumber} --repo ${repo} --json statusCheckRollup -q "${q}"`, { ...args, allowFailure: true })
       .trim();
 
     if (!conclusion) {


### PR DESCRIPTION
Fix release automation to comply with master branch rules.

- Use `gh pr merge --auto` so merges wait for required checks instead of failing when checks have not yet been reported.
- Improve log message when no checks are reported.