### PR TITLE
fix(samples): improve Hosting.Domino debugging

### DIFF
--- a/samples/Hosting.Domino/host/Hosting.Domino.csproj
+++ b/samples/Hosting.Domino/host/Hosting.Domino.csproj
@@ -13,6 +13,7 @@
     <ModuleProj>$(MSBuildProjectDirectory)\..\compiler\HostedDomino.proj</ModuleProj>
     <ModuleOutputDir>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildProjectDirectory)','$(BaseIntermediateOutputPath)','HostedDomino'))))</ModuleOutputDir>
     <ModuleDll>$([System.IO.Path]::Combine('$(ModuleOutputDir)','$(ModuleName).dll'))</ModuleDll>
+    <ModulePdb>$([System.IO.Path]::Combine('$(ModuleOutputDir)','$(ModuleName).pdb'))</ModulePdb>
 
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\..\'))</RepoRoot>
     <LocalJavaScriptRuntimeProject>$(RepoRoot)JavaScriptRuntime\JavaScriptRuntime.csproj</LocalJavaScriptRuntimeProject>
@@ -42,8 +43,9 @@
   </Target>
 
   <Target Name="CopyHostedModuleToOutput" AfterTargets="Build" DependsOnTargets="BuildHostedModule"
-          Inputs="$(ModuleDll)" Outputs="$(TargetDir)$(ModuleName).dll">
+          Inputs="$(ModuleDll);$(ModulePdb)" Outputs="$(TargetDir)$(ModuleName).dll;$(TargetDir)$(ModuleName).pdb">
     <Copy SourceFiles="$(ModuleDll)" DestinationFiles="$(TargetDir)$(ModuleName).dll" SkipUnchangedFiles="true" />
+    <Copy Condition="Exists('$(ModulePdb)')" SourceFiles="$(ModulePdb)" DestinationFiles="$(TargetDir)$(ModuleName).pdb" SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/samples/Hosting.Domino/host/Program.cs
+++ b/samples/Hosting.Domino/host/Program.cs
@@ -37,8 +37,7 @@ internal static class Program
                 return;
             }
 
-            using var exportsDisposable = JsEngine.LoadModule(asm, moduleId: "@mixmark-io/domino");
-            dynamic exports = exportsDisposable;
+            using dynamic exports = JsEngine.LoadModule(asm, moduleId: "@mixmark-io/domino");
 
             dynamic window = exports.createWindow(html);
             dynamic document = window.document;


### PR DESCRIPTION
## Summary
- switch Hosting.Domino sample module load to one-line `using dynamic` declaration
- copy generated `index.pdb` alongside `index.dll` so symbols are available in debugger

## Validation
- dotnet build samples/Hosting.Domino/host/Hosting.Domino.csproj -c Debug -nologo
