### PR TITLE
docs(ecma262): sync coverage + add informational status

### DIFF
--- a/docs/ECMA262/1/Section1.md
+++ b/docs/ECMA262/1/Section1.md
@@ -6,5 +6,5 @@ Defines the overall scope of the ECMAScript specification and how the document i
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 1 | Scope | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-scope) |
+| 1 | Scope | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-scope) |
 

--- a/docs/ECMA262/2/Section2.md
+++ b/docs/ECMA262/2/Section2.md
@@ -10,12 +10,12 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 2 | Conformance | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conformance) |
+| 2 | Conformance | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance) |
 
 ## Subsections
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 2.1 | Example Normative Optional Clause Heading | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conformance-normative-optional) | [Section2_1.md](Section2_1.md) |
-| 2.2 | Example Legacy Clause Heading | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy) | [Section2_2.md](Section2_2.md) |
-| 2.3 | Example Legacy Normative Optional Clause Heading | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy-normative-optional) | [Section2_3.md](Section2_3.md) |
+| 2.1 | Example Normative Optional Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-normative-optional) | [Section2_1.md](Section2_1.md) |
+| 2.2 | Example Legacy Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy) | [Section2_2.md](Section2_2.md) |
+| 2.3 | Example Legacy Normative Optional Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy-normative-optional) | [Section2_3.md](Section2_3.md) |

--- a/docs/ECMA262/2/Section2_1.json
+++ b/docs/ECMA262/2/Section2_1.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "2.1",
   "title": "Example Normative Optional Clause Heading",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-conformance-normative-optional",
   "parent": {
     "clause": "2"

--- a/docs/ECMA262/2/Section2_1.md
+++ b/docs/ECMA262/2/Section2_1.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 2.1: Example Normative Optional Clause Heading
 
@@ -6,5 +6,5 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 2.1 | Example Normative Optional Clause Heading | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conformance-normative-optional) |
+| 2.1 | Example Normative Optional Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-normative-optional) |
 

--- a/docs/ECMA262/2/Section2_2.json
+++ b/docs/ECMA262/2/Section2_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "2.2",
   "title": "Example Legacy Clause Heading",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-conformance-legacy",
   "parent": {
     "clause": "2"

--- a/docs/ECMA262/2/Section2_2.md
+++ b/docs/ECMA262/2/Section2_2.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 2.2: Example Legacy Clause Heading
 
@@ -6,5 +6,5 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 2.2 | Example Legacy Clause Heading | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy) |
+| 2.2 | Example Legacy Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy) |
 

--- a/docs/ECMA262/2/Section2_3.json
+++ b/docs/ECMA262/2/Section2_3.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "2.3",
   "title": "Example Legacy Normative Optional Clause Heading",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-conformance-legacy-normative-optional",
   "parent": {
     "clause": "2"

--- a/docs/ECMA262/2/Section2_3.md
+++ b/docs/ECMA262/2/Section2_3.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 2.3: Example Legacy Normative Optional Clause Heading
 
@@ -6,5 +6,5 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 2.3 | Example Legacy Normative Optional Clause Heading | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy-normative-optional) |
+| 2.3 | Example Legacy Normative Optional Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy-normative-optional) |
 

--- a/docs/ECMA262/20/Section20.md
+++ b/docs/ECMA262/20/Section20.md
@@ -16,8 +16,8 @@ _This section is split into subsection documents for readability._
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 20.1 | Object Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object-objects) | [Section20_1.md](Section20_1.md) |
-| 20.2 | Function Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) | [Section20_2.md](Section20_2.md) |
-| 20.3 | Boolean Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-boolean-objects) | [Section20_3.md](Section20_3.md) |
+| 20.1 | Object Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-object-objects) | [Section20_1.md](Section20_1.md) |
+| 20.2 | Function Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) | [Section20_2.md](Section20_2.md) |
+| 20.3 | Boolean Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-boolean-objects) | [Section20_3.md](Section20_3.md) |
 | 20.4 | Symbol Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-symbol-objects) | [Section20_4.md](Section20_4.md) |
-| 20.5 | Error Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-error-objects) | [Section20_5.md](Section20_5.md) |
+| 20.5 | Error Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error-objects) | [Section20_5.md](Section20_5.md) |

--- a/docs/ECMA262/20/Section20_1.json
+++ b/docs/ECMA262/20/Section20_1.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "20.1",
   "title": "Object Objects",
-  "status": "Untracked",
+  "status": "Incomplete",
   "specUrl": "https://tc39.es/ecma262/#sec-object-objects",
   "parent": {
     "clause": "20"
@@ -12,291 +12,291 @@
     {
       "clause": "20.1.1",
       "title": "The Object Constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-object-constructor"
     },
     {
       "clause": "20.1.1.1",
       "title": "Object ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-object-value"
     },
     {
       "clause": "20.1.2",
       "title": "Properties of the Object Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-object-constructor"
     },
     {
       "clause": "20.1.2.1",
       "title": "Object.assign ( target , ... sources )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.assign"
     },
     {
       "clause": "20.1.2.2",
       "title": "Object.create ( O , Properties )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.create"
     },
     {
       "clause": "20.1.2.3",
       "title": "Object.defineProperties ( O , Properties )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.defineproperties"
     },
     {
       "clause": "20.1.2.3.1",
       "title": "ObjectDefineProperties ( O , Properties )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-objectdefineproperties"
     },
     {
       "clause": "20.1.2.4",
       "title": "Object.defineProperty ( O , P , Attributes )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.defineproperty"
     },
     {
       "clause": "20.1.2.5",
       "title": "Object.entries ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.entries"
     },
     {
       "clause": "20.1.2.6",
       "title": "Object.freeze ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.freeze"
     },
     {
       "clause": "20.1.2.7",
       "title": "Object.fromEntries ( iterable )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.fromentries"
     },
     {
       "clause": "20.1.2.8",
       "title": "Object.getOwnPropertyDescriptor ( O , P )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.getownpropertydescriptor"
     },
     {
       "clause": "20.1.2.9",
       "title": "Object.getOwnPropertyDescriptors ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.getownpropertydescriptors"
     },
     {
       "clause": "20.1.2.10",
       "title": "Object.getOwnPropertyNames ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.getownpropertynames"
     },
     {
       "clause": "20.1.2.11",
       "title": "Object.getOwnPropertySymbols ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.getownpropertysymbols"
     },
     {
       "clause": "20.1.2.11.1",
       "title": "GetOwnPropertyKeys ( O , type )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-getownpropertykeys"
     },
     {
       "clause": "20.1.2.12",
       "title": "Object.getPrototypeOf ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.getprototypeof"
     },
     {
       "clause": "20.1.2.13",
       "title": "Object.groupBy ( items , callback )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.groupby"
     },
     {
       "clause": "20.1.2.14",
       "title": "Object.hasOwn ( O , P )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.hasown"
     },
     {
       "clause": "20.1.2.15",
       "title": "Object.is ( value1 , value2 )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.is"
     },
     {
       "clause": "20.1.2.16",
       "title": "Object.isExtensible ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.isextensible"
     },
     {
       "clause": "20.1.2.17",
       "title": "Object.isFrozen ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.isfrozen"
     },
     {
       "clause": "20.1.2.18",
       "title": "Object.isSealed ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.issealed"
     },
     {
       "clause": "20.1.2.19",
       "title": "Object.keys ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.keys"
     },
     {
       "clause": "20.1.2.20",
       "title": "Object.preventExtensions ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.preventextensions"
     },
     {
       "clause": "20.1.2.21",
       "title": "Object.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype"
     },
     {
       "clause": "20.1.2.22",
       "title": "Object.seal ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.seal"
     },
     {
       "clause": "20.1.2.23",
       "title": "Object.setPrototypeOf ( O , proto )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.setprototypeof"
     },
     {
       "clause": "20.1.2.24",
       "title": "Object.values ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.values"
     },
     {
       "clause": "20.1.3",
       "title": "Properties of the Object Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object"
     },
     {
       "clause": "20.1.3.1",
       "title": "Object.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.constructor"
     },
     {
       "clause": "20.1.3.2",
       "title": "Object.prototype.hasOwnProperty ( V )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.hasownproperty"
     },
     {
       "clause": "20.1.3.3",
       "title": "Object.prototype.isPrototypeOf ( V )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.isprototypeof"
     },
     {
       "clause": "20.1.3.4",
       "title": "Object.prototype.propertyIsEnumerable ( V )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable"
     },
     {
       "clause": "20.1.3.5",
       "title": "Object.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.tolocalestring"
     },
     {
       "clause": "20.1.3.6",
       "title": "Object.prototype.toString ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.tostring"
     },
     {
       "clause": "20.1.3.7",
       "title": "Object.prototype.valueOf ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.valueof"
     },
     {
       "clause": "20.1.3.8",
       "title": "Object.prototype.__proto__",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.__proto__"
     },
     {
       "clause": "20.1.3.8.1",
       "title": "get Object.prototype.__proto__",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-object.prototype.__proto__"
     },
     {
       "clause": "20.1.3.8.2",
       "title": "set Object.prototype.__proto__",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set-object.prototype.__proto__"
     },
     {
       "clause": "20.1.3.9",
       "title": "Legacy Object.prototype Accessor Methods",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype-legacy-accessor-methods"
     },
     {
       "clause": "20.1.3.9.1",
       "title": "Object.prototype.__defineGetter__ ( P , getter )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__"
     },
     {
       "clause": "20.1.3.9.2",
       "title": "Object.prototype.__defineSetter__ ( P , setter )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__"
     },
     {
       "clause": "20.1.3.9.3",
       "title": "Object.prototype.__lookupGetter__ ( P )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__"
     },
     {
       "clause": "20.1.3.9.4",
       "title": "Object.prototype.__lookupSetter__ ( P )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__"
     },
     {
       "clause": "20.1.4",
       "title": "Properties of Object Instances",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-object-instances"
     }
   ],
   "support": {
     "entries": [
       {
-        "clause": "20.1.2.4",
-        "feature": "Number.isNaN(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-number.isnan",
+        "clause": "20.1.1.1",
+        "feature": "Object(value) (callable semantics)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-object-value",
         "testScripts": [
-          "Js2IL.Tests/PrimitiveConversion/JavaScript/PrimitiveConversion_Number_Callable.js"
+          "Js2IL.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js"
         ],
-        "notes": "Implements the ES static method with no coercion: returns true only when x is a Number value and is NaN. Backed by JavaScriptRuntime.Number.isNaN(object?)."
+        "notes": "Calls to Object(...) are lowered to JavaScriptRuntime.Object.Construct(...). Null/undefined return a new empty object; non-null values are returned unchanged (no ToObject boxing/wrapping of primitives)."
       }
     ]
   }

