### PR TITLE
docs(ecma262): audit Sections 15 and 27

### DIFF
--- a/docs/ECMA262/15/Section15_2.json
+++ b/docs/ECMA262/15/Section15_2.json
@@ -63,6 +63,13 @@
         "notes": "Ordinary functions compile end-to-end, including nested functions and closure capture (scope-as-class). Parameter-list limitations apply (no rest params; max 6 params)."
       },
       {
+        "clause": "15.2.2",
+        "feature": "directive prologue / strict mode (\"use strict\") semantics",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-functionbodycontainsusestrict",
+        "notes": "JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists."
+      },
+      {
         "clause": "15.2",
         "feature": "function expressions (assigned/returned) and closures",
         "status": "Supported",

--- a/docs/ECMA262/15/Section15_2.md
+++ b/docs/ECMA262/15/Section15_2.md
@@ -31,3 +31,9 @@ Feature-level support tracking with test script references.
 | function expressions (assigned/returned) and closures | Supported | [`Function_NestedFunctionExpression_ReturnedAndCalledViaVariable.js`](../../../Js2IL.Tests/Function/JavaScript/Function_NestedFunctionExpression_ReturnedAndCalledViaVariable.js)<br>[`Function_CallViaVariable_Reassignment.js`](../../../Js2IL.Tests/Function/JavaScript/Function_CallViaVariable_Reassignment.js)<br>[`Function_Closure_MultiLevel_ReadWriteAcrossScopes.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Closure_MultiLevel_ReadWriteAcrossScopes.js)<br>[`Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.js`](../../../Js2IL.Tests/Function/JavaScript/Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.js) |  |
 | IIFE (immediately-invoked function expressions) | Supported | [`Function_IIFE_Classic.js`](../../../Js2IL.Tests/Function/JavaScript/Function_IIFE_Classic.js)<br>[`Function_IIFE_Recursive.js`](../../../Js2IL.Tests/Function/JavaScript/Function_IIFE_Recursive.js) |  |
 
+### 15.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-functionbodycontainsusestrict))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| directive prologue / strict mode ("use strict") semantics | Supported with Limitations |  | JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists. |
+

--- a/docs/ECMA262/15/Section15_3.json
+++ b/docs/ECMA262/15/Section15_3.json
@@ -63,6 +63,13 @@
         "notes": "Arrow functions compile via the IR pipeline and are emitted as callable methods (see JavaScriptArrowFunctionGenerator)."
       },
       {
+        "clause": "15.3.2",
+        "feature": "directive prologue / strict mode (\"use strict\") semantics",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-concisebodycontainsusestrict",
+        "notes": "JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists."
+      },
+      {
         "clause": "15.3.4",
         "feature": "lexical this for arrow functions",
         "status": "Supported",

--- a/docs/ECMA262/15/Section15_3.md
+++ b/docs/ECMA262/15/Section15_3.md
@@ -28,6 +28,12 @@ Feature-level support tracking with test script references.
 |---|---|---|---|
 | arrow functions (=>) - basic syntax, closure, and invocation | Supported | [`ArrowFunction_SimpleExpression.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_SimpleExpression.js)<br>[`ArrowFunction_BlockBody_Return.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_BlockBody_Return.js)<br>[`ArrowFunction_CapturesOuterVariable.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_CapturesOuterVariable.js)<br>[`ArrowFunction_ClosureMutatesOuterVariable.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_ClosureMutatesOuterVariable.js)<br>[`ArrowFunction_GlobalFunctionWithMultipleParameters.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionWithMultipleParameters.js)<br>[`ArrowFunction_NestedFunctionAccessesMultipleScopes.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_NestedFunctionAccessesMultipleScopes.js)<br>[`ArrowFunction_GlobalFunctionCallsGlobalFunction.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionCallsGlobalFunction.js)<br>[`ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.js)<br>[`ArrowFunction_DefaultParameterValue.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_DefaultParameterValue.js)<br>[`ArrowFunction_DefaultParameterExpression.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_DefaultParameterExpression.js)<br>[`ArrowFunction_ParameterDestructuring_Object.js`](../../../Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_ParameterDestructuring_Object.js) | Arrow functions compile via the IR pipeline and are emitted as callable methods (see JavaScriptArrowFunctionGenerator). |
 
+### 15.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-concisebodycontainsusestrict))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| directive prologue / strict mode ("use strict") semantics | Supported with Limitations |  | JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists. |
+
 ### 15.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-instantiatearrowfunctionexpression))
 
 | Feature name | Status | Test scripts | Notes |

--- a/docs/ECMA262/15/Section15_4.json
+++ b/docs/ECMA262/15/Section15_4.json
@@ -54,6 +54,13 @@
         "notes": "Supports method syntax in object literals and correct this binding when called as obj.m()."
       },
       {
+        "clause": "15.4.1",
+        "feature": "Getter/setter method definitions (get x() / set x(v))",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-method-definitions",
+        "notes": "Getters/setters are currently rejected by the validator in both object literals and classes."
+      },
+      {
         "clause": "15.4.4",
         "feature": "Computed property names in object literals",
         "status": "Supported",

--- a/docs/ECMA262/15/Section15_4.md
+++ b/docs/ECMA262/15/Section15_4.md
@@ -22,6 +22,12 @@
 
 Feature-level support tracking with test script references.
 
+### 15.4.1 ([tc39.es](https://tc39.es/ecma262/#sec-method-definitions-static-semantics-early-errors))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Getter/setter method definitions (get x() / set x(v)) | Not Yet Supported |  | Getters/setters are currently rejected by the validator in both object literals and classes. |
+
 ### 15.4.4 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-definemethod))
 
 | Feature name | Status | Test scripts | Notes |

--- a/docs/ECMA262/15/Section15_9.json
+++ b/docs/ECMA262/15/Section15_9.json
@@ -54,6 +54,13 @@
         "notes": "Covered by Async test fixture. Async arrow functions compile and run, including await and Promise chaining."
       },
       {
+        "clause": "15.9.2",
+        "feature": "directive prologue / strict mode (\"use strict\") semantics",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-asyncconcisebodycontainsusestrict",
+        "notes": "JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists."
+      },
+      {
         "clause": "15.9.4",
         "feature": "lexical this for async arrow functions",
         "status": "Supported",

--- a/docs/ECMA262/15/Section15_9.md
+++ b/docs/ECMA262/15/Section15_9.md
@@ -28,6 +28,12 @@ Feature-level support tracking with test script references.
 |---|---|---|---|
 | async arrow functions (async () => ...) with await | Supported | [`Async_ArrowFunction_SimpleAwait.js`](../../../Js2IL.Tests/Async/JavaScript/Async_ArrowFunction_SimpleAwait.js)<br>[`Async_ArrowFunction_LexicalThis.js`](../../../Js2IL.Tests/Async/JavaScript/Async_ArrowFunction_LexicalThis.js) | Covered by Async test fixture. Async arrow functions compile and run, including await and Promise chaining. |
 
+### 15.9.2 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-asyncconcisebodycontainsusestrict))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| directive prologue / strict mode ("use strict") semantics | Supported with Limitations |  | JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists. |
+
 ### 15.9.4 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-instantiateasyncarrowfunctionexpression))
 
 | Feature name | Status | Test scripts | Notes |

--- a/docs/ECMA262/27/Section27.md
+++ b/docs/ECMA262/27/Section27.md
@@ -10,16 +10,16 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 27 | Control Abstraction Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) |
+| 27 | Control Abstraction Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) |
 
 ## Subsections
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 27.1 | Iteration | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iteration) | [Section27_1.md](Section27_1.md) |
+| 27.1 | Iteration | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteration) | [Section27_1.md](Section27_1.md) |
 | 27.2 | Promise Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise-objects) | [Section27_2.md](Section27_2.md) |
-| 27.3 | GeneratorFunction Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-objects) | [Section27_3.md](Section27_3.md) |
-| 27.4 | AsyncGeneratorFunction Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-objects) | [Section27_4.md](Section27_4.md) |
-| 27.5 | Generator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator-objects) | [Section27_5.md](Section27_5.md) |
-| 27.6 | AsyncGenerator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-objects) | [Section27_6.md](Section27_6.md) |
-| 27.7 | AsyncFunction Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-async-function-objects) | [Section27_7.md](Section27_7.md) |
+| 27.3 | GeneratorFunction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-objects) | [Section27_3.md](Section27_3.md) |
+| 27.4 | AsyncGeneratorFunction Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-objects) | [Section27_4.md](Section27_4.md) |
+| 27.5 | Generator Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generator-objects) | [Section27_5.md](Section27_5.md) |
+| 27.6 | AsyncGenerator Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-objects) | [Section27_6.md](Section27_6.md) |
+| 27.7 | AsyncFunction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-function-objects) | [Section27_7.md](Section27_7.md) |

--- a/docs/ECMA262/27/Section27_1.json
+++ b/docs/ECMA262/27/Section27_1.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "27.1",
   "title": "Iteration",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-iteration",
   "parent": {
     "clause": "27"
@@ -12,301 +12,301 @@
     {
       "clause": "27.1.1",
       "title": "Common Iteration Interfaces",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-common-iteration-interfaces"
     },
     {
       "clause": "27.1.1.1",
       "title": "The Iterable Interface",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-iterable-interface"
     },
     {
       "clause": "27.1.1.2",
       "title": "The Iterator Interface",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator-interface"
     },
     {
       "clause": "27.1.1.3",
       "title": "The Async Iterable Interface",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-asynciterable-interface"
     },
     {
       "clause": "27.1.1.4",
       "title": "The Async Iterator Interface",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-asynciterator-interface"
     },
     {
       "clause": "27.1.1.5",
       "title": "The IteratorResult Interface",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-iteratorresult-interface"
     },
     {
       "clause": "27.1.2",
       "title": "Iterator Helper Objects",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator-helper-objects"
     },
     {
       "clause": "27.1.2.1",
       "title": "The %IteratorHelperPrototype% Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-object"
     },
     {
       "clause": "27.1.2.1.1",
       "title": "%IteratorHelperPrototype%.next ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.next"
     },
     {
       "clause": "27.1.2.1.2",
       "title": "%IteratorHelperPrototype%.return ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return"
     },
     {
       "clause": "27.1.2.1.3",
       "title": "%IteratorHelperPrototype% [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-%symbol.tostringtag%"
     },
     {
       "clause": "27.1.3",
       "title": "Iterator Objects",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator-objects"
     },
     {
       "clause": "27.1.3.1",
       "title": "The Iterator Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator-constructor"
     },
     {
       "clause": "27.1.3.1.1",
       "title": "Iterator ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator"
     },
     {
       "clause": "27.1.3.2",
       "title": "Properties of the Iterator Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-iterator-constructor"
     },
     {
       "clause": "27.1.3.2.1",
       "title": "Iterator.concat ( ... items )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.concat"
     },
     {
       "clause": "27.1.3.2.2",
       "title": "Iterator.from ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.from"
     },
     {
       "clause": "27.1.3.2.2.1",
       "title": "The %WrapForValidIteratorPrototype% Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%-object"
     },
     {
       "clause": "27.1.3.2.2.1.1",
       "title": "%WrapForValidIteratorPrototype%.next ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next"
     },
     {
       "clause": "27.1.3.2.2.1.2",
       "title": "%WrapForValidIteratorPrototype%.return ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.return"
     },
     {
       "clause": "27.1.3.2.3",
       "title": "Iterator.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype"
     },
     {
       "clause": "27.1.3.3",
       "title": "Properties of the Iterator Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%iterator.prototype%-object"
     },
     {
       "clause": "27.1.3.3.1",
       "title": "Iterator.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.constructor"
     },
     {
       "clause": "27.1.3.3.1.1",
       "title": "get Iterator.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-iterator.prototype.constructor"
     },
     {
       "clause": "27.1.3.3.1.2",
       "title": "set Iterator.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set-iterator.prototype.constructor"
     },
     {
       "clause": "27.1.3.3.2",
       "title": "Iterator.prototype.drop ( limit )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.drop"
     },
     {
       "clause": "27.1.3.3.3",
       "title": "Iterator.prototype.every ( predicate )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.every"
     },
     {
       "clause": "27.1.3.3.4",
       "title": "Iterator.prototype.filter ( predicate )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.filter"
     },
     {
       "clause": "27.1.3.3.5",
       "title": "Iterator.prototype.find ( predicate )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.find"
     },
     {
       "clause": "27.1.3.3.6",
       "title": "Iterator.prototype.flatMap ( mapper )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.flatmap"
     },
     {
       "clause": "27.1.3.3.7",
       "title": "Iterator.prototype.forEach ( procedure )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.foreach"
     },
     {
       "clause": "27.1.3.3.8",
       "title": "Iterator.prototype.map ( mapper )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.map"
     },
     {
       "clause": "27.1.3.3.9",
       "title": "Iterator.prototype.reduce ( reducer [ , initialValue ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.reduce"
     },
     {
       "clause": "27.1.3.3.10",
       "title": "Iterator.prototype.some ( predicate )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.some"
     },
     {
       "clause": "27.1.3.3.11",
       "title": "Iterator.prototype.take ( limit )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.take"
     },
     {
       "clause": "27.1.3.3.12",
       "title": "Iterator.prototype.toArray ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype.toarray"
     },
     {
       "clause": "27.1.3.3.13",
       "title": "Iterator.prototype [ %Symbol.iterator% ] ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.iterator%"
     },
     {
       "clause": "27.1.3.3.14",
       "title": "Iterator.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "27.1.3.3.14.1",
       "title": "get Iterator.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-iterator.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "27.1.3.3.14.2",
       "title": "set Iterator.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set-iterator.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "27.1.4",
       "title": "The %AsyncIteratorPrototype% Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asynciteratorprototype"
     },
     {
       "clause": "27.1.4.1",
       "title": "%AsyncIteratorPrototype% [ %Symbol.asyncIterator% ] ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%asynciteratorprototype%-%symbol.asynciterator%"
     },
     {
       "clause": "27.1.5",
       "title": "Async-from-Sync Iterator Objects",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-async-from-sync-iterator-objects"
     },
     {
       "clause": "27.1.5.1",
       "title": "CreateAsyncFromSyncIterator ( syncIteratorRecord )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-createasyncfromsynciterator"
     },
     {
       "clause": "27.1.5.2",
       "title": "The %AsyncFromSyncIteratorPrototype% Object",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object"
     },
     {
       "clause": "27.1.5.2.1",
       "title": "%AsyncFromSyncIteratorPrototype%.next ( [ value ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.next"
     },
     {
       "clause": "27.1.5.2.2",
       "title": "%AsyncFromSyncIteratorPrototype%.return ( [ value ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return"
     },
     {
       "clause": "27.1.5.2.3",
       "title": "%AsyncFromSyncIteratorPrototype%.throw ( [ value ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.throw"
     },
     {
       "clause": "27.1.5.3",
       "title": "Properties of Async-from-Sync Iterator Instances",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-async-from-sync-iterator-instances"
     },
     {
       "clause": "27.1.5.4",
       "title": "AsyncFromSyncIteratorContinuation ( result , promiseCapability , syncIteratorRecord , closeOnRejection )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation"
     }
   ],
@@ -314,102 +314,30 @@
     "entries": [
       {
         "clause": "27.1.1",
-        "feature": "Promise constructor (executor), Promise.resolve, Promise.reject",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-promise-constructor",
+        "feature": "for..of consumes iterables via Symbol.iterator and performs IteratorClose on break/throw",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-iterable-interface",
         "testScripts": [
-          "Js2IL.Tests/Promise/JavaScript/Promise_Executor_Resolved.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Executor_Rejected.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Resolve_Immediate.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Resolve_Delayed.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Reject.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_NonFunctionThen.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Nested.js"
+          "Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Array_Basic.js",
+          "Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js",
+          "Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Let_PerIterationBinding.js",
+          "Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.js",
+          "Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledBreak.js",
+          "Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledContinue.js"
         ],
-        "notes": "Constructor accepts an executor delegate and supports the basic resolve/reject fast-paths and dynamic delegate invocation used in tests. Promise.resolve/reject create already-settled Promise instances, including thenable assimilation (Promise.resolve adopts thenables, handles non-function then properties, and supports nested thenables)."
+        "notes": "Runtime implements iterator protocol consumption for `for..of` over arrays and user-defined iterables via `obj[Symbol.iterator]()`. IteratorClose is implemented: if an iterator has a callable `return`, it is invoked on break/throw paths."
       },
       {
-        "clause": "27.1.1",
-        "feature": "Promise.withResolvers()",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-promise-constructor",
+        "clause": "27.1.1.3",
+        "feature": "for await..of consumes async iterables via Symbol.asyncIterator and falls back to Symbol.iterator (async-from-sync wrapper)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-asynciterable-interface",
         "testScripts": [
-          "Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Resolve.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Reject.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Idempotent.js"
+          "Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_Array.js",
+          "Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_AsyncIterator_BreakCloses.js",
+          "Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js"
         ],
-        "notes": "Implements `Promise.withResolvers()` returning `{ promise, resolve, reject }` (resolve/reject are functions that settle the associated promise)."
-      },
-      {
-        "clause": "27.1.2",
-        "feature": "Promise.prototype.then / catch / finally",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-promise.prototype.then",
-        "testScripts": [
-          "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_Then.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Reject_Then.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_ThenFinally.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Reject_FinallyCatch.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_FinallyThen.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_FinallyThrows.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Then_ReturnsResolvedPromise.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Then_ReturnsRejectedPromise.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Returned_FromHandler.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Catch_ReturnsResolvedPromise.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Catch_ReturnsRejectedPromise.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsResolvedPromise.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsRejectedPromise.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsThenable_PassThrough_Rejected.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Scheduling_StarvationTest.js"
-        ],
-        "notes": "Implements `then`, `catch`, and `finally` with microtask scheduling support. Handlers support Promise/thenable return assimilation. `finally` handlers are treated as observers: non-Promise return values do not alter the settled result, while returned Promises/thenables are awaited and propagated (fixed earlier bug where Promise returns from finally were masked). Tests include chaining, thenable returns, and then/catch/finally interactions."
-      },
-      {
-        "clause": "27.1.3",
-        "feature": "Promise.all",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-promise.all",
-        "testScripts": [
-          "Js2IL.Tests/Promise/JavaScript/Promise_All_AllResolved.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_All_OneRejected.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_All_EmptyArray.js"
-        ],
-        "notes": "Returns a Promise that resolves when all input promises resolve (with an array of results), or rejects when any input promise rejects (with the first rejection reason)."
-      },
-      {
-        "clause": "27.1.3",
-        "feature": "Promise.allSettled",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-promise.all",
-        "testScripts": [
-          "Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_MixedResults.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_AllResolved.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_AllRejected.js"
-        ],
-        "notes": "Returns a Promise that resolves when all input promises have settled (fulfilled or rejected), with an array of outcome objects containing status and value/reason."
-      },
-      {
-        "clause": "27.1.3",
-        "feature": "Promise.any",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-promise.all",
-        "testScripts": [
-          "Js2IL.Tests/Promise/JavaScript/Promise_Any_FirstResolved.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Any_AllRejected.js"
-        ],
-        "notes": "Returns a Promise that resolves as soon as any input promise resolves, or rejects with an AggregateError if all input promises reject."
-      },
-      {
-        "clause": "27.1.3",
-        "feature": "Promise.race",
-        "status": "Supported",
-        "specUrl": "https://tc39.es/ecma262/#sec-promise.all",
-        "testScripts": [
-          "Js2IL.Tests/Promise/JavaScript/Promise_Race_FirstResolved.js",
-          "Js2IL.Tests/Promise/JavaScript/Promise_Race_FirstRejected.js"
-        ],
-        "notes": "Returns a Promise that settles as soon as any input promise settles (resolves or rejects), with the same value or reason."
+        "notes": "Runtime implements async iterator protocol consumption for `for await..of`. When `Symbol.asyncIterator` is missing, it wraps the sync iterator (CreateAsyncFromSyncIterator semantics) and ensures `return()` is invoked on early-exit paths."
       }
     ]
   }

--- a/docs/ECMA262/27/Section27_1.md
+++ b/docs/ECMA262/27/Section27_1.md
@@ -6,62 +6,62 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 27.1 | Iteration | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iteration) |
+| 27.1 | Iteration | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteration) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 27.1.1 | Common Iteration Interfaces | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-common-iteration-interfaces) |
-| 27.1.1.1 | The Iterable Interface | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterable-interface) |
-| 27.1.1.2 | The Iterator Interface | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator-interface) |
-| 27.1.1.3 | The Async Iterable Interface | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asynciterable-interface) |
-| 27.1.1.4 | The Async Iterator Interface | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asynciterator-interface) |
-| 27.1.1.5 | The IteratorResult Interface | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iteratorresult-interface) |
-| 27.1.2 | Iterator Helper Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator-helper-objects) |
-| 27.1.2.1 | The %IteratorHelperPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-object) |
-| 27.1.2.1.1 | %IteratorHelperPrototype%.next ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.next) |
-| 27.1.2.1.2 | %IteratorHelperPrototype%.return ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return) |
-| 27.1.2.1.3 | %IteratorHelperPrototype% [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-%symbol.tostringtag%) |
-| 27.1.3 | Iterator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator-objects) |
-| 27.1.3.1 | The Iterator Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator-constructor) |
-| 27.1.3.1.1 | Iterator ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator) |
-| 27.1.3.2 | Properties of the Iterator Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-iterator-constructor) |
-| 27.1.3.2.1 | Iterator.concat ( ... items ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.concat) |
-| 27.1.3.2.2 | Iterator.from ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.from) |
-| 27.1.3.2.2.1 | The %WrapForValidIteratorPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%-object) |
-| 27.1.3.2.2.1.1 | %WrapForValidIteratorPrototype%.next ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next) |
-| 27.1.3.2.2.1.2 | %WrapForValidIteratorPrototype%.return ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.return) |
-| 27.1.3.2.3 | Iterator.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype) |
-| 27.1.3.3 | Properties of the Iterator Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%iterator.prototype%-object) |
-| 27.1.3.3.1 | Iterator.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.constructor) |
-| 27.1.3.3.1.1 | get Iterator.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-iterator.prototype.constructor) |
-| 27.1.3.3.1.2 | set Iterator.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-set-iterator.prototype.constructor) |
-| 27.1.3.3.2 | Iterator.prototype.drop ( limit ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.drop) |
-| 27.1.3.3.3 | Iterator.prototype.every ( predicate ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.every) |
-| 27.1.3.3.4 | Iterator.prototype.filter ( predicate ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.filter) |
-| 27.1.3.3.5 | Iterator.prototype.find ( predicate ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.find) |
-| 27.1.3.3.6 | Iterator.prototype.flatMap ( mapper ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.flatmap) |
-| 27.1.3.3.7 | Iterator.prototype.forEach ( procedure ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.foreach) |
-| 27.1.3.3.8 | Iterator.prototype.map ( mapper ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.map) |
-| 27.1.3.3.9 | Iterator.prototype.reduce ( reducer [ , initialValue ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.reduce) |
-| 27.1.3.3.10 | Iterator.prototype.some ( predicate ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.some) |
-| 27.1.3.3.11 | Iterator.prototype.take ( limit ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.take) |
-| 27.1.3.3.12 | Iterator.prototype.toArray ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.toarray) |
-| 27.1.3.3.13 | Iterator.prototype [ %Symbol.iterator% ] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.iterator%) |
-| 27.1.3.3.14 | Iterator.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.tostringtag%) |
-| 27.1.3.3.14.1 | get Iterator.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-iterator.prototype-%symbol.tostringtag%) |
-| 27.1.3.3.14.2 | set Iterator.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-set-iterator.prototype-%symbol.tostringtag%) |
-| 27.1.4 | The %AsyncIteratorPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asynciteratorprototype) |
-| 27.1.4.1 | %AsyncIteratorPrototype% [ %Symbol.asyncIterator% ] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%asynciteratorprototype%-%symbol.asynciterator%) |
-| 27.1.5 | Async-from-Sync Iterator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-async-from-sync-iterator-objects) |
-| 27.1.5.1 | CreateAsyncFromSyncIterator ( syncIteratorRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-createasyncfromsynciterator) |
-| 27.1.5.2 | The %AsyncFromSyncIteratorPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object) |
-| 27.1.5.2.1 | %AsyncFromSyncIteratorPrototype%.next ( [ value ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.next) |
-| 27.1.5.2.2 | %AsyncFromSyncIteratorPrototype%.return ( [ value ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return) |
-| 27.1.5.2.3 | %AsyncFromSyncIteratorPrototype%.throw ( [ value ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.throw) |
-| 27.1.5.3 | Properties of Async-from-Sync Iterator Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-async-from-sync-iterator-instances) |
-| 27.1.5.4 | AsyncFromSyncIteratorContinuation ( result , promiseCapability , syncIteratorRecord , closeOnRejection ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation) |
+| 27.1.1 | Common Iteration Interfaces | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-common-iteration-interfaces) |
+| 27.1.1.1 | The Iterable Interface | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iterable-interface) |
+| 27.1.1.2 | The Iterator Interface | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iterator-interface) |
+| 27.1.1.3 | The Async Iterable Interface | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-asynciterable-interface) |
+| 27.1.1.4 | The Async Iterator Interface | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-asynciterator-interface) |
+| 27.1.1.5 | The IteratorResult Interface | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratorresult-interface) |
+| 27.1.2 | Iterator Helper Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator-helper-objects) |
+| 27.1.2.1 | The %IteratorHelperPrototype% Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-object) |
+| 27.1.2.1.1 | %IteratorHelperPrototype%.next ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.next) |
+| 27.1.2.1.2 | %IteratorHelperPrototype%.return ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return) |
+| 27.1.2.1.3 | %IteratorHelperPrototype% [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-%symbol.tostringtag%) |
+| 27.1.3 | Iterator Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator-objects) |
+| 27.1.3.1 | The Iterator Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator-constructor) |
+| 27.1.3.1.1 | Iterator ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator) |
+| 27.1.3.2 | Properties of the Iterator Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-iterator-constructor) |
+| 27.1.3.2.1 | Iterator.concat ( ... items ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.concat) |
+| 27.1.3.2.2 | Iterator.from ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.from) |
+| 27.1.3.2.2.1 | The %WrapForValidIteratorPrototype% Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%-object) |
+| 27.1.3.2.2.1.1 | %WrapForValidIteratorPrototype%.next ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next) |
+| 27.1.3.2.2.1.2 | %WrapForValidIteratorPrototype%.return ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.return) |
+| 27.1.3.2.3 | Iterator.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype) |
+| 27.1.3.3 | Properties of the Iterator Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%iterator.prototype%-object) |
+| 27.1.3.3.1 | Iterator.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.constructor) |
+| 27.1.3.3.1.1 | get Iterator.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-iterator.prototype.constructor) |
+| 27.1.3.3.1.2 | set Iterator.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set-iterator.prototype.constructor) |
+| 27.1.3.3.2 | Iterator.prototype.drop ( limit ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.drop) |
+| 27.1.3.3.3 | Iterator.prototype.every ( predicate ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.every) |
+| 27.1.3.3.4 | Iterator.prototype.filter ( predicate ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.filter) |
+| 27.1.3.3.5 | Iterator.prototype.find ( predicate ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.find) |
+| 27.1.3.3.6 | Iterator.prototype.flatMap ( mapper ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.flatmap) |
+| 27.1.3.3.7 | Iterator.prototype.forEach ( procedure ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.foreach) |
+| 27.1.3.3.8 | Iterator.prototype.map ( mapper ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.map) |
+| 27.1.3.3.9 | Iterator.prototype.reduce ( reducer [ , initialValue ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.reduce) |
+| 27.1.3.3.10 | Iterator.prototype.some ( predicate ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.some) |
+| 27.1.3.3.11 | Iterator.prototype.take ( limit ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.take) |
+| 27.1.3.3.12 | Iterator.prototype.toArray ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype.toarray) |
+| 27.1.3.3.13 | Iterator.prototype [ %Symbol.iterator% ] ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.iterator%) |
+| 27.1.3.3.14 | Iterator.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.tostringtag%) |
+| 27.1.3.3.14.1 | get Iterator.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-iterator.prototype-%symbol.tostringtag%) |
+| 27.1.3.3.14.2 | set Iterator.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set-iterator.prototype-%symbol.tostringtag%) |
+| 27.1.4 | The %AsyncIteratorPrototype% Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asynciteratorprototype) |
+| 27.1.4.1 | %AsyncIteratorPrototype% [ %Symbol.asyncIterator% ] ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%asynciteratorprototype%-%symbol.asynciterator%) |
+| 27.1.5 | Async-from-Sync Iterator Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-from-sync-iterator-objects) |
+| 27.1.5.1 | CreateAsyncFromSyncIterator ( syncIteratorRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createasyncfromsynciterator) |
+| 27.1.5.2 | The %AsyncFromSyncIteratorPrototype% Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object) |
+| 27.1.5.2.1 | %AsyncFromSyncIteratorPrototype%.next ( [ value ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.next) |
+| 27.1.5.2.2 | %AsyncFromSyncIteratorPrototype%.return ( [ value ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return) |
+| 27.1.5.2.3 | %AsyncFromSyncIteratorPrototype%.throw ( [ value ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.throw) |
+| 27.1.5.3 | Properties of Async-from-Sync Iterator Instances | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-async-from-sync-iterator-instances) |
+| 27.1.5.4 | AsyncFromSyncIteratorContinuation ( result , promiseCapability , syncIteratorRecord , closeOnRejection ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation) |
 
 ## Support
 
@@ -71,21 +71,11 @@ Feature-level support tracking with test script references.
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Promise constructor (executor), Promise.resolve, Promise.reject | Supported | [`Promise_Executor_Resolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Executor_Resolved.js)<br>[`Promise_Executor_Rejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Executor_Rejected.js)<br>[`Promise_Thenable_Resolve_Immediate.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Resolve_Immediate.js)<br>[`Promise_Thenable_Resolve_Delayed.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Resolve_Delayed.js)<br>[`Promise_Thenable_Reject.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Reject.js)<br>[`Promise_Thenable_NonFunctionThen.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_NonFunctionThen.js)<br>[`Promise_Thenable_Nested.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Nested.js) | Constructor accepts an executor delegate and supports the basic resolve/reject fast-paths and dynamic delegate invocation used in tests. Promise.resolve/reject create already-settled Promise instances, including thenable assimilation (Promise.resolve adopts thenables, handles non-function then properties, and supports nested thenables). |
-| Promise.withResolvers() | Supported | [`Promise_WithResolvers_Resolve.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Resolve.js)<br>[`Promise_WithResolvers_Reject.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Reject.js)<br>[`Promise_WithResolvers_Idempotent.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Idempotent.js) | Implements `Promise.withResolvers()` returning `{ promise, resolve, reject }` (resolve/reject are functions that settle the associated promise). |
+| for..of consumes iterables via Symbol.iterator and performs IteratorClose on break/throw | Supported with Limitations | [`ControlFlow_ForOf_Array_Basic.js`](../../../Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Array_Basic.js)<br>[`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js)<br>[`ControlFlow_ForOf_Let_PerIterationBinding.js`](../../../Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Let_PerIterationBinding.js)<br>[`ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.js`](../../../Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.js)<br>[`ControlFlow_ForOf_LabeledBreak.js`](../../../Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledBreak.js)<br>[`ControlFlow_ForOf_LabeledContinue.js`](../../../Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledContinue.js) | Runtime implements iterator protocol consumption for `for..of` over arrays and user-defined iterables via `obj[Symbol.iterator]()`. IteratorClose is implemented: if an iterator has a callable `return`, it is invoked on break/throw paths. |
 
-### 27.1.2 ([tc39.es](https://tc39.es/ecma262/#sec-iterator-helper-objects))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Promise.prototype.then / catch / finally | Supported | [`Promise_Resolve_Then.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Resolve_Then.js)<br>[`Promise_Reject_Then.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Reject_Then.js)<br>[`Promise_Resolve_ThenFinally.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Resolve_ThenFinally.js)<br>[`Promise_Reject_FinallyCatch.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Reject_FinallyCatch.js)<br>[`Promise_Resolve_FinallyThen.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Resolve_FinallyThen.js)<br>[`Promise_Resolve_FinallyThrows.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Resolve_FinallyThrows.js)<br>[`Promise_Then_ReturnsResolvedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Then_ReturnsResolvedPromise.js)<br>[`Promise_Then_ReturnsRejectedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Then_ReturnsRejectedPromise.js)<br>[`Promise_Thenable_Returned_FromHandler.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Returned_FromHandler.js)<br>[`Promise_Catch_ReturnsResolvedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Catch_ReturnsResolvedPromise.js)<br>[`Promise_Catch_ReturnsRejectedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Catch_ReturnsRejectedPromise.js)<br>[`Promise_Finally_ReturnsResolvedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsResolvedPromise.js)<br>[`Promise_Finally_ReturnsRejectedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsRejectedPromise.js)<br>[`Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.js)<br>[`Promise_Finally_ReturnsThenable_PassThrough_Rejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsThenable_PassThrough_Rejected.js)<br>[`Promise_Scheduling_StarvationTest.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Scheduling_StarvationTest.js) | Implements `then`, `catch`, and `finally` with microtask scheduling support. Handlers support Promise/thenable return assimilation. `finally` handlers are treated as observers: non-Promise return values do not alter the settled result, while returned Promises/thenables are awaited and propagated (fixed earlier bug where Promise returns from finally were masked). Tests include chaining, thenable returns, and then/catch/finally interactions. |
-
-### 27.1.3 ([tc39.es](https://tc39.es/ecma262/#sec-iterator-objects))
+### 27.1.1.3 ([tc39.es](https://tc39.es/ecma262/#sec-asynciterable-interface))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Promise.all | Supported | [`Promise_All_AllResolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_All_AllResolved.js)<br>[`Promise_All_OneRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_All_OneRejected.js)<br>[`Promise_All_EmptyArray.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_All_EmptyArray.js) | Returns a Promise that resolves when all input promises resolve (with an array of results), or rejects when any input promise rejects (with the first rejection reason). |
-| Promise.allSettled | Supported | [`Promise_AllSettled_MixedResults.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_MixedResults.js)<br>[`Promise_AllSettled_AllResolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_AllResolved.js)<br>[`Promise_AllSettled_AllRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_AllRejected.js) | Returns a Promise that resolves when all input promises have settled (fulfilled or rejected), with an array of outcome objects containing status and value/reason. |
-| Promise.any | Supported | [`Promise_Any_FirstResolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Any_FirstResolved.js)<br>[`Promise_Any_AllRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Any_AllRejected.js) | Returns a Promise that resolves as soon as any input promise resolves, or rejects with an AggregateError if all input promises reject. |
-| Promise.race | Supported | [`Promise_Race_FirstResolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Race_FirstResolved.js)<br>[`Promise_Race_FirstRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Race_FirstRejected.js) | Returns a Promise that settles as soon as any input promise settles (resolves or rejects), with the same value or reason. |
+| for await..of consumes async iterables via Symbol.asyncIterator and falls back to Symbol.iterator (async-from-sync wrapper) | Supported with Limitations | [`Async_ForAwaitOf_Array.js`](../../../Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_Array.js)<br>[`Async_ForAwaitOf_AsyncIterator_BreakCloses.js`](../../../Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_AsyncIterator_BreakCloses.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js) | Runtime implements async iterator protocol consumption for `for await..of`. When `Symbol.asyncIterator` is missing, it wraps the sync iterator (CreateAsyncFromSyncIterator semantics) and ensures `return()` is invoked on early-exit paths. |
 

--- a/docs/ECMA262/27/Section27_2.json
+++ b/docs/ECMA262/27/Section27_2.json
@@ -11,85 +11,85 @@
                        {
                            "clause":  "27.2.1",
                            "title":  "Promise Abstract Operations",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promise-abstract-operations"
                        },
                        {
                            "clause":  "27.2.1.1",
                            "title":  "PromiseCapability Records",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promisecapability-records"
                        },
                        {
                            "clause":  "27.2.1.1.1",
                            "title":  "IfAbruptRejectPromise ( value , capability )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-ifabruptrejectpromise"
                        },
                        {
                            "clause":  "27.2.1.2",
                            "title":  "PromiseReaction Records",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promisereaction-records"
                        },
                        {
                            "clause":  "27.2.1.3",
                            "title":  "CreateResolvingFunctions ( promise )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-createresolvingfunctions"
                        },
                        {
                            "clause":  "27.2.1.4",
                            "title":  "FulfillPromise ( promise , value )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-fulfillpromise"
                        },
                        {
                            "clause":  "27.2.1.5",
                            "title":  "NewPromiseCapability ( C )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-newpromisecapability"
                        },
                        {
                            "clause":  "27.2.1.6",
                            "title":  "IsPromise ( x )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-ispromise"
                        },
                        {
                            "clause":  "27.2.1.7",
                            "title":  "RejectPromise ( promise , reason )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-rejectpromise"
                        },
                        {
                            "clause":  "27.2.1.8",
                            "title":  "TriggerPromiseReactions ( reactions , argument )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-triggerpromisereactions"
                        },
                        {
                            "clause":  "27.2.1.9",
                            "title":  "HostPromiseRejectionTracker ( promise , operation )",
-                           "status":  "Untracked",
+                           "status":  "Not Yet Supported",
                            "specUrl":  "https://tc39.es/ecma262/#sec-host-promise-rejection-tracker"
                        },
                        {
                            "clause":  "27.2.2",
                            "title":  "Promise Jobs",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promise-jobs"
                        },
                        {
                            "clause":  "27.2.2.1",
                            "title":  "NewPromiseReactionJob ( reaction , argument )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-newpromisereactionjob"
                        },
                        {
                            "clause":  "27.2.2.2",
                            "title":  "NewPromiseResolveThenableJob ( promiseToResolve , thenable , then )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-newpromiseresolvethenablejob"
                        },
                        {
@@ -119,13 +119,13 @@
                        {
                            "clause":  "27.2.4.1.1",
                            "title":  "GetPromiseResolve ( promiseConstructor )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-getpromiseresolve"
                        },
                        {
                            "clause":  "27.2.4.1.2",
                            "title":  "PerformPromiseAll ( iteratorRecord , constructor , resultCapability , promiseResolve )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-performpromiseall"
                        },
                        {
@@ -137,7 +137,7 @@
                        {
                            "clause":  "27.2.4.2.1",
                            "title":  "PerformPromiseAllSettled ( iteratorRecord , constructor , resultCapability , promiseResolve )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-performpromiseallsettled"
                        },
                        {
@@ -149,13 +149,13 @@
                        {
                            "clause":  "27.2.4.3.1",
                            "title":  "PerformPromiseAny ( iteratorRecord , constructor , resultCapability , promiseResolve )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-performpromiseany"
                        },
                        {
                            "clause":  "27.2.4.4",
                            "title":  "Promise.prototype",
-                           "status":  "Untracked",
+                           "status":  "Not Yet Supported",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promise.prototype"
                        },
                        {
@@ -167,7 +167,7 @@
                        {
                            "clause":  "27.2.4.5.1",
                            "title":  "PerformPromiseRace ( iteratorRecord , constructor , resultCapability , promiseResolve )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-performpromiserace"
                        },
                        {
@@ -185,13 +185,13 @@
                        {
                            "clause":  "27.2.4.7.1",
                            "title":  "PromiseResolve ( C , x )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promise-resolve"
                        },
                        {
                            "clause":  "27.2.4.8",
                            "title":  "Promise.try ( callback , ... args )",
-                           "status":  "Untracked",
+                           "status":  "Not Yet Supported",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promise.try"
                        },
                        {
@@ -203,13 +203,13 @@
                        {
                            "clause":  "27.2.4.10",
                            "title":  "get Promise [ %Symbol.species% ]",
-                           "status":  "Untracked",
+                           "status":  "Not Yet Supported",
                            "specUrl":  "https://tc39.es/ecma262/#sec-get-promise-%symbol.species%"
                        },
                        {
                            "clause":  "27.2.5",
                            "title":  "Properties of the Promise Prototype Object",
-                           "status":  "Supported",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-properties-of-the-promise-prototype-object"
                        },
                        {
@@ -221,7 +221,7 @@
                        {
                            "clause":  "27.2.5.2",
                            "title":  "Promise.prototype.constructor",
-                           "status":  "Untracked",
+                           "status":  "Not Yet Supported",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promise.prototype.constructor"
                        },
                        {
@@ -239,22 +239,96 @@
                        {
                            "clause":  "27.2.5.4.1",
                            "title":  "PerformPromiseThen ( promise , onFulfilled , onRejected [ , resultCapability ] )",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-performpromisethen"
                        },
                        {
                            "clause":  "27.2.5.5",
                            "title":  "Promise.prototype [ %Symbol.toStringTag% ]",
-                           "status":  "Untracked",
+                           "status":  "Not Yet Supported",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promise.prototype-%symbol.tostringtag%"
                        },
                        {
                            "clause":  "27.2.6",
                            "title":  "Properties of Promise Instances",
-                           "status":  "Untracked",
+                           "status":  "Supported with Limitations",
                            "specUrl":  "https://tc39.es/ecma262/#sec-properties-of-promise-instances"
                        }
                    ],
+    "support":  {
+                    "entries":  [
+                                    {
+                                        "clause":  "27.2.3",
+                                        "feature":  "Promise constructor (executor), Promise.resolve, Promise.reject",
+                                        "status":  "Supported",
+                                        "specUrl":  "https://tc39.es/ecma262/#sec-promise-constructor",
+                                        "testScripts":  [
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Executor_Resolved.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Executor_Rejected.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Resolve_Immediate.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Resolve_Delayed.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Reject.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_NonFunctionThen.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Nested.js"
+                                                        ],
+                                        "notes":  "Constructor accepts an executor delegate and supports resolving/rejecting, including thenable assimilation in Promise.resolve."
+                                    },
+                                    {
+                                        "clause":  "27.2.4.9",
+                                        "feature":  "Promise.withResolvers()",
+                                        "status":  "Supported",
+                                        "specUrl":  "https://tc39.es/ecma262/#sec-promise.withResolvers",
+                                        "testScripts":  [
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Resolve.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Reject.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Idempotent.js"
+                                                        ]
+                                    },
+                                    {
+                                        "clause":  "27.2.5",
+                                        "feature":  "Promise.prototype.then / catch / finally",
+                                        "status":  "Supported",
+                                        "specUrl":  "https://tc39.es/ecma262/#sec-promise.prototype.then",
+                                        "testScripts":  [
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_Then.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Reject_Then.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_ThenFinally.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Reject_FinallyCatch.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_FinallyThen.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Resolve_FinallyThrows.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Then_ReturnsResolvedPromise.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Then_ReturnsRejectedPromise.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Returned_FromHandler.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Catch_ReturnsResolvedPromise.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Catch_ReturnsRejectedPromise.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsResolvedPromise.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsRejectedPromise.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsThenable_PassThrough_Rejected.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Scheduling_StarvationTest.js"
+                                                        ],
+                                        "notes":  "Implements then/catch/finally with scheduling and thenable assimilation for returned values. Limitations remain around full spec-shaped prototype properties (constructor/toStringTag) and host rejection tracking."
+                                    },
+                                    {
+                                        "clause":  "27.2.4.1",
+                                        "feature":  "Promise.all / allSettled / any / race",
+                                        "status":  "Supported",
+                                        "specUrl":  "https://tc39.es/ecma262/#sec-properties-of-the-promise-constructor",
+                                        "testScripts":  [
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_All_AllResolved.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_All_OneRejected.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_All_EmptyArray.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_MixedResults.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_AllResolved.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_AllRejected.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Any_FirstResolved.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Any_AllRejected.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Race_FirstResolved.js",
+                                                            "Js2IL.Tests/Promise/JavaScript/Promise_Race_FirstRejected.js"
+                                                        ]
+                                    }
+                                ]
+                },
     "reference":  {
                       "mode":  "embedded",
                       "convertedFromHtml":  "test_output/ecma262-27.2.html",

--- a/docs/ECMA262/27/Section27_2.md
+++ b/docs/ECMA262/27/Section27_2.md
@@ -10,47 +10,75 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 27.2.1 | Promise Abstract Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promise-abstract-operations) |
-| 27.2.1.1 | PromiseCapability Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promisecapability-records) |
-| 27.2.1.1.1 | IfAbruptRejectPromise ( value , capability ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ifabruptrejectpromise) |
-| 27.2.1.2 | PromiseReaction Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promisereaction-records) |
-| 27.2.1.3 | CreateResolvingFunctions ( promise ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-createresolvingfunctions) |
-| 27.2.1.4 | FulfillPromise ( promise , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-fulfillpromise) |
-| 27.2.1.5 | NewPromiseCapability ( C ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-newpromisecapability) |
-| 27.2.1.6 | IsPromise ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ispromise) |
-| 27.2.1.7 | RejectPromise ( promise , reason ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-rejectpromise) |
-| 27.2.1.8 | TriggerPromiseReactions ( reactions , argument ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-triggerpromisereactions) |
-| 27.2.1.9 | HostPromiseRejectionTracker ( promise , operation ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-host-promise-rejection-tracker) |
-| 27.2.2 | Promise Jobs | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promise-jobs) |
-| 27.2.2.1 | NewPromiseReactionJob ( reaction , argument ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-newpromisereactionjob) |
-| 27.2.2.2 | NewPromiseResolveThenableJob ( promiseToResolve , thenable , then ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-newpromiseresolvethenablejob) |
+| 27.2.1 | Promise Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-promise-abstract-operations) |
+| 27.2.1.1 | PromiseCapability Records | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-promisecapability-records) |
+| 27.2.1.1.1 | IfAbruptRejectPromise ( value , capability ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ifabruptrejectpromise) |
+| 27.2.1.2 | PromiseReaction Records | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-promisereaction-records) |
+| 27.2.1.3 | CreateResolvingFunctions ( promise ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createresolvingfunctions) |
+| 27.2.1.4 | FulfillPromise ( promise , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-fulfillpromise) |
+| 27.2.1.5 | NewPromiseCapability ( C ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-newpromisecapability) |
+| 27.2.1.6 | IsPromise ( x ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ispromise) |
+| 27.2.1.7 | RejectPromise ( promise , reason ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-rejectpromise) |
+| 27.2.1.8 | TriggerPromiseReactions ( reactions , argument ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-triggerpromisereactions) |
+| 27.2.1.9 | HostPromiseRejectionTracker ( promise , operation ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-host-promise-rejection-tracker) |
+| 27.2.2 | Promise Jobs | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-promise-jobs) |
+| 27.2.2.1 | NewPromiseReactionJob ( reaction , argument ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-newpromisereactionjob) |
+| 27.2.2.2 | NewPromiseResolveThenableJob ( promiseToResolve , thenable , then ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-newpromiseresolvethenablejob) |
 | 27.2.3 | The Promise Constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise-constructor) |
 | 27.2.3.1 | Promise ( executor ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise-executor) |
 | 27.2.4 | Properties of the Promise Constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-promise-constructor) |
 | 27.2.4.1 | Promise.all ( iterable ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.all) |
-| 27.2.4.1.1 | GetPromiseResolve ( promiseConstructor ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getpromiseresolve) |
-| 27.2.4.1.2 | PerformPromiseAll ( iteratorRecord , constructor , resultCapability , promiseResolve ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-performpromiseall) |
+| 27.2.4.1.1 | GetPromiseResolve ( promiseConstructor ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getpromiseresolve) |
+| 27.2.4.1.2 | PerformPromiseAll ( iteratorRecord , constructor , resultCapability , promiseResolve ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-performpromiseall) |
 | 27.2.4.2 | Promise.allSettled ( iterable ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.allsettled) |
-| 27.2.4.2.1 | PerformPromiseAllSettled ( iteratorRecord , constructor , resultCapability , promiseResolve ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-performpromiseallsettled) |
+| 27.2.4.2.1 | PerformPromiseAllSettled ( iteratorRecord , constructor , resultCapability , promiseResolve ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-performpromiseallsettled) |
 | 27.2.4.3 | Promise.any ( iterable ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.any) |
-| 27.2.4.3.1 | PerformPromiseAny ( iteratorRecord , constructor , resultCapability , promiseResolve ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-performpromiseany) |
-| 27.2.4.4 | Promise.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype) |
+| 27.2.4.3.1 | PerformPromiseAny ( iteratorRecord , constructor , resultCapability , promiseResolve ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-performpromiseany) |
+| 27.2.4.4 | Promise.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype) |
 | 27.2.4.5 | Promise.race ( iterable ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.race) |
-| 27.2.4.5.1 | PerformPromiseRace ( iteratorRecord , constructor , resultCapability , promiseResolve ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-performpromiserace) |
+| 27.2.4.5.1 | PerformPromiseRace ( iteratorRecord , constructor , resultCapability , promiseResolve ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-performpromiserace) |
 | 27.2.4.6 | Promise.reject ( r ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.reject) |
 | 27.2.4.7 | Promise.resolve ( x ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.resolve) |
-| 27.2.4.7.1 | PromiseResolve ( C , x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promise-resolve) |
-| 27.2.4.8 | Promise.try ( callback , ... args ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promise.try) |
+| 27.2.4.7.1 | PromiseResolve ( C , x ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-promise-resolve) |
+| 27.2.4.8 | Promise.try ( callback , ... args ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.try) |
 | 27.2.4.9 | Promise.withResolvers ( ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.withResolvers) |
-| 27.2.4.10 | get Promise [ %Symbol.species% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-promise-%symbol.species%) |
-| 27.2.5 | Properties of the Promise Prototype Object | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-promise-prototype-object) |
+| 27.2.4.10 | get Promise [ %Symbol.species% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-promise-%symbol.species%) |
+| 27.2.5 | Properties of the Promise Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-promise-prototype-object) |
 | 27.2.5.1 | Promise.prototype.catch ( onRejected ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype.catch) |
-| 27.2.5.2 | Promise.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype.constructor) |
+| 27.2.5.2 | Promise.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype.constructor) |
 | 27.2.5.3 | Promise.prototype.finally ( onFinally ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype.finally) |
 | 27.2.5.4 | Promise.prototype.then ( onFulfilled , onRejected ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype.then) |
-| 27.2.5.4.1 | PerformPromiseThen ( promise , onFulfilled , onRejected [ , resultCapability ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-performpromisethen) |
-| 27.2.5.5 | Promise.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype-%symbol.tostringtag%) |
-| 27.2.6 | Properties of Promise Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-promise-instances) |
+| 27.2.5.4.1 | PerformPromiseThen ( promise , onFulfilled , onRejected [ , resultCapability ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-performpromisethen) |
+| 27.2.5.5 | Promise.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.prototype-%symbol.tostringtag%) |
+| 27.2.6 | Properties of Promise Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-promise-instances) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 27.2.3 ([tc39.es](https://tc39.es/ecma262/#sec-promise-constructor))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Promise constructor (executor), Promise.resolve, Promise.reject | Supported | [`Promise_Executor_Resolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Executor_Resolved.js)<br>[`Promise_Executor_Rejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Executor_Rejected.js)<br>[`Promise_Thenable_Resolve_Immediate.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Resolve_Immediate.js)<br>[`Promise_Thenable_Resolve_Delayed.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Resolve_Delayed.js)<br>[`Promise_Thenable_Reject.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Reject.js)<br>[`Promise_Thenable_NonFunctionThen.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_NonFunctionThen.js)<br>[`Promise_Thenable_Nested.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Nested.js) | Constructor accepts an executor delegate and supports resolving/rejecting, including thenable assimilation in Promise.resolve. |
+
+### 27.2.4.1 ([tc39.es](https://tc39.es/ecma262/#sec-promise.all))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Promise.all / allSettled / any / race | Supported | [`Promise_All_AllResolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_All_AllResolved.js)<br>[`Promise_All_OneRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_All_OneRejected.js)<br>[`Promise_All_EmptyArray.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_All_EmptyArray.js)<br>[`Promise_AllSettled_MixedResults.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_MixedResults.js)<br>[`Promise_AllSettled_AllResolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_AllResolved.js)<br>[`Promise_AllSettled_AllRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_AllSettled_AllRejected.js)<br>[`Promise_Any_FirstResolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Any_FirstResolved.js)<br>[`Promise_Any_AllRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Any_AllRejected.js)<br>[`Promise_Race_FirstResolved.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Race_FirstResolved.js)<br>[`Promise_Race_FirstRejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Race_FirstRejected.js) |  |
+
+### 27.2.4.9 ([tc39.es](https://tc39.es/ecma262/#sec-promise.withResolvers))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Promise.withResolvers() | Supported | [`Promise_WithResolvers_Resolve.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Resolve.js)<br>[`Promise_WithResolvers_Reject.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Reject.js)<br>[`Promise_WithResolvers_Idempotent.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_WithResolvers_Idempotent.js) |  |
+
+### 27.2.5 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-promise-prototype-object))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Promise.prototype.then / catch / finally | Supported | [`Promise_Resolve_Then.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Resolve_Then.js)<br>[`Promise_Reject_Then.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Reject_Then.js)<br>[`Promise_Resolve_ThenFinally.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Resolve_ThenFinally.js)<br>[`Promise_Reject_FinallyCatch.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Reject_FinallyCatch.js)<br>[`Promise_Resolve_FinallyThen.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Resolve_FinallyThen.js)<br>[`Promise_Resolve_FinallyThrows.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Resolve_FinallyThrows.js)<br>[`Promise_Then_ReturnsResolvedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Then_ReturnsResolvedPromise.js)<br>[`Promise_Then_ReturnsRejectedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Then_ReturnsRejectedPromise.js)<br>[`Promise_Thenable_Returned_FromHandler.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Thenable_Returned_FromHandler.js)<br>[`Promise_Catch_ReturnsResolvedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Catch_ReturnsResolvedPromise.js)<br>[`Promise_Catch_ReturnsRejectedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Catch_ReturnsRejectedPromise.js)<br>[`Promise_Finally_ReturnsResolvedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsResolvedPromise.js)<br>[`Promise_Finally_ReturnsRejectedPromise.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsRejectedPromise.js)<br>[`Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.js)<br>[`Promise_Finally_ReturnsThenable_PassThrough_Rejected.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Finally_ReturnsThenable_PassThrough_Rejected.js)<br>[`Promise_Scheduling_StarvationTest.js`](../../../Js2IL.Tests/Promise/JavaScript/Promise_Scheduling_StarvationTest.js) | Implements then/catch/finally with scheduling and thenable assimilation for returned values. Limitations remain around full spec-shaped prototype properties (constructor/toStringTag) and host rejection tracking. |
 
 ## Reference: Converted Spec Text
 

--- a/docs/ECMA262/27/Section27_3.json
+++ b/docs/ECMA262/27/Section27_3.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "27.3",
   "title": "GeneratorFunction Objects",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction-objects",
   "parent": {
     "clause": "27"
@@ -13,74 +13,91 @@
     {
       "clause": "27.3.1",
       "title": "The GeneratorFunction Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction-constructor"
     },
     {
       "clause": "27.3.1.1",
       "title": "GeneratorFunction ( ... parameterArgs , bodyArg )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction"
     },
     {
       "clause": "27.3.2",
       "title": "Properties of the GeneratorFunction Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-constructor"
     },
     {
       "clause": "27.3.2.1",
       "title": "GeneratorFunction.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction.prototype"
     },
     {
       "clause": "27.3.3",
       "title": "Properties of the GeneratorFunction Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object"
     },
     {
       "clause": "27.3.3.1",
       "title": "GeneratorFunction.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction.prototype.constructor"
     },
     {
       "clause": "27.3.3.2",
       "title": "GeneratorFunction.prototype.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype"
     },
     {
       "clause": "27.3.3.3",
       "title": "GeneratorFunction.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "27.3.4",
       "title": "GeneratorFunction Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction-instances"
     },
     {
       "clause": "27.3.4.1",
       "title": "length",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction-instances-length"
     },
     {
       "clause": "27.3.4.2",
       "title": "name",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction-instances-name"
     },
     {
       "clause": "27.3.4.3",
       "title": "prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction-instances-prototype"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "27.3.4",
+        "feature": "Generator function declarations/expressions (`function*`) compile and return generator objects",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-generatorfunction-instances",
+        "testScripts": [
+          "Js2IL.Tests/Generator/JavaScript/Generator_BasicNext.js",
+          "Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_ArrayBasic.js",
+          "Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_NestedGenerator.js",
+          "Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_ReturnForwards.js"
+        ],
+        "notes": "JS2IL supports generator syntax (`function*`, `yield`, `yield*`) but does not currently expose a spec-shaped `GeneratorFunction` constructor/prototype as global intrinsics."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/27/Section27_3.md
+++ b/docs/ECMA262/27/Section27_3.md
@@ -1,139 +1,39 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 27.3: GeneratorFunction Objects
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
-_Lists clause numbers/titles/links only (no spec text) in the index above. See appendix for extracted spec text._ 
+_Lists clause numbers/titles/links only (no spec text) in the index above. See appendix for extracted spec text._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 27.3 | GeneratorFunction Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-objects) |
+| 27.3 | GeneratorFunction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 27.3.1 | The GeneratorFunction Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-constructor) |
-| 27.3.1.1 | GeneratorFunction ( ...parameterArgs, bodyArg ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction) |
-| 27.3.2 | Properties of the GeneratorFunction Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-constructor) |
-| 27.3.2.1 | GeneratorFunction.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype) |
-| 27.3.3 | Properties of the GeneratorFunction Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object) |
-| 27.3.3.1 | GeneratorFunction.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype.constructor) |
-| 27.3.3.2 | GeneratorFunction.prototype.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype) |
-| 27.3.3.3 | GeneratorFunction.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype-%symbol.tostringtag%) |
-| 27.3.4 | GeneratorFunction Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances) |
-| 27.3.4.1 | length | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-length) |
-| 27.3.4.2 | name | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-name) |
-| 27.3.4.3 | prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-prototype) |
+| 27.3.1 | The GeneratorFunction Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-constructor) |
+| 27.3.1.1 | GeneratorFunction ( ... parameterArgs , bodyArg ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction) |
+| 27.3.2 | Properties of the GeneratorFunction Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-constructor) |
+| 27.3.2.1 | GeneratorFunction.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype) |
+| 27.3.3 | Properties of the GeneratorFunction Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object) |
+| 27.3.3.1 | GeneratorFunction.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype.constructor) |
+| 27.3.3.2 | GeneratorFunction.prototype.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype) |
+| 27.3.3.3 | GeneratorFunction.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction.prototype-%symbol.tostringtag%) |
+| 27.3.4 | GeneratorFunction Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances) |
+| 27.3.4.1 | length | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-length) |
+| 27.3.4.2 | name | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-name) |
+| 27.3.4.3 | prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances-prototype) |
 
