### PR TITLE
feat(hosting): generate contracts for module.exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here.
 - Synchronous generators (MVP): `function*` + `yield` lowered to a state machine with iterator-style `next()` semantics. Limitations: `yield*` and `async function*` are not supported yet; `throw/return` propagation through `try/finally` is not fully implemented (PR #388).
 - Hosting: initial library hosting API scaffold (`JsEngine.LoadModule(...)`) with one dedicated script thread per runtime instance, cross-thread marshalling, and deterministic disposal boundaries (fixes #402).
 - Hosting: compiled-module discovery via a compiler-emitted manifest (`JsCompiledModuleAttribute`) plus runtime discovery API and tests covering discovery and module init failure propagation (fixes #403).
+- Hosting: compiler-generated strongly-typed contracts for CommonJS `module.exports` (including nested exports objects and exported classes via `IJsConstructor<T>`), enabling `JsEngine.LoadModule<TExports>()` without passing an assembly or module id (fixes #426).
 
 ### Changed
 - Hosting: reduced public API surface for module discovery and dynamic exports projection (kept internal for now).

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
@@ -528,3 +528,98 @@
 
 } // end of class Program
 
+.class interface public auto ansi abstract Js2IL.CommonJS_Export_NestedObjects.IMath
+	implements [JavaScriptRuntime]Js2IL.Runtime.IJsHandle
+{
+	// Methods
+	.method public hidebysig newslot abstract virtual 
+		instance float64 Add (
+			float64 a,
+			float64 b
+		) cil managed 
+	{
+	} // end of method IMath::Add
+
+	.method public hidebysig newslot abstract virtual 
+		instance float64 Multiply (
+			float64 a,
+			float64 b
+		) cil managed 
+	{
+	} // end of method IMath::Multiply
+
+} // end of class Js2IL.CommonJS_Export_NestedObjects.IMath
+
+.class interface public auto ansi abstract Js2IL.CommonJS_Export_NestedObjects.IUtils
+	implements [JavaScriptRuntime]Js2IL.Runtime.IJsHandle
+{
+	// Methods
+	.method public hidebysig specialname newslot abstract virtual 
+		instance string get_Prefix () cil managed 
+	{
+	} // end of method IUtils::get_Prefix
+
+	.method public hidebysig newslot abstract virtual 
+		instance float64 FormatNum (
+			float64 'value'
+		) cil managed 
+	{
+	} // end of method IUtils::FormatNum
+
+	// Properties
+	.property instance string Prefix()
+	{
+		.get instance string Js2IL.CommonJS_Export_NestedObjects.IUtils::get_Prefix()
+	}
+
+} // end of class Js2IL.CommonJS_Export_NestedObjects.IUtils
+
+.class interface public auto ansi abstract Js2IL.CommonJS_Export_NestedObjects.ICommonJSExportNestedObjectsLibExports
+	implements [System.Runtime]System.IDisposable
+{
+	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
+		01 00 21 43 6f 6d 6d 6f 6e 4a 53 5f 45 78 70 6f
+		72 74 5f 4e 65 73 74 65 64 4f 62 6a 65 63 74 73
+		5f 4c 69 62 00 00
+	)
+	// Methods
+	.method public hidebysig specialname newslot abstract virtual 
+		instance string get_Name () cil managed 
+	{
+	} // end of method ICommonJSExportNestedObjectsLibExports::get_Name
+
+	.method public hidebysig specialname newslot abstract virtual 
+		instance float64 get_Version () cil managed 
+	{
+	} // end of method ICommonJSExportNestedObjectsLibExports::get_Version
+
+	.method public hidebysig specialname newslot abstract virtual 
+		instance class Js2IL.CommonJS_Export_NestedObjects.IMath get_Math () cil managed 
+	{
+	} // end of method ICommonJSExportNestedObjectsLibExports::get_Math
+
+	.method public hidebysig specialname newslot abstract virtual 
+		instance class Js2IL.CommonJS_Export_NestedObjects.IUtils get_Utils () cil managed 
+	{
+	} // end of method ICommonJSExportNestedObjectsLibExports::get_Utils
+
+	// Properties
+	.property instance string Name()
+	{
+		.get instance string Js2IL.CommonJS_Export_NestedObjects.ICommonJSExportNestedObjectsLibExports::get_Name()
+	}
+	.property instance float64 Version()
+	{
+		.get instance float64 Js2IL.CommonJS_Export_NestedObjects.ICommonJSExportNestedObjectsLibExports::get_Version()
+	}
+	.property instance class Js2IL.CommonJS_Export_NestedObjects.IMath Math()
+	{
+		.get instance class Js2IL.CommonJS_Export_NestedObjects.IMath Js2IL.CommonJS_Export_NestedObjects.ICommonJSExportNestedObjectsLibExports::get_Math()
+	}
+	.property instance class Js2IL.CommonJS_Export_NestedObjects.IUtils Utils()
+	{
+		.get instance class Js2IL.CommonJS_Export_NestedObjects.IUtils Js2IL.CommonJS_Export_NestedObjects.ICommonJSExportNestedObjectsLibExports::get_Utils()
+	}
+
+} // end of class Js2IL.CommonJS_Export_NestedObjects.ICommonJSExportNestedObjectsLibExports
+

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -480,3 +480,28 @@
 
 } // end of class Program
 
+.class interface public auto ansi abstract Js2IL.CommonJS_Export_ObjectWithClosure.ICommonJSExportObjectWithClosureLibExports
+	implements [System.Runtime]System.IDisposable
+{
+	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
+		01 00 25 43 6f 6d 6d 6f 6e 4a 53 5f 45 78 70 6f
+		72 74 5f 4f 62 6a 65 63 74 57 69 74 68 43 6c 6f
+		73 75 72 65 5f 4c 69 62 00 00
+	)
+	// Methods
+	.method public hidebysig newslot abstract virtual 
+		instance float64 MultiplyModuleFactor (
+			float64 x
+		) cil managed 
+	{
+	} // end of method ICommonJSExportObjectWithClosureLibExports::MultiplyModuleFactor
+
+	.method public hidebysig newslot abstract virtual 
+		instance object CreateCalculator (
+			object factor
+		) cil managed 
+	{
+	} // end of method ICommonJSExportObjectWithClosureLibExports::CreateCalculator
+
+} // end of class Js2IL.CommonJS_Export_ObjectWithClosure.ICommonJSExportObjectWithClosureLibExports
+

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
@@ -436,3 +436,35 @@
 
 } // end of class Program
 
