### PR TITLE
ci(smoke): fix windows smoke output assertion

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -78,7 +78,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { $output; exit 1 }
           "Program output:" | Write-Output
           $output | Write-Output
-          if ($output -notmatch 'x is') {
+          $outputText = ($output -join "`n")
+          if ($outputText -notmatch 'x is') {
             throw "Smoke test failed: expected output containing 'x is'"
           }
 


### PR DESCRIPTION
## Summary
- fix the Windows smoke output assertion to evaluate the combined stdout text instead of line-array matching semantics

## Root cause
- PowerShell `-notmatch` against an array returns all non-matching elements, which can make a condition truthy even when one line contains the expected text (`x is`).

## Fix
- join command output lines into a single string before running the regex assertion in `.github/workflows/windows-smoke.yml`.

## Validation
- logic now checks the full output text and no longer fails on additional non-matching lines.