### PR TITLE
ci(smoke): run performance before samples

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -76,15 +76,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Build and run Hosting.Domino sample
-        run: |
-          set -euo pipefail
-          output=$(dotnet run --project samples/Hosting.Domino/host/Hosting.Domino.csproj -c Release -p:JavaScriptRuntimePackageVersion="$TOOL_VERSION")
-          echo "Program output:"
-          echo "$output"
-          echo "$output" | grep -i "title=JS2IL Domino Sample"
-          echo "$output" | grep -i "links=2"
-
       - name: Build Jint Comparison Project
         run: |
           cd tests/performance/JintComparison
@@ -100,3 +91,12 @@ jobs:
         run: |
           cd tests/performance
           node RunComparison.js
+
+      - name: Build and run Hosting.Domino sample
+        run: |
+          set -euo pipefail
+          output=$(dotnet run --project samples/Hosting.Domino/host/Hosting.Domino.csproj -c Release -p:JavaScriptRuntimePackageVersion="$TOOL_VERSION")
+          echo "Program output:"
+          echo "$output"
+          echo "$output" | grep -i "title=JS2IL Domino Sample"
+          echo "$output" | grep -i "links=2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+- CI: run performance comparison before samples in the Linux smoke workflow.
 
 ## v0.8.4 - 2026-02-07
 


### PR DESCRIPTION
Reorders linux-smoke workflow steps so performance comparison runs before the samples step. Also updates CHANGELOG.md.