### PR TITLE
docs(ecma262): generator sections + HTML extraction tooling

### DIFF
--- a/docs/ECMA262/Section27_3.md
+++ b/docs/ECMA262/Section27_3.md
@@ -4,6 +4,135 @@
 
 [Back to Section27](Section27.md) | [Back to Index](Index.md)
 
+_Lists clause numbers/titles/links only (no spec text) in the index above. See appendix for extracted spec text._ 
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 27.3 | GeneratorFunction Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 27.3.1 | The GeneratorFunction Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-constructor) |
+| 27.3.1.1 | GeneratorFunction ( ...parameterArgs, bodyArg ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction) |
+| 27.3.2 | Properties of the GeneratorFunction Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-constructor) |
+| 27.3.2.1 | GeneratorFunction.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype) |
+| 27.3.3 | Properties of the GeneratorFunction Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object) |
+| 27.3.3.1 | GeneratorFunction.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype.constructor) |
+| 27.3.3.2 | GeneratorFunction.prototype.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype) |
+| 27.3.3.3 | GeneratorFunction.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype-%symbol.tostringtag%) |
+| 27.3.4 | GeneratorFunction Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances) |
+| 27.3.4.1 | length | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-length) |
+| 27.3.4.2 | name | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-name) |
+| 27.3.4.3 | prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-prototype) |
+
+## Appendix: Extracted Spec Text (Converted)
+
+This appendix is generated from a locally extracted tc39.es HTML fragment. It may be overwritten if this file is regenerated.
+
+### 27.3 GeneratorFunction Objects
+
+GeneratorFunctions are functions that are usually created by evaluating [GeneratorDeclaration](ecmascript-language-functions-and-classes.html#prod-GeneratorDeclaration)s, [GeneratorExpression](ecmascript-language-functions-and-classes.html#prod-GeneratorExpression)s, and [GeneratorMethod](ecmascript-language-functions-and-classes.html#prod-GeneratorMethod)s. They may also be created by calling the [%GeneratorFunction%](control-abstraction-objects.html#sec-generatorfunction-constructor) intrinsic.
+
+    Figure 6 (Informative): Generator Objects Relationships
+
+### 27.3.1 The GeneratorFunction Constructor
+
+The GeneratorFunction [constructor](ecmascript-data-types-and-values.html#constructor):
+
+- is %GeneratorFunction%.
+
+- is a subclass of `Function`.
+
+- creates and initializes a new GeneratorFunction when called as a function rather than as a [constructor](ecmascript-data-types-and-values.html#constructor). Thus the function call `GeneratorFunction (…)` is equivalent to the object creation expression `new GeneratorFunction (…)` with the same arguments.
+
+- may be used as the value of an `extends` clause of a class definition. Subclass [constructors](ecmascript-data-types-and-values.html#constructor) that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction [constructor](ecmascript-data-types-and-values.html#constructor) to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator [function objects](ecmascript-data-types-and-values.html#function-object) create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.
+
+### 27.3.1.1 GeneratorFunction ( ...`parameterArgs`, `bodyArg` )
+
+The last argument (if any) specifies the body (executable code) of a generator function; any preceding arguments specify formal parameters.
+
+This function performs the following steps when called:
+
+- Let `C` be the [active function object](executable-code-and-execution-contexts.html#active-function-object).
+- If `bodyArg` is not present, set `bodyArg` to the empty String.
+- Return ? [CreateDynamicFunction](fundamental-objects.html#sec-createdynamicfunction)(`C`, NewTarget, `generator`, `parameterArgs`, `bodyArg`).
+
+	Note
+
+See NOTE for [20.2.1.1](fundamental-objects.html#sec-function-p1-p2-pn-body).
+
+### 27.3.2 Properties of the GeneratorFunction Constructor
+
+The GeneratorFunction [constructor](ecmascript-data-types-and-values.html#constructor):
+
+- is a standard built-in [function object](ecmascript-data-types-and-values.html#function-object) that inherits from the Function [constructor](ecmascript-data-types-and-values.html#constructor).
+
+- has a `[[Prototype]]` internal slot whose value is [%Function%](fundamental-objects.html#sec-function-constructor).
+
+- has a "length" property whose value is `1`𝔽.
+
+- has a "name" property whose value is "GeneratorFunction".
+
+- has the following properties:
+
+### 27.3.2.1 GeneratorFunction.prototype
+
+The initial value of `GeneratorFunction.prototype` is the [GeneratorFunction prototype object](control-abstraction-objects.html#sec-properties-of-the-generatorfunction-prototype-object).
+
+This property has the attributes { `[[Writable]]`: `false`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `false` }.
+
+### 27.3.3 Properties of the GeneratorFunction Prototype Object
+
+The GeneratorFunction prototype object:
+
+- is %GeneratorFunction.prototype% (see [Figure 6](control-abstraction-objects.html#figure-2)).
+
+- is an [ordinary object](ecmascript-data-types-and-values.html#ordinary-object).
+
+- is not a [function object](ecmascript-data-types-and-values.html#function-object) and does not have an `[[ECMAScriptCode]]` internal slot or any other of the internal slots listed in [Table 28](ordinary-and-exotic-objects-behaviours.html#table-internal-slots-of-ecmascript-function-objects) or [Table 91](control-abstraction-objects.html#table-internal-slots-of-generator-instances).
+
+- has a `[[Prototype]]` internal slot whose value is [%Function.prototype%](fundamental-objects.html#sec-properties-of-the-function-prototype-object).
+
+### 27.3.3.1 GeneratorFunction.prototype.constructor
+
+The initial value of `GeneratorFunction.prototype.constructor` is [%GeneratorFunction%](control-abstraction-objects.html#sec-generatorfunction-constructor).
+
+This property has the attributes { `[[Writable]]`: `false`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `true` }.
+
+### 27.3.3.2 GeneratorFunction.prototype.prototype
+
+The initial value of `GeneratorFunction.prototype.prototype` is [%GeneratorPrototype%](control-abstraction-objects.html#sec-properties-of-generator-prototype).
+
+This property has the attributes { `[[Writable]]`: `false`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `true` }.
+
+### 27.3.3.3 GeneratorFunction.prototype [ %Symbol.toStringTag% ]
+
+The initial value of the [%Symbol.toStringTag%](ecmascript-data-types-and-values.html#sec-well-known-symbols) property is the String value "GeneratorFunction".
+
+This property has the attributes { `[[Writable]]`: `false`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `true` }.
+
+### 27.3.4 GeneratorFunction Instances
+
+Every GeneratorFunction instance is an ECMAScript [function object](ecmascript-data-types-and-values.html#function-object) and has the internal slots listed in [Table 28](ordinary-and-exotic-objects-behaviours.html#table-internal-slots-of-ecmascript-function-objects). The value of the `[[IsClassConstructor]]` internal slot for all such instances is `false`.
+
+Each GeneratorFunction instance has the following own properties:
+
+### 27.3.4.1 length
+
+The specification for the "length" property of Function instances given in [20.2.4.1](fundamental-objects.html#sec-function-instances-length) also applies to GeneratorFunction instances.
+
+### 27.3.4.2 name
+
+The specification for the "name" property of Function instances given in [20.2.4.2](fundamental-objects.html#sec-function-instances-name) also applies to GeneratorFunction instances.
+
+### 27.3.4.3 prototype
+
+Whenever a GeneratorFunction instance is created another [ordinary object](ecmascript-data-types-and-values.html#ordinary-object) is also created and is the initial value of the generator function's "prototype" property. The value of the prototype property is used to initialize the `[[Prototype]]` internal slot of a newly created Generator when the generator [function object](ecmascript-data-types-and-values.html#function-object) is invoked using `[[Call]]`.
+
+This property has the attributes { `[[Writable]]`: `true`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `false` }.
+
+	Note
+
+Unlike Function instances, the object that is the value of a GeneratorFunction's "prototype" property does not have a "constructor" property whose value is the GeneratorFunction instance.

--- a/docs/ECMA262/Section27_4.md
+++ b/docs/ECMA262/Section27_4.md
@@ -4,6 +4,25 @@
 
 [Back to Section27](Section27.md) | [Back to Index](Index.md)
 
+_Lists clause numbers/titles/links only (no spec text)._ 
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 27.4 | AsyncGeneratorFunction Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 27.4.1 | The AsyncGeneratorFunction Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor) |
+| 27.4.1.1 | AsyncGeneratorFunction ( ...parameterArgs, bodyArg ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction) |
+| 27.4.2 | Properties of the AsyncGeneratorFunction Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction) |
+| 27.4.2.1 | AsyncGeneratorFunction.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype) |
+| 27.4.3 | Properties of the AsyncGeneratorFunction Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction-prototype) |
+| 27.4.3.1 | AsyncGeneratorFunction.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-constructor) |
+| 27.4.3.2 | AsyncGeneratorFunction.prototype.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-prototype) |
+| 27.4.3.3 | AsyncGeneratorFunction.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-%symbol.tostringtag%) |
+| 27.4.4 | AsyncGeneratorFunction Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instances) |
+| 27.4.4.1 | length | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-length) |
+| 27.4.4.2 | name | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-name) |
+| 27.4.4.3 | prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-prototype) |

--- a/docs/ECMA262/Section27_5.md
+++ b/docs/ECMA262/Section27_5.md
@@ -4,6 +4,29 @@
 
 [Back to Section27](Section27.md) | [Back to Index](Index.md)
 
+_Lists clause numbers/titles/links only (no spec text)._ 
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 27.5 | Generator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 27.5.1 | The %GeneratorPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-generator-prototype) |
+| 27.5.1.1 | %GeneratorPrototype%.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.constructor) |
+| 27.5.1.2 | %GeneratorPrototype%.next ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.next) |
+| 27.5.1.3 | %GeneratorPrototype%.return ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.return) |
+| 27.5.1.4 | %GeneratorPrototype%.throw ( exception ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.throw) |
+| 27.5.1.5 | %GeneratorPrototype% [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype-%symbol.tostringtag%) |
+| 27.5.2 | Properties of Generator Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-generator-instances) |
+| 27.5.3 | Generator Abstract Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator-abstract-operations) |
+| 27.5.3.1 | GeneratorStart ( generator, generatorBody ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorstart) |
+| 27.5.3.2 | GeneratorValidate ( generator, generatorBrand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorvalidate) |
+| 27.5.3.3 | GeneratorResume ( generator, value, generatorBrand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorresume) |
+| 27.5.3.4 | GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorresumeabrupt) |
+| 27.5.3.5 | GetGeneratorKind ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getgeneratorkind) |
+| 27.5.3.6 | GeneratorYield ( iteratorResult ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatoryield) |
+| 27.5.3.7 | Yield ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-yield) |
+| 27.5.3.8 | CreateIteratorFromClosure ( closure, generatorBrand, generatorPrototype [ , extraSlots ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-createiteratorfromclosure) |

--- a/docs/ECMA262/Section27_6.md
+++ b/docs/ECMA262/Section27_6.md
@@ -4,6 +4,31 @@
 
 [Back to Section27](Section27.md) | [Back to Index](Index.md)
 
+_Lists clause numbers/titles/links only (no spec text)._ 
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 27.6 | AsyncGenerator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 27.6.1 | The %AsyncGeneratorPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-prototype) |
+| 27.6.1.1 | %AsyncGeneratorPrototype%.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-constructor) |
+| 27.6.1.2 | %AsyncGeneratorPrototype%.next ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next) |
+| 27.6.1.3 | %AsyncGeneratorPrototype%.return ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return) |
+| 27.6.1.4 | %AsyncGeneratorPrototype%.throw ( exception ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw) |
+| 27.6.1.5 | %AsyncGeneratorPrototype% [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-%symbol.tostringtag%) |
+| 27.6.2 | Properties of AsyncGenerator Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-intances) |
+| 27.6.3 | AsyncGenerator Abstract Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-abstract-operations) |
+| 27.6.3.1 | AsyncGeneratorRequest Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorrequest-records) |
+| 27.6.3.2 | AsyncGeneratorStart ( generator, generatorBody ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorstart) |
+| 27.6.3.3 | AsyncGeneratorValidate ( generator, generatorBrand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorvalidate) |
+| 27.6.3.4 | AsyncGeneratorEnqueue ( generator, completion, promiseCapability ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorenqueue) |
+| 27.6.3.5 | AsyncGeneratorCompleteStep ( generator, completion, done [ , realm ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorcompletestep) |
+| 27.6.3.6 | AsyncGeneratorResume ( generator, completion ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorresume) |
+| 27.6.3.7 | AsyncGeneratorUnwrapYieldResumption ( resumptionValue ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorunwrapyieldresumption) |
+| 27.6.3.8 | AsyncGeneratorYield ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratoryield) |
+| 27.6.3.9 | AsyncGeneratorAwaitReturn ( generator ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn) |
+| 27.6.3.10 | AsyncGeneratorDrainQueue ( generator ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue) |