-## Appendix: Extracted Spec Text (Converted)
+## Support
 
-This appendix is generated from a locally extracted tc39.es HTML fragment. It may be overwritten if this file is regenerated.
+Feature-level support tracking with test script references.
 
-### 27.3 GeneratorFunction Objects
+### 27.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-generatorfunction-instances))
 
-GeneratorFunctions are functions that are usually created by evaluating [GeneratorDeclaration](ecmascript-language-functions-and-classes.html#prod-GeneratorDeclaration)s, [GeneratorExpression](ecmascript-language-functions-and-classes.html#prod-GeneratorExpression)s, and [GeneratorMethod](ecmascript-language-functions-and-classes.html#prod-GeneratorMethod)s. They may also be created by calling the [%GeneratorFunction%](control-abstraction-objects.html#sec-generatorfunction-constructor) intrinsic.
-
-    Figure 6 (Informative): Generator Objects Relationships
-
-### 27.3.1 The GeneratorFunction Constructor
-
-The GeneratorFunction [constructor](ecmascript-data-types-and-values.html#constructor):
-
-- is %GeneratorFunction%.
-
-- is a subclass of `Function`.
-
-- creates and initializes a new GeneratorFunction when called as a function rather than as a [constructor](ecmascript-data-types-and-values.html#constructor). Thus the function call `GeneratorFunction (â€¦)` is equivalent to the object creation expression `new GeneratorFunction (â€¦)` with the same arguments.
-
-- may be used as the value of an `extends` clause of a class definition. Subclass [constructors](ecmascript-data-types-and-values.html#constructor) that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction [constructor](ecmascript-data-types-and-values.html#constructor) to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator [function objects](ecmascript-data-types-and-values.html#function-object) create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.
-
-### 27.3.1.1 GeneratorFunction ( ...`parameterArgs`, `bodyArg` )
-
-The last argument (if any) specifies the body (executable code) of a generator function; any preceding arguments specify formal parameters.
-
-This function performs the following steps when called:
-
-- Let `C` be the [active function object](executable-code-and-execution-contexts.html#active-function-object).
-- If `bodyArg` is not present, set `bodyArg` to the empty String.
-- Return ? [CreateDynamicFunction](fundamental-objects.html#sec-createdynamicfunction)(`C`, NewTarget, `generator`, `parameterArgs`, `bodyArg`).
-
-	Note
-
-See NOTE for [20.2.1.1](fundamental-objects.html#sec-function-p1-p2-pn-body).
-
-### 27.3.2 Properties of the GeneratorFunction Constructor
-
-The GeneratorFunction [constructor](ecmascript-data-types-and-values.html#constructor):
-
-- is a standard built-in [function object](ecmascript-data-types-and-values.html#function-object) that inherits from the Function [constructor](ecmascript-data-types-and-values.html#constructor).
-
-- has a `[[Prototype]]` internal slot whose value is [%Function%](fundamental-objects.html#sec-function-constructor).
-
-- has a "length" property whose value is `1`ð”½.
-
-- has a "name" property whose value is "GeneratorFunction".
-
-- has the following properties:
-
-### 27.3.2.1 GeneratorFunction.prototype
-
-The initial value of `GeneratorFunction.prototype` is the [GeneratorFunction prototype object](control-abstraction-objects.html#sec-properties-of-the-generatorfunction-prototype-object).
-
-This property has the attributes { `[[Writable]]`: `false`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `false` }.
-
-### 27.3.3 Properties of the GeneratorFunction Prototype Object
-
-The GeneratorFunction prototype object:
-
-- is %GeneratorFunction.prototype% (see [Figure 6](control-abstraction-objects.html#figure-2)).
-
-- is an [ordinary object](ecmascript-data-types-and-values.html#ordinary-object).
-
-- is not a [function object](ecmascript-data-types-and-values.html#function-object) and does not have an `[[ECMAScriptCode]]` internal slot or any other of the internal slots listed in [Table 28](ordinary-and-exotic-objects-behaviours.html#table-internal-slots-of-ecmascript-function-objects) or [Table 91](control-abstraction-objects.html#table-internal-slots-of-generator-instances).
-
-- has a `[[Prototype]]` internal slot whose value is [%Function.prototype%](fundamental-objects.html#sec-properties-of-the-function-prototype-object).
-
-### 27.3.3.1 GeneratorFunction.prototype.constructor
-
-The initial value of `GeneratorFunction.prototype.constructor` is [%GeneratorFunction%](control-abstraction-objects.html#sec-generatorfunction-constructor).
-
-This property has the attributes { `[[Writable]]`: `false`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `true` }.
-
-### 27.3.3.2 GeneratorFunction.prototype.prototype
-
-The initial value of `GeneratorFunction.prototype.prototype` is [%GeneratorPrototype%](control-abstraction-objects.html#sec-properties-of-generator-prototype).
-
-This property has the attributes { `[[Writable]]`: `false`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `true` }.
-
-### 27.3.3.3 GeneratorFunction.prototype [ %Symbol.toStringTag% ]
-
-The initial value of the [%Symbol.toStringTag%](ecmascript-data-types-and-values.html#sec-well-known-symbols) property is the String value "GeneratorFunction".
-
-This property has the attributes { `[[Writable]]`: `false`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `true` }.
-
-### 27.3.4 GeneratorFunction Instances
-
-Every GeneratorFunction instance is an ECMAScript [function object](ecmascript-data-types-and-values.html#function-object) and has the internal slots listed in [Table 28](ordinary-and-exotic-objects-behaviours.html#table-internal-slots-of-ecmascript-function-objects). The value of the `[[IsClassConstructor]]` internal slot for all such instances is `false`.
-
-Each GeneratorFunction instance has the following own properties:
-
-### 27.3.4.1 length
-
-The specification for the "length" property of Function instances given in [20.2.4.1](fundamental-objects.html#sec-function-instances-length) also applies to GeneratorFunction instances.
-
-### 27.3.4.2 name
-
-The specification for the "name" property of Function instances given in [20.2.4.2](fundamental-objects.html#sec-function-instances-name) also applies to GeneratorFunction instances.
-
-### 27.3.4.3 prototype
-
-Whenever a GeneratorFunction instance is created another [ordinary object](ecmascript-data-types-and-values.html#ordinary-object) is also created and is the initial value of the generator function's "prototype" property. The value of the prototype property is used to initialize the `[[Prototype]]` internal slot of a newly created Generator when the generator [function object](ecmascript-data-types-and-values.html#function-object) is invoked using `[[Call]]`.
-
-This property has the attributes { `[[Writable]]`: `true`, `[[Enumerable]]`: `false`, `[[Configurable]]`: `false` }.
-
-	Note
-
-Unlike Function instances, the object that is the value of a GeneratorFunction's "prototype" property does not have a "constructor" property whose value is the GeneratorFunction instance.
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Generator function declarations/expressions (`function*`) compile and return generator objects | Supported | [`Generator_BasicNext.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_BasicNext.js)<br>[`Generator_YieldStar_ArrayBasic.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_ArrayBasic.js)<br>[`Generator_YieldStar_NestedGenerator.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_NestedGenerator.js)<br>[`Generator_YieldStar_ReturnForwards.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_ReturnForwards.js) | JS2IL supports generator syntax (`function*`, `yield`, `yield*`) but does not currently expose a spec-shaped `GeneratorFunction` constructor/prototype as global intrinsics. |
 

--- a/docs/ECMA262/27/Section27_4.json
+++ b/docs/ECMA262/27/Section27_4.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "27.4",
   "title": "AsyncGeneratorFunction Objects",
-  "status": "Untracked",
+  "status": "Not Yet Supported",
   "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-objects",
   "parent": {
     "clause": "27"
@@ -13,73 +13,73 @@
     {
       "clause": "27.4.1",
       "title": "The AsyncGeneratorFunction Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor"
     },
     {
       "clause": "27.4.1.1",
       "title": "AsyncGeneratorFunction ( ... parameterArgs , bodyArg )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction"
     },
     {
       "clause": "27.4.2",
       "title": "Properties of the AsyncGeneratorFunction Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction"
     },
     {
       "clause": "27.4.2.1",
       "title": "AsyncGeneratorFunction.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype"
     },
     {
       "clause": "27.4.3",
       "title": "Properties of the AsyncGeneratorFunction Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction-prototype"
     },
     {
       "clause": "27.4.3.1",
       "title": "AsyncGeneratorFunction.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-constructor"
     },
     {
       "clause": "27.4.3.2",
       "title": "AsyncGeneratorFunction.prototype.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-prototype"
     },
     {
       "clause": "27.4.3.3",
       "title": "AsyncGeneratorFunction.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-%symbol.tostringtag%"
     },
     {
       "clause": "27.4.4",
       "title": "AsyncGeneratorFunction Instances",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instances"
     },
     {
       "clause": "27.4.4.1",
       "title": "length",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-length"
     },
     {
       "clause": "27.4.4.2",
       "title": "name",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-name"
     },
     {
       "clause": "27.4.4.3",
       "title": "prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-prototype"
     }
   ]

--- a/docs/ECMA262/27/Section27_4.md
+++ b/docs/ECMA262/27/Section27_4.md
@@ -1,29 +1,29 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 27.4: AsyncGeneratorFunction Objects
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
-_Lists clause numbers/titles/links only (no spec text)._ 
+_Lists clause numbers/titles/links only (no spec text)._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 27.4 | AsyncGeneratorFunction Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-objects) |
+| 27.4 | AsyncGeneratorFunction Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 27.4.1 | The AsyncGeneratorFunction Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor) |
-| 27.4.1.1 | AsyncGeneratorFunction ( ...parameterArgs, bodyArg ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction) |
-| 27.4.2 | Properties of the AsyncGeneratorFunction Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction) |
-| 27.4.2.1 | AsyncGeneratorFunction.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype) |
-| 27.4.3 | Properties of the AsyncGeneratorFunction Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction-prototype) |
-| 27.4.3.1 | AsyncGeneratorFunction.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-constructor) |
-| 27.4.3.2 | AsyncGeneratorFunction.prototype.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-prototype) |
-| 27.4.3.3 | AsyncGeneratorFunction.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-%symbol.tostringtag%) |
-| 27.4.4 | AsyncGeneratorFunction Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instances) |
-| 27.4.4.1 | length | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-length) |
-| 27.4.4.2 | name | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-name) |
-| 27.4.4.3 | prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-prototype) |
+| 27.4.1 | The AsyncGeneratorFunction Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor) |
+| 27.4.1.1 | AsyncGeneratorFunction ( ... parameterArgs , bodyArg ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction) |
+| 27.4.2 | Properties of the AsyncGeneratorFunction Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction) |
+| 27.4.2.1 | AsyncGeneratorFunction.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype) |
+| 27.4.3 | Properties of the AsyncGeneratorFunction Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction-prototype) |
+| 27.4.3.1 | AsyncGeneratorFunction.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-constructor) |
+| 27.4.3.2 | AsyncGeneratorFunction.prototype.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-prototype) |
+| 27.4.3.3 | AsyncGeneratorFunction.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-%symbol.tostringtag%) |
+| 27.4.4 | AsyncGeneratorFunction Instances | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instances) |
+| 27.4.4.1 | length | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-length) |
+| 27.4.4.2 | name | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-name) |
+| 27.4.4.3 | prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-instance-prototype) |
 