--- a/docs/ECMA262/20/Section20_1.md
+++ b/docs/ECMA262/20/Section20_1.md
@@ -6,66 +6,66 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 20.1 | Object Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object-objects) |
+| 20.1 | Object Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-object-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 20.1.1 | The Object Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object-constructor) |
-| 20.1.1.1 | Object ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object-value) |
-| 20.1.2 | Properties of the Object Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-object-constructor) |
-| 20.1.2.1 | Object.assign ( target , ... sources ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.assign) |
-| 20.1.2.2 | Object.create ( O , Properties ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.create) |
-| 20.1.2.3 | Object.defineProperties ( O , Properties ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.defineproperties) |
-| 20.1.2.3.1 | ObjectDefineProperties ( O , Properties ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-objectdefineproperties) |
-| 20.1.2.4 | Object.defineProperty ( O , P , Attributes ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.defineproperty) |
-| 20.1.2.5 | Object.entries ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.entries) |
-| 20.1.2.6 | Object.freeze ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.freeze) |
-| 20.1.2.7 | Object.fromEntries ( iterable ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.fromentries) |
-| 20.1.2.8 | Object.getOwnPropertyDescriptor ( O , P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertydescriptor) |
-| 20.1.2.9 | Object.getOwnPropertyDescriptors ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertydescriptors) |
-| 20.1.2.10 | Object.getOwnPropertyNames ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertynames) |
-| 20.1.2.11 | Object.getOwnPropertySymbols ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertysymbols) |
-| 20.1.2.11.1 | GetOwnPropertyKeys ( O , type ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getownpropertykeys) |
-| 20.1.2.12 | Object.getPrototypeOf ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.getprototypeof) |
-| 20.1.2.13 | Object.groupBy ( items , callback ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.groupby) |
-| 20.1.2.14 | Object.hasOwn ( O , P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.hasown) |
-| 20.1.2.15 | Object.is ( value1 , value2 ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.is) |
-| 20.1.2.16 | Object.isExtensible ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.isextensible) |
-| 20.1.2.17 | Object.isFrozen ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.isfrozen) |
-| 20.1.2.18 | Object.isSealed ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.issealed) |
-| 20.1.2.19 | Object.keys ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.keys) |
-| 20.1.2.20 | Object.preventExtensions ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.preventextensions) |
-| 20.1.2.21 | Object.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype) |
-| 20.1.2.22 | Object.seal ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.seal) |
-| 20.1.2.23 | Object.setPrototypeOf ( O , proto ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.setprototypeof) |
-| 20.1.2.24 | Object.values ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.values) |
-| 20.1.3 | Properties of the Object Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object) |
-| 20.1.3.1 | Object.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.constructor) |
-| 20.1.3.2 | Object.prototype.hasOwnProperty ( V ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.hasownproperty) |
-| 20.1.3.3 | Object.prototype.isPrototypeOf ( V ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.isprototypeof) |
-| 20.1.3.4 | Object.prototype.propertyIsEnumerable ( V ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable) |
-| 20.1.3.5 | Object.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.tolocalestring) |
-| 20.1.3.6 | Object.prototype.toString ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.tostring) |
-| 20.1.3.7 | Object.prototype.valueOf ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.valueof) |
-| 20.1.3.8 | Object.prototype.__proto__ | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__proto__) |
-| 20.1.3.8.1 | get Object.prototype.__proto__ | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-object.prototype.__proto__) |
-| 20.1.3.8.2 | set Object.prototype.__proto__ | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-set-object.prototype.__proto__) |
-| 20.1.3.9 | Legacy Object.prototype Accessor Methods | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype-legacy-accessor-methods) |
-| 20.1.3.9.1 | Object.prototype.__defineGetter__ ( P , getter ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__) |
-| 20.1.3.9.2 | Object.prototype.__defineSetter__ ( P , setter ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__) |
-| 20.1.3.9.3 | Object.prototype.__lookupGetter__ ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__) |
-| 20.1.3.9.4 | Object.prototype.__lookupSetter__ ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__) |
-| 20.1.4 | Properties of Object Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-object-instances) |
+| 20.1.1 | The Object Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-object-constructor) |
+| 20.1.1.1 | Object ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-object-value) |
+| 20.1.2 | Properties of the Object Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-object-constructor) |
+| 20.1.2.1 | Object.assign ( target , ... sources ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.assign) |
+| 20.1.2.2 | Object.create ( O , Properties ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.create) |
+| 20.1.2.3 | Object.defineProperties ( O , Properties ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.defineproperties) |
+| 20.1.2.3.1 | ObjectDefineProperties ( O , Properties ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-objectdefineproperties) |
+| 20.1.2.4 | Object.defineProperty ( O , P , Attributes ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.defineproperty) |
+| 20.1.2.5 | Object.entries ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.entries) |
+| 20.1.2.6 | Object.freeze ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.freeze) |
+| 20.1.2.7 | Object.fromEntries ( iterable ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.fromentries) |
+| 20.1.2.8 | Object.getOwnPropertyDescriptor ( O , P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertydescriptor) |
+| 20.1.2.9 | Object.getOwnPropertyDescriptors ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertydescriptors) |
+| 20.1.2.10 | Object.getOwnPropertyNames ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertynames) |
+| 20.1.2.11 | Object.getOwnPropertySymbols ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertysymbols) |
+| 20.1.2.11.1 | GetOwnPropertyKeys ( O , type ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-getownpropertykeys) |
+| 20.1.2.12 | Object.getPrototypeOf ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.getprototypeof) |
+| 20.1.2.13 | Object.groupBy ( items , callback ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.groupby) |
+| 20.1.2.14 | Object.hasOwn ( O , P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.hasown) |
+| 20.1.2.15 | Object.is ( value1 , value2 ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.is) |
+| 20.1.2.16 | Object.isExtensible ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.isextensible) |
+| 20.1.2.17 | Object.isFrozen ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.isfrozen) |
+| 20.1.2.18 | Object.isSealed ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.issealed) |
+| 20.1.2.19 | Object.keys ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.keys) |
+| 20.1.2.20 | Object.preventExtensions ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.preventextensions) |
+| 20.1.2.21 | Object.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype) |
+| 20.1.2.22 | Object.seal ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.seal) |
+| 20.1.2.23 | Object.setPrototypeOf ( O , proto ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.setprototypeof) |
+| 20.1.2.24 | Object.values ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.values) |
+| 20.1.3 | Properties of the Object Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object) |
+| 20.1.3.1 | Object.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.constructor) |
+| 20.1.3.2 | Object.prototype.hasOwnProperty ( V ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.hasownproperty) |
+| 20.1.3.3 | Object.prototype.isPrototypeOf ( V ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.isprototypeof) |
+| 20.1.3.4 | Object.prototype.propertyIsEnumerable ( V ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable) |
+| 20.1.3.5 | Object.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.tolocalestring) |
+| 20.1.3.6 | Object.prototype.toString ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.tostring) |
+| 20.1.3.7 | Object.prototype.valueOf ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.valueof) |
+| 20.1.3.8 | Object.prototype.__proto__ | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__proto__) |
+| 20.1.3.8.1 | get Object.prototype.__proto__ | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-object.prototype.__proto__) |
+| 20.1.3.8.2 | set Object.prototype.__proto__ | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set-object.prototype.__proto__) |
+| 20.1.3.9 | Legacy Object.prototype Accessor Methods | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype-legacy-accessor-methods) |
+| 20.1.3.9.1 | Object.prototype.__defineGetter__ ( P , getter ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__) |
+| 20.1.3.9.2 | Object.prototype.__defineSetter__ ( P , setter ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__) |
+| 20.1.3.9.3 | Object.prototype.__lookupGetter__ ( P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__) |
+| 20.1.3.9.4 | Object.prototype.__lookupSetter__ ( P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__) |
+| 20.1.4 | Properties of Object Instances | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-object-instances) |
 
 ## Support
 
 Feature-level support tracking with test script references.
 
-### 20.1.2.4 ([tc39.es](https://tc39.es/ecma262/#sec-object.defineproperty))
+### 20.1.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-object-value))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Number.isNaN(x) | Supported | [`PrimitiveConversion_Number_Callable.js`](../../../Js2IL.Tests/PrimitiveConversion/JavaScript/PrimitiveConversion_Number_Callable.js) | Implements the ES static method with no coercion: returns true only when x is a Number value and is NaN. Backed by JavaScriptRuntime.Number.isNaN(object?). |
+| Object(value) (callable semantics) | Supported with Limitations | [`IntrinsicCallables_Object_Callable_ReturnsObject.js`](../../../Js2IL.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js) | Calls to Object(...) are lowered to JavaScriptRuntime.Object.Construct(...). Null/undefined return a new empty object; non-null values are returned unchanged (no ToObject boxing/wrapping of primitives). |
 

--- a/docs/ECMA262/20/Section20_2.json
+++ b/docs/ECMA262/20/Section20_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "20.2",
   "title": "Function Objects",
