### PR TITLE
fix(runtime): expose Error.prototype as global value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here.
 - Docs(ecma262): update Section 20.2 and 7.3 status/notes for `apply`/`bind`.
 - Runtime/spec: expose global `Object` as a first-class value (including `Object.prototype`) and support Domino-style `Fn.prototype = Object.create(Object.prototype, descriptors)` patterns (fixes #546).
 - Docs(ecma262): update Sections 19.3, 20.1, and 20.2 for `Object.prototype` and function-instance `prototype` behavior.
+- Runtime/spec: expose global `Error` as a first-class value (including `Error.prototype`) for CommonJS/polyfill compatibility (fixes #550).
+- Docs(ecma262): update Section 20.5 status/notes for `Error.prototype`.
 
 ## v0.8.2 - 2026-02-04
 

--- a/Js2IL.Tests/CommonJS/ExecutionTests.cs
+++ b/Js2IL.Tests/CommonJS/ExecutionTests.cs
@@ -178,5 +178,14 @@ namespace Js2IL.Tests.CommonJS
                 nameof(CommonJS_Export_ObjectWithClosure),
                 additionalScripts: new[] { "CommonJS_Export_ObjectWithClosure_Lib" });
         }
+
+        [Fact]
+        public Task CommonJS_Global_ErrorPrototype_Read()
+        {
+            // Issue #550 repro: IR pipeline crash lowering `Error.prototype` property access in a CommonJS module.
+            return ExecutionTest(
+                nameof(CommonJS_Global_ErrorPrototype_Read),
+                additionalScripts: new[] { "CommonJS_Global_ErrorPrototype_Read_Lib" });
+        }
     }
 }

--- a/Js2IL.Tests/CommonJS/GeneratorTests.cs
+++ b/Js2IL.Tests/CommonJS/GeneratorTests.cs
@@ -178,5 +178,14 @@ namespace Js2IL.Tests.CommonJS
                 nameof(CommonJS_Export_ObjectWithClosure),
                 new[] { "CommonJS_Export_ObjectWithClosure_Lib" });
         }
+
+        [Fact]
+        public Task CommonJS_Global_ErrorPrototype_Read()
+        {
+            // Issue #550 repro: IR pipeline crash lowering `Error.prototype` property access in a CommonJS module.
+            return GenerateTest(
+                nameof(CommonJS_Global_ErrorPrototype_Read),
+                new[] { "CommonJS_Global_ErrorPrototype_Read_Lib" });
+        }
     }
 }

--- a/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read.js
+++ b/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// Issue #550 repro: CommonJS module that touches `Error.prototype`.
+// This exercises the IR pipeline (module main method compilation) and previously failed
+// during HIR->LIR lowering because `Error` was not available as an intrinsic global.
+
+const hasErrorPrototype = require('./CommonJS_Global_ErrorPrototype_Read_Lib');
+console.log("hasErrorPrototype:", hasErrorPrototype);

--- a/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read_Lib.js
+++ b/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read_Lib.js
@@ -1,0 +1,7 @@
+"use strict";
+
+// Minimal repro: `Error.prototype` access at module init time.
+// This specifically covers the IR lowering path that previously failed with:
+//   HIR->LIR: failed lowering PropertyAccessExpression (property='prototype')
+var p = Error.prototype;
+module.exports = p ? 1 : 0;

