### PR TITLE
docs: generator lowering spec + GeneratorScope base

### DIFF
--- a/JavaScriptRuntime/GeneratorScope.cs
+++ b/JavaScriptRuntime/GeneratorScope.cs
@@ -1,0 +1,69 @@
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Base class for generated leaf scopes of synchronous generators.
+/// Stores the state needed to suspend and resume across yield points.
+/// </summary>
+public class GeneratorScope
+{
+    // State machine fields
+    public int _genState;
+    public bool _started;
+    public bool _done;
+
+    // Resume protocol inputs
+    public object? _resumeValue;
+    public object? _resumeException;
+    public bool _hasResumeException;
+
+    public object? _returnValue;
+    public bool _hasReturn;
+
+    public int GenState
+    {
+        get => _genState;
+        set => _genState = value;
+    }
+
+    public bool Started
+    {
+        get => _started;
+        set => _started = value;
+    }
+
+    public bool Done
+    {
+        get => _done;
+        set => _done = value;
+    }
+
+    public object? ResumeValue
+    {
+        get => _resumeValue;
+        set => _resumeValue = value;
+    }
+
+    public object? ResumeException
+    {
+        get => _resumeException;
+        set => _resumeException = value;
+    }
+
+    public bool HasResumeException
+    {
+        get => _hasResumeException;
+        set => _hasResumeException = value;
+    }
+
+    public object? ReturnValue
+    {
+        get => _returnValue;
+        set => _returnValue = value;
+    }
+
+    public bool HasReturn
+    {
+        get => _hasReturn;
+        set => _hasReturn = value;
+    }
+}

