### PR TITLE
docs(changelog): note hosting work for #402 and #403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project are documented here.
 ### Added
 - Object literal enhancements: spread properties (`{ ...x }`), computed keys (`{ [expr]: value }`), shorthand properties (`{ a }`), and method definitions (`{ m() { ... } }`) (fixes #290, #291, #292).
 - Synchronous generators (MVP): `function*` + `yield` lowered to a state machine with iterator-style `next()` semantics. Limitations: `yield*` and `async function*` are not supported yet; `throw/return` propagation through `try/finally` is not fully implemented (PR #388).
+- Hosting: initial library hosting API scaffold (`JsEngine.LoadModule(...)`) with one dedicated script thread per runtime instance, cross-thread marshalling, and deterministic disposal boundaries (fixes #402).
+- Hosting: compiled-module discovery via a compiler-emitted manifest (`JsCompiledModuleAttribute`) plus runtime discovery API and tests covering discovery and module init failure propagation (fixes #403).
 
 ### Changed
 - Hosting: reduced public API surface for module discovery and dynamic exports projection (kept internal for now).


### PR DESCRIPTION
Adds Unreleased changelog entries documenting the hosting work completed for #402 and #403.