### PR TITLE
ci: restore dotnet tools in publish workflow

### DIFF
--- a/.github/workflows/publish-tool.yml
+++ b/.github/workflows/publish-tool.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Restore .NET tools
+        run: dotnet tool restore
+
       - name: Compute version from tag
         shell: pwsh
         run: |


### PR DESCRIPTION
Restores local dotnet tools (dotnet-ilverify) in the tag publish workflow so IL verification tests can run during publish.