### PR TITLE
docs(tracking): sync Node gap backlog status

### DIFF
--- a/docs/tracking-issues/NodeGapPopularityBacklog_2026-02-17.md
+++ b/docs/tracking-issues/NodeGapPopularityBacklog_2026-02-17.md
@@ -1,4 +1,4 @@
-# Node Gap Popularity Backlog (2026-02-17)
+# Node Gap Popularity Backlog (2026-02-18)
 
 > Purpose: Persist a holistic, popularity-weighted view of missing functionality so triage context is not lost between sessions.
 > Scope: Node.js compatibility first, with adjacent ECMA impacts called out where they block common Node workloads.
@@ -14,11 +14,11 @@
 
 ## Current Baseline (Snapshot)
 
-- Node docs track **7 modules**, all marked `partial`, and **13 globals** mostly supported.
-- Major blockers explicitly documented:
-  - No `Buffer` support
-  - `require()` only partially supported
-  - no ESM `import.meta.url`
+- Node docs track **8 modules** (all currently `partial`) and **14 globals** (**13 `supported`**, **1 `partial`**).
+- Major blockers currently documented:
+   - `Buffer` is now **partial** (core foundation exists, advanced APIs still missing)
+   - `require(id)` is marked **supported** but still limited to implemented core modules + compiled local modules (no `node_modules` / `package.json` resolution)
+   - no ESM `import.meta.url`
 - ECMA matrix remains sparse (many sections incomplete/untracked), which increases risk for modern package behavior.
 
 ## Popularity-Weighted Missing Functionality
@@ -26,47 +26,61 @@
 ### P0 (Highest impact / broadest unblock)
 
 1. **Buffer + binary I/O path**
+   - Status: 🟡 **In progress**
    - Why: unlocks large portions of npm ecosystem (`fs`, crypto-like flows, parsers, protocol clients).
-   - Current blocker: `fs` is text-only in documented behavior.
+   - Current state: `Buffer.from/isBuffer/alloc/byteLength/concat` and fs sync Buffer read/write are implemented.
+   - Remaining gap: broader Buffer API coverage and deeper binary interoperability across more Node surfaces.
 
 2. **events/EventEmitter core semantics**
+   - Status: 🟡 **Baseline implemented**
    - Why: central dependency pattern across Node packages and many polyfills.
-   - Typical minimum: `on`, `once`, `off/removeListener`, `emit`, listener ordering.
+   - Current state: `on/addListener`, `once`, `off/removeListener`, `emit`, `listenerCount`, `removeAllListeners` are implemented.
+   - Remaining gap: advanced APIs (`errorMonitor`, `prepend*`, `rawListeners`, max listeners controls, async iterator helpers).
 
 3. **util essentials**
+   - Status: 🔴 **Not started in docs/runtime inventory**
    - Why: common in transitive dependencies.
    - Suggested first APIs: `promisify`, `inherits`, `types` subset, `inspect` minimal compatibility.
 
 ### P1 (High value, after P0 foundations)
 
 4. **stream core baseline**
+   - Status: 🔴 **Not started in docs/runtime inventory**
    - Why: critical for many adapters and network/file stacks.
    - Suggested first surface: minimal `Readable`/`Writable` + pipeline primitives required by popular libs.
 
 5. **fs/promises breadth expansion**
+   - Status: 🟡 **Partially implemented**
    - Why: modern Node codepaths prefer async fs APIs.
-   - Suggested additions: `readFile`, `writeFile`, `stat/lstat`, `realpath`, basic `watch` strategy.
+   - Current state: `access`, `readdir({ withFileTypes: true })`, `mkdir({ recursive: true })`, `copyFile` are implemented.
+   - Remaining additions: `readFile`, `writeFile`, `stat/lstat`, `realpath`, basic `watch` strategy.
 
 6. **process expansion**
+   - Status: 🟡 **Partially implemented**
    - Why: common runtime feature checks and environment access.
-   - Suggested additions: `env`, `cwd/chdir`, `nextTick`, `versions`, `platform`.
+   - Current state: `argv`, `exit`, `exitCode`, `env`, `chdir`, `nextTick`, `platform`, and `versions.node` are implemented.
+   - Remaining additions: `cwd()`, broader `versions` surface, and tighter `nextTick` semantics parity.
 
 ### P2 (Important but can follow the core runtime path)
 
 7. **url/querystring compatibility**
+   - Status: 🔴 **Not started in docs/runtime inventory**
    - Why: very common in tooling and HTTP stacks.
    - Suggested additions: robust `URL`, `URLSearchParams`, parse/format compatibility helpers.
 
 8. **crypto minimum practical subset**
+   - Status: 🔴 **Not started in docs/runtime inventory**
    - Why: common package requirement for hashing/randomness.
    - Suggested additions: `createHash`, `randomBytes`, `webcrypto.getRandomValues` bridge.
 
 ### P3 (Large scope / sequence after foundations)
 
 9. **http/https/net/tls layers**
+   - Status: 🔴 **Not started in docs/runtime inventory**
    - Why: high ecosystem reach, but dependent on streams/events/buffer maturity.
 
 10. **ESM interop baseline**
+    - Status: 🔴 **Not started in docs/runtime inventory**
     - Why: increasingly common package entrypoints.
     - Suggested baseline: loader behavior for common import/export shapes and `import.meta.url` support plan.
 
@@ -74,16 +88,17 @@
 
 Observed frequently in tests/samples and therefore good near-term ROI:
 
-- `path`, `fs`, `process`, timers, and `perf_hooks` are actively exercised.
+- `path`, `fs`, `process`, timers, `perf_hooks`, and `events` are actively exercised.
+- `Buffer` now has dedicated execution + generator tests under `Js2IL.Tests/Node/Buffer`.
 - Integration tests reference `node:child_process`, `node:fs`, `node:path`, `node:os`.
-- Existing Node module docs remain partial, indicating broad gaps despite progress in path/fs/process/timers slices.
+- Existing Node module docs remain partial, indicating broad gaps despite progress in path/fs/process/events/buffer slices.
 
 ## Recommended Sequencing (Execution)
 
 ### Two-week slice suggestion
 
-- **Week 1:** Buffer foundation + `fs` binary read/write interoperability tests
-- **Week 2:** `events` baseline + `util.promisify` and one consumer-style integration test
+- **Week 1:** expand `util` baseline (`promisify`, `inherits`, minimal `types`/`inspect`) + add one transitive-dependency integration fixture
+- **Week 2:** expand `fs/promises` (`readFile`, `writeFile`, `stat/lstat`) and tighten `process` parity (`cwd`, richer `versions`, `nextTick` semantics)
 
 ### Gate for each delivered item
 


### PR DESCRIPTION
## Summary\n- sync Node gap backlog baseline counts/status with current docs inventory\n- update P0/P1/P2/P3 items to reflect delivered vs remaining work\n- refresh demand-signal and two-week sequencing notes based on current implementation state\n\n## Files\n- docs/tracking-issues/NodeGapPopularityBacklog_2026-02-17.md