### PR TITLE
ci(smoke): fix windows output matching assertions

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -96,8 +96,9 @@ jobs:
           if ($LASTEXITCODE -ne 0) { $output; exit 1 }
           "Program output:" | Write-Output
           $output | Write-Output
-          if ($output -notmatch 'title=JS2IL Domino Sample') { throw 'Expected output containing title=JS2IL Domino Sample' }
-          if ($output -notmatch 'links=2') { throw 'Expected output containing links=2' }
+          $outputText = ($output -join "`n")
+          if ($outputText -notmatch 'title=JS2IL Domino Sample') { throw 'Expected output containing title=JS2IL Domino Sample' }
+          if ($outputText -notmatch 'links=2') { throw 'Expected output containing links=2' }
 
       - name: Build and run Hosting.Basic sample
         shell: pwsh
@@ -107,8 +108,9 @@ jobs:
           if ($LASTEXITCODE -ne 0) { $output; exit 1 }
           "Program output:" | Write-Output
           $output | Write-Output
-          if ($output -notmatch 'version=') { throw 'Expected output containing version=' }
-          if ($output -notmatch '1\+2=') { throw 'Expected output containing 1+2=' }
+          $outputText = ($output -join "`n")
+          if ($outputText -notmatch 'version=') { throw 'Expected output containing version=' }
+          if ($outputText -notmatch '1\+2=') { throw 'Expected output containing 1+2=' }
 
       - name: Build and run Hosting.Typed sample
         shell: pwsh
@@ -118,9 +120,10 @@ jobs:
           if ($LASTEXITCODE -ne 0) { $output; exit 1 }
           "Program output:" | Write-Output
           $output | Write-Output
-          if ($output -notmatch 'version=') { throw 'Expected output containing version=' }
-          if ($output -notmatch 'add\(1,2\)=') { throw 'Expected output containing add(1,2)=' }
-          if ($output -notmatch 'counter\.add\(5\)=') { throw 'Expected output containing counter.add(5)=' }
-          if ($output -notmatch 'counter\.value=') { throw 'Expected output containing counter.value=' }
-          if ($output -notmatch 'addAsync\(1,2\)=') { throw 'Expected output containing addAsync(1,2)=' }
-          if ($output -notmatch 'created\.add\(1\)=') { throw 'Expected output containing created.add(1)=' }
+          $outputText = ($output -join "`n")
+          if ($outputText -notmatch 'version=') { throw 'Expected output containing version=' }
+          if ($outputText -notmatch 'add\(1,2\)=') { throw 'Expected output containing add(1,2)=' }
+          if ($outputText -notmatch 'counter\.add\(5\)=') { throw 'Expected output containing counter.add(5)=' }
+          if ($outputText -notmatch 'counter\.value=') { throw 'Expected output containing counter.value=' }
+          if ($outputText -notmatch 'addAsync\(1,2\)=') { throw 'Expected output containing addAsync(1,2)=' }
+          if ($outputText -notmatch 'created\.add\(1\)=') { throw 'Expected output containing created.add(1)=' }


### PR DESCRIPTION
## Summary
- Fixes a false-negative assertion in the Windows smoke workflow.
- The `Build and run Hosting.*` steps captured command output as an array and used `-notmatch` directly on that array.
- In PowerShell, array `-notmatch` returns non-matching elements, so the condition can evaluate as truthy even when one line matches.

## Root cause
- Failing run: https://github.com/tomacox74/js2il/actions/runs/22074723826
- Failed step: `Build and run Hosting.Domino sample`
- Logged output contained `title=JS2IL Domino Sample` and `links=2`, but assertion still threw due to array matching semantics.

## Fix
- Normalize captured output to a single string in Windows workflow checks:
  - `$outputText = ($output -join "`n")`
  - Match all expected patterns against `$outputText`.
- Applied to `Hosting.Domino`, `Hosting.Basic`, and `Hosting.Typed` smoke checks for consistency.

## Validation
- Reproduced behavior locally in PowerShell:
  - Array `-notmatch` can fail despite containing the expected line.
  - Joined-string `-notmatch` behaves correctly.

## Impact
- Removes flaky/false failures in `windows-smoke` while preserving the same output expectations.