--- a/docs/ECMA262/readme.md
+++ b/docs/ECMA262/readme.md
@@ -1,0 +1,58 @@
+# ECMA-262 Docs Workflow (docs/ECMA262)
+
+This directory contains JS2IL’s **ECMA-262 coverage index** and per-section “hub” documents.
+
+Important conventions
+- These markdown files are **indexes only**: clause numbers, titles, status, and links.
+- They intentionally **do not copy spec text** into this repo.
+- Status values come from the project’s feature coverage tracking (see docs/ECMA262/Index.md).
+
+Exception
+- If explicitly requested, a section file may include an **appendix** containing converted/extracted spec text as a derived artifact.
+
+## How section docs are generated and maintained
+
+There are two related workflows:
+
+### 1) Split/rollup generation (automated)
+
+Scripts
+- scripts/splitEcma262SectionsIntoSubsections.js (primary)
+- scripts/splitEcma262SectionsIntoSubsections.ps1 (wrapper)
+
+What it does
+- Generates/updates subsection documents (e.g. Section27_3.md) from a parent section’s clause table when applicable.
+- Rebuilds hub pages and updates Index.md rollups.
+
+When to use it
+- After updating the top-level section tables / coverage metadata and you want the subsection docs and rollups refreshed.
+
+### 2) “Structural sync” of a subsection file (manual, links-only)
+
+Sometimes a subsection document exists only as a **stub** (single row) and needs its **subclause structure** filled in so it mirrors the current ECMA-262 clause layout (still links-only).
+
+We do that by extracting the authoritative clause ids/titles from tc39.es and then updating the corresponding markdown table.
+
+Tooling used
+- scripts/extractEcma262SectionHtml.js
+
+Steps
+1. Extract the HTML for the section you want to sync (auto-discovery mode):
+   - node scripts/extractEcma262SectionHtml.js --section 27.6 --auto --no-wrap --out test_output/ecma262-27.6.html
+2. From the extracted HTML, identify each subclause’s:
+   - Section number (from <span class="secnum">…)
+   - Title (from the <h1> text)
+   - Anchor id (from <emu-clause id="…">)
+3. Update the corresponding docs/ECMA262/SectionXX_Y.md file:
+   - Keep it **links-only**.
+   - Add a “## Subclauses” table with columns: Clause | Title | Status | Spec.
+   - For the Spec link, use the extracted id:
+     - https://tc39.es/ecma262/#<id>
+
+Notes
+- Prefer copying the title text as rendered in the heading (including %…% and %Symbol.toStringTag% forms).
+- The extracted HTML is a scratch artifact; it does not need to be committed.
+
+## Repo-local linking
+
+Other docs in this repo may link to these indexes using repo-relative paths under docs/ECMA262/ (instead of linking directly to tc39.es). This keeps cross-references stable and reviewable.

