### PR TITLE
feat(runtime): implement JobCallback host operations (ECMA-262 9.5.1-9.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## Unreleased
 
 - Hosting: project JavaScript `Promise` return values to C# `Task`/`Task<T>` for typed exports and handles (enables `await` without deadlocks).
+- Runtime/spec: implement ECMA-262 §9.5.1–§9.5.3 JobCallback host operations and integrate them into Promise job scheduling (fixes #435).
 
 ## v0.7.3 - 2026-01-23
 

--- a/JavaScriptRuntime/Engine/JobCallback.cs
+++ b/JavaScriptRuntime/Engine/JobCallback.cs
@@ -1,0 +1,34 @@
+namespace JavaScriptRuntime.EngineCore;
+
+/// <summary>
+/// ECMA-262 §9.5.1 JobCallback Records.
+///
+/// In the spec, a JobCallback record has fields:
+/// - [[Callback]]
+/// - [[HostDefined]]
+///
+/// JS2IL currently models Jobs as microtasks (queued Actions). This record provides a
+/// stable place to carry host-defined context alongside callbacks.
+/// </summary>
+internal readonly record struct JobCallbackRecord(Action Callback, object? HostDefined);
+
+/// <summary>
+/// ECMA-262 §9.5.2–§9.5.3 host operations for JobCallback.
+///
+/// JS2IL is a non-browser host, so we use the default behavior.
+/// </summary>
+internal static class HostJobCallbacks
+{
+    internal static JobCallbackRecord HostMakeJobCallback(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        return new JobCallbackRecord(callback, HostDefined: null);
+    }
+
+    internal static void HostCallJobCallback(in JobCallbackRecord jobCallback, object? v, object?[]? argumentsList)
+    {
+        // Default host behavior: call the callback. JS2IL does not currently model
+        // realms/agent state, so HostDefined is unused today.
+        jobCallback.Callback();
+    }
+}

--- a/JavaScriptRuntime/Promise.cs
+++ b/JavaScriptRuntime/Promise.cs
@@ -497,9 +497,11 @@ public sealed class Promise
             throw new InvalidOperationException("No microtask scheduler available");
         }
 
+        var jobCallback = JavaScriptRuntime.EngineCore.HostJobCallbacks.HostMakeJobCallback(() => ProcessReaction(reaction));
+
         scheduler.QueueMicrotask(() =>
         {
-            ProcessReaction(reaction);
+            JavaScriptRuntime.EngineCore.HostJobCallbacks.HostCallJobCallback(jobCallback, v: null, argumentsList: System.Array.Empty<object?>());
         });
     }
 

--- a/docs/ECMA262/9/Section9.md
+++ b/docs/ECMA262/9/Section9.md
@@ -20,7 +20,7 @@ _This section is split into subsection documents for readability._
 | 9.2 | PrivateEnvironment Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-privateenvironment-records) | [Section9_2.md](Section9_2.md) |
 | 9.3 | Realms | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-code-realms) | [Section9_3.md](Section9_3.md) |
 | 9.4 | Execution Contexts | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-execution-contexts) | [Section9_4.md](Section9_4.md) |
-| 9.5 | Jobs and Host Operations to Enqueue Jobs | Partially Supported | [tc39.es](https://tc39.es/ecma262/#sec-jobs) | [Section9_5.md](Section9_5.md) |
+| 9.5 | Jobs and Host Operations to Enqueue Jobs | Supported | [tc39.es](https://tc39.es/ecma262/#sec-jobs) | [Section9_5.md](Section9_5.md) |
 | 9.6 | Agents | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-agents) | [Section9_6.md](Section9_6.md) |
 | 9.7 | Agent Clusters | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-agent-clusters) | [Section9_7.md](Section9_7.md) |
 | 9.8 | Forward Progress | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-forward-progress) | [Section9_8.md](Section9_8.md) |

