### PR TITLE
ci(smoke): align windows smoke with linux perf steps

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -88,6 +88,31 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Build Jint Comparison Project
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Set-Location tests/performance/JintComparison
+          dotnet build -c Release
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: Shutdown build server
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Kill VBCSCompiler and other build processes to free up resources
+          # before running performance benchmarks
+          dotnet build-server shutdown
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: Run Performance Comparison
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Set-Location tests/performance
+          node RunComparison.js
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
       - name: Build and run Hosting.Domino sample
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- add missing performance comparison steps to windows smoke workflow
- mirror linux smoke sequence for Jint comparison build, build-server shutdown, and performance run

## Validation
- workflow file updated and checked for editor-reported errors