+.class interface public auto ansi abstract Js2IL.CommonJS_Export_ObjectWithFunctions.ICommonJSExportObjectWithFunctionsLibExports
+	implements [System.Runtime]System.IDisposable
+{
+	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
+		01 00 27 43 6f 6d 6d 6f 6e 4a 53 5f 45 78 70 6f
+		72 74 5f 4f 62 6a 65 63 74 57 69 74 68 46 75 6e
+		63 74 69 6f 6e 73 5f 4c 69 62 00 00
+	)
+	// Methods
+	.method public hidebysig newslot abstract virtual 
+		instance string Foo () cil managed 
+	{
+	} // end of method ICommonJSExportObjectWithFunctionsLibExports::Foo
+
+	.method public hidebysig newslot abstract virtual 
+		instance float64 Add (
+			float64 a,
+			float64 b
+		) cil managed 
+	{
+	} // end of method ICommonJSExportObjectWithFunctionsLibExports::Add
+
+	.method public hidebysig newslot abstract virtual 
+		instance float64 Multiply (
+			float64 a,
+			float64 b
+		) cil managed 
+	{
+	} // end of method ICommonJSExportObjectWithFunctionsLibExports::Multiply
+
+} // end of class Js2IL.CommonJS_Export_ObjectWithFunctions.ICommonJSExportObjectWithFunctionsLibExports
+

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Reassign.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Reassign.verified.txt
@@ -141,3 +141,25 @@
 
 } // end of class Program
 
+.class interface public auto ansi abstract Js2IL.CommonJS_Module_Exports_Reassign.ICommonJSModuleExportsReassignExports
+	implements [System.Runtime]System.IDisposable
+{
+	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
+		01 00 20 43 6f 6d 6d 6f 6e 4a 53 5f 4d 6f 64 75
+		6c 65 5f 45 78 70 6f 72 74 73 5f 52 65 61 73 73
+		69 67 6e 00 00
+	)
+	// Methods
+	.method public hidebysig specialname newslot abstract virtual 
+		instance string get_NewObject () cil managed 
+	{
+	} // end of method ICommonJSModuleExportsReassignExports::get_NewObject
+
+	// Properties
+	.property instance string NewObject()
+	{
+		.get instance string Js2IL.CommonJS_Module_Exports_Reassign.ICommonJSModuleExportsReassignExports::get_NewObject()
+	}
+
+} // end of class Js2IL.CommonJS_Module_Exports_Reassign.ICommonJSModuleExportsReassignExports
+

