### PR TITLE
chore(ci): default BenchmarkDotNet suite mode to all

### DIFF
--- a/.github/workflows/benchmarkdotnet-suite.yml
+++ b/.github/workflows/benchmarkdotnet-suite.yml
@@ -10,7 +10,7 @@ on:
       mode:
         description: 'Benchmark mode (default/phased/all)'
         required: false
-        default: 'default'
+        default: 'all'
   release:
     types: [published]
 
@@ -47,7 +47,7 @@ jobs:
       - name: Run BenchmarkDotNet Suite
         id: benchmark
         env:
-          BENCHMARK_MODE: ${{ github.event.inputs.mode || 'default' }}
+          BENCHMARK_MODE: ${{ github.event.inputs.mode || 'all' }}
           BENCHMARK_FILTER: ${{ github.event.inputs.benchmark_filter || '*' }}
         run: |
           cd tests/performance/Benchmarks


### PR DESCRIPTION
## Summary
- default `workflow_dispatch` benchmark mode to `all`
- update BENCHMARK_MODE fallback to `all` so non-input runs execute both suites

## Testing
- not run (workflow YAML change only)