### PR TITLE
feat(compiler): relax strict-mode prologue requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here.
 - Runtime/spec: implement minimal `Proxy` support (constructor + `get`/`set`/`has` traps) (fixes #502).
 - Runtime/spec: expose standard global builtins and numeric helpers (`String`, `Number`, `Function`, `parseFloat`, `isFinite`) (fixes #528).
 - Runtime/validator: expose host timer APIs as first-class global function values (`setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`) so DOM polyfills (e.g., domino WindowTimers) validate and compile successfully (fixes #534).
+- Compiler/validator: add `--strictMode=Warn|Ignore` to relax missing top-level `"use strict";` directive prologues for CommonJS modules (fixes #531).
 - Functions/spec: implement minimal implicit `arguments` binding for non-arrow functions (including lexical capture from nested arrow functions) and preserve full call-site arguments only when needed; mapped-arguments aliasing and full Arguments Exotic Object behaviors are not implemented.
 - Docs(ecma262): update Sections 10.2 and 13.2 status/notes for `arguments` binding and arrow lexical capture.
 

--- a/Js2IL.Tests/ValidatorTests.cs
+++ b/Js2IL.Tests/ValidatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Xunit;
+using Js2IL;
 using Js2IL.Services;
 using Js2IL.Validation;
 using Acornima.Ast;
@@ -28,6 +29,19 @@ public class ValidatorTests
         var result = _validator.Validate(ast);
         Assert.False(result.IsValid);
         Assert.Contains(result.Errors, e => e.Contains("requires strict mode", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_MissingUseStrict_StrictModeWarn_ReportsWarning()
+    {
+        var js = "var x = 1;";
+        var ast = _parser.ParseJavaScript(js, "test.js");
+        var warnValidator = new JavaScriptAstValidator(StrictModeDirectivePrologueMode.Warn);
+        var result = warnValidator.Validate(ast);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+        Assert.Contains(result.Warnings, w => w.Contains("requires strict mode", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/Js2IL/CompilerOptions.cs
+++ b/Js2IL/CompilerOptions.cs
@@ -17,11 +17,35 @@ public enum PrototypeChainMode
     On = 2
 }
 
+public enum StrictModeDirectivePrologueMode
+{
+    /// <summary>
+    /// Missing "use strict" is a validation error.
+    /// </summary>
+    Error = 0,
+
+    /// <summary>
+    /// Missing "use strict" is downgraded to a warning.
+    /// </summary>
+    Warn = 1,
+
+    /// <summary>
+    /// Missing "use strict" is ignored (no error/warning).
+    /// </summary>
+    Ignore = 2
+}
+
 public class CompilerOptions
 {
     public string? OutputDirectory { get; set; } = null;
     public bool Verbose { get; set; } = false;
     public bool AnalyzeUnused { get; set; } = false;    
+
+    /// <summary>
+    /// Controls how missing strict-mode directive prologues ("use strict"; at the start of a module/script)
+    /// are reported.
+    /// </summary>
+    public StrictModeDirectivePrologueMode StrictMode { get; set; } = StrictModeDirectivePrologueMode.Error;
 
     /// <summary>
     /// When true, emits Portable PDB debug symbols alongside the generated assembly.

--- a/Js2IL/ModuleLoader.cs
+++ b/Js2IL/ModuleLoader.cs
@@ -13,7 +13,7 @@ namespace Js2IL;
 public class ModuleLoader
 {
     private readonly JavaScriptParser _parser = new JavaScriptParser();
-    private readonly JavaScriptAstValidator _validator = new JavaScriptAstValidator();
+    private readonly JavaScriptAstValidator _validator;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger _logger;
 
@@ -22,6 +22,7 @@ public class ModuleLoader
     public ModuleLoader(CompilerOptions options, IFileSystem fileSystem, ILogger logger)
     {
         _verbose = options.Verbose;
+        _validator = new JavaScriptAstValidator(options.StrictMode);
         _fileSystem = fileSystem;
         _logger = logger;
     }

--- a/Js2IL/Program.cs
+++ b/Js2IL/Program.cs
@@ -35,6 +35,10 @@ public class Js2ILArgs
     [ArgShortcut("--prototypeChain")]
     public PrototypeChainMode PrototypeChain { get; set; } = PrototypeChainMode.Auto;
 
+    [ArgDescription("Strict-mode directive prologue enforcement: Error, Warn, or Ignore")]
+    [ArgShortcut("--strictMode")]
+    public StrictModeDirectivePrologueMode StrictMode { get; set; } = StrictModeDirectivePrologueMode.Error;
+
     [ArgDescription("Show version information and exit")]
     [ArgShortcut("--version")]
     public bool Version { get; set; }
@@ -71,7 +75,8 @@ class Program
                 Verbose = parsed.Verbose,
                 AnalyzeUnused = parsed.AnalyzeUnused,
                 EmitPdb = parsed.EmitPdb,
-                PrototypeChain = parsed.PrototypeChain
+                PrototypeChain = parsed.PrototypeChain,
+                StrictMode = parsed.StrictMode
             });
             var logger = servicesProvider.GetRequiredService<ILogger>();
 
@@ -120,6 +125,7 @@ class Program
         logger.WriteLineError("-a, --analyzeunused    Analyze and report unused properties and methods");
         logger.WriteLineError("--pdb                  Emit Portable PDB debug symbols (.pdb)");
         logger.WriteLineError("--prototypeChain        Prototype chain mode: Auto, On, or Off");
+        logger.WriteLineError("--strictMode           Strict-mode directive prologue enforcement: Error, Warn, or Ignore");
         logger.WriteLineError("--version              Show version information and exit");
         logger.WriteLineError("-h, -?, --help         Show help and exit");
     }

--- a/docs/ECMA262/11/Section11_2.json
+++ b/docs/ECMA262/11/Section11_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "11.2",
   "title": "Types of Source Code",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-types-of-source-code",
   "parent": {
     "clause": "11"
@@ -12,13 +12,13 @@
     {
       "clause": "11.2.1",
       "title": "Directive Prologues and the Use Strict Directive",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive"
     },
     {
       "clause": "11.2.2",
       "title": "Strict Mode Code",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-strict-mode-code"
     },
     {
@@ -33,5 +33,16 @@
       "status": "Untracked",
       "specUrl": "https://tc39.es/ecma262/#sec-non-ecmascript-functions"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "11.2.1",
+        "feature": "Directive prologues; configurable enforcement of \"use strict\"",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive",
+        "notes": "JS2IL recognizes directive prologues and (by default) requires a top-level \"use strict\" directive. For third-party CommonJS modules that omit the directive, the compiler can downgrade the missing prologue to a warning via --strictMode=Warn (or suppress via --strictMode=Ignore). JS2IL still compiles using strict-mode semantics; this option only changes reporting severity for the missing directive prologue."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/11/Section11_2.md
+++ b/docs/ECMA262/11/Section11_2.md
@@ -1,4 +1,4 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 11.2: Types of Source Code
 
@@ -6,5 +6,24 @@
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 11.2 | Types of Source Code | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-types-of-source-code) |
+| 11.2 | Types of Source Code | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-types-of-source-code) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 11.2.1 | Directive Prologues and the Use Strict Directive | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive) |
+| 11.2.2 | Strict Mode Code | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-strict-mode-code) |
+| 11.2.2.1 | Static Semantics: IsStrict ( node ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isstrict) |
+| 11.2.3 | Non-ECMAScript Functions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-non-ecmascript-functions) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 11.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Directive prologues; configurable enforcement of "use strict" | Supported with Limitations |  | JS2IL recognizes directive prologues and (by default) requires a top-level "use strict" directive. For third-party CommonJS modules that omit the directive, the compiler can downgrade the missing prologue to a warning via --strictMode=Warn (or suppress via --strictMode=Ignore). JS2IL still compiles using strict-mode semantics; this option only changes reporting severity for the missing directive prologue. |
 


### PR DESCRIPTION
Fixes #531.

### What changed
- Added `--strictMode` compiler flag to control how missing top-level `"use strict";` directive prologues are reported:
  - `Error` (default): current behavior (validation error)
  - `Warn`: downgrade to validation warning (unblocks CommonJS/vendor modules)
  - `Ignore`: suppress diagnostic
- Wired the option through module loading so it applies across the dependency graph.

### Tests
- Added CLI regression tests ensuring:
  - non-strict input fails by default
  - `--strictMode warn` compiles successfully and produces outputs
- Added validator/module-loader unit tests for warn behavior.

### Docs
- Updated ECMA-262 Section 11.2.1 status/notes to reflect directive prologue handling and the new flag.