### PR TITLE
fix(ir): support unary void operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here.
 - Runtime/spec: expose global `Error` as a first-class value (including `Error.prototype`) for CommonJS/polyfill compatibility (fixes #550).
 - Docs(ecma262): update Section 20.5 status/notes for `Error.prototype`.
 - IR/CommonJS: compile `module.exports = class ... extends Array { ... }` without crashing (fixes #552).
+- IR: support unary `void` operator (`void 0`) lowering (fixes #554).
 
 ## v0.8.2 - 2026-02-04
 

--- a/Js2IL.Tests/UnaryOperator/ExecutionTests.cs
+++ b/Js2IL.Tests/UnaryOperator/ExecutionTests.cs
@@ -57,5 +57,8 @@ namespace Js2IL.Tests.UnaryOperator
 
         [Fact]
         public Task UnaryOperator_DoubleNot_NaNTruthiness() => ExecutionTest(nameof(UnaryOperator_DoubleNot_NaNTruthiness));
+
+        [Fact]
+        public Task UnaryOperator_VoidOperator() => ExecutionTest(nameof(UnaryOperator_VoidOperator));
     }
 }

--- a/Js2IL.Tests/UnaryOperator/GeneratorTests.cs
+++ b/Js2IL.Tests/UnaryOperator/GeneratorTests.cs
@@ -57,5 +57,8 @@ namespace Js2IL.Tests.UnaryOperator
 
         [Fact]
         public Task UnaryOperator_DoubleNot_NaNTruthiness() => GenerateTest(nameof(UnaryOperator_DoubleNot_NaNTruthiness));
+
+        [Fact]
+        public Task UnaryOperator_VoidOperator() => GenerateTest(nameof(UnaryOperator_VoidOperator));
     }
 }

--- a/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_VoidOperator.js
+++ b/Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_VoidOperator.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var x = 0;
+console.log(void 0);
+console.log(void (x = 1));
+console.log(x);
+
+exports.a = void 0;
+console.log(exports.a);

--- a/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_VoidOperator.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/ExecutionTests.UnaryOperator_VoidOperator.verified.txt
@@ -1,0 +1,4 @@
+undefined
+undefined
+1
+undefined