--- a/docs/ECMA262/27/Section27_5.json
+++ b/docs/ECMA262/27/Section27_5.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "27.5",
   "title": "Generator Objects",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-generator-objects",
   "parent": {
     "clause": "27"
@@ -13,98 +13,116 @@
     {
       "clause": "27.5.1",
       "title": "The %GeneratorPrototype% Object",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-generator-prototype"
     },
     {
       "clause": "27.5.1.1",
       "title": "%GeneratorPrototype%.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generator.prototype.constructor"
     },
     {
       "clause": "27.5.1.2",
       "title": "%GeneratorPrototype%.next ( value )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generator.prototype.next"
     },
     {
       "clause": "27.5.1.3",
       "title": "%GeneratorPrototype%.return ( value )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generator.prototype.return"
     },
     {
       "clause": "27.5.1.4",
       "title": "%GeneratorPrototype%.throw ( exception )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-generator.prototype.throw"
     },
     {
       "clause": "27.5.1.5",
       "title": "%GeneratorPrototype% [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-generator.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "27.5.2",
       "title": "Properties of Generator Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-generator-instances"
     },
     {
       "clause": "27.5.3",
       "title": "Generator Abstract Operations",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-generator-abstract-operations"
     },
     {
       "clause": "27.5.3.1",
       "title": "GeneratorStart ( generator , generatorBody )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorstart"
     },
     {
       "clause": "27.5.3.2",
       "title": "GeneratorValidate ( generator , generatorBrand )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorvalidate"
     },
     {
       "clause": "27.5.3.3",
       "title": "GeneratorResume ( generator , value , generatorBrand )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorresume"
     },
     {
       "clause": "27.5.3.4",
       "title": "GeneratorResumeAbrupt ( generator , abruptCompletion , generatorBrand )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-generatorresumeabrupt"
     },
     {
       "clause": "27.5.3.5",
       "title": "GetGeneratorKind ( )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-getgeneratorkind"
     },
     {
       "clause": "27.5.3.6",
       "title": "GeneratorYield ( iteratorResult )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-generatoryield"
     },
     {
       "clause": "27.5.3.7",
       "title": "Yield ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-yield"
     },
     {
       "clause": "27.5.3.8",
       "title": "CreateIteratorFromClosure ( closure , generatorBrand , generatorPrototype [ , extraSlots ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-createiteratorfromclosure"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "27.5.1",
+        "feature": "Generator objects support next/return and yield*/iterator delegation",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-generator-objects",
+        "testScripts": [
+          "Js2IL.Tests/Generator/JavaScript/Generator_BasicNext.js",
+          "Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_ArrayBasic.js",
+          "Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_NestedGenerator.js",
+          "Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_PassNextValue.js",
+          "Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_ReturnForwards.js"
+        ],
+        "notes": "`throw()` is implemented on the runtime object but currently has limited test coverage. Spec-shaped prototype properties like `constructor` and `Symbol.toStringTag` are not currently exposed."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/27/Section27_5.md
+++ b/docs/ECMA262/27/Section27_5.md
@@ -1,33 +1,43 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 27.5: Generator Objects
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
-_Lists clause numbers/titles/links only (no spec text)._ 
+_Lists clause numbers/titles/links only (no spec text)._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 27.5 | Generator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator-objects) |
+| 27.5 | Generator Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generator-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 27.5.1 | The %GeneratorPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-generator-prototype) |
-| 27.5.1.1 | %GeneratorPrototype%.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.constructor) |
-| 27.5.1.2 | %GeneratorPrototype%.next ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.next) |
-| 27.5.1.3 | %GeneratorPrototype%.return ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.return) |
-| 27.5.1.4 | %GeneratorPrototype%.throw ( exception ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.throw) |
-| 27.5.1.5 | %GeneratorPrototype% [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype-%symbol.tostringtag%) |
-| 27.5.2 | Properties of Generator Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-generator-instances) |
-| 27.5.3 | Generator Abstract Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generator-abstract-operations) |
-| 27.5.3.1 | GeneratorStart ( generator, generatorBody ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorstart) |
-| 27.5.3.2 | GeneratorValidate ( generator, generatorBrand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorvalidate) |
-| 27.5.3.3 | GeneratorResume ( generator, value, generatorBrand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorresume) |
-| 27.5.3.4 | GeneratorResumeAbrupt ( generator, abruptCompletion, generatorBrand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatorresumeabrupt) |
-| 27.5.3.5 | GetGeneratorKind ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getgeneratorkind) |
-| 27.5.3.6 | GeneratorYield ( iteratorResult ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-generatoryield) |
-| 27.5.3.7 | Yield ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-yield) |
-| 27.5.3.8 | CreateIteratorFromClosure ( closure, generatorBrand, generatorPrototype [ , extraSlots ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-createiteratorfromclosure) |
+| 27.5.1 | The %GeneratorPrototype% Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-generator-prototype) |
+| 27.5.1.1 | %GeneratorPrototype%.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.constructor) |
+| 27.5.1.2 | %GeneratorPrototype%.next ( value ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.next) |
+| 27.5.1.3 | %GeneratorPrototype%.return ( value ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.return) |
+| 27.5.1.4 | %GeneratorPrototype%.throw ( exception ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype.throw) |
+| 27.5.1.5 | %GeneratorPrototype% [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-generator.prototype-%symbol.tostringtag%) |
+| 27.5.2 | Properties of Generator Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-generator-instances) |
+| 27.5.3 | Generator Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generator-abstract-operations) |
+| 27.5.3.1 | GeneratorStart ( generator , generatorBody ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generatorstart) |
+| 27.5.3.2 | GeneratorValidate ( generator , generatorBrand ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generatorvalidate) |
+| 27.5.3.3 | GeneratorResume ( generator , value , generatorBrand ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generatorresume) |
+| 27.5.3.4 | GeneratorResumeAbrupt ( generator , abruptCompletion , generatorBrand ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generatorresumeabrupt) |
+| 27.5.3.5 | GetGeneratorKind ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getgeneratorkind) |
+| 27.5.3.6 | GeneratorYield ( iteratorResult ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generatoryield) |
+| 27.5.3.7 | Yield ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-yield) |
+| 27.5.3.8 | CreateIteratorFromClosure ( closure , generatorBrand , generatorPrototype [ , extraSlots ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createiteratorfromclosure) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 27.5.1 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-generator-prototype))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Generator objects support next/return and yield*/iterator delegation | Supported | [`Generator_BasicNext.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_BasicNext.js)<br>[`Generator_YieldStar_ArrayBasic.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_ArrayBasic.js)<br>[`Generator_YieldStar_NestedGenerator.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_NestedGenerator.js)<br>[`Generator_YieldStar_PassNextValue.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_PassNextValue.js)<br>[`Generator_YieldStar_ReturnForwards.js`](../../../Js2IL.Tests/Generator/JavaScript/Generator_YieldStar_ReturnForwards.js) | `throw()` is implemented on the runtime object but currently has limited test coverage. Spec-shaped prototype properties like `constructor` and `Symbol.toStringTag` are not currently exposed. |
 

