### PR TITLE
docs: archive Node module support punchlist

### DIFF
--- a/docs/archive/NodeModuleSupport_PunchList.md
+++ b/docs/archive/NodeModuleSupport_PunchList.md
@@ -1,3 +1,5 @@
+> Archived: punch list is complete/obsolete. Kept for historical reference.
+
 # Node module support punch list (internal scripts)
 
 This checklist captures Node.js module APIs required so internal project scripts in scripts/ can be compiled with js2il.


### PR DESCRIPTION
Moves the completed Node module support punch list into docs/archive for historical reference.