### PR TITLE
fix(samples): emit PDBs for Debug builds

### DIFF
--- a/samples/Hosting.Domino/compiler/HostedDomino.proj
+++ b/samples/Hosting.Domino/compiler/HostedDomino.proj
@@ -16,6 +16,10 @@
     <UseLocalJs2ILProject Condition="'$(UseLocalJs2ILProject)' == '' And !Exists('$(LocalJs2ILProject)')">false</UseLocalJs2ILProject>
 
     <UseLocalJs2ILProjectLower>$([System.String]::Copy('$(UseLocalJs2ILProject)').ToLowerInvariant())</UseLocalJs2ILProjectLower>
+
+    <!-- Emit PDBs only for Debug builds. -->
+    <Js2ILPdbFlag Condition="'$(Configuration)' == 'Debug'">--pdb</Js2ILPdbFlag>
+    <Js2ILPdbFlag Condition="'$(Configuration)' != 'Debug'" />
   </PropertyGroup>
 
   <Target Name="NpmRestore">
@@ -29,10 +33,10 @@
          Text="UseLocalJs2ILProject=true but local project not found: $(LocalJs2ILProject)" />
 
     <Exec Condition="'$(UseLocalJs2ILProjectLower)' == 'true'"
-        Command="dotnet run --project &quot;$(LocalJs2ILProject)&quot; -c Release -- &quot;$(JavaScriptFile)&quot; &quot;$(OutputDir)&quot; --strictMode Ignore" />
+      Command="dotnet run --project &quot;$(LocalJs2ILProject)&quot; -c Release -- &quot;$(JavaScriptFile)&quot; &quot;$(OutputDir)&quot; --strictMode Ignore $(Js2ILPdbFlag)" />
 
     <Exec Condition="'$(UseLocalJs2ILProjectLower)' != 'true'"
-        Command="js2il &quot;$(JavaScriptFile)&quot; &quot;$(OutputDir)&quot; --strictMode Ignore" />
+      Command="js2il &quot;$(JavaScriptFile)&quot; &quot;$(OutputDir)&quot; --strictMode Ignore $(Js2ILPdbFlag)" />
   </Target>
 
   <Target Name="Clean">


### PR DESCRIPTION
Adds a conditional `--pdb` flag to the sample compiler invocation so Debug builds emit PDBs, while Release builds remain unchanged.

- Updates: `samples/Hosting.Domino/compiler/HostedDomino.proj`
- Behavior: appends `--pdb` only when `$(Configuration)` is `Debug`