### PR TITLE
fix(generator): avoid dead box/pop for discarded postfix updates

### DIFF
--- a/Js2IL.Tests/Array/Snapshots/GeneratorTests.Array_Some_Basic.verified.txt
+++ b/Js2IL.Tests/Array/Snapshots/GeneratorTests.Array_Some_Basic.verified.txt
@@ -220,7 +220,7 @@
 	{
 		// Method begins at RVA 0x20ec
 		// Header size: 12
-		// Code size: 89 (0x59)
+		// Code size: 80 (0x50)
 		.maxstack 32
 		.locals init (
 			[0] float64,
@@ -235,33 +235,28 @@
 		IL_0003: castclass Scopes.Array_Some_Basic
 		IL_0008: ldfld object Scopes.Array_Some_Basic::calls
 		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: stloc.0
-		IL_0013: ldloc.0
-		IL_0014: box [System.Runtime]System.Double
-		IL_0019: pop
-		IL_001a: ldloc.0
-		IL_001b: ldc.r8 1
-		IL_0024: add
-		IL_0025: stloc.0
-		IL_0026: ldloc.0
-		IL_0027: box [System.Runtime]System.Double
-		IL_002c: stloc.1
-		IL_002d: ldarg.0
-		IL_002e: ldc.i4.0
-		IL_002f: ldelem.ref
-		IL_0030: castclass Scopes.Array_Some_Basic
-		IL_0035: ldloc.1
-		IL_0036: stfld object Scopes.Array_Some_Basic::calls
-		IL_003b: ldarg.1
-		IL_003c: ldc.r8 2
-		IL_0045: box [System.Runtime]System.Double
-		IL_004a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_004f: stloc.2
-		IL_0050: ldloc.2
-		IL_0051: box [System.Runtime]System.Boolean
-		IL_0056: stloc.3
-		IL_0057: ldloc.3
-		IL_0058: ret
+		IL_0012: ldc.r8 1
+		IL_001b: add
+		IL_001c: stloc.0
+		IL_001d: ldloc.0
+		IL_001e: box [System.Runtime]System.Double
+		IL_0023: stloc.1
+		IL_0024: ldarg.0
+		IL_0025: ldc.i4.0
+		IL_0026: ldelem.ref
+		IL_0027: castclass Scopes.Array_Some_Basic
+		IL_002c: ldloc.1
+		IL_002d: stfld object Scopes.Array_Some_Basic::calls
+		IL_0032: ldarg.1
+		IL_0033: ldc.r8 2
+		IL_003c: box [System.Runtime]System.Double
+		IL_0041: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0046: stloc.2
+		IL_0047: ldloc.2
+		IL_0048: box [System.Runtime]System.Boolean
+		IL_004d: stloc.3
+		IL_004e: ldloc.3
+		IL_004f: ret
 	} // end of method ArrowFunction_L8C22::ArrowFunction_L8C22
 
 } // end of class Functions.ArrowFunction_L8C22
@@ -279,7 +274,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2154
+		// Method begins at RVA 0x2148
 		// Header size: 12
 		// Code size: 389 (0x185)
 		.maxstack 32
@@ -443,7 +438,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e5
+		// Method begins at RVA 0x22d9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
@@ -1,4 +1,4 @@
-﻿// IL code: Classes_ClassMethod_While_Increment_Param_Postfix
+// IL code: Classes_ClassMethod_While_Increment_Param_Postfix
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -113,7 +113,7 @@
 	{
 		// Method begins at RVA 0x2088
 		// Header size: 12
-		// Code size: 63 (0x3f)
+		// Code size: 54 (0x36)
 		.maxstack 32
 		.locals init (
 			[0] float64
@@ -124,26 +124,21 @@
 			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0006: ldc.r8 3
 			IL_000f: clt
-			IL_0011: brfalse IL_003d
+			IL_0011: brfalse IL_0034
 
 			IL_0016: ldarg.1
 			IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: box [System.Runtime]System.Double
-			IL_0023: pop
-			IL_0024: ldloc.0
-			IL_0025: ldc.r8 1
-			IL_002e: add
-			IL_002f: stloc.0
-			IL_0030: ldloc.0
-			IL_0031: box [System.Runtime]System.Double
-			IL_0036: starg.s n
-			IL_0038: br IL_0000
+			IL_001c: ldc.r8 1
+			IL_0025: add
+			IL_0026: stloc.0
+			IL_0027: ldloc.0
+			IL_0028: box [System.Runtime]System.Double
+			IL_002d: starg.s n
+			IL_002f: br IL_0000
 		// end loop
 
-		IL_003d: ldnull
-		IL_003e: ret
+		IL_0034: ldnull
+		IL_0035: ret
 	} // end of method Counter::run
 
 } // end of class Classes.Classes_ClassMethod_While_Increment_Param_Postfix.Counter
@@ -161,7 +156,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20d4
+		// Method begins at RVA 0x20cc
 		// Header size: 12
 		// Code size: 102 (0x66)
 		.maxstack 32
