### PR TITLE
chore(ecma262): roll up mixed support as partial

### DIFF
--- a/docs/ECMA262/15/Section15.md
+++ b/docs/ECMA262/15/Section15.md
@@ -10,7 +10,7 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 15 | ECMAScript Language: Functions and Classes | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) |
+| 15 | ECMAScript Language: Functions and Classes | Partially Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) |
 
 ## Subsections
 

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -30,7 +30,7 @@ Important:
 | 12 | ECMAScript Language: Lexical Grammar | Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar) | [Section12.md](12/Section12.md) |
 | 13 | ECMAScript Language: Expressions | Partially Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-expressions) | [Section13.md](13/Section13.md) |
 | 14 | ECMAScript Language: Statements and Declarations | Partially Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) | [Section14.md](14/Section14.md) |
-| 15 | ECMAScript Language: Functions and Classes | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) | [Section15.md](15/Section15.md) |
+| 15 | ECMAScript Language: Functions and Classes | Partially Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) | [Section15.md](15/Section15.md) |
 | 16 | ECMAScript Language: Scripts and Modules | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-scripts-and-modules) | [Section16.md](16/Section16.md) |
 | 17 | Error Handling and Language Extensions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-error-handling-and-language-extensions) | [Section17.md](17/Section17.md) |
 | 18 | ECMAScript Standard Built-in Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects) | [Section18.md](18/Section18.md) |

--- a/scripts/ECMA262/rollupEcma262Statuses.js
+++ b/scripts/ECMA262/rollupEcma262Statuses.js
@@ -1,4 +1,4 @@
-/*
+  /*
  * Rolls up ECMA-262 coverage statuses:
  *   1) From subsection JSON docs (e.g. docs/ECMA262/15/Section15_5.json)
  *      into the parent section hub markdown (e.g. docs/ECMA262/15/Section15.md)
@@ -135,17 +135,32 @@ function validateStatus(status) {
   }
 }
 
-// Rollup precedence (matches splitEcma262SectionsIntoSubsections.js):
-// Not Yet Supported > Partially Supported > Supported > Untracked
+// Rollup policy:
+// - If everything is Untracked -> Untracked
+// - If there is a mix of supported and unsupported -> Partially Supported
+// - Otherwise prefer the “best summary” of what exists
 function getRollupStatus(statuses) {
   const norm = (Array.isArray(statuses) ? statuses : [])
     .map((s) => (s ?? '').trim())
     .filter((s) => s.length > 0);
 
-  if (norm.includes('Not Yet Supported')) return 'Not Yet Supported';
-  if (norm.includes('Not Supported')) return 'Not Yet Supported';
-  if (norm.includes('Partially Supported')) return 'Partially Supported';
-  if (norm.includes('Supported')) return 'Supported';
+  const hasUntracked = norm.includes('Untracked');
+  const hasNotYet = norm.includes('Not Yet Supported') || norm.includes('Not Supported');
+  const hasPartial = norm.includes('Partially Supported');
+  const hasSupported = norm.includes('Supported');
+
+  // Nothing tracked at all.
+  if (!hasNotYet && !hasPartial && !hasSupported && hasUntracked) return 'Untracked';
+
+  // If anything is partially supported, keep it partial.
+  if (hasPartial) return 'Partially Supported';
+
+  // Mixed support implies partial support overall.
+  if (hasSupported && hasNotYet) return 'Partially Supported';
+
+  if (hasSupported) return 'Supported';
+  if (hasNotYet) return 'Not Yet Supported';
+
   return 'Untracked';
 }
 


### PR DESCRIPTION
Changes the ECMA-262 status rollup policy to treat mixed support as **Partially Supported**.

Motivation:
- A section like 15 has some supported/partial subsections (15.5, 15.7, 15.8) even though others are not yet supported (15.2). Reporting the whole section as Not Yet Supported is misleading.

What changed:
- Update rollup logic in `scripts/ECMA262/rollupEcma262Statuses.js`:
  - Mixed `Supported` + `Not Yet Supported` => `Partially Supported`
- Re-runs rollup to update:
  - `docs/ECMA262/15/Section15.md`
  - `docs/ECMA262/Index.md`