-  "status": "Untracked",
+  "status": "Incomplete",
   "specUrl": "https://tc39.es/ecma262/#sec-function-objects",
   "parent": {
     "clause": "20"
@@ -12,443 +12,139 @@
     {
       "clause": "20.2.1",
       "title": "The Function Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function-constructor"
     },
     {
       "clause": "20.2.1.1",
       "title": "Function ( ... parameterArgs , bodyArg )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function-p1-p2-pn-body"
     },
     {
       "clause": "20.2.1.1.1",
       "title": "CreateDynamicFunction ( constructor , newTarget , kind , parameterArgs , bodyArg )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-createdynamicfunction"
     },
     {
       "clause": "20.2.2",
       "title": "Properties of the Function Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-function-constructor"
     },
     {
       "clause": "20.2.2.1",
       "title": "Function.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function.prototype"
     },
     {
       "clause": "20.2.3",
       "title": "Properties of the Function Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object"
     },
     {
       "clause": "20.2.3.1",
       "title": "Function.prototype.apply ( thisArg , argArray )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function.prototype.apply"
     },
     {
       "clause": "20.2.3.2",
       "title": "Function.prototype.bind ( thisArg , ... args )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function.prototype.bind"
     },
     {
       "clause": "20.2.3.3",
       "title": "Function.prototype.call ( thisArg , ... args )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function.prototype.call"
     },
     {
       "clause": "20.2.3.4",
       "title": "Function.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function.prototype.constructor"
     },
     {
       "clause": "20.2.3.5",
       "title": "Function.prototype.toString ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function.prototype.tostring"
     },
     {
       "clause": "20.2.3.6",
       "title": "Function.prototype [ %Symbol.hasInstance% ] ( V )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%"
     },
     {
       "clause": "20.2.4",
       "title": "Function Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-function-instances"
     },
     {
       "clause": "20.2.4.1",
       "title": "length",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function-instances-length"
     },
     {
       "clause": "20.2.4.2",
       "title": "name",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function-instances-name"
     },
     {
       "clause": "20.2.4.3",
       "title": "prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-function-instances-prototype"
     },
     {
       "clause": "20.2.5",
       "title": "HostHasSourceTextAvailable ( func )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-hosthassourcetextavailable"
     }
   ],
   "support": {
     "entries": [
       {
-        "clause": "20.2.1",
-        "feature": "Math.E",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object",
-        "notes": "Euler’s number e."
-      },
-      {
-        "clause": "20.2.1",
-        "feature": "Math.LN2",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object",
-        "notes": "Natural logarithm of 2."
-      },
-      {
-        "clause": "20.2.1",
-        "feature": "Math.LN10",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object",
-        "notes": "Natural logarithm of 10."
-      },
-      {
-        "clause": "20.2.1",
-        "feature": "Math.LOG2E",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object",
-        "notes": "Base-2 logarithm of e."
-      },
-      {
-        "clause": "20.2.1",
-        "feature": "Math.LOG10E",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object",
-        "notes": "Base-10 logarithm of e."
-      },
-      {
-        "clause": "20.2.1",
-        "feature": "Math.PI",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object",
-        "notes": "Ratio of a circle’s circumference to its diameter."
-      },
-      {
-        "clause": "20.2.1",
-        "feature": "Math.SQRT1_2",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object",
-        "notes": "Square root of 1/2."
-      },
-      {
-        "clause": "20.2.1",
-        "feature": "Math.SQRT2",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object",
-        "notes": "Square root of 2."
-      },
-      {
-        "clause": "20.2.2.1",
-        "feature": "Math.abs(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.abs",
-        "notes": "Returns the absolute value; NaN propagates; ±Infinity preserved."
-      },
-      {
-        "clause": "20.2.2.2",
-        "feature": "Math.acos(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.acos",
-        "notes": "Returns arc cosine in radians; out-of-domain yields NaN."
-      },
-      {
-        "clause": "20.2.2.3",
-        "feature": "Math.acosh(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.acosh",
-        "notes": "Inverse hyperbolic cosine; x < 1 yields NaN; Infinity preserved."
-      },
-      {
-        "clause": "20.2.2.4",
-        "feature": "Math.asin(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.asin",
-        "notes": "Returns arc sine in radians; out-of-domain yields NaN."
-      },
-      {
-        "clause": "20.2.2.5",
-        "feature": "Math.asinh(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.asinh",
-        "notes": "Inverse hyperbolic sine; handles ±0, NaN, ±Infinity per spec."
-      },
-      {
-        "clause": "20.2.2.6",
-        "feature": "Math.atan(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.atan",
-        "notes": "Returns arc tangent in radians; NaN propagates; ±Infinity maps to ±π/2."
-      },
-      {
-        "clause": "20.2.2.7",
-        "feature": "Math.atan2(y, x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.atan2",
-        "notes": "Quadrant-aware arc tangent; handles zeros, NaN, and infinities per spec."
-      },
-      {
-        "clause": "20.2.2.9",
-        "feature": "Math.ceil(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.ceil",
+        "clause": "20.2.4",
+        "feature": "Function instances are callable (basic invocation)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-function-instances",
         "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Ceil_Sqrt_Basic.js"
+          "Js2IL.Tests/Function/JavaScript/Function_HelloWorld.js",
+          "Js2IL.Tests/Function/JavaScript/Function_CallViaVariable_Reassignment.js"
         ],
-        "notes": "Implements ceiling for numbers represented as double; arguments coerced via minimal ToNumber semantics. Returns NaN for NaN/undefined or negative zero preserved via .NET semantics."
+        "notes": "JavaScript functions are compiled to CLR delegates and invoked directly (or via a small runtime dispatcher). This does not imply a full spec-level Function object with Function.prototype methods."
       },
       {
-        "clause": "20.2.2.10",
-        "feature": "Math.clz32(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.clz32",
+        "clause": "20.2.4",
+        "feature": "Closures capture and mutate outer variables",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-function-instances",
         "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Imul_Clz32_Basics.js"
+          "Js2IL.Tests/Function/JavaScript/Function_Closure_MultiLevel_ReadWriteAcrossScopes.js"
         ],
-        "notes": "Counts leading zero bits in the 32-bit unsigned integer representation."
+        "notes": "Closures are implemented via the scope-as-class model (scope instances hold variables as fields)."
       },
       {
-        "clause": "20.2.2.11",
-        "feature": "Math.cos(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.cos",
-        "notes": "Cosine of x (radians); NaN propagates; Infinity yields NaN."
-      },
-      {
-        "clause": "20.2.2.12",
-        "feature": "Math.cosh(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.cosh",
-        "notes": "Hyperbolic cosine; handles ±0, NaN, ±Infinity per spec."
-      },
-      {
-        "clause": "20.2.2.13",
-        "feature": "Math.exp(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.exp",
+        "clause": "20.2.4",
+        "feature": "Method calls set dynamic this; arrow functions capture lexical this",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-function-instances",
         "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Log_Exp_Identity.js"
+          "Js2IL.Tests/Function/JavaScript/Function_ObjectLiteralMethod_ThisBinding.js",
+          "Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_LexicalThis_CreatedInMethod.js"
         ],
-        "notes": "e^x; consistent with JS semantics for NaN and infinities."
-      },
-      {
-        "clause": "20.2.2.14",
-        "feature": "Math.expm1(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.expm1",
-        "notes": "Returns e^x - 1 with improved precision for small x."
-      },
-      {
-        "clause": "20.2.2.15",
-        "feature": "Math.floor(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.floor",
-        "notes": "Largest integer less than or equal to x; preserves -0 when appropriate."
-      },
-      {
-        "clause": "20.2.2.16",
-        "feature": "Math.fround(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.fround",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Fround_SignedZero.js"
-        ],
-        "notes": "Rounds to nearest 32-bit float; preserves signed zero."
-      },
-      {
-        "clause": "20.2.2.17",
-        "feature": "Math.hypot(...values)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.hypot",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Hypot_Infinity_NaN.js"
-        ],
-        "notes": "Computes sqrt(sum(x_i^2)); returns Infinity if any arg is ±Infinity; NaN if any arg is NaN and none are Infinity."
-      },
-      {
-        "clause": "20.2.2.18",
-        "feature": "Math.imul(a, b)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.imul",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Imul_Clz32_Basics.js"
-        ],
-        "notes": "C-style 32-bit integer multiplication with wrapping."
-      },
-      {
-        "clause": "20.2.2.19",
-        "feature": "Math.log(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.log",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Log_Exp_Identity.js"
-        ],
-        "notes": "Natural logarithm; log(1) = 0; negative x yields NaN; log(0) = -Infinity."
-      },
-      {
-        "clause": "20.2.2.20",
-        "feature": "Math.log10(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.log10",
-        "notes": "Base-10 logarithm; JS semantics for 0, negatives, NaN, and infinities."
-      },
-      {
-        "clause": "20.2.2.21",
-        "feature": "Math.log1p(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.log1p",
-        "notes": "log(1 + x) with improved precision for small x."
-      },
-      {
-        "clause": "20.2.2.22",
-        "feature": "Math.log2(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.log2",
-        "notes": "Base-2 logarithm; JS semantics for 0, negatives, NaN, and infinities."
-      },
-      {
-        "clause": "20.2.2.23",
-        "feature": "Math.max(...values)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.max",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Min_Max_NaN_EmptyArgs.js"
-        ],
-        "notes": "Returns the largest of the given numbers; with no arguments returns -Infinity; if any argument is NaN returns NaN."
-      },
-      {
-        "clause": "20.2.2.24",
-        "feature": "Math.sqrt(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.sqrt",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Ceil_Sqrt_Basic.js"
-        ],
-        "notes": "Returns the square root for non-negative inputs; negative or NaN yields NaN; Infinity maps to Infinity."
-      },
-      {
-        "clause": "20.2.2.25",
-        "feature": "Math.pow(x, y)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.pow",
-        "notes": "Exponentiation; consistent with JS semantics including NaN and Infinity cases."
-      },
-      {
-        "clause": "20.2.2.26",
-        "feature": "Math.random()",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.random",
-        "notes": "Returns a pseudo-random number in the range [0, 1)."
-      },
-      {
-        "clause": "20.2.2.27",
-        "feature": "Math.round(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.round",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Round_Trunc_NegativeHalves.js"
-        ],
-        "notes": "Rounds to the nearest integer; ties at .5 round up toward +∞; exact -0.5 returns -0."
-      },
-      {
-        "clause": "20.2.2.28",
-        "feature": "Math.sign(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.sign",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Sign_ZeroVariants.js"
-        ],
-        "notes": "Returns 1, -1, 0, -0, or NaN depending on the sign of x; ±Infinity map to ±1."
-      },
-      {
-        "clause": "20.2.2.29",
-        "feature": "Math.sin(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.sin",
-        "notes": "Sine of x (radians); NaN propagates; Infinity yields NaN."
-      },
-      {
-        "clause": "20.2.2.30",
-        "feature": "Math.sinh(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.sinh",
-        "notes": "Hyperbolic sine; handles ±0, NaN, ±Infinity per spec."
-      },
-      {
-        "clause": "20.2.2.31",
-        "feature": "Math.tan(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.tan",
-        "notes": "Tangent of x (radians); NaN propagates; Infinity yields NaN."
-      },
-      {
-        "clause": "20.2.2.32",
-        "feature": "Math.tanh(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.tanh",
-        "notes": "Hyperbolic tangent; handles ±0, NaN, ±Infinity per spec."
-      },
-      {
-        "clause": "20.2.2.33",
-        "feature": "Math.trunc(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.trunc",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Round_Trunc_NegativeHalves.js"
-        ],
-        "notes": "Removes fractional part; preserves sign for zero (can return -0)."
-      },
-      {
-        "clause": "20.2.2.34",
-        "feature": "Math.min(...values)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.min",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Min_Max_NaN_EmptyArgs.js"
-        ],
-        "notes": "Returns the smallest of the given numbers; with no arguments returns Infinity; if any argument is NaN returns NaN."
-      },
-      {
-        "clause": "20.2.2.35",
-        "feature": "Math.cbrt(x)",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-math.cbrt",
-        "testScripts": [
-          "Js2IL.Tests/Math/JavaScript/Math_Cbrt_Negative.js"
-        ],
-        "notes": "Cube root; handles negative values returning negative result; NaN propagates; Infinity preserved."
+        "notes": "Normal functions support receiver-based this for member calls; arrow functions implement lexical this binding via runtime helpers."
       }
     ]
   }

