### PR TITLE
ci: make release workflow run names descriptive

### DIFF
--- a/.github/workflows/benchmarkdotnet-suite.yml
+++ b/.github/workflows/benchmarkdotnet-suite.yml
@@ -1,4 +1,5 @@
 name: BenchmarkDotNet Performance Suite
+run-name: BenchmarkDotNet suite (${{ github.event.release.tag_name || github.ref_name }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -1,4 +1,5 @@
 name: linux-smoke
+run-name: Linux smoke (${{ github.event.release.tag_name || github.ref_name }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -1,4 +1,5 @@
 name: windows-smoke
+run-name: Windows smoke (${{ github.event.release.tag_name || github.ref_name }})
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Updates the release-triggered workflow run names to be descriptive while still including the release version/tag.\n\nUpdated workflows:\n- linux-smoke\n- windows-smoke\n- benchmarkdotnet-suite