--- a/docs/ECMA262/9/Section9_5.md
+++ b/docs/ECMA262/9/Section9_5.md
@@ -6,15 +6,15 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 9.5 | Jobs and Host Operations to Enqueue Jobs | Partially Supported | [tc39.es](https://tc39.es/ecma262/#sec-jobs) |
+| 9.5 | Jobs and Host Operations to Enqueue Jobs | Supported | [tc39.es](https://tc39.es/ecma262/#sec-jobs) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 9.5.1 | JobCallback Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-jobcallback-records) |
-| 9.5.2 | HostMakeJobCallback ( callback ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hostmakejobcallback) |
-| 9.5.3 | HostCallJobCallback ( jobCallback , V , argumentsList ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hostcalljobcallback) |
+| 9.5.1 | JobCallback Records | Supported | [tc39.es](https://tc39.es/ecma262/#sec-jobcallback-records) |
+| 9.5.2 | HostMakeJobCallback ( callback ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-hostmakejobcallback) |
+| 9.5.3 | HostCallJobCallback ( jobCallback , V , argumentsList ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-hostcalljobcallback) |
 | 9.5.4 | HostEnqueuePromiseJob ( job , realm ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-hostenqueuepromisejob) |
 
 ## Reference: Converted Spec Text

--- a/docs/ECMA262/FeatureCoverage.json
+++ b/docs/ECMA262/FeatureCoverage.json
@@ -769,6 +769,84 @@
       ]
     },
     {
+      "section": "9",
+      "title": "Executable Code and Execution Contexts",
+      "url": "https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts",
+      "subsections": [
+        {
+          "subsection": "9.5",
+          "title": "Jobs and Host Operations to Enqueue Jobs",
+          "url": "https://tc39.es/ecma262/#sec-jobs",
+          "paragraphs": [
+            {
+              "paragraph": "9.5.1",
+              "title": "JobCallback Records",
+              "url": "https://tc39.es/ecma262/#sec-jobcallback-records",
+              "features": [
+                {
+                  "feature": "JobCallback Records",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_Then.js",
+                    "Js2IL.Tests/Promise/JavaScript/Promise_Scheduling_StarvationTest.js"
+                  ],
+                  "notes": "Implemented as an internal JobCallback record carrying a callback plus a host-defined context slot (currently null/empty). Used by Promise reaction job scheduling so future host-defined context/realm data can be threaded without changing observable behavior."
+                }
+              ]
+            },
+            {
+              "paragraph": "9.5.2",
+              "title": "HostMakeJobCallback ( callback )",
+              "url": "https://tc39.es/ecma262/#sec-hostmakejobcallback",
+              "features": [
+                {
+                  "feature": "HostMakeJobCallback",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_Then.js",
+                    "Js2IL.Tests/Promise/JavaScript/Promise_Scheduling_StarvationTest.js"
+                  ],
+                  "notes": "Default host behavior: wraps a callback into a JobCallback record with an empty HostDefined field."
+                }
+              ]
+            },
+            {
+              "paragraph": "9.5.3",
+              "title": "HostCallJobCallback ( jobCallback , V , argumentsList )",
+              "url": "https://tc39.es/ecma262/#sec-hostcalljobcallback",
+              "features": [
+                {
+                  "feature": "HostCallJobCallback",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_Then.js",
+                    "Js2IL.Tests/Promise/JavaScript/Promise_Scheduling_StarvationTest.js"
+                  ],
+                  "notes": "Default host behavior: invokes the stored callback. Parameters (V, argumentsList) are accepted for spec-shape compatibility; JS2IL currently models Promise jobs as parameterless Actions."
+                }
+              ]
+            },
+            {
+              "paragraph": "9.5.4",
+              "title": "HostEnqueuePromiseJob ( job , realm )",
+              "url": "https://tc39.es/ecma262/#sec-hostenqueuepromisejob",
+              "features": [
+                {
+                  "feature": "HostEnqueuePromiseJob",
+                  "status": "Supported",
+                  "testScripts": [
+                    "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_Then.js",
+                    "Js2IL.Tests/Promise/JavaScript/Promise_Scheduling_StarvationTest.js"
+                  ],
+                  "notes": "Promise reaction jobs are enqueued onto the runtime microtask queue (IMicrotaskScheduler) and executed by the event loop pump."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "section": "13",
       "title": "ECMAScript Language: Expressions",
       "url": "https://tc39.es/ecma262/#sec-ecmascript-language-expressions",

--- a/docs/compiler/EventLoopAndScheduling.md
+++ b/docs/compiler/EventLoopAndScheduling.md
@@ -41,6 +41,12 @@ Concretely, JS2IL makes the following compatibility guarantees:
 - **Promise reactions are enqueued as Jobs/microtasks.** When a Promise settles, its reactions are queued onto the microtask queue (see TriggerPromiseReactions, ECMA-262 §27.2.1.8).
 - **Microtask checkpoints are bounded to avoid starvation.** After each callback that JS2IL treats as a host “task” (e.g., a `setImmediate` callback or a due timer callback), the pump drains a bounded number of microtasks before continuing. This preserves forward progress for timers/macrotasks in long microtask chains.
 
+JS2IL also implements the JobCallback host abstractions used by the spec to carry host-defined context alongside scheduled Jobs:
+
+- **JobCallback Records** (ECMA-262 §9.5.1)
+- **HostMakeJobCallback** (ECMA-262 §9.5.2)
+- **HostCallJobCallback** (ECMA-262 §9.5.3)
+
 Note that the APIs `setTimeout`/`setInterval`/`setImmediate` are host-defined (not standardized by ECMA-262), so the exact ordering between timer/immediate phases is ultimately a host-compatibility choice rather than a spec requirement.
 
 Note:


### PR DESCRIPTION
Implements ECMA-262 9.5.19.5.3 JobCallback host operations and integrates them into Promise reaction job scheduling.\n\nFixes #435.\n\n## What changed\n- Add internal JobCallback record + default HostMakeJobCallback/HostCallJobCallback host operations.\n- Thread JobCallback through Promise reaction microtask scheduling (no observable behavior change intended).\n- Update docs: section 9.5 status tables + FeatureCoverage + scheduling doc.\n- Add changelog entry.\n\n## Tests\n- dotnet test Js2IL.Tests (filtered: FullyQualifiedName~Js2IL.Tests.Promise)