### PR TITLE
docs(changelog): update unreleased entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+- ECMA-262 §6.1: expand runtime coverage with BigInt-capable arithmetic/bitwise/shift/relational operators, `String.prototype.lastIndexOf`, and `Object.is` SameValue semantics, with corresponding execution + generator coverage.
+- IR/IL operator lowering: introduce dedicated dynamic operator LIR instructions (`LIRBinaryDynamicOperator`, `LIRNegateNumberDynamic`, `LIRBitwiseNotDynamic`) so dynamic paths call `JavaScriptRuntime.Operators` directly; remove now-unused `JavaScriptRuntime.Object` operator bridge methods.
+- Performance telemetry: add Supabase ingestion for benchmark workflows (`performance-comparison`, `benchmarkdotnet-suite`, `linux-smoke`, `windows-smoke`) via `tests/performance/ingestPerfToSupabase.js`, including host/runtime metadata capture and BenchmarkDotNet markdown-summary fallback parsing.
 
 ## v0.8.14 - 2026-02-19
 


### PR DESCRIPTION
## Summary
- update the Unreleased section in CHANGELOG.md
- document ECMA-262 6.1 runtime and test coverage work
- document dynamic operator LIR refactor and runtime bridge cleanup
- document Supabase-based performance telemetry ingestion workflow updates

## Validation
- verified changelog entries align with recently merged PRs (#668 and #669)