--- a/docs/ECMA262/20/Section20_2.md
+++ b/docs/ECMA262/20/Section20_2.md
@@ -6,248 +6,39 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 20.2 | Function Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) |
+| 20.2 | Function Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 20.2.1 | The Function Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-constructor) |
-| 20.2.1.1 | Function ( ... parameterArgs , bodyArg ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-p1-p2-pn-body) |
-| 20.2.1.1.1 | CreateDynamicFunction ( constructor , newTarget , kind , parameterArgs , bodyArg ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-createdynamicfunction) |
-| 20.2.2 | Properties of the Function Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-function-constructor) |
-| 20.2.2.1 | Function.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype) |
-| 20.2.3 | Properties of the Function Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object) |
-| 20.2.3.1 | Function.prototype.apply ( thisArg , argArray ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.apply) |
-| 20.2.3.2 | Function.prototype.bind ( thisArg , ... args ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.bind) |
-| 20.2.3.3 | Function.prototype.call ( thisArg , ... args ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.call) |
-| 20.2.3.4 | Function.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.constructor) |
-| 20.2.3.5 | Function.prototype.toString ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.tostring) |
-| 20.2.3.6 | Function.prototype [ %Symbol.hasInstance% ] ( V ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%) |
-| 20.2.4 | Function Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-instances) |
-| 20.2.4.1 | length | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-instances-length) |
-| 20.2.4.2 | name | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-instances-name) |
-| 20.2.4.3 | prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-instances-prototype) |
-| 20.2.5 | HostHasSourceTextAvailable ( func ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hosthassourcetextavailable) |
+| 20.2.1 | The Function Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function-constructor) |
+| 20.2.1.1 | Function ( ... parameterArgs , bodyArg ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function-p1-p2-pn-body) |
+| 20.2.1.1.1 | CreateDynamicFunction ( constructor , newTarget , kind , parameterArgs , bodyArg ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-createdynamicfunction) |
+| 20.2.2 | Properties of the Function Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-function-constructor) |
+| 20.2.2.1 | Function.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype) |
+| 20.2.3 | Properties of the Function Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object) |
+| 20.2.3.1 | Function.prototype.apply ( thisArg , argArray ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.apply) |
+| 20.2.3.2 | Function.prototype.bind ( thisArg , ... args ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.bind) |
+| 20.2.3.3 | Function.prototype.call ( thisArg , ... args ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.call) |
+| 20.2.3.4 | Function.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.constructor) |
+| 20.2.3.5 | Function.prototype.toString ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype.tostring) |
+| 20.2.3.6 | Function.prototype [ %Symbol.hasInstance% ] ( V ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%) |
+| 20.2.4 | Function Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-function-instances) |
+| 20.2.4.1 | length | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function-instances-length) |
+| 20.2.4.2 | name | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function-instances-name) |
+| 20.2.4.3 | prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-function-instances-prototype) |
+| 20.2.5 | HostHasSourceTextAvailable ( func ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-hosthassourcetextavailable) |
 
 ## Support
 
 Feature-level support tracking with test script references.
 
