### PR TITLE
refactor: clarify scope type emission and nesting

### DIFF
--- a/Js2IL/Services/AssemblyGenerator.cs
+++ b/Js2IL/Services/AssemblyGenerator.cs
@@ -72,7 +72,6 @@ namespace Js2IL.Services
                 _metadataBuilder,
                 _bclReferences,
                 methodBodyStream,
-                _serviceProvider.GetRequiredService<ModuleTypeMetadataRegistry>(),
                 _variableRegistry,
                 deferredCtorStartRow: _metadataBuilder.GetRowCount(TableIndex.MethodDef) + totalCallableMethods + totalModuleInitMethods + 1);
 


### PR DESCRIPTION
Second-pass cleanup: TypeGenerator now focuses purely on emitting scope TypeDefs and registering handles, and explicitly documents that NestedClass relationships are established later via JsMethodCompiler.EstablishModuleNesting and NestedTypeRelationshipRegistry. Removes misleading module-type coupling.