### PR TITLE
fix(ci): windows smoke PowerShell interpolation parse error

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -53,7 +53,7 @@ jobs:
               exit 0
             }
 
-            "Attempt $i/$tries: js2il $env:TOOL_VERSION not available yet on NuGet; waiting ${delaySeconds}s..." | Write-Output
+            "Attempt $i/${tries}: js2il $env:TOOL_VERSION not available yet on NuGet; waiting ${delaySeconds}s..." | Write-Output
             Start-Sleep -Seconds $delaySeconds
           }
 


### PR DESCRIPTION
﻿## Summary
- Fix Windows smoke workflow PowerShell parser error in retry logging.
- Change $tries: interpolation to ${tries} in the retry status message.

## Root Cause
PowerShell interpreted $tries: as an invalid variable reference because : immediately followed the variable name inside a double-quoted string.

## Validation
- Reproduced failing run error from windows-smoke release run 22026965298.
- Verified the corrected interpolation pattern executes without parser errors.

## Scope
- Windows workflow only: .github/workflows/windows-smoke.yml
- No Linux workflow changes.