-### 20.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-function-constructor))
+### 20.2.4 ([tc39.es](https://tc39.es/ecma262/#sec-function-instances))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Math.E | Supported |  | Euler’s number e. |
-| Math.LN2 | Supported |  | Natural logarithm of 2. |
-| Math.LN10 | Supported |  | Natural logarithm of 10. |
-| Math.LOG2E | Supported |  | Base-2 logarithm of e. |
-| Math.LOG10E | Supported |  | Base-10 logarithm of e. |
-| Math.PI | Supported |  | Ratio of a circle’s circumference to its diameter. |
-| Math.SQRT1_2 | Supported |  | Square root of 1/2. |
-| Math.SQRT2 | Supported |  | Square root of 2. |
-
-### 20.2.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-function.prototype))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.abs(x) | Supported |  | Returns the absolute value; NaN propagates; ±Infinity preserved. |
-
-### 20.2.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-math.acos))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.acos(x) | Supported |  | Returns arc cosine in radians; out-of-domain yields NaN. |
-
-### 20.2.2.3 ([tc39.es](https://tc39.es/ecma262/#sec-math.acosh))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.acosh(x) | Supported |  | Inverse hyperbolic cosine; x < 1 yields NaN; Infinity preserved. |
-
-### 20.2.2.4 ([tc39.es](https://tc39.es/ecma262/#sec-math.asin))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.asin(x) | Supported |  | Returns arc sine in radians; out-of-domain yields NaN. |
-
-### 20.2.2.5 ([tc39.es](https://tc39.es/ecma262/#sec-math.asinh))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.asinh(x) | Supported |  | Inverse hyperbolic sine; handles ±0, NaN, ±Infinity per spec. |
-
-### 20.2.2.6 ([tc39.es](https://tc39.es/ecma262/#sec-math.atan))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.atan(x) | Supported |  | Returns arc tangent in radians; NaN propagates; ±Infinity maps to ±π/2. |
-
-### 20.2.2.7 ([tc39.es](https://tc39.es/ecma262/#sec-math.atan2))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.atan2(y, x) | Supported |  | Quadrant-aware arc tangent; handles zeros, NaN, and infinities per spec. |
-
-### 20.2.2.9 ([tc39.es](https://tc39.es/ecma262/#sec-math.ceil))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.ceil(x) | Supported | [`Math_Ceil_Sqrt_Basic.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Ceil_Sqrt_Basic.js) | Implements ceiling for numbers represented as double; arguments coerced via minimal ToNumber semantics. Returns NaN for NaN/undefined or negative zero preserved via .NET semantics. |
-
-### 20.2.2.10 ([tc39.es](https://tc39.es/ecma262/#sec-math.clz32))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.clz32(x) | Supported | [`Math_Imul_Clz32_Basics.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Imul_Clz32_Basics.js) | Counts leading zero bits in the 32-bit unsigned integer representation. |
-
-### 20.2.2.11 ([tc39.es](https://tc39.es/ecma262/#sec-math.cos))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.cos(x) | Supported |  | Cosine of x (radians); NaN propagates; Infinity yields NaN. |
-
-### 20.2.2.12 ([tc39.es](https://tc39.es/ecma262/#sec-math.cosh))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.cosh(x) | Supported |  | Hyperbolic cosine; handles ±0, NaN, ±Infinity per spec. |
-
-### 20.2.2.13 ([tc39.es](https://tc39.es/ecma262/#sec-math.exp))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.exp(x) | Supported | [`Math_Log_Exp_Identity.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Log_Exp_Identity.js) | e^x; consistent with JS semantics for NaN and infinities. |
-
-### 20.2.2.14 ([tc39.es](https://tc39.es/ecma262/#sec-math.expm1))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.expm1(x) | Supported |  | Returns e^x - 1 with improved precision for small x. |
-
-### 20.2.2.15 ([tc39.es](https://tc39.es/ecma262/#sec-math.floor))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.floor(x) | Supported |  | Largest integer less than or equal to x; preserves -0 when appropriate. |
-
-### 20.2.2.16 ([tc39.es](https://tc39.es/ecma262/#sec-math.fround))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.fround(x) | Supported | [`Math_Fround_SignedZero.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Fround_SignedZero.js) | Rounds to nearest 32-bit float; preserves signed zero. |
-
-### 20.2.2.17 ([tc39.es](https://tc39.es/ecma262/#sec-math.hypot))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.hypot(...values) | Supported | [`Math_Hypot_Infinity_NaN.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Hypot_Infinity_NaN.js) | Computes sqrt(sum(x_i^2)); returns Infinity if any arg is ±Infinity; NaN if any arg is NaN and none are Infinity. |
-
-### 20.2.2.18 ([tc39.es](https://tc39.es/ecma262/#sec-math.imul))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.imul(a, b) | Supported | [`Math_Imul_Clz32_Basics.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Imul_Clz32_Basics.js) | C-style 32-bit integer multiplication with wrapping. |
-
-### 20.2.2.19 ([tc39.es](https://tc39.es/ecma262/#sec-math.log))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.log(x) | Supported | [`Math_Log_Exp_Identity.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Log_Exp_Identity.js) | Natural logarithm; log(1) = 0; negative x yields NaN; log(0) = -Infinity. |
-
-### 20.2.2.20 ([tc39.es](https://tc39.es/ecma262/#sec-math.log10))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.log10(x) | Supported |  | Base-10 logarithm; JS semantics for 0, negatives, NaN, and infinities. |
-
-### 20.2.2.21 ([tc39.es](https://tc39.es/ecma262/#sec-math.log1p))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.log1p(x) | Supported |  | log(1 + x) with improved precision for small x. |
-
-### 20.2.2.22 ([tc39.es](https://tc39.es/ecma262/#sec-math.log2))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.log2(x) | Supported |  | Base-2 logarithm; JS semantics for 0, negatives, NaN, and infinities. |
-
-### 20.2.2.23 ([tc39.es](https://tc39.es/ecma262/#sec-math.max))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.max(...values) | Supported | [`Math_Min_Max_NaN_EmptyArgs.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Min_Max_NaN_EmptyArgs.js) | Returns the largest of the given numbers; with no arguments returns -Infinity; if any argument is NaN returns NaN. |
-
-### 20.2.2.24 ([tc39.es](https://tc39.es/ecma262/#sec-math.sqrt))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.sqrt(x) | Supported | [`Math_Ceil_Sqrt_Basic.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Ceil_Sqrt_Basic.js) | Returns the square root for non-negative inputs; negative or NaN yields NaN; Infinity maps to Infinity. |
-
-### 20.2.2.25 ([tc39.es](https://tc39.es/ecma262/#sec-math.pow))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.pow(x, y) | Supported |  | Exponentiation; consistent with JS semantics including NaN and Infinity cases. |
-
-### 20.2.2.26 ([tc39.es](https://tc39.es/ecma262/#sec-math.random))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.random() | Supported |  | Returns a pseudo-random number in the range [0, 1). |
-
-### 20.2.2.27 ([tc39.es](https://tc39.es/ecma262/#sec-math.round))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.round(x) | Supported | [`Math_Round_Trunc_NegativeHalves.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Round_Trunc_NegativeHalves.js) | Rounds to the nearest integer; ties at .5 round up toward +∞; exact -0.5 returns -0. |
-
-### 20.2.2.28 ([tc39.es](https://tc39.es/ecma262/#sec-math.sign))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.sign(x) | Supported | [`Math_Sign_ZeroVariants.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Sign_ZeroVariants.js) | Returns 1, -1, 0, -0, or NaN depending on the sign of x; ±Infinity map to ±1. |
-
-### 20.2.2.29 ([tc39.es](https://tc39.es/ecma262/#sec-math.sin))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.sin(x) | Supported |  | Sine of x (radians); NaN propagates; Infinity yields NaN. |
-
-### 20.2.2.30 ([tc39.es](https://tc39.es/ecma262/#sec-math.sinh))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.sinh(x) | Supported |  | Hyperbolic sine; handles ±0, NaN, ±Infinity per spec. |
-
-### 20.2.2.31 ([tc39.es](https://tc39.es/ecma262/#sec-math.tan))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.tan(x) | Supported |  | Tangent of x (radians); NaN propagates; Infinity yields NaN. |
-
-### 20.2.2.32 ([tc39.es](https://tc39.es/ecma262/#sec-math.tanh))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.tanh(x) | Supported |  | Hyperbolic tangent; handles ±0, NaN, ±Infinity per spec. |
-
-### 20.2.2.33 ([tc39.es](https://tc39.es/ecma262/#sec-math.trunc))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.trunc(x) | Supported | [`Math_Round_Trunc_NegativeHalves.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Round_Trunc_NegativeHalves.js) | Removes fractional part; preserves sign for zero (can return -0). |
-
-### 20.2.2.34 ([tc39.es](https://tc39.es/ecma262/#sec-math.min))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.min(...values) | Supported | [`Math_Min_Max_NaN_EmptyArgs.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Min_Max_NaN_EmptyArgs.js) | Returns the smallest of the given numbers; with no arguments returns Infinity; if any argument is NaN returns NaN. |
-
-### 20.2.2.35 ([tc39.es](https://tc39.es/ecma262/#sec-math.cbrt))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Math.cbrt(x) | Supported | [`Math_Cbrt_Negative.js`](../../../Js2IL.Tests/Math/JavaScript/Math_Cbrt_Negative.js) | Cube root; handles negative values returning negative result; NaN propagates; Infinity preserved. |
+| Closures capture and mutate outer variables | Supported with Limitations | [`Function_Closure_MultiLevel_ReadWriteAcrossScopes.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Closure_MultiLevel_ReadWriteAcrossScopes.js) | Closures are implemented via the scope-as-class model (scope instances hold variables as fields). |
+| Function instances are callable (basic invocation) | Supported with Limitations | [`Function_HelloWorld.js`](../../../Js2IL.Tests/Function/JavaScript/Function_HelloWorld.js)<br>[`Function_CallViaVariable_Reassignment.js`](../../../Js2IL.Tests/Function/JavaScript/Function_CallViaVariable_Reassignment.js) | JavaScript functions are compiled to CLR delegates and invoked directly (or via a small runtime dispatcher). This does not imply a full spec-level Function object with Function.prototype methods. |
+| Method calls set dynamic this; arrow functions capture lexical this | Supported with Limitations | [`Function_ObjectLiteralMethod_ThisBinding.js`](../../../Js2IL.Tests/Function/JavaScript/Function_ObjectLiteralMethod_ThisBinding.js)<br>[`ArrowFunction_LexicalThis_CreatedInMethod.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_LexicalThis_CreatedInMethod.js) | Normal functions support receiver-based this for member calls; arrow functions implement lexical this binding via runtime helpers. |
 

--- a/docs/ECMA262/20/Section20_3.json
+++ b/docs/ECMA262/20/Section20_3.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "20.3",
   "title": "Boolean Objects",
-  "status": "Untracked",
+  "status": "Incomplete",
   "specUrl": "https://tc39.es/ecma262/#sec-boolean-objects",
   "parent": {
     "clause": "20"
@@ -12,62 +12,86 @@
     {
       "clause": "20.3.1",
       "title": "The Boolean Constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-boolean-constructor"
     },
     {
       "clause": "20.3.1.1",
       "title": "Boolean ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value"
     },
     {
       "clause": "20.3.2",
       "title": "Properties of the Boolean Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-boolean-constructor"
     },
     {
       "clause": "20.3.2.1",
       "title": "Boolean.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-boolean.prototype"
     },
     {
       "clause": "20.3.3",
       "title": "Properties of the Boolean Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-boolean-prototype-object"
     },
     {
       "clause": "20.3.3.1",
       "title": "Boolean.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-boolean.prototype.constructor"
     },
     {
       "clause": "20.3.3.2",
       "title": "Boolean.prototype.toString ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-boolean.prototype.tostring"
     },
     {
       "clause": "20.3.3.3",
       "title": "Boolean.prototype.valueOf ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-boolean.prototype.valueof"
     },
     {
       "clause": "20.3.3.3.1",
       "title": "ThisBooleanValue ( value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-thisbooleanvalue"
     },
     {
       "clause": "20.3.4",
       "title": "Properties of Boolean Instances",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-boolean-instances"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "20.3.1.1",
+        "feature": "Boolean(value) (callable primitive conversion)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value",
+        "testScripts": [
+          "Js2IL.Tests/PrimitiveConversion/JavaScript/PrimitiveConversion_Boolean_Callable.js"
+        ],
+        "notes": "Lowered by the compiler to truthiness conversion (JavaScriptRuntime.TypeUtilities.ToBoolean). Limitations: some runtime-only types (e.g. BigInt/BigInteger) are currently treated as always truthy."
+      },
+      {
+        "clause": "20.3.1.1",
+        "feature": "new Boolean(value)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value",
+        "testScripts": [
+          "Js2IL.Tests/Literals/JavaScript/NewExpression_Boolean_Sugar.js"
+        ],
+        "notes": "Implemented as compiler sugar that returns a primitive boolean. This does not create a Boolean wrapper object, so behavior differs from spec in cases where object/primitive distinction matters (e.g. truthiness, prototype methods)."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/20/Section20_3.md
+++ b/docs/ECMA262/20/Section20_3.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 20.3: Boolean Objects
 
@@ -6,5 +6,31 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 20.3 | Boolean Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-boolean-objects) |
+| 20.3 | Boolean Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-boolean-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 20.3.1 | The Boolean Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-boolean-constructor) |
+| 20.3.1.1 | Boolean ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value) |
+| 20.3.2 | Properties of the Boolean Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-boolean-constructor) |
+| 20.3.2.1 | Boolean.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-boolean.prototype) |
+| 20.3.3 | Properties of the Boolean Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-boolean-prototype-object) |
+| 20.3.3.1 | Boolean.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-boolean.prototype.constructor) |
+| 20.3.3.2 | Boolean.prototype.toString ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-boolean.prototype.tostring) |
+| 20.3.3.3 | Boolean.prototype.valueOf ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-boolean.prototype.valueof) |
+| 20.3.3.3.1 | ThisBooleanValue ( value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-thisbooleanvalue) |
+| 20.3.4 | Properties of Boolean Instances | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-boolean-instances) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 20.3.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Boolean(value) (callable primitive conversion) | Supported with Limitations | [`PrimitiveConversion_Boolean_Callable.js`](../../../Js2IL.Tests/PrimitiveConversion/JavaScript/PrimitiveConversion_Boolean_Callable.js) | Lowered by the compiler to truthiness conversion (JavaScriptRuntime.TypeUtilities.ToBoolean). Limitations: some runtime-only types (e.g. BigInt/BigInteger) are currently treated as always truthy. |
+| new Boolean(value) | Supported with Limitations | [`NewExpression_Boolean_Sugar.js`](../../../Js2IL.Tests/Literals/JavaScript/NewExpression_Boolean_Sugar.js) | Implemented as compiler sugar that returns a primitive boolean. This does not create a Boolean wrapper object, so behavior differs from spec in cases where object/primitive distinction matters (e.g. truthiness, prototype methods). |
 

