### PR TITLE
refactor: extract scope nesting planner

### DIFF
--- a/Js2IL/JsMethodCompiler.cs
+++ b/Js2IL/JsMethodCompiler.cs
@@ -218,7 +218,7 @@ internal sealed class JsMethodCompiler
     {
         if (expectedMethodDef.IsNil) throw new ArgumentException("Expected MethodDef cannot be nil.", nameof(expectedMethodDef));
 
-        var className = GetRegistryClassName(classScope);
+        var className = ScopeNaming.GetRegistryClassName(classScope);
         var funcExpr = methodDef.Value as FunctionExpression;
         var methodScope = funcExpr != null ? symbolTable.FindScopeByAstNode(funcExpr) : null;
         methodScope ??= classScope;
@@ -350,13 +350,6 @@ internal sealed class JsMethodCompiler
         };
 
         return CreateILCompiler().TryCompileCallableBody(callable, expectedMethodDef, methodDescriptor, lirMethod!, methodBodyStreamEncoder);
-    }
-
-    private static string GetRegistryClassName(Scope classScope)
-    {
-        var ns = classScope.DotNetNamespace ?? "Classes";
-        var name = classScope.DotNetTypeName ?? classScope.Name;
-        return $"{ns}.{name}";
     }
 
     public MethodDefinitionHandle TryCompileMethod(TypeBuilder typeBuilder, string methodName, Node node, Scope scope, MethodBodyStreamEncoder methodBodyStreamEncoder)

--- a/Js2IL/Services/Nesting/ScopeNestingPlanner.cs
+++ b/Js2IL/Services/Nesting/ScopeNestingPlanner.cs
@@ -65,10 +65,8 @@ internal sealed class ScopeNestingPlanner
         List<(TypeDefinitionHandle Nested, TypeDefinitionHandle Enclosing)> relationships,
         HashSet<string> visited)
     {
-        var parentKey = ScopeNaming.GetRegistryScopeName(parentScope);
-        var parentTypeHandle = GetScopeTypeHandleOrThrow(parentKey);
-
         var parentScopeKey = ScopeNaming.GetRegistryScopeName(parentScope);
+        var parentTypeHandle = GetScopeTypeHandleOrThrow(parentScopeKey);
 
         foreach (var child in parentScope.Children)
         {
@@ -100,7 +98,7 @@ internal sealed class ScopeNestingPlanner
                 var classRegistry = _serviceProvider.GetService<ClassRegistry>();
                 if (classRegistry != null)
                 {
-                    var registryClassName = GetRegistryClassName(parentScope);
+                    var registryClassName = ScopeNaming.GetRegistryClassName(parentScope);
                     if (classRegistry.TryGet(registryClassName, out var classTypeHandle) && !classTypeHandle.IsNil)
                     {
                         relationships.Add((childTypeHandle, classTypeHandle));
@@ -125,7 +123,7 @@ internal sealed class ScopeNestingPlanner
                 var classRegistry = _serviceProvider.GetService<ClassRegistry>();
                 if (classRegistry != null)
                 {
-                    var registryClassName = GetRegistryClassName(child);
+                    var registryClassName = ScopeNaming.GetRegistryClassName(child);
                     if (classRegistry.TryGet(registryClassName, out var classTypeHandle) && !classTypeHandle.IsNil)
                     {
                         relationships.Add((childTypeHandle, classTypeHandle));
@@ -190,10 +188,4 @@ internal sealed class ScopeNestingPlanner
         }
     }
 
-    private static string GetRegistryClassName(Scope classScope)
-    {
-        var ns = classScope.DotNetNamespace ?? "Classes";
-        var name = classScope.DotNetTypeName ?? classScope.Name;
-        return $"{ns}.{name}";
-    }
 }

--- a/Js2IL/Utilities/ScopeNaming.cs
+++ b/Js2IL/Utilities/ScopeNaming.cs
@@ -1,3 +1,4 @@
+using System;
 using Js2IL.SymbolTables;
 
 namespace Js2IL.Utilities;
@@ -26,5 +27,13 @@ internal static class ScopeNaming
 
         var moduleName = GetModuleName(scope);
         return $"{moduleName}/{scope.GetQualifiedName()}";
+    }
+
+    public static string GetRegistryClassName(Scope classScope)
+    {
+        if (classScope == null) throw new ArgumentNullException(nameof(classScope));
+        var ns = classScope.DotNetNamespace ?? "Classes";
+        var name = classScope.DotNetTypeName ?? classScope.Name;
+        return $"{ns}.{name}";
     }
 }


### PR DESCRIPTION
Extracts scope nesting relationship planning into a dedicated service (behavior-preserving), and updates JsMethodCompiler to use it.

- Moves module/scope nesting planning into Services/Nesting/ScopeNestingPlanner
- Keeps NestedTypeRelationshipRegistry as the single sorted-emission point
- Build + full test suite passed locally