--- a/Js2IL.Tests/Hosting/GeneratedContractTests.cs
+++ b/Js2IL.Tests/Hosting/GeneratedContractTests.cs
@@ -1,0 +1,196 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using JavaScriptRuntime;
+using Js2IL.Services;
+using Js2IL.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Js2IL.Tests.Hosting;
+
+public class GeneratedContractTests
+{
+    private const string HostingJavaScriptResourcePrefix = "Js2IL.Tests.Hosting.JavaScript.";
+
+    [Fact]
+    public void GeneratedContracts_Enable_LoadModule_NoArgs_And_InvokeMembers()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            rootModuleName: "hosting",
+            scriptResourcePath: "Hosting_TypedExports.js");
+
+        // Entry-module exports contract naming per docs/DotNetLibraryHosting.md:
+        //   Js2IL.<AssemblyName>.I<AssemblyName>Exports
+        var contractType = module.Assembly.GetType("Js2IL.hosting.IHostingExports", throwOnError: true)!;
+
+        var attr = contractType.GetCustomAttribute<Js2IL.Runtime.JsModuleAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal("hosting", attr!.ModuleId);
+
+        var loadNoArgs = typeof(Js2IL.Runtime.JsEngine)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(Js2IL.Runtime.JsEngine.LoadModule)
+                      && m.IsGenericMethodDefinition
+                      && m.GetParameters().Length == 0);
+
+        var exportsObj = loadNoArgs.MakeGenericMethod(contractType).Invoke(null, null);
+        Assert.NotNull(exportsObj);
+
+        using var exports = (IDisposable)exportsObj!;
+
+        var version = (string)contractType.GetProperty("Version")!.GetValue(exportsObj)!;
+        Assert.Equal("1.2.3", version);
+
+        var add = contractType.GetMethod("Add")!;
+        var sum = add.Invoke(exportsObj, new object?[] { 1.0, 2.0 });
+        Assert.Equal(3.0, Convert.ToDouble(sum));
+
+        // Exported class -> IJsConstructor<T> property + instance handle interface
+        var counterCtor = contractType.GetProperty("Counter")!.GetValue(exportsObj);
+        Assert.NotNull(counterCtor);
+
+        var construct = counterCtor!.GetType().GetMethod("Construct")!;
+        var counterObj = construct.Invoke(counterCtor, new object?[] { new object?[] { 10.0 } });
+        Assert.NotNull(counterObj);
+
+        var counterType = module.Assembly.GetType("Js2IL.hosting.ICounter", throwOnError: true)!;
+
+        var addDelta = counterType.GetMethod("Add")!;
+        var newValue = addDelta.Invoke(counterObj, new object?[] { 5.0 });
+        Assert.Equal(15.0, Convert.ToDouble(newValue));
+
+        var valueProp = counterType.GetProperty("Value");
+        if (valueProp != null)
+        {
+            var current = valueProp.GetValue(counterObj);
+            Assert.Equal(15.0, Convert.ToDouble(current));
+        }
+        else
+        {
+            var getValue = counterType.GetMethod("GetValue")!;
+            var current = getValue.Invoke(counterObj, System.Array.Empty<object?>());
+            Assert.Equal(15.0, Convert.ToDouble(current));
+        }
+
+        // Dispose the handle proxy and ensure it becomes unusable
+        ((IDisposable)counterObj!).Dispose();
+        var tie = Assert.Throws<TargetInvocationException>(() => addDelta.Invoke(counterObj, new object?[] { 1.0 }));
+        Assert.IsType<ObjectDisposedException>(tie.InnerException);
+    }
+
+    private sealed class CompiledModuleAssembly : IDisposable
+    {
+        private readonly string _outputDir;
+        private readonly string _uniqueAssemblyPath;
+        private readonly AssemblyLoadContext _alc;
+
+        public Assembly Assembly { get; }
+
+        public CompiledModuleAssembly(string outputDir, string uniqueAssemblyPath, AssemblyLoadContext alc, Assembly assembly)
+        {
+            _outputDir = outputDir;
+            _uniqueAssemblyPath = uniqueAssemblyPath;
+            _alc = alc;
+            Assembly = assembly;
+        }
+
+        public void Dispose()
+        {
+            if (_alc.IsCollectible)
+            {
+                _alc.Unload();
+            }
+            try { File.Delete(_uniqueAssemblyPath); } catch { }
+            try { Directory.Delete(_outputDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string LoadHostingJavaScript(string resourcePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourcePath);
+
+        var normalized = resourcePath.Trim().Replace('\\', '/');
+        var resourceName = HostingJavaScriptResourcePrefix + normalized.Replace("/", ".");
+
+        var assembly = typeof(GeneratedContractTests).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream == null)
+        {
+            var candidates = assembly.GetManifestResourceNames()
+                .Where(n => n.StartsWith(HostingJavaScriptResourcePrefix, StringComparison.Ordinal))
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            throw new InvalidOperationException(
+                $"Could not find embedded resource '{resourceName}' for script '{resourcePath}'. " +
+                $"Available Hosting JavaScript resources: {string.Join(", ", candidates)}");
+        }
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    private static CompiledModuleAssembly CompileAndLoadModuleAssemblyFromResource(string rootModuleName, string scriptResourcePath)
+    {
+        var outputDir = Path.Combine(Path.GetTempPath(), "Js2IL.Tests", "GeneratedContracts", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDir);
+
+        var js = LoadHostingJavaScript(scriptResourcePath);
+
+        var filePath = Path.Combine(outputDir, rootModuleName + ".js");
+        var mockFs = new MockFileSystem();
+        mockFs.AddFile(filePath, js);
+
+        var options = new CompilerOptions { OutputDirectory = outputDir, GenerateModuleExportContracts = true };
+        var logger = new TestLogger();
+        var sp = CompilerServices.BuildServiceProvider(options, mockFs, logger);
+        var compiler = sp.GetRequiredService<Compiler>();
+
+        Assert.True(compiler.Compile(filePath), logger.Errors);
+
+        var compiledPath = Path.Combine(outputDir, rootModuleName + ".dll");
+        Assert.True(File.Exists(compiledPath), $"Expected compiled output at '{compiledPath}'");
+
+        var jsRuntimeAsm = typeof(EnvironmentProvider).Assembly;
+        var uniquePath = Path.Combine(outputDir, rootModuleName + ".run-" + Guid.NewGuid().ToString("N") + ".dll");
+        File.Copy(compiledPath, uniquePath, overwrite: true);
+
+        var alc = new HostingTestAssemblyLoadContext(jsRuntimeAsm, outputDir);
+        Assembly compiledAssembly;
+        using (var stream = File.OpenRead(uniquePath))
+        {
+            compiledAssembly = alc.LoadFromStream(stream);
+        }
+
+        return new CompiledModuleAssembly(outputDir, uniquePath, alc, compiledAssembly);
+    }
+
+    private sealed class HostingTestAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly Assembly _jsRuntimeAssembly;
+        private readonly string _baseDirectory;
+
+        public HostingTestAssemblyLoadContext(Assembly jsRuntimeAssembly, string baseDirectory)
+            : base(isCollectible: false)
+        {
+            _jsRuntimeAssembly = jsRuntimeAssembly;
+            _baseDirectory = baseDirectory;
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            if (string.Equals(assemblyName.Name, _jsRuntimeAssembly.GetName().Name, StringComparison.Ordinal))
+            {
+                return _jsRuntimeAssembly;
+            }
+
+            var candidatePath = Path.Combine(_baseDirectory, (assemblyName.Name ?? "") + ".dll");
+            if (File.Exists(candidatePath))
+            {
+                return LoadFromAssemblyPath(candidatePath);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Js2IL/CompilerOptions.cs
+++ b/Js2IL/CompilerOptions.cs
@@ -3,4 +3,10 @@ public class CompilerOptions
     public string? OutputDirectory { get; set; } = null;
     public bool Verbose { get; set; } = false;
     public bool AnalyzeUnused { get; set; } = false;    
+
+    /// <summary>
+    /// When true, JS2IL emits strongly-typed .NET contracts for CommonJS <c>module.exports</c>
+    /// into the compiled assembly for hosting via <see cref="Js2IL.Runtime.JsEngine"/>.
+    /// </summary>
+    public bool GenerateModuleExportContracts { get; set; } = true;
 }

--- a/Js2IL/Services/AssemblyGenerator.cs
+++ b/Js2IL/Services/AssemblyGenerator.cs
@@ -4,6 +4,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using Js2IL.Services.ILGenerators;
+using Js2IL.Services.Contracts;
 using Js2IL.Services.TwoPhaseCompilation;
 using Js2IL.SymbolTables;
 using Js2IL.Utilities.Ecma335;
@@ -207,6 +208,14 @@ namespace Js2IL.Services
 
             // create the entry point for spining up the execution engine
             createEntryPoint(methodBodyStream);
+
+            // Emit strongly-typed hosting contracts for module.exports (interfaces) if enabled.
+            var options = _serviceProvider.GetRequiredService<CompilerOptions>();
+            if (options.GenerateModuleExportContracts)
+            {
+                new ModuleExportsContractEmitter(_metadataBuilder, _bclReferences)
+                    .Emit(modules, assemblyName);
+            }
 
             // Emit NestedClass table rows in one globally sorted pass.
             // This must happen after all TypeDefs have been created.

--- a/Js2IL/Services/BaseClassLibraryReferences.cs
+++ b/Js2IL/Services/BaseClassLibraryReferences.cs
@@ -52,6 +52,9 @@ namespace Js2IL.Services
         public MemberReferenceHandle JsCompiledModuleAttribute_Ctor_Ref =>
             _memberRefRegistry.GetOrAddConstructor(typeof(Js2IL.Runtime.JsCompiledModuleAttribute), new[] { typeof(string) });
 
+        public MemberReferenceHandle JsModuleAttribute_Ctor_Ref =>
+            _memberRefRegistry.GetOrAddConstructor(typeof(Js2IL.Runtime.JsModuleAttribute), new[] { typeof(string) });
+
         public MemberReferenceHandle GetFuncCtorRef(int jsParamCount)
         {
             if (!_funcTypesByParamCount.TryGetValue(jsParamCount, out var funcType))

--- a/Js2IL/Services/Contracts/ModuleExportsContractEmitter.cs
+++ b/Js2IL/Services/Contracts/ModuleExportsContractEmitter.cs
@@ -1,0 +1,970 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using Acornima;
+using Acornima.Ast;
+using Js2IL.SymbolTables;
+using Js2IL.Utilities.Ecma335;
+
+namespace Js2IL.Services.Contracts;
+
+/// <summary>
+/// Emits strongly-typed .NET contract interfaces for CommonJS <c>module.exports</c>.
+///
+/// Design goals:
+/// - Minimal, conservative shape inference (safe defaults to <see cref="object"/>)
+/// - Hosting-friendly: exports contracts implement <see cref="IDisposable"/>, nested objects/instances implement <see cref="Js2IL.Runtime.IJsHandle"/>
+/// - Exports contracts are annotated with <see cref="Js2IL.Runtime.JsModuleAttribute"/> so <see cref="Js2IL.Runtime.JsEngine.LoadModule{TExports}()"/> can resolve the module id.
+/// </summary>
+internal sealed class ModuleExportsContractEmitter
+{
+    private readonly MetadataBuilder _metadata;
+    private readonly BaseClassLibraryReferences _bcl;
+    private readonly TypeReferenceRegistry _typeRefs;
+
+    public ModuleExportsContractEmitter(MetadataBuilder metadataBuilder, BaseClassLibraryReferences bclReferences)
+    {
+        _metadata = metadataBuilder ?? throw new ArgumentNullException(nameof(metadataBuilder));
+        _bcl = bclReferences ?? throw new ArgumentNullException(nameof(bclReferences));
+        _typeRefs = bclReferences.TypeReferenceRegistry;
+    }
+
+    public void Emit(Modules modules, string assemblyName)
+    {
+        ArgumentNullException.ThrowIfNull(modules);
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyName);
+
+        var rootModulePath = modules.rootModule.Path;
+
+        foreach (var module in modules._modules.Values)
+        {
+            var moduleId = JavaScriptRuntime.CommonJS.ModuleName.GetModuleIdForManifestFromPath(module.Path, rootModulePath);
+            var isRoot = ReferenceEquals(module, modules.rootModule);
+
+            if (!TryGetModuleExportsObject(module.Ast, out var exportsObject))
+            {
+                continue;
+            }
+
+            EmitModuleContracts(module, assemblyName, moduleId, isRoot, exportsObject);
+        }
+    }
+
+    private void EmitModuleContracts(ModuleDefinition module, string assemblyName, string moduleId, bool isRootModule, ObjectExpression exportsObject)
+    {
+        var symbolTable = module.SymbolTable;
+
+        var (contractNamespace, exportsInterfaceName) = GetExportsContractName(assemblyName, moduleId, isRootModule);
+
+        var topLevel = BuildTopLevelDeclarationIndex(module.Ast);
+
+        // IMPORTANT: Metadata ordering. In ECMA-335, TypeDef.MethodList (and similar lists) must be non-decreasing.
+        // If we emit MethodDefs for the exports interface before emitting the TypeDefs for instance/nested interfaces,
+        // then later-created TypeDefs can end up with MethodList pointers that are greater than the exports TypeDef,
+        // and the CLR will refuse to load the generated types.
+        //
+        // Strategy:
+        // 1) Emit all dependent TypeDefs first (class instance + nested object interfaces)
+        // 2) Then emit exports interface MethodDefs/PropertyDefs and add its TypeDef last.
+
+        // Emit class instance interfaces first so function inference can reference them without creating new TypeDefs later.
+        var instanceInterfacesByClassName = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+        foreach (var kvp in topLevel.Classes.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+        {
+            var className = kvp.Key;
+            var classDecl = kvp.Value;
+            instanceInterfacesByClassName[className] = EmitHandleInterface(
+                contractNamespace,
+                "I" + ToPascalCase(className),
+                members: classDecl,
+                symbolTable: symbolTable,
+                classNameForFields: className);
+        }
+
+        TypeDefinitionHandle? TryGetClassInstanceInterface(string className)
+        {
+            return instanceInterfacesByClassName.TryGetValue(className, out var handle) ? handle : null;
+        }
+
+        // Emit nested-object interfaces that are directly exported (module.exports = { nested: { ... } }).
+        var nestedInterfacesByExportName = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+        foreach (var prop in exportsObject.Properties)
+        {
+            if (prop is not Property p)
+            {
+                continue;
+            }
+
+            if (!TryGetPropertyName(p.Key, out var exportName))
+            {
+                continue;
+            }
+
+            if (p.Value is ObjectExpression nestedObj)
+            {
+                var nestedInterfaceName = "I" + ToPascalCase(exportName);
+                var nestedType = EmitHandleInterface(contractNamespace, nestedInterfaceName, members: nestedObj, symbolTable: symbolTable, classNameForFields: null);
+                nestedInterfacesByExportName[exportName] = nestedType;
+            }
+        }
+
+        // Now emit the exports interface.
+        var exportsTypeBuilder = new TypeBuilder(_metadata, contractNamespace, exportsInterfaceName);
+        PropertyDefinitionHandle firstExportsProperty = default;
+
+        // Add members (methods + property getters) before adding the TypeDef.
+        foreach (var prop in exportsObject.Properties)
+        {
+            if (prop is not Property p)
+            {
+                continue;
+            }
+
+            if (!TryGetPropertyName(p.Key, out var exportName))
+            {
+                continue;
+            }
+
+            // Determine the exported value expression.
+            var valueNode = p.Value;
+
+            // Shorthand: { version } -> Property with key 'version' and value Identifier 'version'.
+            // We treat it the same as an explicit value.
+
+            if (TryResolveExportAsClass(valueNode, topLevel, out var className))
+            {
+                var instanceInterface = TryGetClassInstanceInterface(className);
+                if (!instanceInterface.HasValue)
+                {
+                    // If we can't resolve the class instance interface, fall back to object.
+                    var phFallback = EmitReadOnlyProperty(exportsTypeBuilder, ToPascalCase(exportName), TypeOrHandle.FromClr(typeof(object)));
+                    if (firstExportsProperty.IsNil)
+                    {
+                        firstExportsProperty = phFallback;
+                    }
+                    continue;
+                }
+
+                var openCtorRef = _typeRefs.GetOrAdd(typeof(Js2IL.Runtime.IJsConstructor<>));
+                var ph = EmitReadOnlyProperty(
+                    exportsTypeBuilder,
+                    ToPascalCase(exportName),
+                    TypeOrHandle.FromGenericInstantiation(openCtorRef, instanceInterface.Value));
+                if (firstExportsProperty.IsNil)
+                {
+                    firstExportsProperty = ph;
+                }
+                continue;
+            }
+
+            if (TryResolveExportAsFunction(valueNode, topLevel, out var functionNode, out var functionNameForInference))
+            {
+                var methodName = ToPascalCase(exportName);
+                var method = BuildContractMethodFromFunction(methodName, functionNode, topLevel, instanceInterfacesByClassName, ensureClassInstanceInterface: null);
+                EmitInterfaceMethod(exportsTypeBuilder, method);
+                continue;
+            }
+
+            if (valueNode is ObjectExpression nestedObj)
+            {
+                // Nested exported object: interface was emitted in the pre-pass.
+                if (!nestedInterfacesByExportName.TryGetValue(exportName, out var nestedType))
+                {
+                    // Shouldn't happen, but fall back to object.
+                    var phFallback = EmitReadOnlyProperty(exportsTypeBuilder, ToPascalCase(exportName), TypeOrHandle.FromClr(typeof(object)));
+                    if (firstExportsProperty.IsNil)
+                    {
+                        firstExportsProperty = phFallback;
+                    }
+                    continue;
+                }
+
+                var ph = EmitReadOnlyProperty(exportsTypeBuilder, ToPascalCase(exportName), TypeOrHandle.FromHandle(nestedType));
+                if (firstExportsProperty.IsNil)
+                {
+                    firstExportsProperty = ph;
+                }
+                continue;
+            }
+
+            // Default: exported value projected as a read-only property.
+            var clrType = InferClrTypeFromExpression(valueNode, topLevel, classFields: null, instanceInterfacesByClassName, ensureClassInstanceInterface: null);
+            var propHandle = EmitReadOnlyProperty(exportsTypeBuilder, ToPascalCase(exportName), clrType);
+            if (firstExportsProperty.IsNil)
+            {
+                firstExportsProperty = propHandle;
+            }
+        }
+
+        var exportsTypeDef = exportsTypeBuilder.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract,
+            default);
+
+        if (!firstExportsProperty.IsNil)
+        {
+            _metadata.AddPropertyMap(exportsTypeDef, firstExportsProperty);
+        }
+
+        // Exports contracts should be disposable so they can shut down the runtime.
+        _metadata.AddInterfaceImplementation(exportsTypeDef, _typeRefs.GetOrAdd(typeof(IDisposable)));
+
+        AddJsModuleAttribute(exportsTypeDef, moduleId);
+    }
+
+    private TypeDefinitionHandle EmitHandleInterface(
+        string @namespace,
+        string interfaceName,
+        object? members,
+        SymbolTable? symbolTable,
+        string? classNameForFields)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, @namespace, interfaceName);
+        PropertyDefinitionHandle firstProperty = default;
+
+        Dictionary<string, Type>? stableFields = null;
+        if (!string.IsNullOrWhiteSpace(classNameForFields) && symbolTable?.Root is Js2IL.SymbolTables.Scope rootScope)
+        {
+            var classScope = FindClassScope(rootScope, classNameForFields!);
+            stableFields = classScope?.StableInstanceFieldClrTypes;
+        }
+
+        if (members is ClassDeclaration classDecl)
+        {
+            // Instance field properties (stable inferred only)
+            if (stableFields != null)
+            {
+                foreach (var field in stableFields.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+                {
+                    var propName = ToPascalCase(field.Key);
+                    var propType = TypeOrHandle.FromClr(MapClrType(field.Value));
+                    var ph = EmitReadOnlyProperty(typeBuilder, propName, propType);
+                    if (firstProperty.IsNil)
+                    {
+                        firstProperty = ph;
+                    }
+                }
+            }
+
+            // Instance methods
+            foreach (var element in classDecl.Body.Body)
+            {
+                if (element is not Acornima.Ast.MethodDefinition md)
+                {
+                    continue;
+                }
+
+                if (md.Kind == PropertyKind.Constructor)
+                {
+                    continue;
+                }
+
+                if (!TryGetPropertyName(md.Key, out var name))
+                {
+                    continue;
+                }
+
+                if (md.Value is not FunctionExpression fn)
+                {
+                    continue;
+                }
+
+                var methodName = ToPascalCase(name);
+                var method = BuildContractMethodFromFunction(
+                    methodName,
+                    fn,
+                    topLevelIndex: null,
+                    instanceInterfacesByClassName: null,
+                    ensureClassInstanceInterface: null,
+                    classFields: stableFields);
+                EmitInterfaceMethod(typeBuilder, method);
+            }
+        }
+        else if (members is ObjectExpression obj)
+        {
+            // Nested object interface projected as a handle.
+            foreach (var prop in obj.Properties)
+            {
+                if (prop is not Property p)
+                {
+                    continue;
+                }
+
+                if (!TryGetPropertyName(p.Key, out var memberName))
+                {
+                    continue;
+                }
+
+                var valueNode = p.Value;
+
+                if (valueNode is FunctionExpression fn)
+                {
+                    var method = BuildContractMethodFromFunction(
+                        ToPascalCase(memberName),
+                        fn,
+                        topLevelIndex: null,
+                        instanceInterfacesByClassName: null,
+                        ensureClassInstanceInterface: null);
+                    EmitInterfaceMethod(typeBuilder, method);
+                    continue;
+                }
+
+                var clrType = InferClrTypeFromExpression(
+                    valueNode,
+                    topLevelIndex: null,
+                    classFields: null,
+                    instanceInterfacesByClassName: null,
+                    ensureClassInstanceInterface: null);
+                var ph = EmitReadOnlyProperty(typeBuilder, ToPascalCase(memberName), clrType);
+                if (firstProperty.IsNil)
+                {
+                    firstProperty = ph;
+                }
+            }
+        }
+
+        var typeDef = typeBuilder.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract,
+            default);
+
+        if (!firstProperty.IsNil)
+        {
+            _metadata.AddPropertyMap(typeDef, firstProperty);
+        }
+
+        // Handles should be projected via JsHandleProxy.
+        _metadata.AddInterfaceImplementation(typeDef, _typeRefs.GetOrAdd(typeof(Js2IL.Runtime.IJsHandle)));
+
+        return typeDef;
+    }
+
+    private static Js2IL.SymbolTables.Scope? FindClassScope(Js2IL.SymbolTables.Scope scope, string className)
+    {
+        if (scope.Kind == ScopeKind.Class && string.Equals(scope.Name, className, StringComparison.Ordinal))
+        {
+            return scope;
+        }
+
+        foreach (var child in scope.Children)
+        {
+            var found = FindClassScope(child, className);
+            if (found != null)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    private readonly record struct TopLevelIndex(
+        IReadOnlyDictionary<string, FunctionDeclaration> Functions,
+        IReadOnlyDictionary<string, ClassDeclaration> Classes,
+        IReadOnlyDictionary<string, Expression> VariableInitializers);
+
+    private static TopLevelIndex BuildTopLevelDeclarationIndex(Acornima.Ast.Program program)
+    {
+        var functions = new Dictionary<string, FunctionDeclaration>(StringComparer.Ordinal);
+        var classes = new Dictionary<string, ClassDeclaration>(StringComparer.Ordinal);
+        var vars = new Dictionary<string, Expression>(StringComparer.Ordinal);
+
+        foreach (var stmt in program.Body)
+        {
+            switch (stmt)
+            {
+                case FunctionDeclaration fd when fd.Id is Identifier id:
+                    functions[id.Name] = fd;
+                    break;
+                case ClassDeclaration cd when cd.Id is Identifier id:
+                    classes[id.Name] = cd;
+                    break;
+                case VariableDeclaration vd:
+                    foreach (var decl in vd.Declarations)
+                    {
+                        if (decl.Id is Identifier vid && decl.Init is Expression init)
+                        {
+                            vars[vid.Name] = init;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return new TopLevelIndex(functions, classes, vars);
+    }
+
+    private static bool TryGetModuleExportsObject(Acornima.Ast.Program program, out ObjectExpression exports)
+    {
+        exports = null!;
+
+        // Walk top-level statements and take the last assignment to module.exports.
+        ObjectExpression? last = null;
+
+        foreach (var stmt in program.Body)
+        {
+            if (stmt is not ExpressionStatement es)
+            {
+                continue;
+            }
+
+            if (es.Expression is not AssignmentExpression assign)
+            {
+                continue;
+            }
+
+            if (!IsModuleExportsLValue(assign.Left))
+            {
+                continue;
+            }
+
+            if (assign.Right is ObjectExpression obj)
+            {
+                last = obj;
+            }
+        }
+
+        if (last == null)
+        {
+            return false;
+        }
+
+        exports = last;
+        return true;
+    }
+
+    private static bool IsModuleExportsLValue(Node left)
+    {
+        // module.exports = ...
+        if (left is MemberExpression { Object: Identifier { Name: "module" }, Property: Identifier { Name: "exports" } })
+        {
+            return true;
+        }
+
+        // module["exports"] = ...
+        if (left is MemberExpression { Object: Identifier { Name: "module" }, Property: Literal { Value: "exports" } })
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetPropertyName(Expression key, out string name)
+    {
+        switch (key)
+        {
+            case Identifier id:
+                name = id.Name;
+                return true;
+            case Literal lit when lit.Value is string s:
+                name = s;
+                return true;
+            default:
+                name = string.Empty;
+                return false;
+        }
+    }
+
+    private static (string Namespace, string ExportsInterfaceName) GetExportsContractName(string assemblyName, string moduleId, bool isRootModule)
+    {
+        // See docs/DotNetLibraryHosting.md "Naming generated export contracts for nested modules".
+        var rootNamespace = $"Js2IL.{assemblyName}";
+
+        if (isRootModule)
+        {
+            return (rootNamespace, "I" + ToPascalCase(assemblyName) + "Exports");
+        }
+
+        var segments = moduleId.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            return (rootNamespace, "IExports");
+        }
+
+        var namespaceSegments = segments.Length > 1
+            ? segments.Take(segments.Length - 1).Select(ToPascalCase).ToArray()
+            : Array.Empty<string>();
+
+        var ns = namespaceSegments.Length == 0
+            ? rootNamespace
+            : rootNamespace + "." + string.Join(".", namespaceSegments);
+
+        var last = segments[^1];
+        var displayName = (string.Equals(last, "index", StringComparison.OrdinalIgnoreCase) && segments.Length > 1)
+            ? segments[^2]
+            : last;
+
+        var iface = "I" + ToPascalCase(displayName) + "Exports";
+        return (ns, iface);
+    }
+
+    private static bool TryResolveExportAsClass(Node valueNode, TopLevelIndex topLevel, out string className)
+    {
+        className = string.Empty;
+
+        if (valueNode is Identifier id && topLevel.Classes.ContainsKey(id.Name))
+        {
+            className = id.Name;
+            return true;
+        }
+
+        if (valueNode is ClassExpression ce && ce.Id is Identifier cid)
+        {
+            className = cid.Name;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveExportAsFunction(Node valueNode, TopLevelIndex topLevel, out Node functionNode, out string? nameForInference)
+    {
+        nameForInference = null;
+
+        switch (valueNode)
+        {
+            case Identifier id when topLevel.Functions.TryGetValue(id.Name, out var decl):
+                functionNode = decl;
+                nameForInference = id.Name;
+                return true;
+            case FunctionExpression fe:
+                functionNode = fe;
+                nameForInference = fe.Id is Identifier fid ? fid.Name : null;
+                return true;
+            case ArrowFunctionExpression af:
+                functionNode = af;
+                nameForInference = null;
+                return true;
+            default:
+                functionNode = null!;
+                return false;
+        }
+    }
+
+    private sealed record ContractMethod(string Name, IReadOnlyList<string> ParamNames, IReadOnlyList<TypeOrHandle> ParamTypes, TypeOrHandle ReturnType);
+
+    private readonly record struct TypeOrHandle(Type? ClrType, EntityHandle? Handle, TypeReferenceHandle? OpenGenericTypeRef, EntityHandle? GenericArg)
+    {
+        public static TypeOrHandle FromClr(Type type) => new(type, null, null, null);
+        public static TypeOrHandle FromHandle(EntityHandle handle) => new(null, handle, null, null);
+
+        public static TypeOrHandle FromGenericInstantiation(TypeReferenceHandle openGenericTypeRef, EntityHandle genericArg)
+            => new(null, null, openGenericTypeRef, genericArg);
+    }
+
+    private static ContractMethod BuildContractMethodFromFunction(
+        string methodName,
+        Node functionNode,
+        TopLevelIndex? topLevelIndex,
+        Dictionary<string, TypeDefinitionHandle>? instanceInterfacesByClassName,
+        Func<string, TypeDefinitionHandle>? ensureClassInstanceInterface,
+        Dictionary<string, Type>? classFields = null)
+    {
+        var paramNames = new List<string>();
+        foreach (var p in GetFunctionParams(functionNode))
+        {
+            if (p is Identifier pid)
+            {
+                paramNames.Add(pid.Name);
+            }
+            else
+            {
+                // Destructuring, defaults, etc. Keep names stable but generic.
+                paramNames.Add("arg" + (paramNames.Count + 1));
+            }
+        }
+
+        var returnType = InferReturnTypeFromFunction(functionNode, topLevelIndex, classFields, instanceInterfacesByClassName, ensureClassInstanceInterface);
+
+        // Very conservative parameter typing: if the return type is numeric, assume numeric params.
+        var paramTypes = new List<TypeOrHandle>(paramNames.Count);
+        for (var i = 0; i < paramNames.Count; i++)
+        {
+            if (returnType.ClrType == typeof(double))
+            {
+                paramTypes.Add(TypeOrHandle.FromClr(typeof(double)));
+            }
+            else
+            {
+                paramTypes.Add(TypeOrHandle.FromClr(typeof(object)));
+            }
+        }
+
+        return new ContractMethod(methodName, paramNames, paramTypes, returnType);
+    }
+
+    private static IEnumerable<Node> GetFunctionParams(Node functionNode)
+    {
+        return functionNode switch
+        {
+            FunctionDeclaration fd => fd.Params,
+            FunctionExpression fe => fe.Params,
+            ArrowFunctionExpression af => af.Params,
+            _ => Array.Empty<Node>()
+        };
+    }
+
+    private static TypeOrHandle InferReturnTypeFromFunction(
+        Node functionNode,
+        TopLevelIndex? topLevelIndex,
+        Dictionary<string, Type>? classFields,
+        Dictionary<string, TypeDefinitionHandle>? instanceInterfacesByClassName,
+        Func<string, TypeDefinitionHandle>? ensureClassInstanceInterface)
+    {
+        // Arrow with expression body
+        if (functionNode is ArrowFunctionExpression { Body: Expression exprBody })
+        {
+            return InferClrTypeFromExpression(exprBody, topLevelIndex, classFields, instanceInterfacesByClassName, ensureClassInstanceInterface);
+        }
+
+        // Block body: look for a single return statement.
+        if (GetFunctionBody(functionNode) is BlockStatement block)
+        {
+            ReturnStatement? onlyReturn = null;
+            var returnCount = 0;
+
+            foreach (var stmt in block.Body)
+            {
+                if (stmt is ReturnStatement rs)
+                {
+                    returnCount++;
+                    onlyReturn ??= rs;
+                }
+            }
+
+            if (returnCount == 0)
+            {
+                return TypeOrHandle.FromClr(typeof(void));
+            }
+
+            if (returnCount == 1 && onlyReturn != null)
+            {
+                if (onlyReturn.Argument is Expression arg)
+                {
+                    return InferClrTypeFromExpression(arg, topLevelIndex, classFields, instanceInterfacesByClassName, ensureClassInstanceInterface);
+                }
+
+                return TypeOrHandle.FromClr(typeof(void));
+            }
+        }
+
+        return TypeOrHandle.FromClr(typeof(object));
+    }
+
+    private static Node? GetFunctionBody(Node functionNode)
+    {
+        return functionNode switch
+        {
+            FunctionDeclaration fd => fd.Body,
+            FunctionExpression fe => fe.Body,
+            ArrowFunctionExpression af => af.Body,
+            _ => null
+        };
+    }
+
+    private static TypeOrHandle InferClrTypeFromExpression(
+        Node expr,
+        TopLevelIndex? topLevelIndex,
+        Dictionary<string, Type>? classFields,
+        Dictionary<string, TypeDefinitionHandle>? instanceInterfacesByClassName,
+        Func<string, TypeDefinitionHandle>? ensureClassInstanceInterface)
+    {
+        switch (expr)
+        {
+            case Literal lit:
+                return lit.Value switch
+                {
+                    string => TypeOrHandle.FromClr(typeof(string)),
+                    bool => TypeOrHandle.FromClr(typeof(bool)),
+                    int or long or float or double or decimal => TypeOrHandle.FromClr(typeof(double)),
+                    _ => TypeOrHandle.FromClr(typeof(object))
+                };
+
+            case BinaryExpression be:
+                // Conservative: arithmetic returns double, comparisons return bool.
+                return be.Operator is Operator.Equality or Operator.Inequality or Operator.StrictEquality or Operator.StrictInequality
+                    or Operator.GreaterThan or Operator.GreaterThanOrEqual or Operator.LessThan or Operator.LessThanOrEqual
+                    ? TypeOrHandle.FromClr(typeof(bool))
+                    : TypeOrHandle.FromClr(typeof(double));
+
+            case UnaryExpression ue when ue.Operator == Operator.LogicalNot:
+                return TypeOrHandle.FromClr(typeof(bool));
+
+            case Identifier id when topLevelIndex != null:
+                if (topLevelIndex.Value.VariableInitializers.TryGetValue(id.Name, out var init))
+                {
+                    return InferClrTypeFromExpression(init, topLevelIndex, classFields, instanceInterfacesByClassName, ensureClassInstanceInterface);
+                }
+                return TypeOrHandle.FromClr(typeof(object));
+
+            case NewExpression ne when ne.Callee is Identifier ctorId && instanceInterfacesByClassName != null:
+                // new Counter(...) => ICounter (handle) if we have a known instance contract.
+                if (instanceInterfacesByClassName.TryGetValue(ctorId.Name, out var instanceHandle) && !instanceHandle.IsNil)
+                {
+                    return TypeOrHandle.FromHandle(instanceHandle);
+                }
+                return TypeOrHandle.FromClr(typeof(object));
+
+            case MemberExpression { Object: ThisExpression, Property: Identifier pid } when classFields != null:
+                if (classFields.TryGetValue(pid.Name, out var fieldType))
+                {
+                    return TypeOrHandle.FromClr(MapClrType(fieldType));
+                }
+                return TypeOrHandle.FromClr(typeof(object));
+
+            default:
+                return TypeOrHandle.FromClr(typeof(object));
+        }
+    }
+
+    private static Type MapClrType(Type type)
+    {
+        if (type == typeof(double) || type == typeof(bool) || type == typeof(string))
+        {
+            return type;
+        }
+
+        return typeof(object);
+    }
+
+    private void EmitInterfaceMethod(TypeBuilder typeBuilder, ContractMethod method)
+    {
+        ArgumentNullException.ThrowIfNull(typeBuilder);
+
+        // Emit parameter metadata first so we can pass the correct ParamList handle.
+        ParameterHandle firstParam = default;
+        for (ushort i = 0; i < method.ParamNames.Count; i++)
+        {
+            var name = method.ParamNames[i] ?? string.Empty;
+            var handle = _metadata.AddParameter(
+                attributes: ParameterAttributes.None,
+                name: _metadata.GetOrAddString(name),
+                sequenceNumber: (ushort)(i + 1));
+
+            if (i == 0)
+            {
+                firstParam = handle;
+            }
+        }
+
+        var signature = BuildMethodSignature(
+            isInstance: true,
+            paramNames: method.ParamNames,
+            paramTypes: method.ParamTypes,
+            returnType: method.ReturnType);
+
+        typeBuilder.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Abstract | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            method.Name,
+            signature,
+            bodyOffset: -1,
+            parameterList: firstParam);
+    }
+
+    private PropertyDefinitionHandle EmitReadOnlyProperty(TypeBuilder typeBuilder, string propertyName, TypeOrHandle propertyType)
+    {
+        // get_PropertyName()
+        var getterName = "get_" + propertyName;
+
+        var getterSig = BuildMethodSignature(
+            isInstance: true,
+            paramNames: Array.Empty<string>(),
+            paramTypes: Array.Empty<TypeOrHandle>(),
+            returnType: propertyType);
+
+        var getter = typeBuilder.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Abstract | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.NewSlot,
+            getterName,
+            getterSig,
+            bodyOffset: -1);
+
+        // Property signature
+        var propSig = BuildPropertySignature(propertyType);
+        var propHandle = _metadata.AddProperty(
+            attributes: PropertyAttributes.None,
+            name: _metadata.GetOrAddString(propertyName),
+            signature: propSig);
+
+        _metadata.AddMethodSemantics(propHandle, MethodSemanticsAttributes.Getter, getter);
+
+        // No setters (exports are read-only).
+
+        return propHandle;
+    }
+
+    private BlobHandle BuildPropertySignature(TypeOrHandle returnType)
+    {
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig)
+            .PropertySignature(isInstanceProperty: true)
+            .Parameters(0,
+                returnTypeEncoder => EncodeReturnType(returnTypeEncoder, returnType),
+                parameters => { });
+
+        return _metadata.GetOrAddBlob(sig);
+    }
+
+    private BlobHandle BuildMethodSignature(bool isInstance, IReadOnlyList<string> paramNames, IReadOnlyList<TypeOrHandle> paramTypes, TypeOrHandle returnType)
+    {
+        var sig = new BlobBuilder();
+        var encoder = new BlobEncoder(sig)
+            .MethodSignature(isInstanceMethod: isInstance);
+
+        encoder.Parameters(
+            parameterCount: paramTypes.Count,
+            returnType: r => EncodeReturnType(r, returnType),
+            parameters: p =>
+            {
+                for (var i = 0; i < paramTypes.Count; i++)
+                {
+                    EncodeParamType(p.AddParameter().Type(), paramTypes[i]);
+                }
+            });
+
+        return _metadata.GetOrAddBlob(sig);
+    }
+
+    private void EncodeReturnType(ReturnTypeEncoder encoder, TypeOrHandle type)
+    {
+        if (type.ClrType == typeof(void))
+        {
+            encoder.Void();
+            return;
+        }
+
+        EncodeParamType(encoder.Type(), type);
+    }
+
+    private void EncodeParamType(SignatureTypeEncoder encoder, TypeOrHandle type)
+    {
+        if (type.OpenGenericTypeRef.HasValue && type.GenericArg.HasValue)
+        {
+            var inst = encoder.GenericInstantiation(type.OpenGenericTypeRef.Value, genericArgumentCount: 1, isValueType: false);
+            inst.AddArgument().Type(type.GenericArg.Value, isValueType: false);
+            return;
+        }
+
+        if (type.ClrType != null)
+        {
+            if (type.ClrType == typeof(object)) { encoder.Object(); return; }
+            if (type.ClrType == typeof(string)) { encoder.String(); return; }
+            if (type.ClrType == typeof(double)) { encoder.Double(); return; }
+            if (type.ClrType == typeof(bool)) { encoder.Boolean(); return; }
+
+            encoder.Object();
+            return;
+        }
+
+        if (type.Handle.HasValue)
+        {
+            encoder.Type(type.Handle.Value, isValueType: false);
+            return;
+        }
+
+        encoder.Object();
+    }
+
+    private void AddJsModuleAttribute(TypeDefinitionHandle exportsTypeDef, string moduleId)
+    {
+        var valueBlob = CreateSingleStringCustomAttributeValue(moduleId);
+
+        _metadata.AddCustomAttribute(
+            parent: exportsTypeDef,
+            constructor: _bcl.JsModuleAttribute_Ctor_Ref,
+            value: valueBlob);
+    }
+
+    private BlobHandle CreateSingleStringCustomAttributeValue(string value)
+    {
+        var blob = new BlobBuilder();
+        blob.WriteUInt16(0x0001);
+        WriteSerString(blob, value);
+        blob.WriteUInt16(0);
+        return _metadata.GetOrAddBlob(blob);
+    }
+
+    private static void WriteSerString(BlobBuilder blob, string value)
+    {
+        var utf8 = Encoding.UTF8.GetBytes(value);
+        WriteCompressedUInt32(blob, (uint)utf8.Length);
+        blob.WriteBytes(utf8);
+    }
+
+    private static void WriteCompressedUInt32(BlobBuilder blob, uint value)
+    {
+        if (value <= 0x7Fu)
+        {
+            blob.WriteByte((byte)value);
+            return;
+        }
+
+        if (value <= 0x3FFFu)
+        {
+            blob.WriteByte((byte)((value >> 8) | 0x80u));
+            blob.WriteByte((byte)(value & 0xFFu));
+            return;
+        }
+
+        if (value <= 0x1FFFFFFFu)
+        {
+            blob.WriteByte((byte)((value >> 24) | 0xC0u));
+            blob.WriteByte((byte)((value >> 16) & 0xFFu));
+            blob.WriteByte((byte)((value >> 8) & 0xFFu));
+            blob.WriteByte((byte)(value & 0xFFu));
+            return;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(value), "Value too large for compressed integer encoding.");
+    }
+
+    private static string ToPascalCase(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "";
+        }
+
+        // Split on common separators and non-alphanumerics.
+        var parts = new List<string>();
+        var sb = new StringBuilder();
+
+        foreach (var c in value)
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                sb.Append(c);
+            }
+            else
+            {
+                if (sb.Length > 0)
+                {
+                    parts.Add(sb.ToString());
+                    sb.Clear();
+                }
+            }
+        }
+
+        if (sb.Length > 0)
+        {
+            parts.Add(sb.ToString());
+        }
+
+        if (parts.Count == 0)
+        {
+            return value;
+        }
+
+        var result = new StringBuilder();
+        foreach (var part in parts)
+        {
+            if (part.Length == 0) continue;
+            result.Append(char.ToUpperInvariant(part[0]));
+            if (part.Length > 1)
+            {
+                result.Append(part.Substring(1));
+            }
+        }
+
+        return result.ToString();
+    }
+}

--- a/docs/DotNetLibraryHosting.md
+++ b/docs/DotNetLibraryHosting.md
@@ -322,7 +322,7 @@ Recommended behavior:
 
 Modules commonly have path-like ids (e.g., `calculator/index`). Generated contract names should avoid collisions while remaining pleasant to use.
 
-Generated contract namespaces should default to being prefixed with the **compiled assembly name**.
+Generated contract namespaces should default to being prefixed with `Js2IL.` + the **compiled assembly name**.
 
 Notes:
 
@@ -331,11 +331,11 @@ Notes:
 
 Recommended convention:
 
-1. Root namespace is `<AssemblyName>`.
+1. Root namespace is `Js2IL.<AssemblyName>`.
 2. The “entry module” exports interface is `I<AssemblyName>Exports`.
-      - Example: `foo.IFooExports`
+      - Example: `Js2IL.foo.IFooExports`
 3. For non-entry modules (including `require(...)` dependencies), use:
-      - namespace: `<AssemblyName>.<ModuleName>`
+      - namespace: `Js2IL.<AssemblyName>.<ModuleName>`
       - exports interface: `I<ModuleName>Exports`
 4. `<ModuleName>` is derived from the module id:
       - split on `/` and `\\`
@@ -344,13 +344,13 @@ Recommended convention:
 
 Examples (within `foo.dll`):
 
-- entry module → `foo.IFooExports`
-- module id `calculator/index` → `foo.Calculator.ICalculatorExports`
-- module id `calculator/advanced` → `foo.Calculator.IAdvancedExports`
+- entry module → `Js2IL.foo.IFooExports`
+- module id `calculator/index` → `Js2IL.foo.Calculator.ICalculatorExports`
+- module id `calculator/advanced` → `Js2IL.foo.Calculator.IAdvancedExports`
 
 Exports for `require(...)` dependencies follow the same rule:
 
-- `<AssemblyName>.<ModuleName>.I<ModuleName>Exports`
+- `Js2IL.<AssemblyName>.<ModuleName>.I<ModuleName>Exports`
 
  This is preferred over `calculator.IIndexExports` because:
 


### PR DESCRIPTION
Resolves #426.

### What
- Adds compile-time generation of strongly-typed .NET contracts for CommonJS `module.exports`.
- Contracts are emitted into the compiled assembly metadata and annotated with `[JsModule(moduleId)]`.
- Enables `JsEngine.LoadModule<TExports>()` (no args) by letting the contract carry module identity.
- Generated contract namespaces are prefixed with `Js2IL.<AssemblyName>.*`.

### Tests
- Added end-to-end hosting test covering generated contract load + invocation.
- Updated generator snapshots impacted by the additional emitted metadata.

### Notes
- Contract generation remains configurable via `CompilerOptions.GenerateModuleExportContracts` (default: on).