--- a/docs/ECMA262/20/Section20_5.json
+++ b/docs/ECMA262/20/Section20_5.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "20.5",
   "title": "Error Objects",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-error-objects",
   "parent": {
     "clause": "20"
@@ -12,242 +12,288 @@
     {
       "clause": "20.5.1",
       "title": "The Error Constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-error-constructor"
     },
     {
       "clause": "20.5.1.1",
       "title": "Error ( message [ , options ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-error-message"
     },
     {
       "clause": "20.5.2",
       "title": "Properties of the Error Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-error-constructor"
     },
     {
       "clause": "20.5.2.1",
       "title": "Error.isError ( arg )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-error.iserror"
     },
     {
       "clause": "20.5.2.2",
       "title": "Error.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-error.prototype"
     },
     {
       "clause": "20.5.3",
       "title": "Properties of the Error Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-error-prototype-object"
     },
     {
       "clause": "20.5.3.1",
       "title": "Error.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-error.prototype.constructor"
     },
     {
       "clause": "20.5.3.2",
       "title": "Error.prototype.message",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-error.prototype.message"
     },
     {
       "clause": "20.5.3.3",
       "title": "Error.prototype.name",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-error.prototype.name"
     },
     {
       "clause": "20.5.3.4",
       "title": "Error.prototype.toString ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-error.prototype.tostring"
     },
     {
       "clause": "20.5.4",
       "title": "Properties of Error Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-error-instances"
     },
     {
       "clause": "20.5.5",
       "title": "Native Error Types Used in This Standard",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
     },
     {
       "clause": "20.5.5.1",
       "title": "EvalError",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-evalerror"
     },
     {
       "clause": "20.5.5.2",
       "title": "RangeError",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror"
     },
     {
       "clause": "20.5.5.3",
       "title": "ReferenceError",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror"
     },
     {
       "clause": "20.5.5.4",
       "title": "SyntaxError",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror"
     },
     {
       "clause": "20.5.5.5",
       "title": "TypeError",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror"
     },
     {
       "clause": "20.5.5.6",
       "title": "URIError",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-urierror"
     },
     {
       "clause": "20.5.6",
       "title": "NativeError Object Structure",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-nativeerror-object-structure"
     },
     {
       "clause": "20.5.6.1",
       "title": "The NativeError Constructors",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-nativeerror-constructors"
     },
     {
       "clause": "20.5.6.1.1",
       "title": "NativeError ( message [ , options ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-nativeerror"
     },
     {
       "clause": "20.5.6.2",
       "title": "Properties of the NativeError Constructors",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-nativeerror-constructors"
     },
     {
       "clause": "20.5.6.2.1",
       "title": "NativeError .prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-nativeerror.prototype"
     },
     {
       "clause": "20.5.6.3",
       "title": "Properties of the NativeError Prototype Objects",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-nativeerror-prototype-objects"
     },
     {
       "clause": "20.5.6.3.1",
       "title": "NativeError .prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-nativeerror.prototype.constructor"
     },
     {
       "clause": "20.5.6.3.2",
       "title": "NativeError .prototype.message",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-nativeerror.prototype.message"
     },
     {
       "clause": "20.5.6.3.3",
       "title": "NativeError .prototype.name",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-nativeerror.prototype.name"
     },
     {
       "clause": "20.5.6.4",
       "title": "Properties of NativeError Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-nativeerror-instances"
     },
     {
       "clause": "20.5.7",
       "title": "AggregateError Objects",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error-objects"
     },
     {
       "clause": "20.5.7.1",
       "title": "The AggregateError Constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error-constructor"
     },
     {
       "clause": "20.5.7.1.1",
       "title": "AggregateError ( errors , message [ , options ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error"
     },
     {
       "clause": "20.5.7.2",
       "title": "Properties of the AggregateError Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-constructors"
     },
     {
       "clause": "20.5.7.2.1",
       "title": "AggregateError.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error.prototype"
     },
     {
       "clause": "20.5.7.3",
       "title": "Properties of the AggregateError Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects"
     },
     {
       "clause": "20.5.7.3.1",
       "title": "AggregateError.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error.prototype.constructor"
     },
     {
       "clause": "20.5.7.3.2",
       "title": "AggregateError.prototype.message",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error.prototype.message"
     },
     {
       "clause": "20.5.7.3.3",
       "title": "AggregateError.prototype.name",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error.prototype.name"
     },
     {
       "clause": "20.5.7.4",
       "title": "Properties of AggregateError Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-aggregate-error-instances"
     },
     {
       "clause": "20.5.8",
       "title": "Abstract Operations for Error Objects",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-abstract-operations-for-error-objects"
     },
     {
       "clause": "20.5.8.1",
       "title": "InstallErrorCause ( O , options )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-installerrorcause"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "20.5.1.1",
+        "feature": "Error(message) (callable creates instance)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-error-message",
+        "testScripts": [
+          "Js2IL.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_Callable_CreatesInstances.js"
+        ],
+        "notes": "Compiler lowers built-in error callables (Error/TypeError/...) to construction of JavaScriptRuntime error types. Currently supports 0 or 1 argument; the optional 'options' parameter is not supported."
+      },
+      {
+        "clause": "20.5.1.1",
+        "feature": "new Error(message) and new NativeError(message)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-error-message",
+        "testScripts": [
+          "Js2IL.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js"
+        ],
+        "notes": "Constructs JavaScriptRuntime.Error (and derived types) with message stringification via DotNet2JSConversions.ToString. The runtime does not currently model spec prototype objects; behavior is closer to .NET exceptions with JS-like surface properties."
+      },
+      {
+        "clause": "20.5.4",
+        "feature": "Error instance properties: name, message, stack",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-error-instances",
+        "testScripts": [
+          "Js2IL.Tests/TryCatch/JavaScript/TryCatch_CallMember_MissingMethod_IsTypeError.js",
+          "Js2IL.Tests/Variable/JavaScript/Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.js"
+        ],
+        "notes": "name/message are exposed as instance properties on JavaScriptRuntime.Error. stack is backed by the .NET stack trace (or a captured construction-time stack if not thrown yet)."
+      },
+      {
+        "clause": "20.5.7.1.1",
+        "feature": "AggregateError constructors and .errors",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error",
+        "testScripts": [
+          "Js2IL.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js",
+          "Js2IL.Tests/Promise/JavaScript/Promise_Any_AllRejected.js"
+        ],
+        "notes": "JavaScriptRuntime.AggregateError stores errors in a JavaScriptRuntime.Array. Signature differs from spec in some cases (e.g., the test uses new AggregateError(\"agg\") which maps to a message-only overload). 'options' / 'cause' are not supported."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/20/Section20_5.md
+++ b/docs/ECMA262/20/Section20_5.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 20.5: Error Objects
 
@@ -6,5 +6,73 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 20.5 | Error Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-error-objects) |
+| 20.5 | Error Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 20.5.1 | The Error Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error-constructor) |
+| 20.5.1.1 | Error ( message [ , options ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error-message) |
+| 20.5.2 | Properties of the Error Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-error-constructor) |
+| 20.5.2.1 | Error.isError ( arg ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.iserror) |
+| 20.5.2.2 | Error.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype) |
+| 20.5.3 | Properties of the Error Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-error-prototype-object) |
+| 20.5.3.1 | Error.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype.constructor) |
+| 20.5.3.2 | Error.prototype.message | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype.message) |
+| 20.5.3.3 | Error.prototype.name | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype.name) |
+| 20.5.3.4 | Error.prototype.toString ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype.tostring) |
+| 20.5.4 | Properties of Error Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-error-instances) |
+| 20.5.5 | Native Error Types Used in This Standard | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard) |
+| 20.5.5.1 | EvalError | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-evalerror) |
+| 20.5.5.2 | RangeError | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror) |
+| 20.5.5.3 | ReferenceError | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror) |
+| 20.5.5.4 | SyntaxError | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror) |
+| 20.5.5.5 | TypeError | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror) |
+| 20.5.5.6 | URIError | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-urierror) |
+| 20.5.6 | NativeError Object Structure | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-nativeerror-object-structure) |
+| 20.5.6.1 | The NativeError Constructors | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-nativeerror-constructors) |
+| 20.5.6.1.1 | NativeError ( message [ , options ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-nativeerror) |
+| 20.5.6.2 | Properties of the NativeError Constructors | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-nativeerror-constructors) |
+| 20.5.6.2.1 | NativeError .prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-nativeerror.prototype) |
+| 20.5.6.3 | Properties of the NativeError Prototype Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-nativeerror-prototype-objects) |
+| 20.5.6.3.1 | NativeError .prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-nativeerror.prototype.constructor) |
+| 20.5.6.3.2 | NativeError .prototype.message | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-nativeerror.prototype.message) |
+| 20.5.6.3.3 | NativeError .prototype.name | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-nativeerror.prototype.name) |
+| 20.5.6.4 | Properties of NativeError Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-nativeerror-instances) |
+| 20.5.7 | AggregateError Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error-objects) |
+| 20.5.7.1 | The AggregateError Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error-constructor) |
+| 20.5.7.1.1 | AggregateError ( errors , message [ , options ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error) |
+| 20.5.7.2 | Properties of the AggregateError Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-constructors) |
+| 20.5.7.2.1 | AggregateError.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype) |
+| 20.5.7.3 | Properties of the AggregateError Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects) |
+| 20.5.7.3.1 | AggregateError.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.constructor) |
+| 20.5.7.3.2 | AggregateError.prototype.message | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.message) |
+| 20.5.7.3.3 | AggregateError.prototype.name | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.name) |
+| 20.5.7.4 | Properties of AggregateError Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-aggregate-error-instances) |
+| 20.5.8 | Abstract Operations for Error Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-error-objects) |
+| 20.5.8.1 | InstallErrorCause ( O , options ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-installerrorcause) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 20.5.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-error-message))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Error(message) (callable creates instance) | Supported with Limitations | [`IntrinsicCallables_Error_Callable_CreatesInstances.js`](../../../Js2IL.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_Callable_CreatesInstances.js) | Compiler lowers built-in error callables (Error/TypeError/...) to construction of JavaScriptRuntime error types. Currently supports 0 or 1 argument; the optional 'options' parameter is not supported. |
+| new Error(message) and new NativeError(message) | Supported with Limitations | [`TryCatch_NewExpression_BuiltInErrors.js`](../../../Js2IL.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js) | Constructs JavaScriptRuntime.Error (and derived types) with message stringification via DotNet2JSConversions.ToString. The runtime does not currently model spec prototype objects; behavior is closer to .NET exceptions with JS-like surface properties. |
+
+### 20.5.4 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-error-instances))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Error instance properties: name, message, stack | Supported with Limitations | [`TryCatch_CallMember_MissingMethod_IsTypeError.js`](../../../Js2IL.Tests/TryCatch/JavaScript/TryCatch_CallMember_MissingMethod_IsTypeError.js)<br>[`Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.js`](../../../Js2IL.Tests/Variable/JavaScript/Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.js) | name/message are exposed as instance properties on JavaScriptRuntime.Error. stack is backed by the .NET stack trace (or a captured construction-time stack if not thrown yet). |
+
+### 20.5.7.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-aggregate-error))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| AggregateError constructors and .errors | Supported with Limitations | [`TryCatch_NewExpression_BuiltInErrors.js`](../../../Js2IL.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js)<br>[`Promise_Any_AllRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Any_AllRejected.js) | JavaScriptRuntime.AggregateError stores errors in a JavaScriptRuntime.Array. Signature differs from spec in some cases (e.g., the test uses new AggregateError("agg") which maps to a message-only overload). 'options' / 'cause' are not supported. |
 