--- a/docs/SynchronousGenerators_LoweringSpec.md
+++ b/docs/SynchronousGenerators_LoweringSpec.md
@@ -1,0 +1,281 @@
+# 0. Synchronous Generator Lowering Spec (JS2IL)
+
+## 1. Goals
+
+- Support ECMAScript synchronous generators:
+  - `function* f() { ... }`, `function* () { ... }`, generator methods.
+  - `yield <expr>` and `yield* <iterable>`.
+- Preserve JavaScript semantics:
+  - Left-to-right evaluation order.
+  - Correct `next(value)`, `throw(error)`, and `return(value)` behavior.
+  - Correct interaction with `try/catch/finally` inside generator bodies.
+- Reuse JS2IL’s **scope-as-class** closure model and scopes-array ABI.
+- Keep the runtime small and avoid reflection-heavy hot paths.
+
+## 2. Non-Goals (initial implementation)
+
+- Async generators (`async function*`) and `for await (...)`.
+- Symbol keys (e.g., `Symbol.iterator`) beyond what JS2IL already models.
+- Full spec-accurate iterator closing semantics for every exotic host iterable on day 1.
+
+## 3. Terminology
+
+- **Generator function**: `function* g() { ... }`.
+- **Generator object**: result of calling a generator function; implements `next`, `throw`, `return`.
+- **Suspension point**: a `yield` / `yield*` where execution pauses and control returns to caller.
+- **Resume**: a subsequent `next/throw/return` call.
+- **Leaf scope**: per-invocation scope instance allocated for the generator body (JS2IL “scope-as-class”).
+
+## 4. Semantics Summary
+
+### 4.1. Calling a generator function
+
+Calling a generator function does **not** execute the body immediately.
+
+- It returns a generator object `gen`.
+- The body runs only when `gen.next(...)` / `gen.throw(...)` / `gen.return(...)` is invoked.
+
+### 4.2. Iterator result shape
+
+Each `next/throw/return` returns an **iterator result** object:
+
+- `{ value: any, done: boolean }`
+
+JS2IL runtime will model this as an `ExpandoObject` (or a small dedicated runtime type), consistent with existing object-literal behavior.
+
+### 4.3. `next(value)`
+
+- On first `next(value)`, `value` is ignored (per JS semantics).
+- On subsequent `next(value)`, `value` becomes the result of the paused `yield` expression.
+
+### 4.4. `yield expr`
+
+- Evaluates `expr`.
+- Produces `{ value: <expr>, done: false }` and suspends.
+- When resumed by `next(v)`, the `yield expr` expression evaluates to `v`.
+
+### 4.5. `throw(error)`
+
+- Resumes the generator by throwing `error` at the suspended `yield`.
+- If not caught in the generator, the call to `throw` rethrows to the caller and the generator becomes completed.
+
+### 4.6. `return(value)`
+
+- Forces generator completion.
+- Runs any pending `finally` blocks.
+- Returns `{ value, done: true }`.
+
+## 5. High-level lowering strategy
+
+### 5.1. Shape
+
+Lower each generator function into:
+
+1. An **outer factory method** matching the original callable signature that returns a runtime generator object.
+2. A **state machine step method** (like async’s `MoveNext`) that:
+   - runs until it hits a `yield` or completes
+   - can be resumed with one of three operations: `next`, `throw`, `return`
+
+### 5.2. Where state lives
+
+All state that must survive across `yield` lives on the **leaf scope instance** for that generator invocation.
+
+Reference: [ADR 0002: Resumable Callable State Storage (Scope-Attached vs Separate State Object)](adr/0002-resumable-state-scope-vs-stateobject.md)
+
+Proposed approach: have the generated leaf scope type inherit from a runtime base class (e.g., `JavaScriptRuntime.GeneratorScope`) that provides the standard resumable fields.
+
+Proposed fields on `GeneratorScope`:
+
+- `int _genState` — program counter
+- `bool _started` — whether first `next` has happened
+- `bool _done` — completion flag
+- `object? _resumeValue` — the value passed to `next(v)`
+- `object? _resumeException` — exception passed to `throw(e)`
+- `bool _hasResumeException`
+- `object? _returnValue` — value passed to `return(v)`
+- `bool _hasReturn`
+- Spill slots for temps/locals that must survive across yields (same approach as async).
+
+Rationale: matches JS2IL’s existing closure lifetime and avoids separate heap allocations.
+
+### 5.3. Step method signature
+
+A minimal, explicit interface avoids dynamic dispatch:
+
+```csharp
+// Conceptual signature (exact types TBD)
+static object Step(object[] scopes, int op, object? arg)
+// op: 0=Next, 1=Throw, 2=Return
+// returns: iterator-result object { value, done }
+```
+
+An optimized variant can accept the strongly typed leaf scope to avoid casts:
+
+```csharp
+static object Step(Scopes.MyGeneratorScope scope, object[] scopes, int op, object? arg)
+```
+
+### 5.4. Runtime generator object
+
+The factory method returns a runtime object that stores:
+
+- the scopes array
+- a reference to the compiled step function
+- a small bit of per-generator bookkeeping (or reuse the leaf scope fields exclusively)
+
+It exposes:
+
+- `next(arg)`
+- `throw(arg)`
+- `return(arg)`
+
+Each method calls into `Step(...)`.
+
+## 6. Detailed lowering
+
+### 6.1. Basic `yield`
+
+Example:
+
+```js
+function* g() {
+  const a = 1;
+  yield a;
+  yield 2;
+  return 3;
+}
+```
+
+Lowered conceptually into:
+
+- Factory:
+  - allocate leaf scope instance
+  - build scopes array
+  - return `JavaScriptRuntime.GeneratorObject` with `Step` delegate + scopes
+
+- Step method:
+  - `switch (_genState)`
+  - case 0: init locals; set state=1; return `{ value: a, done:false }`
+  - case 1: set state=2; return `{ value: 2, done:false }`
+  - case 2: mark done; return `{ value: 3, done:true }`
+
+### 6.2. `yield` expression result wiring
+
+At each suspension point, the generator must resume with either:
+
+- a **value** from `next(v)` that becomes the yield-expression result
+- an **exception** from `throw(e)` that is thrown at the suspension point
+- a **forced return** from `return(v)` that unwinds and completes
+
+Plan:
+
+- When `Step(op,arg)` is called:
+  - if `op==Next` and not started: ignore `arg`
+  - store `arg` into `_resumeValue` for later consumption
+  - if `op==Throw`: store into `_resumeException` and set `_hasResumeException`
+  - if `op==Return`: store into `_returnValue` and set `_hasReturn`
+
+Then, immediately before executing code “after a yield”, emit:
+
+- if `_hasReturn`: jump to a dedicated completion/unwind path
+- else if `_hasResumeException`: clear flag and `throw _resumeException`
+- else: use `_resumeValue` as the yield expression value
+
+### 6.3. `try/catch/finally`
+
+`finally` must run when:
+
+- the generator completes normally
+- the caller invokes `return(v)`
+- the caller invokes `throw(e)` and it propagates out
+
+Plan (phase-based):
+
+- Phase 1: support `try/catch` around yields (propagate correctly).
+- Phase 2: support `finally` by adding explicit unwind labels and storing an unwind “reason” in scope:
+  - `int _unwindKind` (0=none, 1=return, 2=throw)
+  - `object? _unwindValue`
+
+This mirrors the async lowering style: switch-based resume + explicit labels for try regions.
+
+### 6.4. `yield* iterable`
+
+`yield*` delegates iteration to another iterator.
+
+Plan:
+
+- Lower `yield* expr` into a small nested “delegation” sub-state machine:
+  - Evaluate `expr` once
+  - Get an iterator from runtime (`RuntimeServices.GetIterator(expr)` or similar)
+  - Repeatedly call `.next(resumeValue)` and yield each produced value
+  - If caller calls `throw(e)`, forward to inner `.throw(e)` if present; otherwise throw into outer generator
+  - If caller calls `return(v)`, forward to inner `.return(v)` if present; otherwise complete outer
+  - When inner is done, the `yield*` expression evaluates to the inner iterator’s completion value
+
+This requires a runtime helper for “get iterator” and optional `throw/return` forwarding.
+
+## 7. Compiler work breakdown
+
+### 7.1. Parser / AST validation
+
+- Accept `FunctionDeclaration` / `FunctionExpression` / `MethodDefinition` with generator flag.
+- Validate `yield` only inside generator bodies.
+- Validate `yield*` only inside generator bodies.
+
+### 7.2. Symbol table / scopes
+
+- Ensure generator bodies still follow scope-as-class rules.
+- Spill across yields:
+  - any local that is live across a `yield` becomes a field on the leaf scope.
+
+### 7.3. IR
+
+- Add HIR nodes:
+  - `HIRYieldExpression` (value expression, location)
+  - `HIRYieldStarExpression` (iterable expression, location)
+- LIR:
+  - `LIRYield` / `LIRYieldStar` or reuse a generalized “suspend” instruction, similar to async’s `LIRAwait`.
+
+### 7.4. IL emission
+
+- Add a generator-oriented orchestrator similar to `JavaScriptFunctionGenerator`:
+  - Emits factory + step method
+  - Emits a `switch` over `_genState`
+  - Emits resume plumbing for Next/Throw/Return
+
+### 7.5. Runtime additions (proposed)
+
+- `JavaScriptRuntime.GeneratorObject`
+  - stores scopes + step delegate
+  - methods: `next`, `throw`, `return`
+- `JavaScriptRuntime.IteratorResult`
+  - either a tiny class/struct or an ExpandoObject creator helper
+- Optional: `RuntimeServices.GetIterator(obj)` and helpers for `yield*`
+
+## 8. Testing plan
+
+Add tests under `Js2IL.Tests/Generator/`:
+
+1. Basic yield sequence:
+   - `g().next()` returns expected `{value,done}` triples
+2. Passing values into `next(v)`:
+   - `const x = yield 1; console.log(x);`
+3. `throw(e)` into suspended generator:
+   - caught and uncaught cases
+4. `return(v)`:
+   - completes and runs `finally`
+5. `yield*`:
+   - delegates over arrays and over another generator
+
+Execution tests should validate observable JS behavior; generator tests can snapshot IL for stability.
+
+## 9. Rollout phases
+
+- **Phase 1 (MVP)**: `function*`, `yield`, `next()`, completion via `return` statement in body.
+- **Phase 2**: `throw` and `return` methods on generator object; `try/catch/finally` support.
+- **Phase 3**: `yield*` delegation semantics.
+- **Phase 4**: Generator methods in classes/object literals + `super`/`this` interactions.
+
+---
+
+This document is a plan/spec and intentionally leaves some runtime/API naming flexible so we can fit it cleanly into existing `JavaScriptRuntime` patterns.