--- a/Js2IL.Tests/CommonJS/Snapshots/ExecutionTests.CommonJS_Global_ErrorPrototype_Read.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/ExecutionTests.CommonJS_Global_ErrorPrototype_Read.verified.txt
@@ -1,0 +1,1 @@
+hasErrorPrototype: 1

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Global_ErrorPrototype_Read.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Global_ErrorPrototype_Read.verified.txt
@@ -1,0 +1,188 @@
+// IL code: CommonJS_Global_ErrorPrototype_Read
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.CommonJS_Global_ErrorPrototype_Read
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2107
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 69 (0x45)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.CommonJS_Global_ErrorPrototype_Read/Scope,
+			[1] object,
+			[2] object[]
+		)
+
+		IL_0000: newobj instance void Modules.CommonJS_Global_ErrorPrototype_Read/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldstr "./CommonJS_Global_ErrorPrototype_Read_Lib"
+		IL_0013: stelem.ref
+		IL_0014: stloc.2
+		IL_0015: ldarg.1
+		IL_0016: ldc.i4.1
+		IL_0017: newarr [System.Runtime]System.Object
+		IL_001c: dup
+		IL_001d: ldc.i4.0
+		IL_001e: ldnull
+		IL_001f: stelem.ref
+		IL_0020: ldloc.2
+		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0026: stloc.1
+		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_002c: ldc.i4.2
+		IL_002d: newarr [System.Runtime]System.Object
+		IL_0032: dup
+		IL_0033: ldc.i4.0
+		IL_0034: ldstr "hasErrorPrototype:"
+		IL_0039: stelem.ref
+		IL_003a: dup
+		IL_003b: ldc.i4.1
+		IL_003c: ldloc.1
+		IL_003d: stelem.ref
+		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0043: pop
+		IL_0044: ret
+	} // end of method CommonJS_Global_ErrorPrototype_Read::__js_module_init__
+
+} // end of class Modules.CommonJS_Global_ErrorPrototype_Read
+
+.class private auto ansi beforefieldinit Modules.CommonJS_Global_ErrorPrototype_Read_Lib
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2110
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x20a4
+		// Header size: 12
+		// Code size: 87 (0x57)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.CommonJS_Global_ErrorPrototype_Read_Lib/Scope,
+			[1] object,
+			[2] bool,
+			[3] object,
+			[4] object
+		)
+
+		IL_0000: newobj instance void Modules.CommonJS_Global_ErrorPrototype_Read_Lib/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Error()
+		IL_000b: ldstr "prototype"
+		IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_001c: stloc.2
+		IL_001d: ldloc.2
+		IL_001e: brfalse IL_0038
+
+		IL_0023: ldc.r8 1
+		IL_002c: box [System.Runtime]System.Double
+		IL_0031: stloc.s 4
+		IL_0033: br IL_0048
+
+		IL_0038: ldc.r8 0.0
+		IL_0041: box [System.Runtime]System.Double
+		IL_0046: stloc.s 4
+
+		IL_0048: ldarg.2
+		IL_0049: ldstr "exports"
+		IL_004e: ldloc.s 4
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0055: pop
+		IL_0056: ret
+	} // end of method CommonJS_Global_ErrorPrototype_Read_Lib::__js_module_init__
+
+} // end of class Modules.CommonJS_Global_ErrorPrototype_Read_Lib
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2119
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.CommonJS_Global_ErrorPrototype_Read::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/docs/ECMA262/20/Section20_5.json
+++ b/docs/ECMA262/20/Section20_5.json
@@ -24,7 +24,7 @@
     {
       "clause": "20.5.2",
       "title": "Properties of the Error Constructor",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-error-constructor"
     },
     {
@@ -36,7 +36,7 @@
     {
       "clause": "20.5.2.2",
       "title": "Error.prototype",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-error.prototype"
     },
     {
@@ -271,6 +271,17 @@
           "Js2IL.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js"
         ],
         "notes": "Constructs JavaScriptRuntime.Error (and derived types) with message stringification via DotNet2JSConversions.ToString. The runtime does not currently model spec prototype objects; behavior is closer to .NET exceptions with JS-like surface properties."
+      },
+      {
+        "clause": "20.5.2.2",
+        "feature": "Error.prototype data property exists (minimal)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-error.prototype",
+        "testScripts": [
+          "Js2IL.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read.js",
+          "Js2IL.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read_Lib.js"
+        ],
+        "notes": "Exposes the global Error value as a first-class intrinsic and provides a writable Error.prototype object for libraries that read/attach prototype members (e.g., CommonJS polyfills). Error(...) invocation and standard prototype methods/properties are not yet implemented as spec-defined objects."
       },
       {
         "clause": "20.5.4",

--- a/docs/ECMA262/20/Section20_5.md
+++ b/docs/ECMA262/20/Section20_5.md
@@ -14,9 +14,9 @@
 |---:|---|---|---|
 | 20.5.1 | The Error Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error-constructor) |
 | 20.5.1.1 | Error ( message [ , options ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error-message) |
-| 20.5.2 | Properties of the Error Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-error-constructor) |
+| 20.5.2 | Properties of the Error Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-error-constructor) |
 | 20.5.2.1 | Error.isError ( arg ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.iserror) |
-| 20.5.2.2 | Error.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype) |
+| 20.5.2.2 | Error.prototype | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype) |
 | 20.5.3 | Properties of the Error Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-error-prototype-object) |
 | 20.5.3.1 | Error.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype.constructor) |
 | 20.5.3.2 | Error.prototype.message | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-error.prototype.message) |
@@ -63,6 +63,12 @@ Feature-level support tracking with test script references.
 |---|---|---|---|
 | Error(message) (callable creates instance) | Supported with Limitations | [`IntrinsicCallables_Error_Callable_CreatesInstances.js`](../../../Js2IL.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_Callable_CreatesInstances.js) | Compiler lowers built-in error callables (Error/TypeError/...) to construction of JavaScriptRuntime error types. Currently supports 0 or 1 argument; the optional 'options' parameter is not supported. |
 | new Error(message) and new NativeError(message) | Supported with Limitations | [`TryCatch_NewExpression_BuiltInErrors.js`](../../../Js2IL.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js) | Constructs JavaScriptRuntime.Error (and derived types) with message stringification via DotNet2JSConversions.ToString. The runtime does not currently model spec prototype objects; behavior is closer to .NET exceptions with JS-like surface properties. |
+
+### 20.5.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-error.prototype))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Error.prototype data property exists (minimal) | Supported with Limitations | [`CommonJS_Global_ErrorPrototype_Read.js`](../../../Js2IL.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read.js)<br>[`CommonJS_Global_ErrorPrototype_Read_Lib.js`](../../../Js2IL.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read_Lib.js) | Exposes the global Error value as a first-class intrinsic and provides a writable Error.prototype object for libraries that read/attach prototype members (e.g., CommonJS polyfills). Error(...) invocation and standard prototype methods/properties are not yet implemented as spec-defined objects. |
 
 ### 20.5.4 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-error-instances))
 


### PR DESCRIPTION
Fixes #550.

Summary:
- Expose `Error` as a first-class intrinsic global value so `Error.prototype` reads in third-party CommonJS modules lower/compile successfully.
- Provide a minimal writable `Error.prototype` object via `PropertyDescriptorStore`.
- Add a clinical CommonJS repro test (`CommonJS_Global_ErrorPrototype_Read`) with execution + generator snapshots.
- Update ECMA262 docs (Section 20.5) and add changelog entry.

Validation:
- `dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj --filter FullyQualifiedName~CommonJS_Global_ErrorPrototype_Read`
- Repro: `dotnet run --project Js2IL -- artifacts/temp/issue499-domino/node_modules/@mixmark-io/domino/lib/DOMException.js -o <out> --strictMode Warn` now succeeds.