--- a/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_VoidOperator.verified.txt
+++ b/Js2IL.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_VoidOperator.verified.txt
@@ -1,0 +1,130 @@
+﻿// IL code: UnaryOperator_VoidOperator
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.UnaryOperator_VoidOperator
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20e9
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 141 (0x8d)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.UnaryOperator_VoidOperator/Scope,
+			[1] float64,
+			[2] object
+		)
+
+		IL_0000: newobj instance void Modules.UnaryOperator_VoidOperator/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.r8 0.0
+		IL_000f: stloc.1
+		IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0015: ldc.i4.1
+		IL_0016: newarr [System.Runtime]System.Object
+		IL_001b: dup
+		IL_001c: ldc.i4.0
+		IL_001d: ldnull
+		IL_001e: stelem.ref
+		IL_001f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0024: pop
+		IL_0025: ldc.r8 1
+		IL_002e: stloc.1
+		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0034: ldc.i4.1
+		IL_0035: newarr [System.Runtime]System.Object
+		IL_003a: dup
+		IL_003b: ldc.i4.0
+		IL_003c: ldnull
+		IL_003d: stelem.ref
+		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0043: pop
+		IL_0044: ldloc.1
+		IL_0045: box [System.Runtime]System.Double
+		IL_004a: stloc.2
+		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0050: ldc.i4.1
+		IL_0051: newarr [System.Runtime]System.Object
+		IL_0056: dup
+		IL_0057: ldc.i4.0
+		IL_0058: ldloc.2
+		IL_0059: stelem.ref
+		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_005f: pop
+		IL_0060: ldarg.0
+		IL_0061: ldstr "a"
+		IL_0066: ldnull
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_006c: pop
+		IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0072: ldc.i4.1
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldarg.0
+		IL_007b: ldstr "a"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0085: stelem.ref
+		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_008b: pop
+		IL_008c: ret
+	} // end of method UnaryOperator_VoidOperator::__js_module_init__
+
+} // end of class Modules.UnaryOperator_VoidOperator
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x20f2
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.UnaryOperator_VoidOperator::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL/IR/LIR/HIRToLIRLowerer.ExpressionUnary.cs
+++ b/Js2IL/IR/LIR/HIRToLIRLowerer.ExpressionUnary.cs
@@ -13,6 +13,20 @@ public sealed partial class HIRToLIRLowerer
     {
         resultTempVar = CreateTempVariable();
 
+        // void operator: evaluate operand for side-effects, then yield `undefined`.
+        // This is commonly used by transpiled/compiled JS as `void 0`.
+        if (unaryExpr.Operator == Acornima.Operator.Void)
+        {
+            if (!TryLowerExpressionDiscardResult(unaryExpr.Argument))
+            {
+                return false;
+            }
+
+            _methodBodyIR.Instructions.Add(new LIRConstUndefined(resultTempVar));
+            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            return true;
+        }
+
         // delete operator requires lvalue semantics (delete obj[prop] / delete obj.prop)
         if (unaryExpr.Operator == Acornima.Operator.Delete)
         {

--- a/docs/ECMA262/13/Section13_5.json
+++ b/docs/ECMA262/13/Section13_5.json
@@ -30,13 +30,13 @@
     {
       "clause": "13.5.2",
       "title": "The void Operator",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-void-operator"
     },
     {
       "clause": "13.5.2.1",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-void-operator-runtime-semantics-evaluation"
     },
     {
@@ -102,6 +102,16 @@
   ],
   "support": {
     "entries": [
+      {
+        "clause": "13.5.2",
+        "feature": "Unary void operator (void)",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-void-operator",
+        "testScripts": [
+          "Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_VoidOperator.js"
+        ],
+        "notes": "Evaluates operand for side effects and yields undefined (commonly used as `void 0` by transpiled/compiled JS). Implemented in IR lowering (HIR->LIR)."
+      },
       {
         "clause": "13.5.1",
         "feature": "Binary + (Addition)",

--- a/docs/ECMA262/13/Section13_5.md
+++ b/docs/ECMA262/13/Section13_5.md
@@ -15,8 +15,8 @@
 | 13.5.1 | The delete Operator | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-delete-operator) |
 | 13.5.1.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-delete-operator-static-semantics-early-errors) |
 | 13.5.1.2 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation) |
-| 13.5.2 | The void Operator | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-void-operator) |
-| 13.5.2.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-void-operator-runtime-semantics-evaluation) |
+| 13.5.2 | The void Operator | Supported | [tc39.es](https://tc39.es/ecma262/#sec-void-operator) |
+| 13.5.2.1 | Runtime Semantics: Evaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-void-operator-runtime-semantics-evaluation) |
 | 13.5.3 | The typeof Operator | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typeof-operator) |
 | 13.5.3.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typeof-operator-runtime-semantics-evaluation) |
 | 13.5.4 | Unary + Operator | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-unary-plus-operator) |
@@ -43,6 +43,7 @@ Feature-level support tracking with test script references.
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
 | Binary - (Subtraction) | Supported | [`BinaryOperator_SubNumberNumber.js`](../../../Js2IL.Tests/BinaryOperator/JavaScript/BinaryOperator_SubNumberNumber.js)<br>[`Classes_ClassConstructor_TwoParams_SubtractMethod.js`](../../../Js2IL.Tests/Classes/JavaScript/Classes_ClassConstructor_TwoParams_SubtractMethod.js) | Numeric subtraction; matches JS semantics for non-numeric via coercion helpers where applicable. |
+| Unary void operator (void) | Supported | [`UnaryOperator_VoidOperator.js`](../../../Js2IL.Tests/UnaryOperator/JavaScript/UnaryOperator_VoidOperator.js) | Evaluates operand for side effects and yields undefined (commonly used as `void 0` by transpiled/compiled JS). Implemented in IR lowering (HIR->LIR). |
 
 ### 13.5.3 ([tc39.es](https://tc39.es/ecma262/#sec-typeof-operator))
 


### PR DESCRIPTION
Fixes #554.

Summary:
- Add IR lowering support for the unary `void` operator (e.g. `void 0`), evaluating the operand for side effects and yielding `undefined`.
- Add execution + generator regression tests under `UnaryOperator`.
- Update ECMA-262 docs (Section 13.5.2) and changelog.

Repro from #554:
- `@mixmark-io/domino` `style_parser.js` uses `exports.hyphenate = exports.parse = void 0;` which previously crashed IR lowering.