--- a/docs/adr/0002-resumable-state-scope-vs-stateobject.md
+++ b/docs/adr/0002-resumable-state-scope-vs-stateobject.md
@@ -1,0 +1,113 @@
+# ADR 0002: Resumable Callable State Storage (Scope-Attached vs Separate State Object)
+
+- Date: 2026-01-17
+- Status: Proposed
+
+## Context
+
+JS2IL lowers certain JavaScript constructs into **resumable** execution:
+
+- `async function` / `await` (already implemented)
+- `function*` / `yield` / `yield*` (planned)
+
+Resumable execution requires persisting state across suspension points:
+
+- a program counter (state id)
+- spill slots for locals/temps that are live across suspension
+- bookkeeping for exceptional resume (`throw`) and forced completion (`return`)
+
+JS2IL’s core compilation model is **scope-as-class**:
+
+- Every JS scope becomes a .NET class.
+- Variables become fields on that scope instance.
+- Closures are implemented by allocating scope instances and passing them through a `scopes` array ABI.
+
+Given this, we must choose where to store resumable state:
+
+1. Attach resumable state to the **leaf scope instance** (per invocation) that JS2IL already allocates.
+2. Allocate a **separate state-machine object** (activation record) to hold resumable state.
+
+This ADR is about both async/await and synchronous generators because the tradeoffs are largely shared.
+
+## Decision (proposed)
+
+Prefer **scope-attached resumable state** as the default strategy:
+
+- Store resumable state (e.g., `_asyncState` / `_genState` plus spill fields) on the **leaf scope instance** for that invocation.
+- Keep any protocol wrapper objects minimal:
+  - async: the returned `Promise` / resolver handles
+  - generators: a small generator object exposing `next/throw/return` that calls into a compiled step function
+
+This choice aligns with the existing JS2IL architecture and minimizes additional mandatory allocations.
+
+## Consequences
+
+### Positive
+
+- **Avoids an extra allocation per invocation** in the common case.
+  - The leaf scope instance must exist anyway for closure semantics.
+- **Unified lifetime model**:
+  - Variables captured by closures and variables spilled across `await`/`yield` share the same storage mechanism.
+- **Simpler plumbing**:
+  - No need to synchronize a separate state machine object with a scope instance.
+- **Naturally supports closures** in resumable callables:
+  - Resumed execution already has access to the correct scope chain via the scope instance.
+
+### Negative
+
+- **Leaf scope bloat**:
+  - Adding resumable fields and many spill slots can increase memory footprint of the scope object.
+- **Potentially worse locality**:
+  - A monolithic scope object can mix unrelated fields (closure vars + spill slots + bookkeeping).
+- **Harder to optimize with pooling / structs**:
+  - Separate state objects are sometimes easier to pool or specialize (though pooling is complicated for JS semantics).
+
+### Mitigations
+
+- **Hybrid approach** (recommended even with scope-attached state):
+  - Keep “protocol” objects small and store only what must persist in the scope.
+  - For generators, keep iterator protocol bookkeeping minimal in the generator object and store spill slots/state in the scope.
+- **Minimize spill fields**:
+  - Only promote locals to scope fields when they are live across suspension points.
+- **Typed locals optimization**:
+  - Continue using strongly-typed scope locals where possible to avoid extra casts; keep step methods optimized.
+
+## Alternatives Considered
+
+### 1) Separate state-machine object per resumable invocation
+
+**Description**: allocate an activation/state object that stores `_state` and spill slots; the scope instance only stores closure variables.
+
+**Pros**
+
+- Potentially **smaller leaf scope objects** for functions that are resumable but have few captured variables.
+- State object can be **layout-optimized** specifically for the state machine.
+- Clear conceptual separation: scope = closures, state object = suspension.
+
+**Cons**
+
+- **Extra allocation** per async invocation (and per generator invocation) becomes unavoidable.
+- Additional indirection and plumbing:
+  - step method must reference both the scope chain and the state object
+  - careful lifetime handling needed when closures reference state
+- Can become complex when closures and spilled locals overlap:
+  - values may need to move between scope and state object or be duplicated.
+
+### 2) .NET compiler-generated state machines (C#-style)
+
+**Description**: emit a struct/class similar to C# async/generator state machines.
+
+Rejected because JS2IL’s runtime model and ABI differs:
+
+- Scope-as-class is already the closure mechanism.
+- JS semantics (dynamic types, `this`, `arguments`, `with`-like patterns, etc.) complicate using idiomatic C# patterns directly.
+- It would likely introduce significant churn in IL emission and runtime conventions.
+
+## Notes
+
+- This ADR does not lock in the exact runtime surface for generators. It only records the state-storage decision.
+- If memory footprint becomes an issue, we can revisit and adopt more of the hybrid strategy (or selectively use a separate state object for specific cases).
+
+## References
+
+- [Synchronous Generator Lowering Spec](../SynchronousGenerators_LoweringSpec.md)


### PR DESCRIPTION
Adds documentation cross-links and section numbering for easier referencing, and introduces a runtime base class to hold generator resumable state.

Changes:
- JavaScriptRuntime.GeneratorScope base class with standard generator fields
- Generator lowering spec: numbered sections + ADR link
- ADR 0002: back-reference to generator lowering spec