@@ -223,7 +218,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2146
+		// Method begins at RVA 0x213e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -689,7 +689,7 @@
 			object index
 		) cil managed 
 	{
-		// Method begins at RVA 0x24b8
+		// Method begins at RVA 0x24b0
 		// Header size: 12
 		// Code size: 91 (0x5b)
 		.maxstack 32
@@ -752,7 +752,7 @@
 			object range_stop
 		) cil managed 
 	{
-		// Method begins at RVA 0x2268
+		// Method begins at RVA 0x2260
 		// Header size: 12
 		// Code size: 578 (0x242)
 		.maxstack 32
@@ -1031,7 +1031,7 @@
 			object index
 		) cil managed 
 	{
-		// Method begins at RVA 0x2520
+		// Method begins at RVA 0x2518
 		// Header size: 12
 		// Code size: 78 (0x4e)
 		.maxstack 32
@@ -1089,7 +1089,7 @@
 	{
 		// Method begins at RVA 0x221c
 		// Header size: 12
-		// Code size: 62 (0x3e)
+		// Code size: 53 (0x35)
 		.maxstack 32
 		.locals init (
 			[0] float64,
@@ -1105,26 +1105,21 @@
 			IL_0009: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
 			IL_000e: stloc.1
 			IL_000f: ldloc.1
-			IL_0010: brfalse IL_003c
+			IL_0010: brfalse IL_0033
 
 			IL_0015: ldarg.1
 			IL_0016: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001b: stloc.0
-			IL_001c: ldloc.0
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: pop
-			IL_0023: ldloc.0
-			IL_0024: ldc.r8 1
-			IL_002d: add
-			IL_002e: stloc.0
-			IL_002f: ldloc.0
-			IL_0030: box [System.Runtime]System.Double
-			IL_0035: starg.s index
-			IL_0037: br IL_0000
+			IL_001b: ldc.r8 1
+			IL_0024: add
+			IL_0025: stloc.0
+			IL_0026: ldloc.0
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: starg.s index
+			IL_002e: br IL_0000
 		// end loop
 
-		IL_003c: ldarg.1
-		IL_003d: ret
+		IL_0033: ldarg.1
+		IL_0034: ret
 	} // end of method BitArray::searchBitFalse
 
 } // end of class Classes.Compile_Performance_PrimeJavaScript.BitArray
@@ -1206,7 +1201,7 @@
 	.method public hidebysig 
 		instance object runSieve () cil managed 
 	{
-		// Method begins at RVA 0x257c
+		// Method begins at RVA 0x2574
 		// Header size: 12
 		// Code size: 249 (0xf9)
 		.maxstack 32
@@ -1335,7 +1330,7 @@
 	.method public hidebysig 
 		instance object countPrimes () cil managed 
 	{
-		// Method begins at RVA 0x2918
+		// Method begins at RVA 0x2910
 		// Header size: 12
 		// Code size: 130 (0x82)
 		.maxstack 32
@@ -1409,7 +1404,7 @@
 			object max
 		) cil managed 
 	{
-		// Method begins at RVA 0x29a8
+		// Method begins at RVA 0x29a0
 		// Header size: 12
 		// Code size: 245 (0xf5)
 		.maxstack 32
@@ -1525,7 +1520,7 @@
 			object verbose
 		) cil managed 
 	{
-		// Method begins at RVA 0x2684
+		// Method begins at RVA 0x267c
 		// Header size: 12
 		// Code size: 647 (0x287)
 		.maxstack 32
@@ -1762,7 +1757,7 @@
 			object $p0
 		) cil managed 
 	{
-		// Method begins at RVA 0x2aac
+		// Method begins at RVA 0x2aa4
 		// Header size: 12
 		// Code size: 527 (0x20f)
 		.maxstack 32
@@ -2008,7 +2003,7 @@
 			object timeLimitSeconds
 		) cil managed 
 	{
-		// Method begins at RVA 0x2cc8
+		// Method begins at RVA 0x2cc0
 		// Header size: 12
 		// Code size: 249 (0xf9)
 		.maxstack 32
@@ -2139,7 +2134,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2dd0
+		// Method begins at RVA 0x2dc8
 		// Header size: 12
 		// Code size: 489 (0x1e9)
 		.maxstack 32
@@ -2326,7 +2321,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2fc5
+		// Method begins at RVA 0x2fbd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetInterval_ExecutesThreeTimes_ThenClears.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.SetInterval_ExecutesThreeTimes_ThenClears.verified.txt
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x206c
 		// Header size: 12
-		// Code size: 193 (0xc1)
+		// Code size: 184 (0xb8)
 		.maxstack 32
 		.locals init (
 			[0] float64,
@@ -98,73 +98,68 @@
 		IL_0003: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
 		IL_0008: ldfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::count
 		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: stloc.0
-		IL_0013: ldloc.0
-		IL_0014: box [System.Runtime]System.Double
-		IL_0019: pop
-		IL_001a: ldloc.0
-		IL_001b: ldc.r8 1
-		IL_0024: add
-		IL_0025: stloc.0
-		IL_0026: ldloc.0
-		IL_0027: box [System.Runtime]System.Double
-		IL_002c: stloc.1
-		IL_002d: ldarg.0
-		IL_002e: ldc.i4.0
-		IL_002f: ldelem.ref
-		IL_0030: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
-		IL_0035: ldloc.1
-		IL_0036: stfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::count
-		IL_003b: ldstr "tick "
-		IL_0040: ldarg.0
-		IL_0041: ldc.i4.0
-		IL_0042: ldelem.ref
-		IL_0043: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
-		IL_0048: ldfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::count
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0052: stloc.2
-		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0058: ldc.i4.1
-		IL_0059: newarr [System.Runtime]System.Object
-		IL_005e: dup
-		IL_005f: ldc.i4.0
-		IL_0060: ldloc.2
-		IL_0061: stelem.ref
-		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0067: pop
-		IL_0068: ldarg.0
-		IL_0069: ldc.i4.0
-		IL_006a: ldelem.ref
-		IL_006b: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
-		IL_0070: ldfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::count
-		IL_0075: stloc.3
-		IL_0076: ldloc.3
-		IL_0077: ldc.r8 3
-		IL_0080: box [System.Runtime]System.Double
-		IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_008a: stloc.s 4
-		IL_008c: ldloc.s 4
-		IL_008e: brfalse IL_00bf
+		IL_0012: ldc.r8 1
+		IL_001b: add
+		IL_001c: stloc.0
+		IL_001d: ldloc.0
+		IL_001e: box [System.Runtime]System.Double
+		IL_0023: stloc.1
+		IL_0024: ldarg.0
+		IL_0025: ldc.i4.0
+		IL_0026: ldelem.ref
+		IL_0027: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
+		IL_002c: ldloc.1
+		IL_002d: stfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::count
+		IL_0032: ldstr "tick "
+		IL_0037: ldarg.0
+		IL_0038: ldc.i4.0
+		IL_0039: ldelem.ref
+		IL_003a: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
+		IL_003f: ldfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::count
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0049: stloc.2
+		IL_004a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004f: ldc.i4.1
+		IL_0050: newarr [System.Runtime]System.Object
+		IL_0055: dup
+		IL_0056: ldc.i4.0
+		IL_0057: ldloc.2
+		IL_0058: stelem.ref
+		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_005e: pop
+		IL_005f: ldarg.0
+		IL_0060: ldc.i4.0
+		IL_0061: ldelem.ref
+		IL_0062: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
+		IL_0067: ldfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::count
+		IL_006c: stloc.3
+		IL_006d: ldloc.3
+		IL_006e: ldc.r8 3
+		IL_0077: box [System.Runtime]System.Double
+		IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0081: stloc.s 4
+		IL_0083: ldloc.s 4
+		IL_0085: brfalse IL_00b6
 
-		IL_0093: ldarg.0
-		IL_0094: ldc.i4.0
-		IL_0095: ldelem.ref
-		IL_0096: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
-		IL_009b: ldfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::id
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearInterval(object)
-		IL_00a5: pop
-		IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ab: ldc.i4.1
-		IL_00ac: newarr [System.Runtime]System.Object
-		IL_00b1: dup
-		IL_00b2: ldc.i4.0
-		IL_00b3: ldstr "cleared"
-		IL_00b8: stelem.ref
-		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00be: pop
+		IL_008a: ldarg.0
+		IL_008b: ldc.i4.0
+		IL_008c: ldelem.ref
+		IL_008d: castclass Scopes.SetInterval_ExecutesThreeTimes_ThenClears
+		IL_0092: ldfld object Scopes.SetInterval_ExecutesThreeTimes_ThenClears::id
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearInterval(object)
+		IL_009c: pop
+		IL_009d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a2: ldc.i4.1
+		IL_00a3: newarr [System.Runtime]System.Object
+		IL_00a8: dup
+		IL_00a9: ldc.i4.0
+		IL_00aa: ldstr "cleared"
+		IL_00af: stelem.ref
+		IL_00b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00b5: pop
 
-		IL_00bf: ldnull
-		IL_00c0: ret
+		IL_00b6: ldnull
+		IL_00b7: ret
 	} // end of method ArrowFunction_L3C24::ArrowFunction_L3C24
 
 } // end of class Functions.ArrowFunction_L3C24
@@ -182,7 +177,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x213c
+		// Method begins at RVA 0x2130
 		// Header size: 12
 		// Code size: 114 (0x72)
 		.maxstack 32
@@ -239,7 +234,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ba
+		// Method begins at RVA 0x21ae
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
This change avoids emitting a dead `box`/`pop` pair for postfix update expressions when the expression result is not used (e.g. `n++;` as an expression statement, or a `for` loop update clause).

- Adds a discard-result lowering path so `x++` can skip materializing the postfix value when unused
- Keeps postfix semantics unchanged when the value *is* consumed
- Updates generator snapshots affected by the IL change

Fixes #359