--- a/docs/ECMA262/27/Section27_6.json
+++ b/docs/ECMA262/27/Section27_6.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "27.6",
   "title": "AsyncGenerator Objects",
-  "status": "Untracked",
+  "status": "Not Yet Supported",
   "specUrl": "https://tc39.es/ecma262/#sec-asyncgenerator-objects",
   "parent": {
     "clause": "27"
@@ -13,109 +13,109 @@
     {
       "clause": "27.6.1",
       "title": "The %AsyncGeneratorPrototype% Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-prototype"
     },
     {
       "clause": "27.6.1.1",
       "title": "%AsyncGeneratorPrototype%.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgenerator-prototype-constructor"
     },
     {
       "clause": "27.6.1.2",
       "title": "%AsyncGeneratorPrototype%.next ( value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next"
     },
     {
       "clause": "27.6.1.3",
       "title": "%AsyncGeneratorPrototype%.return ( value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return"
     },
     {
       "clause": "27.6.1.4",
       "title": "%AsyncGeneratorPrototype%.throw ( exception )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw"
     },
     {
       "clause": "27.6.1.5",
       "title": "%AsyncGeneratorPrototype% [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgenerator-prototype-%symbol.tostringtag%"
     },
     {
       "clause": "27.6.2",
       "title": "Properties of AsyncGenerator Instances",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-intances"
     },
     {
       "clause": "27.6.3",
       "title": "AsyncGenerator Abstract Operations",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgenerator-abstract-operations"
     },
     {
       "clause": "27.6.3.1",
       "title": "AsyncGeneratorRequest Records",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorrequest-records"
     },
     {
       "clause": "27.6.3.2",
       "title": "AsyncGeneratorStart ( generator , generatorBody )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorstart"
     },
     {
       "clause": "27.6.3.3",
       "title": "AsyncGeneratorValidate ( generator , generatorBrand )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorvalidate"
     },
     {
       "clause": "27.6.3.4",
       "title": "AsyncGeneratorEnqueue ( generator , completion , promiseCapability )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorenqueue"
     },
     {
       "clause": "27.6.3.5",
       "title": "AsyncGeneratorCompleteStep ( generator , completion , done [ , realm ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorcompletestep"
     },
     {
       "clause": "27.6.3.6",
       "title": "AsyncGeneratorResume ( generator , completion )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorresume"
     },
     {
       "clause": "27.6.3.7",
       "title": "AsyncGeneratorUnwrapYieldResumption ( resumptionValue )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorunwrapyieldresumption"
     },
     {
       "clause": "27.6.3.8",
       "title": "AsyncGeneratorYield ( value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratoryield"
     },
     {
       "clause": "27.6.3.9",
       "title": "AsyncGeneratorAwaitReturn ( generator )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn"
     },
     {
       "clause": "27.6.3.10",
       "title": "AsyncGeneratorDrainQueue ( generator )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue"
     }
   ]