--- a/docs/ECMA262/3/Section3.md
+++ b/docs/ECMA262/3/Section3.md
@@ -6,5 +6,5 @@ Lists the normative references that ECMAScript relies on.
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 3 | Normative References | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-normative-references) |
+| 3 | Normative References | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-normative-references) |
 

--- a/docs/ECMA262/4/Section4.md
+++ b/docs/ECMA262/4/Section4.md
@@ -10,14 +10,14 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 4 | Overview | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-overview) |
+| 4 | Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-overview) |
 
 ## Subsections
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 4.1 | Web Scripting | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-web-scripting) | [Section4_1.md](Section4_1.md) |
-| 4.2 | Hosts and Implementations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hosts-and-implementations) | [Section4_2.md](Section4_2.md) |
-| 4.3 | ECMAScript Overview | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-overview) | [Section4_3.md](Section4_3.md) |
-| 4.4 | Terms and Definitions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions) | [Section4_4.md](Section4_4.md) |
-| 4.5 | Organization of This Specification | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-organization-of-this-specification) | [Section4_5.md](Section4_5.md) |
+| 4.1 | Web Scripting | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-web-scripting) | [Section4_1.md](Section4_1.md) |
+| 4.2 | Hosts and Implementations | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-hosts-and-implementations) | [Section4_2.md](Section4_2.md) |
+| 4.3 | ECMAScript Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-overview) | [Section4_3.md](Section4_3.md) |
+| 4.4 | Terms and Definitions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions) | [Section4_4.md](Section4_4.md) |
+| 4.5 | Organization of This Specification | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-organization-of-this-specification) | [Section4_5.md](Section4_5.md) |

--- a/docs/ECMA262/4/Section4_1.json
+++ b/docs/ECMA262/4/Section4_1.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "4.1",
   "title": "Web Scripting",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-web-scripting",
   "parent": {
     "clause": "4"

--- a/docs/ECMA262/4/Section4_1.md
+++ b/docs/ECMA262/4/Section4_1.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 4.1: Web Scripting
 
@@ -6,5 +6,5 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 4.1 | Web Scripting | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-web-scripting) |
+| 4.1 | Web Scripting | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-web-scripting) |
 

--- a/docs/ECMA262/4/Section4_2.json
+++ b/docs/ECMA262/4/Section4_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "4.2",
   "title": "Hosts and Implementations",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-hosts-and-implementations",
   "parent": {
     "clause": "4"

--- a/docs/ECMA262/4/Section4_2.md
+++ b/docs/ECMA262/4/Section4_2.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 4.2: Hosts and Implementations
 
@@ -6,5 +6,5 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 4.2 | Hosts and Implementations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hosts-and-implementations) |
+| 4.2 | Hosts and Implementations | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-hosts-and-implementations) |
 

--- a/docs/ECMA262/4/Section4_3.json
+++ b/docs/ECMA262/4/Section4_3.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "4.3",
   "title": "ECMAScript Overview",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-ecmascript-overview",
   "parent": {
     "clause": "4"

--- a/docs/ECMA262/4/Section4_3.md
+++ b/docs/ECMA262/4/Section4_3.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 4.3: ECMAScript Overview
 
@@ -6,5 +6,12 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 4.3 | ECMAScript Overview | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-overview) |
+| 4.3 | ECMAScript Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-overview) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 4.3.1 | Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-objects) |
+| 4.3.2 | The Strict Variant of ECMAScript | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-strict-variant-of-ecmascript) |
 

--- a/docs/ECMA262/4/Section4_4.json
+++ b/docs/ECMA262/4/Section4_4.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "4.4",
   "title": "Terms and Definitions",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions",
   "parent": {
     "clause": "4"

--- a/docs/ECMA262/4/Section4_4.md
+++ b/docs/ECMA262/4/Section4_4.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 4.4: Terms and Definitions
 
@@ -6,5 +6,52 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 4.4 | Terms and Definitions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions) |
+| 4.4 | Terms and Definitions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 4.4.1 | implementation-approximated | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-implementation-approximated) |
+| 4.4.2 | implementation-defined | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-implementation-defined) |
+| 4.4.3 | host-defined | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-host-defined) |
+| 4.4.4 | type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-type) |
+| 4.4.5 | primitive value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-primitive-value) |
+| 4.4.6 | object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-object) |
+| 4.4.7 | constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-constructor) |
+| 4.4.8 | prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-prototype) |
+| 4.4.9 | ordinary object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object) |
+| 4.4.10 | exotic object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-exotic-object) |
+| 4.4.11 | standard object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-standard-object) |
+| 4.4.12 | built-in object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-object) |
+| 4.4.13 | undefined value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-undefined-value) |
+| 4.4.14 | Undefined type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-undefined-type) |
+| 4.4.15 | null value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-null-value) |
+| 4.4.16 | Null type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-null-type) |
+| 4.4.17 | Boolean value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-boolean-value) |
+| 4.4.18 | Boolean type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-boolean-type) |
+| 4.4.19 | Boolean object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-boolean-object) |
+| 4.4.20 | String value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-string-value) |
+| 4.4.21 | String type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-string-type) |
+| 4.4.22 | String object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-object) |
+| 4.4.23 | Number value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-number-value) |
+| 4.4.24 | Number type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-number-type) |
+| 4.4.25 | Number object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number-object) |
+| 4.4.26 | Infinity | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-infinity) |
+| 4.4.27 | NaN | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-nan) |
+| 4.4.28 | BigInt value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-value) |
+| 4.4.29 | BigInt type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-type) |
+| 4.4.30 | BigInt object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-bigint-object) |
+| 4.4.31 | Symbol value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-symbol-value) |
+| 4.4.32 | Symbol type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-symbol-type) |
+| 4.4.33 | Symbol object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-symbol-object) |
+| 4.4.34 | function | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-function) |
+| 4.4.35 | built-in function | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function) |
+| 4.4.36 | built-in constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-constructor) |
+| 4.4.37 | property | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-property) |
+| 4.4.38 | method | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-method) |
+| 4.4.39 | built-in method | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-method) |
+| 4.4.40 | attribute | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-attribute) |
+| 4.4.41 | own property | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-own-property) |
+| 4.4.42 | inherited property | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-inherited-property) |
 

--- a/docs/ECMA262/4/Section4_5.json
+++ b/docs/ECMA262/4/Section4_5.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "4.5",
   "title": "Organization of This Specification",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-organization-of-this-specification",
   "parent": {
     "clause": "4"

--- a/docs/ECMA262/4/Section4_5.md
+++ b/docs/ECMA262/4/Section4_5.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 4.5: Organization of This Specification
 
@@ -6,5 +6,5 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 4.5 | Organization of This Specification | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-organization-of-this-specification) |
+| 4.5 | Organization of This Specification | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-organization-of-this-specification) |
 

--- a/docs/ECMA262/5/Section5.md
+++ b/docs/ECMA262/5/Section5.md
@@ -10,11 +10,11 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 5 | Notational Conventions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) |
+| 5 | Notational Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) |
 
 ## Subsections
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 5.1 | Syntactic and Lexical Grammars | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-syntactic-and-lexical-grammars) | [Section5_1.md](Section5_1.md) |
-| 5.2 | Algorithm Conventions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions) | [Section5_2.md](Section5_2.md) |
+| 5.1 | Syntactic and Lexical Grammars | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-syntactic-and-lexical-grammars) | [Section5_1.md](Section5_1.md) |
+| 5.2 | Algorithm Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions) | [Section5_2.md](Section5_2.md) |