--- a/docs/SynchronousGenerators_LoweringSpec.md
+++ b/docs/SynchronousGenerators_LoweringSpec.md
@@ -26,11 +26,35 @@
 - **Resume**: a subsequent `next/throw/return` call.
 - **Leaf scope**: per-invocation scope instance allocated for the generator body (JS2IL “scope-as-class”).
 
+### 3.1. ECMA-262 references (local docs)
+
+Primary ECMA-262 sections relevant to synchronous generators:
+
+- Index / navigation: [docs/ECMA262/Index.md](ECMA262/Index.md)
+- Generator syntax + semantics:
+  - Generator Function Definitions: [docs/ECMA262/Section15_5.md](ECMA262/Section15_5.md)
+  - Method Definitions (generator methods are a form of method definition): [docs/ECMA262/Section15_4.md](ECMA262/Section15_4.md)
+- Generator runtime objects:
+  - GeneratorFunction Objects: [docs/ECMA262/Section27_3.md](ECMA262/Section27_3.md)
+  - Generator Objects (`next`/`throw`/`return`): [docs/ECMA262/Section27_5.md](ECMA262/Section27_5.md)
+- Iterator protocol and iterator closing used by `yield*`:
+  - Operations on Iterator Objects: [docs/ECMA262/Section7_4.md](ECMA262/Section7_4.md)
+- Statements that interact with generator control flow:
+  - The `return` Statement: [docs/ECMA262/Section14_10.md](ECMA262/Section14_10.md)
+  - The `throw` Statement: [docs/ECMA262/Section14_14.md](ECMA262/Section14_14.md)
+  - The `try` Statement: [docs/ECMA262/Section14_15.md](ECMA262/Section14_15.md)
+
+Coverage tracking reference:
+
+- [docs/ECMA262/FeatureCoverage.md](ECMA262/FeatureCoverage.md)
+
 ## 4. Semantics Summary
 
 ### 4.1. Calling a generator function
 
 Calling a generator function does **not** execute the body immediately.
