### PR TITLE
docs: archive lowering pipeline migration punchlist

### DIFF
--- a/docs/ECMA262/ECMA262_RemainingWork_v0.7.2.md
+++ b/docs/ECMA262/ECMA262_RemainingWork_v0.7.2.md
@@ -65,7 +65,7 @@ See [docs/NodeSupport.md](../NodeSupport.md) for the Node-side coverage view.
 
 ### Known intrinsic gaps explicitly called out elsewhere
 
-From [docs/LoweringPipeline_Migration_PunchList.md](../LoweringPipeline_Migration_PunchList.md):
+From [docs/archive/LoweringPipeline_Migration_PunchList.md](../archive/LoweringPipeline_Migration_PunchList.md):
 - **Callable-only intrinsics (no `new`)**: `String(x)`, `Number(x)`, `Boolean(x)` are supported, but other callable-only intrinsics are not yet supported: `Date(...)`, `RegExp(...)`, `Error(...)`, `Array(...)`, `Object(...)`, `Symbol(...)`, `BigInt(...)`.
 
 ## Detailed list (Partially Supported + Not Yet Supported)

--- a/docs/archive/LoweringPipeline_Migration_PunchList.md
+++ b/docs/archive/LoweringPipeline_Migration_PunchList.md
@@ -1,3 +1,5 @@
+> Archived: migration complete. Kept for historical reference.
+
 # Lowering Pipeline Migration Punch List (AST → HIR → LIR → IL)
 
 ## Purpose


### PR DESCRIPTION
Moves the completed lowering pipeline migration punch list into docs/archive for historical reference and updates the remaining-work doc link.