--- a/docs/ECMA262/27/Section27_6.md
+++ b/docs/ECMA262/27/Section27_6.md
@@ -1,35 +1,35 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 27.6: AsyncGenerator Objects
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
-_Lists clause numbers/titles/links only (no spec text)._ 
+_Lists clause numbers/titles/links only (no spec text)._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 27.6 | AsyncGenerator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-objects) |
+| 27.6 | AsyncGenerator Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 27.6.1 | The %AsyncGeneratorPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-prototype) |
-| 27.6.1.1 | %AsyncGeneratorPrototype%.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-constructor) |
-| 27.6.1.2 | %AsyncGeneratorPrototype%.next ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next) |
-| 27.6.1.3 | %AsyncGeneratorPrototype%.return ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return) |
-| 27.6.1.4 | %AsyncGeneratorPrototype%.throw ( exception ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw) |
-| 27.6.1.5 | %AsyncGeneratorPrototype% [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-%symbol.tostringtag%) |
-| 27.6.2 | Properties of AsyncGenerator Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-intances) |
-| 27.6.3 | AsyncGenerator Abstract Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-abstract-operations) |
-| 27.6.3.1 | AsyncGeneratorRequest Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorrequest-records) |
-| 27.6.3.2 | AsyncGeneratorStart ( generator, generatorBody ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorstart) |
-| 27.6.3.3 | AsyncGeneratorValidate ( generator, generatorBrand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorvalidate) |
-| 27.6.3.4 | AsyncGeneratorEnqueue ( generator, completion, promiseCapability ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorenqueue) |
-| 27.6.3.5 | AsyncGeneratorCompleteStep ( generator, completion, done [ , realm ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorcompletestep) |
-| 27.6.3.6 | AsyncGeneratorResume ( generator, completion ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorresume) |
-| 27.6.3.7 | AsyncGeneratorUnwrapYieldResumption ( resumptionValue ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorunwrapyieldresumption) |
-| 27.6.3.8 | AsyncGeneratorYield ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratoryield) |
-| 27.6.3.9 | AsyncGeneratorAwaitReturn ( generator ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn) |
-| 27.6.3.10 | AsyncGeneratorDrainQueue ( generator ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue) |
+| 27.6.1 | The %AsyncGeneratorPrototype% Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-prototype) |
+| 27.6.1.1 | %AsyncGeneratorPrototype%.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-constructor) |
+| 27.6.1.2 | %AsyncGeneratorPrototype%.next ( value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next) |
+| 27.6.1.3 | %AsyncGeneratorPrototype%.return ( value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return) |
+| 27.6.1.4 | %AsyncGeneratorPrototype%.throw ( exception ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw) |
+| 27.6.1.5 | %AsyncGeneratorPrototype% [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-prototype-%symbol.tostringtag%) |
+| 27.6.2 | Properties of AsyncGenerator Instances | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-intances) |
+| 27.6.3 | AsyncGenerator Abstract Operations | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgenerator-abstract-operations) |
+| 27.6.3.1 | AsyncGeneratorRequest Records | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorrequest-records) |
+| 27.6.3.2 | AsyncGeneratorStart ( generator , generatorBody ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorstart) |
+| 27.6.3.3 | AsyncGeneratorValidate ( generator , generatorBrand ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorvalidate) |
+| 27.6.3.4 | AsyncGeneratorEnqueue ( generator , completion , promiseCapability ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorenqueue) |
+| 27.6.3.5 | AsyncGeneratorCompleteStep ( generator , completion , done [ , realm ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorcompletestep) |
+| 27.6.3.6 | AsyncGeneratorResume ( generator , completion ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorresume) |
+| 27.6.3.7 | AsyncGeneratorUnwrapYieldResumption ( resumptionValue ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorunwrapyieldresumption) |
+| 27.6.3.8 | AsyncGeneratorYield ( value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratoryield) |
+| 27.6.3.9 | AsyncGeneratorAwaitReturn ( generator ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn) |
+| 27.6.3.10 | AsyncGeneratorDrainQueue ( generator ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue) |
 

--- a/docs/ECMA262/27/Section27_7.json
+++ b/docs/ECMA262/27/Section27_7.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "27.7",
   "title": "AsyncFunction Objects",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-async-function-objects",
   "parent": {
     "clause": "27"
@@ -12,86 +12,107 @@
     {
       "clause": "27.7.1",
       "title": "The AsyncFunction Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-constructor"
     },
     {
       "clause": "27.7.1.1",
       "title": "AsyncFunction ( ... parameterArgs , bodyArg )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-constructor-arguments"
     },
     {
       "clause": "27.7.2",
       "title": "Properties of the AsyncFunction Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-constructor-properties"
     },
     {
       "clause": "27.7.2.1",
       "title": "AsyncFunction.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-constructor-prototype"
     },
     {
       "clause": "27.7.3",
       "title": "Properties of the AsyncFunction Prototype Object",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-prototype-properties"
     },
     {
       "clause": "27.7.3.1",
       "title": "AsyncFunction.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-prototype-properties-constructor"
     },
     {
       "clause": "27.7.3.2",
       "title": "AsyncFunction.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-prototype-%symbol.tostringtag%"
     },
     {
       "clause": "27.7.4",
       "title": "AsyncFunction Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-instances"
     },
     {
       "clause": "27.7.4.1",
       "title": "length",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-instances-length"
     },
     {
       "clause": "27.7.4.2",
       "title": "name",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-async-function-instances-name"
     },
     {
       "clause": "27.7.5",
       "title": "Async Functions Abstract Operations",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-async-functions-abstract-operations"
     },
     {
       "clause": "27.7.5.1",
       "title": "AsyncFunctionStart ( promiseCapability , asyncFunctionBody )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-async-functions-abstract-operations-async-function-start"
     },
     {
       "clause": "27.7.5.2",
       "title": "AsyncBlockStart ( promiseCapability , asyncBody , asyncContext )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-asyncblockstart"
     },
     {
       "clause": "27.7.5.3",
       "title": "Await ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#await"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "27.7.5.3",
+        "feature": "async/await lowers to Promise-based state machine and supports await of pending Promises",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#await",
+        "testScripts": [
+          "Js2IL.Tests/Async/JavaScript/Async_SimpleAwait.js",
+          "Js2IL.Tests/Async/JavaScript/Async_ReturnValue.js",
+          "Js2IL.Tests/Async/JavaScript/Async_PendingPromiseAwait.js",
+          "Js2IL.Tests/Async/JavaScript/Async_RealSuspension_SetTimeout.js",
+          "Js2IL.Tests/Async/JavaScript/Async_TryCatch_AwaitReject.js",
+          "Js2IL.Tests/Async/JavaScript/Async_TryCatchFinally_AwaitInFinally_OnReject.js",
+          "Js2IL.Tests/Async/JavaScript/Async_TryFinally_ReturnPreservedThroughAwait.js",
+          "Js2IL.Tests/Async/JavaScript/Async_TryFinally_PreservesExceptionThroughAwait.js"
+        ],
+        "notes": "Async functions are supported via syntax (`async function`, `await`) and runtime Promise integration. The spec-level `AsyncFunction` constructor/prototype intrinsics are not currently exposed."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/27/Section27_7.md
+++ b/docs/ECMA262/27/Section27_7.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 27.7: AsyncFunction Objects
 
@@ -6,5 +6,34 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 27.7 | AsyncFunction Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-async-function-objects) |
+| 27.7 | AsyncFunction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-function-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 27.7.1 | The AsyncFunction Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-constructor) |
+| 27.7.1.1 | AsyncFunction ( ... parameterArgs , bodyArg ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-constructor-arguments) |
+| 27.7.2 | Properties of the AsyncFunction Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-constructor-properties) |
+| 27.7.2.1 | AsyncFunction.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-constructor-prototype) |
+| 27.7.3 | Properties of the AsyncFunction Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-prototype-properties) |
+| 27.7.3.1 | AsyncFunction.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-prototype-properties-constructor) |
+| 27.7.3.2 | AsyncFunction.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-prototype-%symbol.tostringtag%) |
+| 27.7.4 | AsyncFunction Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-function-instances) |
+| 27.7.4.1 | length | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-instances-length) |
+| 27.7.4.2 | name | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-instances-name) |
+| 27.7.5 | Async Functions Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-functions-abstract-operations) |
+| 27.7.5.1 | AsyncFunctionStart ( promiseCapability , asyncFunctionBody ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-functions-abstract-operations-async-function-start) |
+| 27.7.5.2 | AsyncBlockStart ( promiseCapability , asyncBody , asyncContext ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-asyncblockstart) |
+| 27.7.5.3 | Await ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#await) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 27.7.5.3 ([tc39.es](https://tc39.es/ecma262/#await))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| async/await lowers to Promise-based state machine and supports await of pending Promises | Supported | [`Async_SimpleAwait.js`](../../../Js2IL.Tests/Async/JavaScript/Async_SimpleAwait.js)<br>[`Async_ReturnValue.js`](../../../Js2IL.Tests/Async/JavaScript/Async_ReturnValue.js)<br>[`Async_PendingPromiseAwait.js`](../../../Js2IL.Tests/Async/JavaScript/Async_PendingPromiseAwait.js)<br>[`Async_RealSuspension_SetTimeout.js`](../../../Js2IL.Tests/Async/JavaScript/Async_RealSuspension_SetTimeout.js)<br>[`Async_TryCatch_AwaitReject.js`](../../../Js2IL.Tests/Async/JavaScript/Async_TryCatch_AwaitReject.js)<br>[`Async_TryCatchFinally_AwaitInFinally_OnReject.js`](../../../Js2IL.Tests/Async/JavaScript/Async_TryCatchFinally_AwaitInFinally_OnReject.js)<br>[`Async_TryFinally_ReturnPreservedThroughAwait.js`](../../../Js2IL.Tests/Async/JavaScript/Async_TryFinally_ReturnPreservedThroughAwait.js)<br>[`Async_TryFinally_PreservesExceptionThroughAwait.js`](../../../Js2IL.Tests/Async/JavaScript/Async_TryFinally_PreservesExceptionThroughAwait.js) | Async functions are supported via syntax (`async function`, `await`) and runtime Promise integration. The spec-level `AsyncFunction` constructor/prototype intrinsics are not currently exposed. |
 

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -53,7 +53,7 @@ Notes:
 | 24 | Keyed Collections | Supported | [tc39.es](https://tc39.es/ecma262/#sec-keyed-collections) | [Section24.md](24/Section24.md) |
 | 25 | Structured Data | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-structured-data) | [Section25.md](25/Section25.md) |
 | 26 | Managing Memory | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-managing-memory) | [Section26.md](26/Section26.md) |
-| 27 | Control Abstraction Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) | [Section27.md](27/Section27.md) |
+| 27 | Control Abstraction Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) | [Section27.md](27/Section27.md) |
 | 28 | Reflection | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflection) | [Section28.md](28/Section28.md) |
 | 29 | Memory Model | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-memory-model) | [Section29.md](29/Section29.md) |
 


### PR DESCRIPTION
This PR updates the ECMA-262 support matrix/docs for:

- Section 15 (Function-related grammar):
  - Track strict-mode directive prologue semantics (15.2.2, 15.3.2, 15.9.2).
  - Document accessor (get/set) limitations under Method Definitions.
- Section 27 (Promise):
  - Clause-by-clause audit updates across 27.1-27.7.
  - Regenerated subsection markdown and updated rollups.

Docs were regenerated via:
- node scripts/ECMA262/generateEcma262SectionMarkdown.js
- node scripts/ECMA262/rollupEcma262Statuses.js
