### PR TITLE
fix(spec): iteration-statement early errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here.
 - Runtime/spec: implement ECMA-262 §9.5.1–§9.5.3 JobCallback host operations and integrate them into Promise job scheduling (fixes #435).
 - Classes/spec: support `class B extends A { ... }`, `super(...)` in derived constructors, and `super.m(...)` base method calls (fixes #293, #294).
 - Generators/spec: support `yield*` delegation for synchronous generators (fixes #389).
+- Validator/spec: enforce and consistently surface iteration-statement early errors (break/continue targets and for-in/of head constraints) and fix labeled-statement AST traversal (fixes #463).
 
 ## v0.7.3 - 2026-01-23
 

--- a/Js2IL.Tests/ModuleLoaderTests.cs
+++ b/Js2IL.Tests/ModuleLoaderTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Js2IL.Tests;
+
+public class ModuleLoaderTests
+{
+    [Fact]
+    public void LoadModules_ParseError_ReturnsNullAndLogsErrors()
+    {
+        var fileSystem = new MockFileSystem();
+        var logger = new TestLogger();
+        var options = new CompilerOptions { Verbose = false };
+        var loader = new ModuleLoader(options, fileSystem, logger);
+
+        var modulePath = Path.GetFullPath("C:\\temp\\bad.js");
+        fileSystem.AddFile(modulePath, "while (false) { notALoop: { continue notALoop; } }");
+
+        var modules = loader.LoadModules(modulePath);
+
+        Assert.Null(modules);
+        Assert.Contains("Parse Errors", logger.Errors);
+        Assert.Contains("does not denote an iteration statement", logger.Errors);
+    }
+}

--- a/Js2IL.Tests/ParserTests.cs
+++ b/Js2IL.Tests/ParserTests.cs
@@ -54,4 +54,52 @@ public class ParserTests
         Assert.Contains(NodeType.ReturnStatement, visitedNodes);
         Assert.Contains(NodeType.BinaryExpression, visitedNodes);
     }
+
+    [Fact]
+    public void Parse_ContinueToNonLoopLabel_ThrowsException()
+    {
+        var js = "while (false) { notALoop: { continue notALoop; } }";
+        var ex = Assert.Throws<Exception>(() => _parser.ParseJavaScript(js, "test.js"));
+        Assert.Contains("does not denote an iteration statement", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_BreakToUndefinedLabel_ThrowsException()
+    {
+        var js = "while (false) { break missing; }";
+        var ex = Assert.Throws<Exception>(() => _parser.ParseJavaScript(js, "test.js"));
+        Assert.Contains("Undefined label", ex.Message);
+        Assert.Contains("missing", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_ForOfWithMultipleDeclarators_ThrowsException()
+    {
+        var js = "for (let a, b of [1,2,3]) { }";
+        var ex = Assert.Throws<Exception>(() => _parser.ParseJavaScript(js, "test.js"));
+        Assert.Contains("for-of", ex.Message);
+        Assert.Contains("single binding", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_ForOfWithInitializer_ThrowsException()
+    {
+        var js = "for (let x = 0 of [1,2,3]) { }";
+        var ex = Assert.Throws<Exception>(() => _parser.ParseJavaScript(js, "test.js"));
+        Assert.Contains("for-of", ex.Message);
+        Assert.Contains("initializer", ex.Message);
+    }
+
+    [Fact]
+    public void VisitAst_LabeledStatement_VisitsNestedNodes()
+    {
+        var js = "label: { var x = 1; }";
+        var ast = _parser.ParseJavaScript(js, "test.js");
+        var visitedNodes = new List<NodeType>();
+
+        _parser.VisitAst(ast, node => visitedNodes.Add(node.Type));
+
+        Assert.Contains(NodeType.LabeledStatement, visitedNodes);
+        Assert.Contains(NodeType.VariableDeclaration, visitedNodes);
+    }
 } 

--- a/Js2IL/ModuleLoader.cs
+++ b/Js2IL/ModuleLoader.cs
@@ -49,7 +49,18 @@ public class ModuleLoader
     private bool TryLoadAndParseModule(string modulePath, string rootModulePath, out ModuleDefinition? module)
     {
         var jsSource = _fileSystem.ReadAllText(modulePath);
-        var ast = _parser.ParseJavaScript(jsSource, modulePath);
+        Acornima.Ast.Program ast;
+        try
+        {
+            ast = _parser.ParseJavaScript(jsSource, modulePath);
+        }
+        catch (Exception ex)
+        {
+            module = null;
+            _logger.WriteLineError("\nParse Errors:");
+            _logger.WriteLineError($"Error: {ex.Message}");
+            return false;
+        }
 
         var moduleName = JavaScriptRuntime.CommonJS.ModuleName.GetModuleIdFromPath(modulePath, rootModulePath);
 

--- a/Js2IL/Utilities/AstWalker.cs
+++ b/Js2IL/Utilities/AstWalker.cs
@@ -114,6 +114,10 @@ public class AstWalker
                 VisitNodes(switchCase.Consequent, visitor);
                 break;
 
+            case LabeledStatement labeledStmt:
+                Visit(labeledStmt.Body, visitor);
+                break;
+
             case TryStatement tryStmt:
                 Visit(tryStmt.Block, visitor);
                 Visit(tryStmt.Handler, visitor);
@@ -305,6 +309,10 @@ public class AstWalker
             case SwitchCase switchCase:
                 VisitWithContext(switchCase.Test, enterNode, exitNode);
                 VisitNodesWithContext(switchCase.Consequent, enterNode, exitNode);
+                break;
+
+            case LabeledStatement labeledStmt:
+                VisitWithContext(labeledStmt.Body, enterNode, exitNode);
                 break;
 
             case TryStatement tryStmt:

--- a/docs/ECMA262/14/Section14_7.json
+++ b/docs/ECMA262/14/Section14_7.json
@@ -37,7 +37,7 @@
     {
       "clause": "14.7.2.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Partially Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-do-while-statement-static-semantics-early-errors"
     },
     {
@@ -55,7 +55,7 @@
     {
       "clause": "14.7.3.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Partially Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-while-statement-static-semantics-early-errors"
     },
     {
@@ -73,7 +73,7 @@
     {
       "clause": "14.7.4.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Partially Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-for-statement-static-semantics-early-errors"
     },
     {
@@ -103,7 +103,7 @@
     {
       "clause": "14.7.5.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Partially Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements-static-semantics-early-errors"
     },
     {


### PR DESCRIPTION
## Summary
- Enforce/centralize iteration-statement early errors (break/continue target rules + for-in/of head constraints) at validation time.
- Fix AST walking so labeled statement bodies are traversed (prevents missed validation under labels).
- Surface parse-time early errors as structured loader errors instead of throwing.

## Tests
- `dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj --filter FullyQualifiedName~ParserTests`
- `dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj --filter FullyQualifiedName~ModuleLoaderTests`

Closes #463
