### PR TITLE
feat(node): expand fs/promises async lifecycle to writeFile and copyFile

### DIFF
--- a/Js2IL.Tests/Node/FS/ExecutionTests.cs
+++ b/Js2IL.Tests/Node/FS/ExecutionTests.cs
@@ -189,5 +189,16 @@ namespace Js2IL.Tests.Node.FS
                     var temp = System.IO.Path.GetTempPath().Replace('\\', '/');
                     s.AddScrubber(sb => sb.Replace(temp, "{TempPath}"));
                 });
+
+        [Fact]
+        public Task FSPromises_CopyFile()
+            => ExecutionTest(
+                nameof(FSPromises_CopyFile),
+                configureSettings: s =>
+                {
+                    s.AddScrubber(sb => sb.Replace('\\', '/'));
+                    var temp = System.IO.Path.GetTempPath().Replace('\\', '/');
+                    s.AddScrubber(sb => sb.Replace(temp, "{TempPath}"));
+                });
     }
 }

--- a/Js2IL.Tests/Node/FS/JavaScript/FSPromises_CopyFile.js
+++ b/Js2IL.Tests/Node/FS/JavaScript/FSPromises_CopyFile.js
@@ -1,0 +1,23 @@
+"use strict";
+const fs = require('fs/promises');
+const syncFs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const src = path.join(os.tmpdir(), 'test-copyfile-src.txt');
+const dst = path.join(os.tmpdir(), 'test-copyfile-dst.txt');
+
+syncFs.writeFileSync(src, 'copied content', 'utf8');
+
+fs.copyFile(src, dst)
+    .then(() => {
+        const content = syncFs.readFileSync(dst, 'utf8');
+        console.log('Copied content:', content);
+    })
+    .catch(err => {
+        console.error('Error:', err.message);
+    })
+    .finally(() => {
+        syncFs.rmSync(src, { force: true });
+        syncFs.rmSync(dst, { force: true });
+    });

--- a/Js2IL.Tests/Node/FS/Snapshots/ExecutionTests.FSPromises_CopyFile.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/ExecutionTests.FSPromises_CopyFile.verified.txt
@@ -1,0 +1,1 @@
+Copied content: copied content


### PR DESCRIPTION
## Summary
- expand `fs/promises` non-blocking lifecycle pattern to additional APIs in `FSPromises`
- convert `writeFile` to async file I/O paths (`WriteAllBytesAsync` / `WriteAllTextAsync`) with `BeginIo`/`EndIo(...)`
- convert `copyFile` to async stream copy (`FileStream` + `CopyToAsync`) with `BeginIo`/`EndIo(...)`
- keep fire-and-forget helper task pattern with internal exception handling routed through scheduler `EndIo(...)`
- add execution test coverage for `fs/promises.copyFile`

## Validation
- `runTests` on `Js2IL.Tests/Node/FS/ExecutionTests.cs`
- Result: 19 passed, 0 failed