+
+Reference: [docs/ECMA262/Section15_5.md](ECMA262/Section15_5.md), [docs/ECMA262/Section27_5.md](ECMA262/Section27_5.md)
 
 - It returns a generator object `gen`.
 - The body runs only when `gen.next(...)` / `gen.throw(...)` / `gen.return(...)` is invoked.
@@ -54,16 +78,22 @@ JS2IL runtime will model this as an `ExpandoObject` (or a small dedicated runtim
 - Produces `{ value: <expr>, done: false }` and suspends.
 - When resumed by `next(v)`, the `yield expr` expression evaluates to `v`.
 
+Reference: [docs/ECMA262/Section15_5.md](ECMA262/Section15_5.md)
+
 ### 4.5. `throw(error)`
 
 - Resumes the generator by throwing `error` at the suspended `yield`.
 - If not caught in the generator, the call to `throw` rethrows to the caller and the generator becomes completed.
+
+Reference: [docs/ECMA262/Section27_5.md](ECMA262/Section27_5.md), [docs/ECMA262/Section14_14.md](ECMA262/Section14_14.md), [docs/ECMA262/Section14_15.md](ECMA262/Section14_15.md)
 
 ### 4.6. `return(value)`
 
 - Forces generator completion.
 - Runs any pending `finally` blocks.
 - Returns `{ value, done: true }`.
+
+Reference: [docs/ECMA262/Section27_5.md](ECMA262/Section27_5.md), [docs/ECMA262/Section14_10.md](ECMA262/Section14_10.md), [docs/ECMA262/Section14_15.md](ECMA262/Section14_15.md)
 
 ## 5. High-level lowering strategy
 
@@ -201,6 +231,8 @@ This mirrors the async lowering style: switch-based resume + explicit labels for
 ### 6.4. `yield* iterable`
 
 `yield*` delegates iteration to another iterator.
+
+Reference: [docs/ECMA262/Section7_4.md](ECMA262/Section7_4.md), [docs/ECMA262/Section15_5.md](ECMA262/Section15_5.md)
 
 Plan:
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "verify:update:root": "node scripts/updateVerifiedFiles.js --root Js2IL.Tests",
     "generate:ecma262-subsections": "node scripts/splitEcma262SectionsIntoSubsections.js",
     "generate:node-support": "node scripts/generateNodeSupportMd.js",
+    "ecma262:extract-section-html": "node scripts/extractEcma262SectionHtml.js",
     "release:patch": "node scripts/bumpVersion.js patch",
     "release:minor": "node scripts/bumpVersion.js minor",
     "release:major": "node scripts/bumpVersion.js major",

--- a/scripts/convertEcmaExtractHtmlToMarkdown.js
+++ b/scripts/convertEcmaExtractHtmlToMarkdown.js
@@ -1,0 +1,163 @@
+/*
+ * Convert an extracted ECMA-262 multipage HTML fragment (typically produced by
+ * scripts/extractEcma262SectionHtml.js --no-wrap) into a Markdown approximation.
+ *
+ * This is intentionally dependency-free; it handles the common HTML tags and
+ * ecmarkup custom elements found in tc39.es.
+ *
+ * Usage:
+ *   node scripts/convertEcmaExtractHtmlToMarkdown.js --in test_output/ecma262-27.3.html --out test_output/ecma262-27.3.md
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs(argv) {
+  const args = { inFile: '', outFile: '' };
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+
+    if (a === '--in' || a === '-i') {
+      args.inFile = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--in=')) {
+      args.inFile = a.substring('--in='.length);
+      continue;
+    }
+
+    if (a === '--out' || a === '-o') {
+      args.outFile = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--out=')) {
+      args.outFile = a.substring('--out='.length);
+      continue;
+    }
+  }
+
+  return args;
+}
+
+function decodeEntities(s) {
+  return s
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(parseInt(dec, 10)));
+}
+
+function stripTags(s) {
+  return s.replace(/<[^>]+>/g, '');
+}
+
+function convertHtmlToMarkdown(html) {
+  let text = html.replace(/\r\n/g, '\n');
+
+  // Convert <pre> blocks first, replacing them with placeholders.
+  const preBlocks = [];
+  text = text.replace(/<pre\b[\s\S]*?<\/pre>/gi, (block) => {
+    const idx = preBlocks.length;
+
+    const langMatch = /class=["'][^"']*language-([^"'\s]+)[^"']*["']/i.exec(block);
+    const lang = (langMatch && langMatch[1]) || '';
+
+    // Prefer inner <code> content if present.
+    let inner = block;
+    inner = inner.replace(/^[\s\S]*?<code\b[^>]*>/i, '');
+    inner = inner.replace(/<\/code>[\s\S]*$/i, '');
+
+    inner = decodeEntities(stripTags(inner));
+
+    const fence = '```' + (lang ? ` ${lang}` : '');
+    preBlocks.push(`\n${fence}\n${inner.trim()}\n\`\`\`\n`);
+
+    return `@@PRE_${idx}@@`;
+  });
+
+  // Anchors
+  text = text.replace(
+    /<a\b[^>]*href=\"([^\"]+)\"[^>]*>([\s\S]*?)<\/a>/gi,
+    (_, href, inner) => {
+      const label = decodeEntities(stripTags(inner)).replace(/\s+/g, ' ').trim();
+      return `[${label}](${href})`;
+    }
+  );
+
+  // Headings (ecmarkup tends to use h1 repeatedly inside nested clauses)
+  text = text.replace(/<h1\b[^>]*>/gi, '\n\n### ').replace(/<\/h1>/gi, '\n');
+  text = text.replace(/<h2\b[^>]*>/gi, '\n\n#### ').replace(/<\/h2>/gi, '\n');
+  text = text.replace(/<h3\b[^>]*>/gi, '\n\n##### ').replace(/<\/h3>/gi, '\n');
+
+  // Paragraph-ish
+  text = text.replace(/<p\b[^>]*>/gi, '\n\n').replace(/<\/p>/gi, '\n');
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+
+  // Lists
+  text = text.replace(/<li\b[^>]*>/gi, '\n- ').replace(/<\/li>/gi, '');
+  text = text.replace(/<ul\b[^>]*>/gi, '\n').replace(/<\/ul>/gi, '\n');
+  text = text.replace(/<ol\b[^>]*>/gi, '\n').replace(/<\/ol>/gi, '\n');
+
+  // Inline code-ish elements
+  text = text.replace(/<code\b[^>]*>/gi, '`').replace(/<\/code>/gi, '`');
+  text = text.replace(/<var\b[^>]*>/gi, '`').replace(/<\/var>/gi, '`');
+  text = text.replace(/<emu-val\b[^>]*>/gi, '`').replace(/<\/emu-val>/gi, '`');
+  text = text.replace(/<emu-const\b[^>]*>/gi, '`').replace(/<\/emu-const>/gi, '`');
+
+  // Drop remaining tags (including emu-* wrappers)
+  text = stripTags(text);
+  text = decodeEntities(text);
+
+  // Restore pre blocks
+  for (let i = 0; i < preBlocks.length; i++) {
+    text = text.replace(`@@PRE_${i}@@`, preBlocks[i]);
+  }
+
+  // Cleanup
+  text = text
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{4,}/g, '\n\n\n')
+    .trim();
+
+  return text + '\n';
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.inFile) throw new Error('Missing --in <input.html>');
+  if (!args.outFile) throw new Error('Missing --out <output.md>');
+
+  const inPath = path.resolve(process.cwd(), args.inFile);
+  const outPath = path.resolve(process.cwd(), args.outFile);
+
+  const html = fs.readFileSync(inPath, 'utf8');
+  const md = convertHtmlToMarkdown(html);
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, md, 'utf8');
+
+  // eslint-disable-next-line no-console
+  console.log(`Converted ${args.inFile} -> ${args.outFile} (${md.split(/\n/).length} lines)`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err && err.message ? err.message : err);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/extractEcma262SectionHtml.js
+++ b/scripts/extractEcma262SectionHtml.js
@@ -1,0 +1,562 @@
+/*
+ * Extract a section's HTML from a locally saved ECMA-262 multipage HTML file.
+ *
+ * Why local input?
+ * - This avoids baking "download the spec" behavior into the repo tooling.
+ * - You can point it at an HTML file you already have (e.g. saved from tc39.es).
+ *
+ * Usage:
+ *   node scripts/extractEcma262SectionHtml.js --section 27.3 --in control-abstraction-objects.html --out Section27_3.html
+ *   node scripts/extractEcma262SectionHtml.js --section 27.3 --url https://tc39.es/ecma262/multipage/control-abstraction-objects.html --out Section27_3.html
+ *
+ * Options:
+ *   --section, -s   Section number to extract (e.g. 27.3)
+ *   --in, -i        Input HTML file path
+ *   --url, -u       Fetch input HTML from URL instead of --in
+ *   --auto          Auto-discover the correct multipage URL from the multipage index (implies network fetch)
+ *   --index-url     Multipage index URL used by --auto (default: https://tc39.es/ecma262/multipage/)
+ *   --out, -o       Output file path
+ *   --id            Explicit element id to extract (e.g. sec-generatorfunction-objects)
+ *   --wrap          Wrap output as standalone HTML (default)
+ *   --no-wrap       Output only the extracted element HTML
+ *   --base          Optional <base href="..."> to inject when wrapping
+ *   --help, -h      Show help
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+function parseArgs(argv) {
+  const args = {
+    section: '',
+    inFile: '',
+    url: '',
+    auto: false,
+    indexUrl: 'https://tc39.es/ecma262/multipage/',
+    outFile: '',
+    id: '',
+    wrap: true,
+    baseHref: '',
+    help: false,
+  };
+
+  const positionals = [];
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+
+    if (a === '--help' || a === '-h') {
+      args.help = true;
+      continue;
+    }
+
+    if (a === '--section' || a === '-s') {
+      args.section = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--section=')) {
+      args.section = a.substring('--section='.length);
+      continue;
+    }
+
+    if (a === '--in' || a === '-i') {
+      args.inFile = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--in=')) {
+      args.inFile = a.substring('--in='.length);
+      continue;
+    }
+
+    if (a === '--url' || a === '-u') {
+      args.url = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--url=')) {
+      args.url = a.substring('--url='.length);
+      continue;
+    }
+
+    if (a === '--auto') {
+      args.auto = true;
+      continue;
+    }
+
+    if (a === '--index-url') {
+      args.indexUrl = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--index-url=')) {
+      args.indexUrl = a.substring('--index-url='.length);
+      continue;
+    }
+
+    if (a === '--out' || a === '-o') {
+      args.outFile = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--out=')) {
+      args.outFile = a.substring('--out='.length);
+      continue;
+    }
+
+    if (a === '--id') {
+      args.id = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--id=')) {
+      args.id = a.substring('--id='.length);
+      continue;
+    }
+
+    if (a === '--wrap') {
+      args.wrap = true;
+      continue;
+    }
+
+    if (a === '--no-wrap') {
+      args.wrap = false;
+      continue;
+    }
+
+    if (a === '--base') {
+      args.baseHref = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--base=')) {
+      args.baseHref = a.substring('--base='.length);
+      continue;
+    }
+
+    positionals.push(a);
+  }
+
+  // Positional fallback:
+  //   node script.js 27.3 input.html output.html
+  if (!args.section && positionals.length >= 1) args.section = positionals[0];
+  if (!args.inFile && !args.url && positionals.length >= 2) args.inFile = positionals[1];
+  if (!args.outFile && positionals.length >= 3) args.outFile = positionals[2];
+
+  return args;
+}
+
+function fetchTextWithHttps(urlString, maxRedirects = 5) {
+  return new Promise((resolve, reject) => {
+    let urlObj;
+    try {
+      urlObj = new URL(urlString);
+    } catch {
+      reject(new Error(`Invalid URL: ${urlString}`));
+      return;
+    }
+
+    if (urlObj.protocol !== 'https:') {
+      reject(new Error(`Only https:// URLs are supported by the https fallback. Got: ${urlString}`));
+      return;
+    }
+
+    const req = https.request(
+      urlObj,
+      {
+        method: 'GET',
+        headers: {
+          // Avoid needing to implement gzip/br decoding.
+          'Accept-Encoding': 'identity',
+          'User-Agent': 'js2il-docs-script',
+        },
+      },
+      (res) => {
+        const status = res.statusCode || 0;
+        const location = res.headers.location;
+
+        if (status >= 300 && status < 400 && location) {
+          if (maxRedirects <= 0) {
+            res.resume();
+            reject(new Error(`Too many redirects fetching ${urlString}`));
+            return;
+          }
+
+          const nextUrl = new URL(location, urlObj).toString();
+          res.resume();
+          fetchTextWithHttps(nextUrl, maxRedirects - 1).then(resolve, reject);
+          return;
+        }
+
+        if (status < 200 || status >= 300) {
+          res.resume();
+          reject(new Error(`HTTP ${status} fetching ${urlString}`));
+          return;
+        }
+
+        res.setEncoding('utf8');
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => resolve(data));
+      }
+    );
+
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function fetchText(urlString) {
+  // Prefer the built-in fetch (Node 18+). Fall back to https for older Node.
+  if (typeof fetch === 'function') {
+    const res = await fetch(urlString, {
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'js2il-docs-script',
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} fetching ${urlString}`);
+    }
+
+    return await res.text();
+  }
+
+  return await fetchTextWithHttps(urlString);
+}
+
+function detectEol(text) {
+  return text.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function writeTextPreserveEol(filePath, text) {
+  let eol = '\n';
+  let existingText = null;
+
+  if (fs.existsSync(filePath)) {
+    existingText = fs.readFileSync(filePath, 'utf8');
+    eol = detectEol(existingText);
+  }
+
+  // Normalize line endings in output to preserve existing file style.
+  const normalized = text.replace(/\r\n|\n/g, eol);
+
+  if (existingText !== null && existingText === normalized) {
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, normalized, 'utf8');
+}
+
+function findTagNameAt(html, tagStart) {
+  if (tagStart < 0 || html[tagStart] !== '<') return '';
+
+  const afterLt = tagStart + 1;
+  const slash = html[afterLt] === '/';
+  const nameStart = slash ? afterLt + 1 : afterLt;
+
+  let i = nameStart;
+  while (i < html.length) {
+    const ch = html[i];
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n' || ch === '>' || ch === '/') {
+      break;
+    }
+    i++;
+  }
+
+  return html.substring(nameStart, i);
+}
+
+function extractElementById(html, elementId) {
+  const idDouble = `id="${elementId}"`;
+  const idSingle = `id='${elementId}'`;
+
+  let idIndex = html.indexOf(idDouble);
+  if (idIndex < 0) idIndex = html.indexOf(idSingle);
+  if (idIndex < 0) {
+    throw new Error(`Could not find id '${elementId}' in input HTML.`);
+  }
+
+  const tagStart = html.lastIndexOf('<', idIndex);
+  if (tagStart < 0) {
+    throw new Error(`Could not locate tag start for id '${elementId}'.`);
+  }
+
+  const tagName = findTagNameAt(html, tagStart);
+  if (!tagName) {
+    throw new Error(`Could not determine tag name for id '${elementId}'.`);
+  }
+
+  // Walk matching open/close tags of the same tag name.
+  const tagRe = new RegExp(`<\\/?${escapeRegExp(tagName)}\\b[^>]*>`, 'gi');
+  tagRe.lastIndex = tagStart;
+
+  let depth = 0;
+  let startIndex = -1;
+
+  while (true) {
+    const m = tagRe.exec(html);
+    if (!m) break;
+
+    const token = m[0];
+
+    if (startIndex < 0) {
+      startIndex = m.index;
+    }
+
+    const isClose = token.startsWith(`</`);
+    if (isClose) {
+      depth--;
+      if (depth === 0) {
+        const endIndex = tagRe.lastIndex;
+        return {
+          tagName,
+          html: html.substring(startIndex, endIndex),
+        };
+      }
+    } else {
+      depth++;
+    }
+  }
+
+  throw new Error(`Could not find a matching closing </${tagName}> for id '${elementId}'.`);
+}
+
+function resolveSectionLinkFromMultipageIndexHtml(indexHtml, section) {
+  const sectionEsc = escapeRegExp(section);
+
+  // The multipage index contains TOC links like:
+  //   <a href="control-abstraction-objects.html#sec-generatorfunction-objects"> <span class="secnum">27.3</span> ...</a>
+  // Constrain match to within a single <a>..</a> to avoid spanning.
+  const re = new RegExp(
+    `<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*${sectionEsc}\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>`,
+    'i'
+  );
+
+  const m = re.exec(indexHtml);
+  const href = (m && (m[1] || m[2])) || '';
+  if (!href) return null;
+
+  const hashIndex = href.indexOf('#');
+  const filePart = hashIndex >= 0 ? href.substring(0, hashIndex) : href;
+  const fragment = hashIndex >= 0 ? href.substring(hashIndex + 1) : '';
+
+  return {
+    href,
+    filePart,
+    fragment,
+  };
+}
+
+function resolveSectionIdFromHtml(html, section) {
+  const sectionEsc = escapeRegExp(section);
+
+  // Most reliable across tc39.es multipage output: the Table of Contents contains an <a href="...#<id>">
+  // with a <span class="secnum">27.3</span>.
+  {
+    const re = new RegExp(
+      `<a\\b[^>]*href=(?:\"[^\"]*#([^\"#]+)\"|'[^']*#([^'#]+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*${sectionEsc}\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>`,
+      'i'
+    );
+    const m = re.exec(html);
+    if (m) return m[1] || m[2] || '';
+  }
+
+  // Most reliable (ecmarkup output): <emu-clause id="sec-..."> ... <span class="secnum">27.3</span>
+  // The section number is often not a raw text prefix of the heading; it is typically wrapped in a <span class="secnum">.
+  {
+    const re = new RegExp(
+      `<emu-clause\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,8000}?<h[1-6]\\b[^>]*>[\\s\\S]{0,1200}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*${sectionEsc}\\s*<\\/span>[\\s\\S]{0,1200}?<\\/h[1-6]>`,
+      'i'
+    );
+    const m = re.exec(html);
+    if (m) return m[1] || m[2] || '';
+  }
+
+  // Fallback: id on a heading element
+  {
+    // Handle either raw text "27.3" or <span class="secnum">27.3</span> within the heading.
+    const re = new RegExp(
+      `<h[1-6]\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,1200}?(?:\\s*${sectionEsc}\\b|<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*${sectionEsc}\\s*<\\/span>)`,
+      'i'
+    );
+    const m = re.exec(html);
+    if (m) return m[1] || m[2] || '';
+  }
+
+  return '';
+}
+
+function wrapAsStandaloneHtml(extractedHtml, options) {
+  const title = options.title || 'ECMA-262 Section Extract';
+  const baseHref = options.baseHref || '';
+
+  const baseTag = baseHref ? `  <base href="${baseHref}">\n` : '';
+
+  // Minimal CSS to make ecmarkup custom elements readable without pulling in tc39 styles.
+  const css = `  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }
+    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }
+    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }
+    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }
+    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }
+  </style>\n`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+${baseTag}${css}  <title>${title}</title>
+</head>
+<body>
+${extractedHtml}
+</body>
+</html>
+`;
+}
+
+function printHelp() {
+  console.log('Extract a section\'s HTML from a locally saved ECMA-262 multipage HTML file.');
+  console.log('You can also fetch the input HTML from the web using Node\'s built-in fetch/https.');
+  console.log('');
+  console.log('Usage:');
+  console.log('  node scripts/extractEcma262SectionHtml.js --section 27.3 --in <input.html> --out <output.html>');
+  console.log('  node scripts/extractEcma262SectionHtml.js --section 27.3 --url <https://...> --out <output.html>');
+  console.log('  node scripts/extractEcma262SectionHtml.js --section 27.3 --auto --out <output.html>');
+  console.log('');
+  console.log('Options:');
+  console.log('  --section, -s   Section number to extract (e.g. 27.3)');
+  console.log('  --in, -i        Input HTML file path');
+  console.log('  --url, -u       Fetch input HTML from URL instead of --in');
+  console.log('  --auto          Auto-discover the correct multipage URL from the multipage index');
+  console.log('  --index-url     Multipage index URL used by --auto (default: https://tc39.es/ecma262/multipage/)');
+  console.log('  --out, -o       Output file path');
+  console.log('  --id            Explicit element id to extract (e.g. sec-generatorfunction-objects)');
+  console.log('  --wrap          Wrap output as standalone HTML (default)');
+  console.log('  --no-wrap       Output only the extracted element HTML');
+  console.log('  --base          Optional <base href="..."> to inject when wrapping');
+  console.log('  --help, -h      Show help');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  if (!args.section) {
+    throw new Error('Missing required --section (e.g. 27.3).');
+  }
+
+  // If no input is provided, default to auto-discovery.
+  if (!args.inFile && !args.url) {
+    args.auto = true;
+  }
+
+  const providedInputs = [args.inFile ? 1 : 0, args.url ? 1 : 0, args.auto ? 1 : 0].reduce((a, b) => a + b, 0);
+  if (providedInputs !== 1) {
+    throw new Error('Provide exactly one input mode: --in, --url, or --auto.');
+  }
+
+  if (!args.outFile) {
+    throw new Error('Missing required --out <output.html>.');
+  }
+
+  const outPath = path.resolve(process.cwd(), args.outFile);
+
+  let html;
+  let inferredBaseHref = '';
+  let resolvedElementIdFromIndex = '';
+
+  if (args.auto) {
+    const indexUrl = (args.indexUrl || 'https://tc39.es/ecma262/multipage/').trim();
+    if (!indexUrl) {
+      throw new Error('Missing --index-url value.');
+    }
+
+    const indexHtml = await fetchText(indexUrl);
+    const link = resolveSectionLinkFromMultipageIndexHtml(indexHtml, args.section.trim());
+    if (!link) {
+      throw new Error(`Could not find section '${args.section}' in multipage index: ${indexUrl}`);
+    }
+
+    const resolvedUrl = new URL(link.filePart || link.href, indexUrl).toString();
+    resolvedElementIdFromIndex = link.fragment || '';
+
+    html = await fetchText(resolvedUrl);
+    inferredBaseHref = resolvedUrl;
+  } else if (args.url) {
+    const urlString = args.url.trim();
+    html = await fetchText(urlString);
+    inferredBaseHref = urlString;
+  } else {
+    const inputPath = path.resolve(process.cwd(), args.inFile);
+    if (!fs.existsSync(inputPath)) {
+      throw new Error(`Input file not found: ${inputPath}`);
+    }
+    html = fs.readFileSync(inputPath, 'utf8');
+  }
+
+  let elementId = (args.id || '').trim();
+  if (!elementId && resolvedElementIdFromIndex) {
+    elementId = resolvedElementIdFromIndex;
+  }
+
+  if (!elementId) {
+    elementId = resolveSectionIdFromHtml(html, args.section.trim());
+  }
+
+  if (!elementId) {
+    throw new Error(
+      `Could not infer an element id for section '${args.section}'. Try passing --id sec-... explicitly.`
+    );
+  }
+
+  const extracted = extractElementById(html, elementId);
+
+  let outText = extracted.html;
+  if (args.wrap) {
+    const baseHref = args.baseHref || inferredBaseHref || '';
+    outText = wrapAsStandaloneHtml(outText, {
+      title: `ECMA-262 ${args.section}`,
+      baseHref,
+    });
+  }
+
+  writeTextPreserveEol(outPath, outText);
+
+  // eslint-disable-next-line no-console
+  console.log(`Extracted section ${args.section} (id=${elementId}, tag=${extracted.tagName}) -> ${outPath}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error(err && err.message ? err.message : err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Adds/expands generator-related ECMA-262 section index docs (27.3/27.4/27.5/27.6) and links them from the synchronous generator lowering spec.\n\nAlso adds a small workflow README under docs/ECMA262 and two helper scripts:\n- scripts/extractEcma262SectionHtml.js: extract a clause fragment from tc39 multipage HTML (supports --auto)\n- scripts/convertEcmaExtractHtmlToMarkdown.js: convert extracted HTML fragment to Markdown for appendices\n\nNotes:\n- Section27_3 includes an appendix with converted spec text (explicitly requested).