--- a/docs/ECMA262/5/Section5_1.json
+++ b/docs/ECMA262/5/Section5_1.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "5.1",
   "title": "Syntactic and Lexical Grammars",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-syntactic-and-lexical-grammars",
   "parent": {
     "clause": "5"
@@ -12,49 +12,49 @@
     {
       "clause": "5.1.1",
       "title": "Context-Free Grammars",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-context-free-grammars"
     },
     {
       "clause": "5.1.2",
       "title": "The Lexical and RegExp Grammars",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-lexical-and-regexp-grammars"
     },
     {
       "clause": "5.1.3",
       "title": "The Numeric String Grammar",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-numeric-string-grammar"
     },
     {
       "clause": "5.1.4",
       "title": "The Syntactic Grammar",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-syntactic-grammar"
     },
     {
       "clause": "5.1.5",
       "title": "Grammar Notation",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-grammar-notation"
     },
     {
       "clause": "5.1.5.1",
       "title": "Terminal Symbols",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terminal-symbols"
     },
     {
       "clause": "5.1.5.2",
       "title": "Nonterminal Symbols and Productions",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-nonterminal-symbols-and-productions"
     },
     {
       "clause": "5.1.5.3",
       "title": "Optional Symbols",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-optional-symbols"
     },
     {

--- a/docs/ECMA262/5/Section5_1.md
+++ b/docs/ECMA262/5/Section5_1.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 5.1: Syntactic and Lexical Grammars
 
@@ -6,5 +6,25 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 5.1 | Syntactic and Lexical Grammars | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-syntactic-and-lexical-grammars) |
+| 5.1 | Syntactic and Lexical Grammars | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-syntactic-and-lexical-grammars) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 5.1.1 | Context-Free Grammars | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-context-free-grammars) |
+| 5.1.2 | The Lexical and RegExp Grammars | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-lexical-and-regexp-grammars) |
+| 5.1.3 | The Numeric String Grammar | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-numeric-string-grammar) |
+| 5.1.4 | The Syntactic Grammar | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-syntactic-grammar) |
+| 5.1.5 | Grammar Notation | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-grammar-notation) |
+| 5.1.5.1 | Terminal Symbols | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terminal-symbols) |
+| 5.1.5.2 | Nonterminal Symbols and Productions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-nonterminal-symbols-and-productions) |
+| 5.1.5.3 | Optional Symbols | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-optional-symbols) |
+| 5.1.5.4 | Grammatical Parameters | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-grammatical-parameters) |
+| 5.1.5.5 | one of | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-one-of) |
+| 5.1.5.6 | [empty] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-empty) |
+| 5.1.5.7 | Lookahead Restrictions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-lookahead-restrictions) |
+| 5.1.5.8 | [no LineTerminator here] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-no-lineterminator-here) |
+| 5.1.5.9 | but not | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-but-not) |
+| 5.1.5.10 | Descriptive Phrases | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-descriptive-phrases) |
 

--- a/docs/ECMA262/5/Section5_2.json
+++ b/docs/ECMA262/5/Section5_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "5.2",
   "title": "Algorithm Conventions",
-  "status": "Untracked",
+  "status": "N/A (informational)",
   "specUrl": "https://tc39.es/ecma262/#sec-algorithm-conventions",
   "parent": {
     "clause": "5"

--- a/docs/ECMA262/5/Section5_2.md
+++ b/docs/ECMA262/5/Section5_2.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 5.2: Algorithm Conventions
 
@@ -6,5 +6,22 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 5.2 | Algorithm Conventions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions) |
+| 5.2 | Algorithm Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 5.2.1 | Evaluation Order | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-evaluation-order) |
+| 5.2.2 | Abstract Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations) |
+| 5.2.3 | Syntax-Directed Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations) |
+| 5.2.4 | Runtime Semantics | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics) |
+| 5.2.4.1 | Completion ( completionRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-completion-ao) |
+| 5.2.4.2 | Throw an Exception | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-throw-an-exception) |
+| 5.2.4.3 | Shorthands for Unwrapping Completion Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-shorthands-for-unwrapping-completion-records) |
+| 5.2.4.4 | Implicit Normal Completion | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-implicit-normal-completion) |
+| 5.2.5 | Static Semantics | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantic-rules) |
+| 5.2.6 | Mathematical Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-mathematical-operations) |
+| 5.2.7 | Value Notation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-value-notation) |
+| 5.2.8 | Identity | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-identity) |
 

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -12,6 +12,7 @@ Important:
 - `Supported with Limitations`: Safe for general/daily-driver use, but has known edge-case/spec-corner gaps (documented in subsection notes).
 - `Incomplete`: Some implementation exists, but missing core semantics and not safe to rely on broadly.
 - `Not Yet Supported`: Not implemented (or intentionally rejected by validator) for the documented scope.
+- `N/A (informational)`: Spec clause is informational/organizational (not a JS runtime/compiler feature).
 - `Untracked`: Not evaluated/documented yet; may work, but not claimed.
 
 Notes:
@@ -26,11 +27,11 @@ Notes:
 
 | Section | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 1 | Scope | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-scope) | [Section1.md](1/Section1.md) |
-| 2 | Conformance | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conformance) | [Section2.md](2/Section2.md) |
-| 3 | Normative References | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-normative-references) | [Section3.md](3/Section3.md) |
-| 4 | Overview | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-overview) | [Section4.md](4/Section4.md) |
-| 5 | Notational Conventions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) | [Section5.md](5/Section5.md) |
+| 1 | Scope | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-scope) | [Section1.md](1/Section1.md) |
+| 2 | Conformance | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance) | [Section2.md](2/Section2.md) |
+| 3 | Normative References | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-normative-references) | [Section3.md](3/Section3.md) |
+| 4 | Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-overview) | [Section4.md](4/Section4.md) |
+| 5 | Notational Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) | [Section5.md](5/Section5.md) |
 | 6 | ECMAScript Data Types and Values | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section6.md](6/Section6.md) |
 | 7 | Abstract Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section7.md](7/Section7.md) |
 | 8 | Syntax-Directed Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section8.md](8/Section8.md) |

--- a/docs/ECMA262/SectionDoc.schema.json
+++ b/docs/ECMA262/SectionDoc.schema.json
@@ -10,13 +10,14 @@
       "type": "string",
       "enum": [
         "Untracked",
+        "N/A (informational)",
         "Not Yet Supported",
         "Incomplete",
         "Supported with Limitations",
         "Supported",
         "Partially Supported"
       ],
-      "description": "Support status used throughout docs. Prefer 'Incomplete' or 'Supported with Limitations'. 'Partially Supported' is a deprecated legacy status kept for backwards compatibility."
+      "description": "Support status used throughout docs. Use 'N/A (informational)' for spec clauses that describe the document, process, or notation rather than runtime/compile-time behavior. Prefer 'Incomplete' or 'Supported with Limitations'. 'Partially Supported' is a deprecated legacy status kept for backwards compatibility."
     },
     "supportEntry": {
       "type": "object",

--- a/scripts/ECMA262/generateEcma262SectionMarkdown.js
+++ b/scripts/ECMA262/generateEcma262SectionMarkdown.js
@@ -114,6 +114,7 @@ function requireString(obj, key) {
 function validateStatus(status) {
   const allowed = [
     'Untracked',
+    'N/A (informational)',
     'Not Yet Supported',
     'Incomplete',
     'Supported with Limitations',

--- a/scripts/ECMA262/rollupEcma262Statuses.js
+++ b/scripts/ECMA262/rollupEcma262Statuses.js
@@ -131,6 +131,7 @@ function escapePipes(text) {
 function validateStatus(status) {
   const allowed = [
     'Untracked',
+    'N/A (informational)',
     'Not Yet Supported',
     'Incomplete',
     'Supported with Limitations',
@@ -166,11 +167,18 @@ function getRollupStatus(statuses) {
       return s;
     });
 
-  const hasUntracked = norm.includes('Untracked');
-  const hasNotYet = norm.includes('Not Yet Supported');
-  const hasIncomplete = norm.includes('Incomplete');
-  const hasLimitations = norm.includes('Supported with Limitations');
-  const hasSupported = norm.includes('Supported');
+  // Treat informational clauses as neutral for rollups.
+  // If *everything* is informational, the rollup should be informational.
+  const withoutInformational = norm.filter((s) => s !== 'N/A (informational)');
+  if (norm.length > 0 && withoutInformational.length === 0) return 'N/A (informational)';
+
+  const effective = withoutInformational;
+
+  const hasUntracked = effective.includes('Untracked');
+  const hasNotYet = effective.includes('Not Yet Supported');
+  const hasIncomplete = effective.includes('Incomplete');
+  const hasLimitations = effective.includes('Supported with Limitations');
+  const hasSupported = effective.includes('Supported');
 
   // Nothing tracked at all.
   if (!hasNotYet && !hasIncomplete && !hasLimitations && !hasSupported && hasUntracked) return 'Untracked';

--- a/scripts/ECMA262/splitEcma262SectionsIntoSubsections.js
+++ b/scripts/ECMA262/splitEcma262SectionsIntoSubsections.js
@@ -8,6 +8,7 @@
  *
  * Status rollup precedence:
  *   Not Yet Supported > Incomplete > Supported with Limitations > Supported > Untracked
+ *   N/A (informational) is neutral and only wins when all statuses are informational.
  * Legacy "Not Supported" is treated as "Not Yet Supported".
  * Legacy "Partially Supported" is treated as "Supported with Limitations".
  */
@@ -114,12 +115,17 @@ function getRollupStatus(statuses) {
     .map((s) => (s ?? '').trim())
     .filter((s) => s.length > 0);
 
-  if (norm.includes('Not Yet Supported')) return 'Not Yet Supported';
-  if (norm.includes('Not Supported')) return 'Not Yet Supported';
-  if (norm.includes('Incomplete')) return 'Incomplete';
-  if (norm.includes('Supported with Limitations')) return 'Supported with Limitations';
-  if (norm.includes('Partially Supported')) return 'Supported with Limitations';
-  if (norm.includes('Supported')) return 'Supported';
+  const withoutInformational = norm.filter((s) => s !== 'N/A (informational)');
+  if (norm.length > 0 && withoutInformational.length === 0) return 'N/A (informational)';
+
+  const effective = withoutInformational;
+
+  if (effective.includes('Not Yet Supported')) return 'Not Yet Supported';
+  if (effective.includes('Not Supported')) return 'Not Yet Supported';
+  if (effective.includes('Incomplete')) return 'Incomplete';
+  if (effective.includes('Supported with Limitations')) return 'Supported with Limitations';
+  if (effective.includes('Partially Supported')) return 'Supported with Limitations';
+  if (effective.includes('Supported')) return 'Supported';
   return 'Untracked';
 }
 


### PR DESCRIPTION
## Summary

This PR syncs the ECMA-262 coverage documentation with current JS2IL implementation/tests and improves the docs tooling to better represent non-applicable spec clauses.

## Changes

- Add a new status `N/A (informational)` for clauses that describe spec organization/conformance text rather than implementable runtime semantics.
- Apply `N/A (informational)` to Sections 1–5 and regenerate their subsection markdown.
- Fix drift in Section 20.2 (Function Objects) docs, replacing incorrect content and reflecting current supported Function/closure behavior.
- Regenerate affected ECMA-262 markdown pages and update the index legend/rollups.

## Notes

- Rollup script (`node scripts/ECMA262/rollupEcma262Statuses.js`) reports no further changes needed after this update.
