### PR TITLE
fix(commonjs): normalize RequireDelegate calls in LIR

### DIFF
--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2175
+			// Method begins at RVA 0x2161
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,66 +40,57 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 170 (0xaa)
+		// Code size: 150 (0x96)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_Class/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_Class/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.3
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Export_Class_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.3
 		IL_0012: ldloc.3
-		IL_0013: ldstr "./CommonJS_Export_Class_Lib"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.s 4
-		IL_001f: ldloc.s 4
-		IL_0021: stloc.1
-		IL_0022: ldloc.1
-		IL_0023: ldc.i4.0
-		IL_0024: newarr [System.Runtime]System.Object
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_002e: stloc.s 4
-		IL_0030: ldloc.s 4
-		IL_0032: stloc.2
-		IL_0033: ldloc.2
-		IL_0034: ldstr "add"
-		IL_0039: ldc.r8 2
-		IL_0042: box [System.Runtime]System.Double
-		IL_0047: ldc.r8 3
-		IL_0050: box [System.Runtime]System.Double
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_005a: stloc.s 4
-		IL_005c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0061: ldstr "add:"
-		IL_0066: ldloc.s 4
-		IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_006d: pop
-		IL_006e: ldloc.2
-		IL_006f: ldstr "multiply"
-		IL_0074: ldc.r8 4
-		IL_007d: box [System.Runtime]System.Double
-		IL_0082: ldc.r8 5
-		IL_008b: box [System.Runtime]System.Double
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0095: stloc.s 4
-		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009c: ldstr "multiply:"
-		IL_00a1: ldloc.s 4
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00a8: pop
-		IL_00a9: ret
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: ldc.i4.0
+		IL_0016: newarr [System.Runtime]System.Object
+		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0020: stloc.3
+		IL_0021: ldloc.3
+		IL_0022: stloc.2
+		IL_0023: ldloc.2
+		IL_0024: ldstr "add"
+		IL_0029: ldc.r8 2
+		IL_0032: box [System.Runtime]System.Double
+		IL_0037: ldc.r8 3
+		IL_0040: box [System.Runtime]System.Double
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_004a: stloc.3
+		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0050: ldstr "add:"
+		IL_0055: ldloc.3
+		IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_005b: pop
+		IL_005c: ldloc.2
+		IL_005d: ldstr "multiply"
+		IL_0062: ldc.r8 4
+		IL_006b: box [System.Runtime]System.Double
+		IL_0070: ldc.r8 5
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0083: stloc.3
+		IL_0084: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0089: ldstr "multiply:"
+		IL_008e: ldloc.3
+		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0094: pop
+		IL_0095: ret
 	} // end of method CommonJS_Export_Class::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_Class
@@ -119,7 +110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2187
+				// Method begins at RVA 0x2173
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -139,7 +130,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2190
+				// Method begins at RVA 0x217c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -159,7 +150,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2199
+				// Method begins at RVA 0x2185
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -177,7 +168,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2133
+			// Method begins at RVA 0x211f
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -193,7 +184,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x213c
+			// Method begins at RVA 0x2128
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -215,7 +206,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x2154
+			// Method begins at RVA 0x2140
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -243,7 +234,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217e
+			// Method begins at RVA 0x216a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -267,7 +258,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2108
+		// Method begins at RVA 0x20f4
 		// Header size: 12
 		// Code size: 31 (0x1f)
 		.maxstack 8
@@ -298,7 +289,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a2
+		// Method begins at RVA 0x218e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d4
+			// Method begins at RVA 0x21c4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,98 +40,89 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 237 (0xed)
+		// Code size: 223 (0xdf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ClassWithConstructor/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object[],
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_ClassWithConstructor/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 4
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Export_ClassWithConstructor_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 4
 		IL_0013: ldloc.s 4
-		IL_0015: ldstr "./CommonJS_Export_ClassWithConstructor_Lib"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 5
-		IL_0021: ldloc.s 5
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldc.i4.2
-		IL_0026: newarr [System.Runtime]System.Object
-		IL_002b: dup
-		IL_002c: ldc.i4.0
-		IL_002d: ldstr "Default"
-		IL_0032: stelem.ref
-		IL_0033: dup
-		IL_0034: ldc.i4.1
-		IL_0035: ldc.r8 25
-		IL_003e: box [System.Runtime]System.Double
-		IL_0043: stelem.ref
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0049: stloc.s 5
-		IL_004b: ldloc.s 5
-		IL_004d: stloc.2
-		IL_004e: ldloc.2
-		IL_004f: ldstr "greet"
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0059: stloc.s 5
-		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0060: ldstr "default greeting:"
-		IL_0065: ldloc.s 5
-		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_006c: pop
-		IL_006d: ldloc.1
-		IL_006e: ldc.i4.2
-		IL_006f: newarr [System.Runtime]System.Object
-		IL_0074: dup
-		IL_0075: ldc.i4.0
-		IL_0076: ldstr "Alice"
-		IL_007b: stelem.ref
-		IL_007c: dup
-		IL_007d: ldc.i4.1
-		IL_007e: ldc.r8 30
-		IL_0087: box [System.Runtime]System.Double
-		IL_008c: stelem.ref
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0092: stloc.s 5
-		IL_0094: ldloc.s 5
-		IL_0096: stloc.3
-		IL_0097: ldloc.3
-		IL_0098: ldstr "greet"
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00a2: stloc.s 5
-		IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a9: ldstr "alice greeting:"
-		IL_00ae: ldloc.s 5
-		IL_00b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b5: pop
-		IL_00b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bb: ldstr "alice name:"
-		IL_00c0: ldloc.3
-		IL_00c1: ldstr "name"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00d0: pop
-		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d6: ldstr "alice age:"
-		IL_00db: ldloc.3
-		IL_00dc: ldstr "age"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00eb: pop
-		IL_00ec: ret
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldc.i4.2
+		IL_0018: newarr [System.Runtime]System.Object
+		IL_001d: dup
+		IL_001e: ldc.i4.0
+		IL_001f: ldstr "Default"
+		IL_0024: stelem.ref
+		IL_0025: dup
+		IL_0026: ldc.i4.1
+		IL_0027: ldc.r8 25
+		IL_0030: box [System.Runtime]System.Double
+		IL_0035: stelem.ref
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_003b: stloc.s 4
+		IL_003d: ldloc.s 4
+		IL_003f: stloc.2
+		IL_0040: ldloc.2
+		IL_0041: ldstr "greet"
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_004b: stloc.s 4
+		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0052: ldstr "default greeting:"
+		IL_0057: ldloc.s 4
+		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_005e: pop
+		IL_005f: ldloc.1
+		IL_0060: ldc.i4.2
+		IL_0061: newarr [System.Runtime]System.Object
+		IL_0066: dup
+		IL_0067: ldc.i4.0
+		IL_0068: ldstr "Alice"
+		IL_006d: stelem.ref
+		IL_006e: dup
+		IL_006f: ldc.i4.1
+		IL_0070: ldc.r8 30
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: stelem.ref
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0084: stloc.s 4
+		IL_0086: ldloc.s 4
+		IL_0088: stloc.3
+		IL_0089: ldloc.3
+		IL_008a: ldstr "greet"
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0094: stloc.s 4
+		IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009b: ldstr "alice greeting:"
+		IL_00a0: ldloc.s 4
+		IL_00a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a7: pop
+		IL_00a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ad: ldstr "alice name:"
+		IL_00b2: ldloc.3
+		IL_00b3: ldstr "name"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00c2: pop
+		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c8: ldstr "alice age:"
+		IL_00cd: ldloc.3
+		IL_00ce: ldstr "age"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00dd: pop
+		IL_00de: ret
 	} // end of method CommonJS_Export_ClassWithConstructor::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ClassWithConstructor
@@ -151,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e6
+				// Method begins at RVA 0x21d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -171,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ef
+				// Method begins at RVA 0x21df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f8
+				// Method begins at RVA 0x21e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -216,7 +207,7 @@
 				object age
 			) cil managed 
 		{
-			// Method begins at RVA 0x2177
+			// Method begins at RVA 0x2167
 			// Header size: 1
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -235,7 +226,7 @@
 		.method public hidebysig 
 			instance object greet () cil managed 
 		{
-			// Method begins at RVA 0x2190
+			// Method begins at RVA 0x2180
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -274,7 +265,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21dd
+			// Method begins at RVA 0x21cd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -298,7 +289,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x214c
+		// Method begins at RVA 0x213c
 		// Header size: 12
 		// Code size: 31 (0x1f)
 		.maxstack 8
@@ -329,7 +320,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2201
+		// Method begins at RVA 0x21f1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Function.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Function.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2112
+			// Method begins at RVA 0x2106
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,52 +40,44 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 80 (0x50)
+		// Code size: 66 (0x42)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_Function/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object
+			[3] object,
+			[4] object[]
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_Function/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.3
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Export_Function_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.3
 		IL_0012: ldloc.3
-		IL_0013: ldstr "./CommonJS_Export_Function_Lib"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.s 4
-		IL_001f: ldloc.s 4
-		IL_0021: stloc.1
-		IL_0022: ldc.i4.1
-		IL_0023: newarr [System.Runtime]System.Object
-		IL_0028: dup
-		IL_0029: ldc.i4.0
-		IL_002a: ldnull
-		IL_002b: stelem.ref
-		IL_002c: stloc.3
-		IL_002d: ldloc.1
+		IL_0013: stloc.1
+		IL_0014: ldc.i4.1
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: dup
+		IL_001b: ldc.i4.0
+		IL_001c: ldnull
+		IL_001d: stelem.ref
+		IL_001e: stloc.s 4
+		IL_0020: ldloc.1
+		IL_0021: ldloc.s 4
+		IL_0023: ldstr "World"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_002d: stloc.3
 		IL_002e: ldloc.3
-		IL_002f: ldstr "World"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0039: stloc.s 4
-		IL_003b: ldloc.s 4
-		IL_003d: stloc.2
-		IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0043: ldstr "result:"
-		IL_0048: ldloc.2
-		IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_004e: pop
-		IL_004f: ret
+		IL_002f: stloc.2
+		IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0035: ldstr "result:"
+		IL_003a: ldloc.2
+		IL_003b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0040: pop
+		IL_0041: ret
 	} // end of method CommonJS_Export_Function::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_Function
@@ -105,7 +97,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2124
+				// Method begins at RVA 0x2118
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,7 +118,7 @@
 				object name
 			) cil managed 
 		{
-			// Method begins at RVA 0x20ec
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -162,7 +154,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211b
+			// Method begins at RVA 0x210f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -186,7 +178,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ac
+		// Method begins at RVA 0x20a0
 		// Header size: 12
 		// Code size: 50 (0x32)
 		.maxstack 8
@@ -228,7 +220,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212d
+		// Method begins at RVA 0x2121
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22fa
+			// Method begins at RVA 0x22ee
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,104 +40,95 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 317 (0x13d)
+		// Code size: 305 (0x131)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_NestedObjects/Scope,
 			[1] object,
-			[2] object[],
-			[3] object
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_NestedObjects/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Export_NestedObjects_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "./CommonJS_Export_NestedObjects_Lib"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0025: ldstr "name:"
-		IL_002a: ldloc.1
-		IL_002b: ldstr "name"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0035: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_003a: pop
-		IL_003b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0040: ldstr "version:"
-		IL_0045: ldloc.1
-		IL_0046: ldstr "version"
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0055: pop
-		IL_0056: ldloc.1
-		IL_0057: ldstr "math"
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0061: stloc.3
-		IL_0062: ldloc.3
-		IL_0063: ldstr "add"
-		IL_0068: ldc.r8 10
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: ldc.r8 5
-		IL_007f: box [System.Runtime]System.Double
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0089: stloc.3
-		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008f: ldstr "add:"
-		IL_0094: ldloc.3
-		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_009a: pop
-		IL_009b: ldloc.1
-		IL_009c: ldstr "math"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00a6: stloc.3
-		IL_00a7: ldloc.3
-		IL_00a8: ldstr "multiply"
-		IL_00ad: ldc.r8 4
-		IL_00b6: box [System.Runtime]System.Double
-		IL_00bb: ldc.r8 3
-		IL_00c4: box [System.Runtime]System.Double
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00ce: stloc.3
-		IL_00cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d4: ldstr "multiply:"
-		IL_00d9: ldloc.3
-		IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00df: pop
-		IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e5: ldstr "prefix:"
-		IL_00ea: ldloc.1
-		IL_00eb: ldstr "utils"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00f5: ldstr "prefix"
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0104: pop
-		IL_0105: ldloc.1
-		IL_0106: ldstr "utils"
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0110: stloc.3
-		IL_0111: ldloc.3
-		IL_0112: ldstr "formatNum"
-		IL_0117: ldc.r8 42
-		IL_0120: box [System.Runtime]System.Double
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_012a: stloc.3
-		IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0130: ldstr "formatNum:"
-		IL_0135: ldloc.3
-		IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_013b: pop
-		IL_013c: ret
+		IL_0013: stloc.1
+		IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0019: ldstr "name:"
+		IL_001e: ldloc.1
+		IL_001f: ldstr "name"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_002e: pop
+		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0034: ldstr "version:"
+		IL_0039: ldloc.1
+		IL_003a: ldstr "version"
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0049: pop
+		IL_004a: ldloc.1
+		IL_004b: ldstr "math"
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0055: stloc.2
+		IL_0056: ldloc.2
+		IL_0057: ldstr "add"
+		IL_005c: ldc.r8 10
+		IL_0065: box [System.Runtime]System.Double
+		IL_006a: ldc.r8 5
+		IL_0073: box [System.Runtime]System.Double
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_007d: stloc.2
+		IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0083: ldstr "add:"
+		IL_0088: ldloc.2
+		IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008e: pop
+		IL_008f: ldloc.1
+		IL_0090: ldstr "math"
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_009a: stloc.2
+		IL_009b: ldloc.2
+		IL_009c: ldstr "multiply"
+		IL_00a1: ldc.r8 4
+		IL_00aa: box [System.Runtime]System.Double
+		IL_00af: ldc.r8 3
+		IL_00b8: box [System.Runtime]System.Double
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00c2: stloc.2
+		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c8: ldstr "multiply:"
+		IL_00cd: ldloc.2
+		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00d3: pop
+		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d9: ldstr "prefix:"
+		IL_00de: ldloc.1
+		IL_00df: ldstr "utils"
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00e9: ldstr "prefix"
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00f8: pop
+		IL_00f9: ldloc.1
+		IL_00fa: ldstr "utils"
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0104: stloc.2
+		IL_0105: ldloc.2
+		IL_0106: ldstr "formatNum"
+		IL_010b: ldc.r8 42
+		IL_0114: box [System.Runtime]System.Double
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_011e: stloc.2
+		IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0124: ldstr "formatNum:"
+		IL_0129: ldloc.2
+		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_012f: pop
+		IL_0130: ret
 	} // end of method CommonJS_Export_NestedObjects::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_NestedObjects
@@ -157,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230c
+				// Method begins at RVA 0x2300
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -179,7 +170,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x2298
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -208,7 +199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2315
+				// Method begins at RVA 0x2309
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,7 +221,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x22bc
+			// Method begins at RVA 0x22b0
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -262,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231e
+				// Method begins at RVA 0x2312
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -283,7 +274,7 @@
 				object 'value'
 			) cil managed 
 		{
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22d4
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -308,7 +299,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2303
+			// Method begins at RVA 0x22f7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -332,7 +323,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x219c
+		// Method begins at RVA 0x2190
 		// Header size: 12
 		// Code size: 251 (0xfb)
 		.maxstack 9
@@ -443,7 +434,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2327
+		// Method begins at RVA 0x231b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2267
+			// Method begins at RVA 0x2253
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,70 +40,61 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 182 (0xb6)
+		// Code size: 162 (0xa2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ObjectWithClosure/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_ObjectWithClosure/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.3
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Export_ObjectWithClosure_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.3
 		IL_0012: ldloc.3
-		IL_0013: ldstr "./CommonJS_Export_ObjectWithClosure_Lib"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.s 4
-		IL_001f: ldloc.s 4
-		IL_0021: stloc.1
-		IL_0022: ldloc.1
-		IL_0023: ldstr "multiplyModuleFactor"
-		IL_0028: ldc.r8 3
-		IL_0031: box [System.Runtime]System.Double
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_003b: stloc.s 4
-		IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0042: ldstr "lib.multiplyModuleFactor(3):"
-		IL_0047: ldloc.s 4
-		IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_004e: pop
-		IL_004f: ldloc.1
-		IL_0050: ldstr "createCalculator"
-		IL_0055: ldc.r8 10
-		IL_005e: box [System.Runtime]System.Double
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0068: stloc.s 4
-		IL_006a: ldloc.s 4
-		IL_006c: stloc.2
-		IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0072: ldstr "calc.factor:"
-		IL_0077: ldloc.2
-		IL_0078: ldstr "factor"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0082: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0087: pop
-		IL_0088: ldloc.2
-		IL_0089: ldstr "multiply"
-		IL_008e: ldc.r8 5
-		IL_0097: box [System.Runtime]System.Double
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a1: stloc.s 4
-		IL_00a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a8: ldstr "calc.multiply(5):"
-		IL_00ad: ldloc.s 4
-		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b4: pop
-		IL_00b5: ret
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: ldstr "multiplyModuleFactor"
+		IL_001a: ldc.r8 3
+		IL_0023: box [System.Runtime]System.Double
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_002d: stloc.3
+		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0033: ldstr "lib.multiplyModuleFactor(3):"
+		IL_0038: ldloc.3
+		IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_003e: pop
+		IL_003f: ldloc.1
+		IL_0040: ldstr "createCalculator"
+		IL_0045: ldc.r8 10
+		IL_004e: box [System.Runtime]System.Double
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0058: stloc.3
+		IL_0059: ldloc.3
+		IL_005a: stloc.2
+		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0060: ldstr "calc.factor:"
+		IL_0065: ldloc.2
+		IL_0066: ldstr "factor"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0075: pop
+		IL_0076: ldloc.2
+		IL_0077: ldstr "multiply"
+		IL_007c: ldc.r8 5
+		IL_0085: box [System.Runtime]System.Double
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008f: stloc.3
+		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0095: ldstr "calc.multiply(5):"
+		IL_009a: ldloc.3
+		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a0: pop
+		IL_00a1: ret
 	} // end of method CommonJS_Export_ObjectWithClosure::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ObjectWithClosure
@@ -123,7 +114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2279
+				// Method begins at RVA 0x2265
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +136,7 @@
 				object x
 			) cil managed 
 		{
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x2198
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -184,7 +175,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x228b
+					// Method begins at RVA 0x2277
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -206,7 +197,7 @@
 					object x
 				) cil managed 
 			{
-				// Method begins at RVA 0x2238
+				// Method begins at RVA 0x2224
 				// Header size: 12
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -250,7 +241,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2282
+				// Method begins at RVA 0x226e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -272,7 +263,7 @@
 				object factor
 			) cil managed 
 		{
-			// Method begins at RVA 0x21d4
+			// Method begins at RVA 0x21c0
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -348,7 +339,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2270
+			// Method begins at RVA 0x225c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -372,7 +363,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2114
+		// Method begins at RVA 0x2100
 		// Header size: 12
 		// Code size: 139 (0x8b)
 		.maxstack 8
@@ -446,7 +437,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2294
+		// Method begins at RVA 0x2280
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21fd
+			// Method begins at RVA 0x21f1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,67 +40,58 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 176 (0xb0)
+		// Code size: 164 (0xa4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ObjectWithFunctions/Scope,
 			[1] object,
-			[2] object[],
-			[3] object
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Export_ObjectWithFunctions_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "./CommonJS_Export_ObjectWithFunctions_Lib"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: ldloc.1
-		IL_0021: ldstr "add"
-		IL_0026: ldc.r8 2
-		IL_002f: box [System.Runtime]System.Double
-		IL_0034: ldc.r8 3
-		IL_003d: box [System.Runtime]System.Double
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0047: stloc.3
-		IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004d: ldstr "add:"
-		IL_0052: ldloc.3
-		IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0058: pop
-		IL_0059: ldloc.1
-		IL_005a: ldstr "multiply"
-		IL_005f: ldc.r8 4
-		IL_0068: box [System.Runtime]System.Double
-		IL_006d: ldc.r8 5
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0080: stloc.3
-		IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0086: ldstr "multiply:"
-		IL_008b: ldloc.3
-		IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0091: pop
-		IL_0092: ldloc.1
-		IL_0093: ldstr "foo"
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_009d: stloc.3
-		IL_009e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a3: ldstr "foo:"
-		IL_00a8: ldloc.3
-		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00ae: pop
-		IL_00af: ret
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: ldstr "add"
+		IL_001a: ldc.r8 2
+		IL_0023: box [System.Runtime]System.Double
+		IL_0028: ldc.r8 3
+		IL_0031: box [System.Runtime]System.Double
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_003b: stloc.2
+		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0041: ldstr "add:"
+		IL_0046: ldloc.2
+		IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_004c: pop
+		IL_004d: ldloc.1
+		IL_004e: ldstr "multiply"
+		IL_0053: ldc.r8 4
+		IL_005c: box [System.Runtime]System.Double
+		IL_0061: ldc.r8 5
+		IL_006a: box [System.Runtime]System.Double
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0074: stloc.2
+		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007a: ldstr "multiply:"
+		IL_007f: ldloc.2
+		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0085: pop
+		IL_0086: ldloc.1
+		IL_0087: ldstr "foo"
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0091: stloc.2
+		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0097: ldstr "foo:"
+		IL_009c: ldloc.2
+		IL_009d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a2: pop
+		IL_00a3: ret
 	} // end of method CommonJS_Export_ObjectWithFunctions::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ObjectWithFunctions
@@ -120,7 +111,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220f
+				// Method begins at RVA 0x2203
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +131,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x21bb
+			// Method begins at RVA 0x21af
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -162,7 +153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2218
+				// Method begins at RVA 0x220c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -184,7 +175,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -213,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2221
+				// Method begins at RVA 0x2215
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -235,7 +226,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x21dc
+			// Method begins at RVA 0x21d0
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -274,7 +265,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2206
+			// Method begins at RVA 0x21fa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -298,7 +289,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x210c
+		// Method begins at RVA 0x2100
 		// Header size: 12
 		// Code size: 163 (0xa3)
 		.maxstack 8
@@ -386,7 +377,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x222a
+		// Method begins at RVA 0x221e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Global_ErrorPrototype_Read.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Global_ErrorPrototype_Read.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f0
+			// Method begins at RVA 0x20e4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,37 +40,28 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 50 (0x32)
+		// Code size: 38 (0x26)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Global_ErrorPrototype_Read/Scope,
 			[1] object,
-			[2] object[],
-			[3] object
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Global_ErrorPrototype_Read/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Global_ErrorPrototype_Read_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "./CommonJS_Global_ErrorPrototype_Read_Lib"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0025: ldstr "hasErrorPrototype:"
-		IL_002a: ldloc.1
-		IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0030: pop
-		IL_0031: ret
+		IL_0013: stloc.1
+		IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0019: ldstr "hasErrorPrototype:"
+		IL_001e: ldloc.1
+		IL_001f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0024: pop
+		IL_0025: ret
 	} // end of method CommonJS_Global_ErrorPrototype_Read::__js_module_init__
 
 } // end of class Modules.CommonJS_Global_ErrorPrototype_Read
@@ -86,7 +77,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f9
+			// Method begins at RVA 0x20ed
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -110,7 +101,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2090
+		// Method begins at RVA 0x2084
 		// Header size: 12
 		// Code size: 84 (0x54)
 		.maxstack 8
@@ -159,7 +150,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2102
+		// Method begins at RVA 0x20f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x214e
+			// Method begins at RVA 0x2142
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,49 +40,40 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 94 (0x5e)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_ChainedAssignment/Scope,
 			[1] object,
-			[2] object[],
-			[3] object
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Module_Exports_ChainedAssignment/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Module_Exports_ChainedAssignment_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "./CommonJS_Module_Exports_ChainedAssignment_Lib"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0025: ldstr "answer:"
-		IL_002a: ldloc.1
-		IL_002b: ldstr "answer"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0035: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_003a: pop
-		IL_003b: ldloc.1
-		IL_003c: ldstr "greet"
-		IL_0041: ldstr "world"
-		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_004b: stloc.3
-		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0051: ldstr "greet:"
-		IL_0056: ldloc.3
-		IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_005c: pop
-		IL_005d: ret
+		IL_0013: stloc.1
+		IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0019: ldstr "answer:"
+		IL_001e: ldloc.1
+		IL_001f: ldstr "answer"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_002e: pop
+		IL_002f: ldloc.1
+		IL_0030: ldstr "greet"
+		IL_0035: ldstr "world"
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_003f: stloc.2
+		IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0045: ldstr "greet:"
+		IL_004a: ldloc.2
+		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0050: pop
+		IL_0051: ret
 	} // end of method CommonJS_Module_Exports_ChainedAssignment::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Exports_ChainedAssignment
@@ -102,7 +93,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2160
+				// Method begins at RVA 0x2154
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -123,7 +114,7 @@
 				object name
 			) cil managed 
 		{
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x2128
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -148,7 +139,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2157
+			// Method begins at RVA 0x214b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -172,7 +163,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20bc
+		// Method begins at RVA 0x20b0
 		// Header size: 12
 		// Code size: 107 (0x6b)
 		.maxstack 8
@@ -230,7 +221,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2169
+		// Method begins at RVA 0x215d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_ParentChildren.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_ParentChildren.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23be
+				// Method begins at RVA 0x23a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -36,7 +36,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23b5
+			// Method begins at RVA 0x2399
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -62,149 +62,132 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 451 (0x1c3)
+		// Code size: 423 (0x1a7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_ParentChildren/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object,
-			[5] bool,
-			[6] object
+			[3] object,
+			[4] bool,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Module_ParentChildren/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.3
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Module_ParentChildren_Child1"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.3
 		IL_0012: ldloc.3
-		IL_0013: ldstr "./CommonJS_Module_ParentChildren_Child1"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.s 4
-		IL_001f: ldloc.s 4
-		IL_0021: stloc.1
-		IL_0022: ldc.i4.1
-		IL_0023: newarr [System.Runtime]System.Object
-		IL_0028: dup
-		IL_0029: ldc.i4.0
-		IL_002a: ldnull
-		IL_002b: stelem.ref
-		IL_002c: stloc.3
-		IL_002d: ldarg.1
-		IL_002e: ldloc.3
-		IL_002f: ldstr "./CommonJS_Module_ParentChildren_Child2"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0039: stloc.s 4
-		IL_003b: ldloc.s 4
-		IL_003d: stloc.2
-		IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0043: ldstr "main module.parent:"
-		IL_0048: ldarg.2
-		IL_0049: ldstr "parent"
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0058: pop
-		IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005e: ldstr "main module.children type:"
-		IL_0063: ldarg.2
-		IL_0064: ldstr "children"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_006e: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0073: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0078: pop
-		IL_0079: ldarg.2
-		IL_007a: ldstr "children"
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0084: call bool [JavaScriptRuntime]JavaScriptRuntime.Array::isArray(object)
-		IL_0089: stloc.s 5
-		IL_008b: ldloc.s 5
-		IL_008d: box [System.Runtime]System.Boolean
-		IL_0092: stloc.s 6
-		IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0099: ldstr "main module.children is array:"
-		IL_009e: ldloc.s 6
-		IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00a5: pop
-		IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ab: ldstr "main module.children length:"
-		IL_00b0: ldarg.2
-		IL_00b1: ldstr "children"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_00c0: box [System.Runtime]System.Double
-		IL_00c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00ca: pop
-		IL_00cb: ldarg.2
-		IL_00cc: ldstr "children"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_00db: ldc.r8 2
-		IL_00e4: clt
-		IL_00e6: ldc.i4.0
-		IL_00e7: ceq
-		IL_00e9: brfalse IL_018c
+		IL_0013: stloc.1
+		IL_0014: ldarg.1
+		IL_0015: ldstr "./CommonJS_Module_ParentChildren_Child2"
+		IL_001a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_001f: stloc.3
+		IL_0020: ldloc.3
+		IL_0021: stloc.2
+		IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0027: ldstr "main module.parent:"
+		IL_002c: ldarg.2
+		IL_002d: ldstr "parent"
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0037: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_003c: pop
+		IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0042: ldstr "main module.children type:"
+		IL_0047: ldarg.2
+		IL_0048: ldstr "children"
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_005c: pop
+		IL_005d: ldarg.2
+		IL_005e: ldstr "children"
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0068: call bool [JavaScriptRuntime]JavaScriptRuntime.Array::isArray(object)
+		IL_006d: stloc.s 4
+		IL_006f: ldloc.s 4
+		IL_0071: box [System.Runtime]System.Boolean
+		IL_0076: stloc.s 5
+		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007d: ldstr "main module.children is array:"
+		IL_0082: ldloc.s 5
+		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0089: pop
+		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008f: ldstr "main module.children length:"
+		IL_0094: ldarg.2
+		IL_0095: ldstr "children"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_009f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_00a4: box [System.Runtime]System.Double
+		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ae: pop
+		IL_00af: ldarg.2
+		IL_00b0: ldstr "children"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00ba: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_00bf: ldc.r8 2
+		IL_00c8: clt
+		IL_00ca: ldc.i4.0
+		IL_00cb: ceq
+		IL_00cd: brfalse IL_0170
 
-		IL_00ee: ldarg.2
-		IL_00ef: ldstr "children"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00f9: ldc.r8 0.0
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-		IL_0107: ldstr "id"
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0116: ldstr "string"
-		IL_011b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0120: stloc.s 5
-		IL_0122: ldloc.s 5
-		IL_0124: box [System.Runtime]System.Boolean
-		IL_0129: stloc.s 6
-		IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0130: ldstr "child 0 has id:"
-		IL_0135: ldloc.s 6
-		IL_0137: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_013c: pop
-		IL_013d: ldarg.2
-		IL_013e: ldstr "children"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0148: ldc.r8 1
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-		IL_0156: ldstr "id"
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0160: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0165: ldstr "string"
-		IL_016a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_016f: stloc.s 5
-		IL_0171: ldloc.s 5
-		IL_0173: box [System.Runtime]System.Boolean
-		IL_0178: stloc.s 6
-		IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017f: ldstr "child 1 has id:"
-		IL_0184: ldloc.s 6
-		IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_018b: pop
+		IL_00d2: ldarg.2
+		IL_00d3: ldstr "children"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00dd: ldc.r8 0.0
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_00eb: ldstr "id"
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00f5: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_00fa: ldstr "string"
+		IL_00ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0104: stloc.s 4
+		IL_0106: ldloc.s 4
+		IL_0108: box [System.Runtime]System.Boolean
+		IL_010d: stloc.s 5
+		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0114: ldstr "child 0 has id:"
+		IL_0119: ldloc.s 5
+		IL_011b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0120: pop
+		IL_0121: ldarg.2
+		IL_0122: ldstr "children"
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_012c: ldc.r8 1
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_013a: ldstr "id"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0149: ldstr "string"
+		IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0153: stloc.s 4
+		IL_0155: ldloc.s 4
+		IL_0157: box [System.Runtime]System.Boolean
+		IL_015c: stloc.s 5
+		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0163: ldstr "child 1 has id:"
+		IL_0168: ldloc.s 5
+		IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_016f: pop
 
-		IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0191: ldstr "child1 export:"
-		IL_0196: ldloc.1
-		IL_0197: ldstr "name"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_01a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01a6: pop
-		IL_01a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ac: ldstr "child2 export:"
-		IL_01b1: ldloc.2
-		IL_01b2: ldstr "name"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_01bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01c1: pop
-		IL_01c2: ret
+		IL_0170: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0175: ldstr "child1 export:"
+		IL_017a: ldloc.1
+		IL_017b: ldstr "name"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_018a: pop
+		IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0190: ldstr "child2 export:"
+		IL_0195: ldloc.2
+		IL_0196: ldstr "name"
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_01a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01a5: pop
+		IL_01a6: ret
 	} // end of method CommonJS_Module_ParentChildren::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_ParentChildren
@@ -224,7 +207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d0
+				// Method begins at RVA 0x23b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -242,7 +225,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23c7
+			// Method begins at RVA 0x23ab
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -266,7 +249,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2220
+		// Method begins at RVA 0x2204
 		// Header size: 12
 		// Code size: 189 (0xbd)
 		.maxstack 8
@@ -355,7 +338,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23e2
+				// Method begins at RVA 0x23c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -373,7 +356,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23d9
+			// Method begins at RVA 0x23bd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -397,7 +380,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x22ec
+		// Method begins at RVA 0x22d0
 		// Header size: 12
 		// Code size: 189 (0xbd)
 		.maxstack 8
@@ -478,7 +461,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23eb
+		// Method begins at RVA 0x23cf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Require.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Require.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212f
+			// Method begins at RVA 0x2121
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,15 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 211 (0xd3)
+		// Code size: 197 (0xc5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Require/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object[],
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Module_Require/Scope::.ctor()
@@ -61,61 +60,53 @@
 		IL_001b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 		IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 		IL_0025: pop
-		IL_0026: ldc.i4.1
-		IL_0027: newarr [System.Runtime]System.Object
-		IL_002c: dup
-		IL_002d: ldc.i4.0
-		IL_002e: ldnull
-		IL_002f: stelem.ref
-		IL_0030: stloc.s 4
-		IL_0032: ldarg.1
+		IL_0026: ldarg.1
+		IL_0027: ldstr "path"
+		IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0031: stloc.s 4
 		IL_0033: ldloc.s 4
-		IL_0035: ldstr "path"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003f: stloc.s 5
-		IL_0041: ldloc.s 5
-		IL_0043: stloc.1
-		IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0049: ldstr "path module type:"
-		IL_004e: ldloc.1
-		IL_004f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0059: pop
-		IL_005a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005f: ldstr "path.join type:"
-		IL_0064: ldloc.1
-		IL_0065: ldstr "join"
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_006f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0079: pop
-		IL_007a: ldloc.1
-		IL_007b: ldstr "join"
-		IL_0080: ldstr "a"
-		IL_0085: ldstr "b"
-		IL_008a: ldstr "c"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0094: stloc.s 5
-		IL_0096: ldloc.s 5
-		IL_0098: stloc.2
-		IL_0099: ldloc.2
-		IL_009a: ldstr "split"
-		IL_009f: ldstr "\\"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a9: stloc.s 5
-		IL_00ab: ldloc.s 5
-		IL_00ad: ldstr "join"
-		IL_00b2: ldstr "/"
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00bc: stloc.s 5
-		IL_00be: ldloc.s 5
-		IL_00c0: stloc.3
-		IL_00c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c6: ldstr "path.join result:"
-		IL_00cb: ldloc.3
-		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00d1: pop
-		IL_00d2: ret
+		IL_0035: stloc.1
+		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_003b: ldstr "path module type:"
+		IL_0040: ldloc.1
+		IL_0041: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_004b: pop
+		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0051: ldstr "path.join type:"
+		IL_0056: ldloc.1
+		IL_0057: ldstr "join"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0061: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_006b: pop
+		IL_006c: ldloc.1
+		IL_006d: ldstr "join"
+		IL_0072: ldstr "a"
+		IL_0077: ldstr "b"
+		IL_007c: ldstr "c"
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0086: stloc.s 4
+		IL_0088: ldloc.s 4
+		IL_008a: stloc.2
+		IL_008b: ldloc.2
+		IL_008c: ldstr "split"
+		IL_0091: ldstr "\\"
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_009b: stloc.s 4
+		IL_009d: ldloc.s 4
+		IL_009f: ldstr "join"
+		IL_00a4: ldstr "/"
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ae: stloc.s 4
+		IL_00b0: ldloc.s 4
+		IL_00b2: stloc.3
+		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b8: ldstr "path.join result:"
+		IL_00bd: ldloc.3
+		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00c3: pop
+		IL_00c4: ret
 	} // end of method CommonJS_Module_Require::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Require
@@ -127,7 +118,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2138
+		// Method begins at RVA 0x212a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2394
+				// Method begins at RVA 0x2388
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				object x
 			) cil managed 
 		{
-			// Method begins at RVA 0x2204
+			// Method begins at RVA 0x21f8
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23af
+				// Method begins at RVA 0x23a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x21fc
 			// Header size: 12
 			// Code size: 66 (0x42)
 			.maxstack 8
@@ -137,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x239d
+				// Method begins at RVA 0x2391
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -157,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a6
+				// Method begins at RVA 0x239a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +180,7 @@
 				object[] scopes
 			) cil managed 
 		{
-			// Method begins at RVA 0x2258
+			// Method begins at RVA 0x224c
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -201,7 +201,7 @@
 		.method public hidebysig 
 			instance object Log () cil managed 
 		{
-			// Method begins at RVA 0x2274
+			// Method begins at RVA 0x2268
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -258,7 +258,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x238b
+			// Method begins at RVA 0x237f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -284,14 +284,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 231 (0xe7)
+		// Code size: 217 (0xd9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Basic/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] class Modules.CommonJS_Require_Basic/CommonClassName
+			[3] class Modules.CommonJS_Require_Basic/CommonClassName
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Require_Basic/Scope::.ctor()
@@ -335,55 +334,47 @@
 		IL_0068: stelem.ref
 		IL_0069: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::map(object[])
 		IL_006e: pop
-		IL_006f: ldc.i4.1
-		IL_0070: newarr [System.Runtime]System.Object
-		IL_0075: dup
-		IL_0076: ldc.i4.0
-		IL_0077: ldnull
-		IL_0078: stelem.ref
-		IL_0079: stloc.3
-		IL_007a: ldarg.1
-		IL_007b: ldloc.3
-		IL_007c: ldstr "./CommonJS_Require_Dependency"
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0086: pop
-		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008c: ldc.i4.1
-		IL_008d: newarr [System.Runtime]System.Object
-		IL_0092: dup
-		IL_0093: ldc.i4.0
-		IL_0094: ldstr "CommonJS_Require_Basic has been loaded"
-		IL_0099: stelem.ref
-		IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_009f: pop
-		IL_00a0: ldloc.0
-		IL_00a1: ldstr "CommonJS_Require_Basic"
-		IL_00a6: stfld string Modules.CommonJS_Require_Basic/Scope::moduleName
-		IL_00ab: ldc.i4.1
-		IL_00ac: newarr [System.Runtime]System.Object
-		IL_00b1: dup
-		IL_00b2: ldc.i4.0
-		IL_00b3: ldloc.0
-		IL_00b4: stelem.ref
-		IL_00b5: newobj instance void Modules.CommonJS_Require_Basic/CommonClassName::.ctor(object[])
-		IL_00ba: stloc.s 4
-		IL_00bc: ldloc.s 4
-		IL_00be: ldstr "Log"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00c8: pop
-		IL_00c9: ldnull
-		IL_00ca: ldftn object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(object[], object)
-		IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_00d5: ldc.i4.1
-		IL_00d6: newarr [System.Runtime]System.Object
-		IL_00db: dup
-		IL_00dc: ldc.i4.0
-		IL_00dd: ldloc.0
-		IL_00de: stelem.ref
-		IL_00df: ldnull
-		IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
-		IL_00e5: pop
-		IL_00e6: ret
+		IL_006f: ldarg.1
+		IL_0070: ldstr "./CommonJS_Require_Dependency"
+		IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_007a: pop
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldc.i4.1
+		IL_0081: newarr [System.Runtime]System.Object
+		IL_0086: dup
+		IL_0087: ldc.i4.0
+		IL_0088: ldstr "CommonJS_Require_Basic has been loaded"
+		IL_008d: stelem.ref
+		IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0093: pop
+		IL_0094: ldloc.0
+		IL_0095: ldstr "CommonJS_Require_Basic"
+		IL_009a: stfld string Modules.CommonJS_Require_Basic/Scope::moduleName
+		IL_009f: ldc.i4.1
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldloc.0
+		IL_00a8: stelem.ref
+		IL_00a9: newobj instance void Modules.CommonJS_Require_Basic/CommonClassName::.ctor(object[])
+		IL_00ae: stloc.3
+		IL_00af: ldloc.3
+		IL_00b0: ldstr "Log"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00ba: pop
+		IL_00bb: ldnull
+		IL_00bc: ldftn object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(object[], object)
+		IL_00c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_00c7: ldc.i4.1
+		IL_00c8: newarr [System.Runtime]System.Object
+		IL_00cd: dup
+		IL_00ce: ldc.i4.0
+		IL_00cf: ldloc.0
+		IL_00d0: stelem.ref
+		IL_00d1: ldnull
+		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
+		IL_00d7: pop
+		IL_00d8: ret
 	} // end of method CommonJS_Require_Basic::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Basic
@@ -409,7 +400,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c1
+				// Method begins at RVA 0x23b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -430,7 +421,7 @@
 				object x
 			) cil managed 
 		{
-			// Method begins at RVA 0x22c7
+			// Method begins at RVA 0x22bb
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -452,7 +443,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23dc
+				// Method begins at RVA 0x23d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -473,7 +464,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x22cc
+			// Method begins at RVA 0x22c0
 			// Header size: 12
 			// Code size: 66 (0x42)
 			.maxstack 8
@@ -522,7 +513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ca
+				// Method begins at RVA 0x23be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -542,7 +533,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d3
+				// Method begins at RVA 0x23c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -565,7 +556,7 @@
 				object[] scopes
 			) cil managed 
 		{
-			// Method begins at RVA 0x231c
+			// Method begins at RVA 0x2310
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -586,7 +577,7 @@
 		.method public hidebysig 
 			instance object Log () cil managed 
 		{
-			// Method begins at RVA 0x2338
+			// Method begins at RVA 0x232c
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -643,7 +634,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23b8
+			// Method begins at RVA 0x23ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -667,7 +658,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2144
+		// Method begins at RVA 0x2138
 		// Header size: 12
 		// Code size: 180 (0xb4)
 		.maxstack 8
@@ -758,7 +749,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23e5
+		// Method begins at RVA 0x23d9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23b3
+			// Method begins at RVA 0x239b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,49 +40,32 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 80 (0x50)
+		// Code size: 56 (0x38)
 		.maxstack 8
-		.locals init (
-			[0] class Modules.a/Scope,
-			[1] object[]
+		.locals (
+			[0] class Modules.a/Scope
 		)
 
 		IL_0000: newobj instance void Modules.a/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.1
-		IL_0011: ldarg.1
-		IL_0012: ldloc.1
-		IL_0013: ldstr "./b"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./b"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: pop
+		IL_0012: ldarg.1
+		IL_0013: ldstr "./helpers/b"
+		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
 		IL_001d: pop
-		IL_001e: ldc.i4.1
-		IL_001f: newarr [System.Runtime]System.Object
-		IL_0024: dup
-		IL_0025: ldc.i4.0
-		IL_0026: ldnull
-		IL_0027: stelem.ref
-		IL_0028: stloc.1
-		IL_0029: ldarg.1
-		IL_002a: ldloc.1
-		IL_002b: ldstr "./helpers/b"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0035: pop
-		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003b: ldc.i4.1
-		IL_003c: newarr [System.Runtime]System.Object
-		IL_0041: dup
-		IL_0042: ldc.i4.0
-		IL_0043: ldstr "CommonJS_Require_NestedNameConflict a has been loaded"
-		IL_0048: stelem.ref
-		IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_004e: pop
-		IL_004f: ret
+		IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0023: ldc.i4.1
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: dup
+		IL_002a: ldc.i4.0
+		IL_002b: ldstr "CommonJS_Require_NestedNameConflict a has been loaded"
+		IL_0030: stelem.ref
+		IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0036: pop
+		IL_0037: ret
 	} // end of method a::__js_module_init__
 
 } // end of class Modules.a
@@ -108,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c5
+				// Method begins at RVA 0x23ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -129,7 +112,7 @@
 				object x
 			) cil managed 
 		{
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x2214
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -151,7 +134,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23e0
+				// Method begins at RVA 0x23c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -172,7 +155,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2230
+			// Method begins at RVA 0x2218
 			// Header size: 12
 			// Code size: 66 (0x42)
 			.maxstack 8
@@ -221,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ce
+				// Method begins at RVA 0x23b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -241,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d7
+				// Method begins at RVA 0x23bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +247,7 @@
 				object[] scopes
 			) cil managed 
 		{
-			// Method begins at RVA 0x2280
+			// Method begins at RVA 0x2268
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -285,7 +268,7 @@
 		.method public hidebysig 
 			instance object Log () cil managed 
 		{
-			// Method begins at RVA 0x229c
+			// Method begins at RVA 0x2284
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -342,7 +325,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23bc
+			// Method begins at RVA 0x23a4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -366,7 +349,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ac
+		// Method begins at RVA 0x2094
 		// Header size: 12
 		// Code size: 180 (0xb4)
 		.maxstack 8
@@ -471,7 +454,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f2
+				// Method begins at RVA 0x23da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -492,7 +475,7 @@
 				object x
 			) cil managed 
 		{
-			// Method begins at RVA 0x22ef
+			// Method begins at RVA 0x22d7
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -514,7 +497,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x240d
+				// Method begins at RVA 0x23f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -535,7 +518,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x22f4
+			// Method begins at RVA 0x22dc
 			// Header size: 12
 			// Code size: 66 (0x42)
 			.maxstack 8
@@ -584,7 +567,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23fb
+				// Method begins at RVA 0x23e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -604,7 +587,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2404
+				// Method begins at RVA 0x23ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -627,7 +610,7 @@
 				object[] scopes
 			) cil managed 
 		{
-			// Method begins at RVA 0x2344
+			// Method begins at RVA 0x232c
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -648,7 +631,7 @@
 		.method public hidebysig 
 			instance object Log () cil managed 
 		{
-			// Method begins at RVA 0x2360
+			// Method begins at RVA 0x2348
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -705,7 +688,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23e9
+			// Method begins at RVA 0x23d1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -729,7 +712,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x216c
+		// Method begins at RVA 0x2154
 		// Header size: 12
 		// Code size: 180 (0xb4)
 		.maxstack 8
@@ -820,7 +803,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2416
+		// Method begins at RVA 0x23fe
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_RelativeFromModule.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_RelativeFromModule.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2131
+			// Method begins at RVA 0x2119
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,37 +40,28 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 56 (0x38)
+		// Code size: 44 (0x2c)
 		.maxstack 8
-		.locals init (
-			[0] class Modules.a/Scope,
-			[1] object[]
+		.locals (
+			[0] class Modules.a/Scope
 		)
 
 		IL_0000: newobj instance void Modules.a/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.1
-		IL_0011: ldarg.1
-		IL_0012: ldloc.1
-		IL_0013: ldstr "./helpers/b"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: pop
-		IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0023: ldc.i4.1
-		IL_0024: newarr [System.Runtime]System.Object
-		IL_0029: dup
-		IL_002a: ldc.i4.0
-		IL_002b: ldstr "CommonJS_Require_RelativeFromModule a has been loaded"
-		IL_0030: stelem.ref
-		IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0036: pop
-		IL_0037: ret
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./helpers/b"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: pop
+		IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0017: ldc.i4.1
+		IL_0018: newarr [System.Runtime]System.Object
+		IL_001d: dup
+		IL_001e: ldc.i4.0
+		IL_001f: ldstr "CommonJS_Require_RelativeFromModule a has been loaded"
+		IL_0024: stelem.ref
+		IL_0025: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_002a: pop
+		IL_002b: ret
 	} // end of method a::__js_module_init__
 
 } // end of class Modules.a
@@ -86,7 +77,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213a
+			// Method begins at RVA 0x2122
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -110,50 +101,41 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2094
+		// Method begins at RVA 0x2088
 		// Header size: 12
-		// Code size: 77 (0x4d)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.helpers_b/Scope,
 			[1] string,
-			[2] object[],
-			[3] string
+			[2] string
 		)
 
 		IL_0000: newobj instance void Modules.helpers_b/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldstr "CommonJS_Require_RelativeFromModule/helpers/b"
 		IL_000b: stloc.1
-		IL_000c: ldc.i4.1
-		IL_000d: newarr [System.Runtime]System.Object
-		IL_0012: dup
-		IL_0013: ldc.i4.0
-		IL_0014: ldnull
-		IL_0015: stelem.ref
-		IL_0016: stloc.2
-		IL_0017: ldarg.1
-		IL_0018: ldloc.2
-		IL_0019: ldstr "./c"
-		IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0023: pop
-		IL_0024: ldloc.1
-		IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_002a: stloc.3
-		IL_002b: ldstr "CommonJS_Require_RelativeFromModule loaded: "
-		IL_0030: ldloc.3
-		IL_0031: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0036: stloc.3
-		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003c: ldc.i4.1
-		IL_003d: newarr [System.Runtime]System.Object
-		IL_0042: dup
-		IL_0043: ldc.i4.0
-		IL_0044: ldloc.3
-		IL_0045: stelem.ref
-		IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_004b: pop
-		IL_004c: ret
+		IL_000c: ldarg.1
+		IL_000d: ldstr "./c"
+		IL_0012: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0017: pop
+		IL_0018: ldloc.1
+		IL_0019: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_001e: stloc.2
+		IL_001f: ldstr "CommonJS_Require_RelativeFromModule loaded: "
+		IL_0024: ldloc.2
+		IL_0025: call string [System.Runtime]System.String::Concat(string, string)
+		IL_002a: stloc.2
+		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0030: ldc.i4.1
+		IL_0031: newarr [System.Runtime]System.Object
+		IL_0036: dup
+		IL_0037: ldc.i4.0
+		IL_0038: ldloc.2
+		IL_0039: stelem.ref
+		IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method helpers_b::__js_module_init__
 
 } // end of class Modules.helpers_b
@@ -169,7 +151,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2143
+			// Method begins at RVA 0x212b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -193,7 +175,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20f0
+		// Method begins at RVA 0x20d8
 		// Header size: 12
 		// Code size: 53 (0x35)
 		.maxstack 8
@@ -235,7 +217,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214c
+		// Method begins at RVA 0x2134
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_SharedDependency_ExecutedOnce.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_SharedDependency_ExecutedOnce.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b1
+			// Method begins at RVA 0x2181
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,11 +40,10 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 105 (0x69)
+		// Code size: 81 (0x51)
 		.maxstack 8
-		.locals init (
-			[0] class Modules.a/Scope,
-			[1] object[]
+		.locals (
+			[0] class Modules.a/Scope
 		)
 
 		IL_0000: newobj instance void Modules.a/Scope::.ctor()
@@ -58,40 +57,24 @@
 		IL_0018: stelem.ref
 		IL_0019: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001e: pop
-		IL_001f: ldc.i4.1
-		IL_0020: newarr [System.Runtime]System.Object
-		IL_0025: dup
-		IL_0026: ldc.i4.0
-		IL_0027: ldnull
-		IL_0028: stelem.ref
-		IL_0029: stloc.1
-		IL_002a: ldarg.1
-		IL_002b: ldloc.1
-		IL_002c: ldstr "./b"
-		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_001f: ldarg.1
+		IL_0020: ldstr "./b"
+		IL_0025: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_002a: pop
+		IL_002b: ldarg.1
+		IL_002c: ldstr "./c"
+		IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
 		IL_0036: pop
-		IL_0037: ldc.i4.1
-		IL_0038: newarr [System.Runtime]System.Object
-		IL_003d: dup
-		IL_003e: ldc.i4.0
-		IL_003f: ldnull
-		IL_0040: stelem.ref
-		IL_0041: stloc.1
-		IL_0042: ldarg.1
-		IL_0043: ldloc.1
-		IL_0044: ldstr "./c"
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_004e: pop
-		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0054: ldc.i4.1
-		IL_0055: newarr [System.Runtime]System.Object
-		IL_005a: dup
-		IL_005b: ldc.i4.0
-		IL_005c: ldstr "a end"
-		IL_0061: stelem.ref
-		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0067: pop
-		IL_0068: ret
+		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_003c: ldc.i4.1
+		IL_003d: newarr [System.Runtime]System.Object
+		IL_0042: dup
+		IL_0043: ldc.i4.0
+		IL_0044: ldstr "a end"
+		IL_0049: stelem.ref
+		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_004f: pop
+		IL_0050: ret
 	} // end of method a::__js_module_init__
 
 } // end of class Modules.a
@@ -107,7 +90,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ba
+			// Method begins at RVA 0x218a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -131,13 +114,12 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20c8
+		// Method begins at RVA 0x20b0
 		// Header size: 12
-		// Code size: 81 (0x51)
+		// Code size: 69 (0x45)
 		.maxstack 8
-		.locals init (
-			[0] class Modules.b/Scope,
-			[1] object[]
+		.locals (
+			[0] class Modules.b/Scope
 		)
 
 		IL_0000: newobj instance void Modules.b/Scope::.ctor()
@@ -151,28 +133,20 @@
 		IL_0018: stelem.ref
 		IL_0019: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001e: pop
-		IL_001f: ldc.i4.1
-		IL_0020: newarr [System.Runtime]System.Object
-		IL_0025: dup
-		IL_0026: ldc.i4.0
-		IL_0027: ldnull
-		IL_0028: stelem.ref
-		IL_0029: stloc.1
-		IL_002a: ldarg.1
-		IL_002b: ldloc.1
-		IL_002c: ldstr "./d"
-		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0036: pop
-		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003c: ldc.i4.1
-		IL_003d: newarr [System.Runtime]System.Object
-		IL_0042: dup
-		IL_0043: ldc.i4.0
-		IL_0044: ldstr "b end"
-		IL_0049: stelem.ref
-		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_004f: pop
-		IL_0050: ret
+		IL_001f: ldarg.1
+		IL_0020: ldstr "./d"
+		IL_0025: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_002a: pop
+		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0030: ldc.i4.1
+		IL_0031: newarr [System.Runtime]System.Object
+		IL_0036: dup
+		IL_0037: ldc.i4.0
+		IL_0038: ldstr "b end"
+		IL_003d: stelem.ref
+		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0043: pop
+		IL_0044: ret
 	} // end of method b::__js_module_init__
 
 } // end of class Modules.b
@@ -188,7 +162,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c3
+			// Method begins at RVA 0x2193
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -212,7 +186,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2128
+		// Method begins at RVA 0x2104
 		// Header size: 12
 		// Code size: 32 (0x20)
 		.maxstack 8
@@ -247,7 +221,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21cc
+			// Method begins at RVA 0x219c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -271,13 +245,12 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2154
+		// Method begins at RVA 0x2130
 		// Header size: 12
-		// Code size: 81 (0x51)
+		// Code size: 69 (0x45)
 		.maxstack 8
-		.locals init (
-			[0] class Modules.c/Scope,
-			[1] object[]
+		.locals (
+			[0] class Modules.c/Scope
 		)
 
 		IL_0000: newobj instance void Modules.c/Scope::.ctor()
@@ -291,28 +264,20 @@
 		IL_0018: stelem.ref
 		IL_0019: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_001e: pop
-		IL_001f: ldc.i4.1
-		IL_0020: newarr [System.Runtime]System.Object
-		IL_0025: dup
-		IL_0026: ldc.i4.0
-		IL_0027: ldnull
-		IL_0028: stelem.ref
-		IL_0029: stloc.1
-		IL_002a: ldarg.1
-		IL_002b: ldloc.1
-		IL_002c: ldstr "./d"
-		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0036: pop
-		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003c: ldc.i4.1
-		IL_003d: newarr [System.Runtime]System.Object
-		IL_0042: dup
-		IL_0043: ldc.i4.0
-		IL_0044: ldstr "c end"
-		IL_0049: stelem.ref
-		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_004f: pop
-		IL_0050: ret
+		IL_001f: ldarg.1
+		IL_0020: ldstr "./d"
+		IL_0025: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_002a: pop
+		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0030: ldc.i4.1
+		IL_0031: newarr [System.Runtime]System.Object
+		IL_0036: dup
+		IL_0037: ldc.i4.0
+		IL_0038: ldstr "c end"
+		IL_003d: stelem.ref
+		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0043: pop
+		IL_0044: ret
 	} // end of method c::__js_module_init__
 
 } // end of class Modules.c
@@ -324,7 +289,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d5
+		// Method begins at RVA 0x21a5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/Js2IL.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b0a
+					// Method begins at RVA 0x2af2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b01
+				// Method begins at RVA 0x2ae9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -61,7 +61,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x232c
+			// Method begins at RVA 0x2314
 			// Header size: 12
 			// Code size: 159 (0x9f)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b13
+				// Method begins at RVA 0x2afb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +162,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x23d8
+			// Method begins at RVA 0x23c0
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -242,7 +242,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b25
+					// Method begins at RVA 0x2b0d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -270,7 +270,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2b40
+							// Method begins at RVA 0x2b28
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -290,7 +290,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2b49
+							// Method begins at RVA 0x2b31
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -308,7 +308,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b37
+						// Method begins at RVA 0x2b1f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -326,7 +326,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b2e
+					// Method begins at RVA 0x2b16
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -344,7 +344,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b1c
+				// Method begins at RVA 0x2b04
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -366,7 +366,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x2460
+			// Method begins at RVA 0x2448
 			// Header size: 12
 			// Code size: 518 (0x206)
 			.maxstack 8
@@ -613,7 +613,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b52
+				// Method begins at RVA 0x2b3a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -636,7 +636,7 @@
 				object getter
 			) cil managed 
 		{
-			// Method begins at RVA 0x2674
+			// Method begins at RVA 0x265c
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -712,7 +712,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2af8
+			// Method begins at RVA 0x2ae0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -738,7 +738,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 287 (0x11f)
+		// Code size: 273 (0x111)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom/Scope,
@@ -809,54 +809,46 @@
 		IL_008d: stloc.s 6
 		IL_008f: ldloc.s 6
 		IL_0091: stloc.3
-		IL_0092: ldc.i4.1
-		IL_0093: newarr [System.Runtime]System.Object
-		IL_0098: dup
-		IL_0099: ldc.i4.0
-		IL_009a: ldnull
-		IL_009b: stelem.ref
-		IL_009c: stloc.s 7
-		IL_009e: ldarg.1
-		IL_009f: ldloc.s 7
-		IL_00a1: ldstr "./Import_ExportNamedFrom_LibB.mjs"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00ab: stloc.s 6
-		IL_00ad: ldloc.s 6
-		IL_00af: stloc.s 4
-		IL_00b1: ldloc.0
-		IL_00b2: ldloc.s 4
-		IL_00b4: ldstr "value"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00be: stfld object Modules.Import_ExportNamedFrom/Scope::'value'
-		IL_00c3: ldloc.s 4
-		IL_00c5: ldstr "doubled"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00cf: stloc.s 5
-		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d6: ldstr "value:"
-		IL_00db: ldloc.0
-		IL_00dc: ldfld object Modules.Import_ExportNamedFrom/Scope::'value'
-		IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00e6: pop
-		IL_00e7: ldc.i4.1
-		IL_00e8: newarr [System.Runtime]System.Object
-		IL_00ed: dup
-		IL_00ee: ldc.i4.0
-		IL_00ef: ldnull
-		IL_00f0: stelem.ref
-		IL_00f1: stloc.s 7
-		IL_00f3: ldloc.s 5
-		IL_00f5: ldloc.s 7
-		IL_00f7: ldc.r8 5
-		IL_0100: box [System.Runtime]System.Double
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_010a: stloc.s 6
-		IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0111: ldstr "doubled:"
-		IL_0116: ldloc.s 6
-		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_011d: pop
-		IL_011e: ret
+		IL_0092: ldarg.1
+		IL_0093: ldstr "./Import_ExportNamedFrom_LibB.mjs"
+		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_009d: stloc.s 6
+		IL_009f: ldloc.s 6
+		IL_00a1: stloc.s 4
+		IL_00a3: ldloc.0
+		IL_00a4: ldloc.s 4
+		IL_00a6: ldstr "value"
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00b0: stfld object Modules.Import_ExportNamedFrom/Scope::'value'
+		IL_00b5: ldloc.s 4
+		IL_00b7: ldstr "doubled"
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00c1: stloc.s 5
+		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c8: ldstr "value:"
+		IL_00cd: ldloc.0
+		IL_00ce: ldfld object Modules.Import_ExportNamedFrom/Scope::'value'
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00d8: pop
+		IL_00d9: ldc.i4.1
+		IL_00da: newarr [System.Runtime]System.Object
+		IL_00df: dup
+		IL_00e0: ldc.i4.0
+		IL_00e1: ldnull
+		IL_00e2: stelem.ref
+		IL_00e3: stloc.s 7
+		IL_00e5: ldloc.s 5
+		IL_00e7: ldloc.s 7
+		IL_00e9: ldc.r8 5
+		IL_00f2: box [System.Runtime]System.Double
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_00fc: stloc.s 6
+		IL_00fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0103: ldstr "doubled:"
+		IL_0108: ldloc.s 6
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_010f: pop
+		IL_0110: ret
 	} // end of method Import_ExportNamedFrom::__js_module_init__
 
 } // end of class Modules.Import_ExportNamedFrom
@@ -876,7 +868,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b64
+				// Method begins at RVA 0x2b4c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -897,7 +889,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x26ed
+			// Method begins at RVA 0x26d5
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -925,7 +917,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b6d
+				// Method begins at RVA 0x2b55
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -946,7 +938,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2706
+			// Method begins at RVA 0x26ee
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -978,7 +970,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b7f
+					// Method begins at RVA 0x2b67
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -996,7 +988,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b76
+				// Method begins at RVA 0x2b5e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1017,7 +1009,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2720
+			// Method begins at RVA 0x2708
 			// Header size: 12
 			// Code size: 159 (0x9f)
 			.maxstack 8
@@ -1097,7 +1089,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b88
+				// Method begins at RVA 0x2b70
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1118,7 +1110,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x27cc
+			// Method begins at RVA 0x27b4
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1198,7 +1190,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b9a
+					// Method begins at RVA 0x2b82
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1226,7 +1218,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2bb5
+							// Method begins at RVA 0x2b9d
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1246,7 +1238,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2bbe
+							// Method begins at RVA 0x2ba6
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1264,7 +1256,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bac
+						// Method begins at RVA 0x2b94
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1282,7 +1274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ba3
+					// Method begins at RVA 0x2b8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1300,7 +1292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b91
+				// Method begins at RVA 0x2b79
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1322,7 +1314,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x2854
+			// Method begins at RVA 0x283c
 			// Header size: 12
 			// Code size: 518 (0x206)
 			.maxstack 8
@@ -1569,7 +1561,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bc7
+				// Method begins at RVA 0x2baf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1592,7 +1584,7 @@
 				object getter
 			) cil managed 
 		{
-			// Method begins at RVA 0x2a68
+			// Method begins at RVA 0x2a50
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -1667,7 +1659,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b5b
+			// Method begins at RVA 0x2b43
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1691,17 +1683,16 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x217c
+		// Method begins at RVA 0x2170
 		// Header size: 12
-		// Code size: 312 (0x138)
+		// Code size: 298 (0x12a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom_LibB/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object,
-			[5] object[]
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportNamedFrom_LibB/Scope::.ctor()
@@ -1762,72 +1753,64 @@
 		IL_008d: stloc.s 4
 		IL_008f: ldloc.s 4
 		IL_0091: stloc.3
-		IL_0092: ldc.i4.1
-		IL_0093: newarr [System.Runtime]System.Object
-		IL_0098: dup
-		IL_0099: ldc.i4.0
-		IL_009a: ldnull
-		IL_009b: stelem.ref
-		IL_009c: stloc.s 5
-		IL_009e: ldarg.1
-		IL_009f: ldloc.s 5
-		IL_00a1: ldstr "./Import_ExportNamedFrom_LibA.cjs"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00ab: stloc.s 4
-		IL_00ad: ldloc.0
-		IL_00ae: ldloc.s 4
-		IL_00b0: stfld object Modules.Import_ExportNamedFrom_LibB/Scope::__js2il_esm_mod_0
-		IL_00b5: ldnull
-		IL_00b6: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L4C28::__js_call__(object[], object)
-		IL_00bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_00c1: ldc.i4.1
-		IL_00c2: newarr [System.Runtime]System.Object
-		IL_00c7: dup
-		IL_00c8: ldc.i4.0
-		IL_00c9: ldloc.0
-		IL_00ca: stelem.ref
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_00d0: stloc.s 4
-		IL_00d2: ldnull
-		IL_00d3: ldftn object Modules.Import_ExportNamedFrom_LibB/__js2il_esm_export::__js_call__(object[], object, object, object)
-		IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
+		IL_0092: ldarg.1
+		IL_0093: ldstr "./Import_ExportNamedFrom_LibA.cjs"
+		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_009d: stloc.s 4
+		IL_009f: ldloc.0
+		IL_00a0: ldloc.s 4
+		IL_00a2: stfld object Modules.Import_ExportNamedFrom_LibB/Scope::__js2il_esm_mod_0
+		IL_00a7: ldnull
+		IL_00a8: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L4C28::__js_call__(object[], object)
+		IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_00b3: ldc.i4.1
+		IL_00b4: newarr [System.Runtime]System.Object
+		IL_00b9: dup
+		IL_00ba: ldc.i4.0
+		IL_00bb: ldloc.0
+		IL_00bc: stelem.ref
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00c2: stloc.s 4
+		IL_00c4: ldnull
+		IL_00c5: ldftn object Modules.Import_ExportNamedFrom_LibB/__js2il_esm_export::__js_call__(object[], object, object, object)
+		IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+		IL_00d0: ldc.i4.1
+		IL_00d1: newarr [System.Runtime]System.Object
+		IL_00d6: dup
+		IL_00d7: ldc.i4.0
+		IL_00d8: ldloc.0
+		IL_00d9: stelem.ref
+		IL_00da: ldnull
+		IL_00db: ldstr "value"
+		IL_00e0: ldloc.s 4
+		IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::Invoke(object[], object, object, object)
+		IL_00e7: pop
 		IL_00e8: ldnull
-		IL_00e9: ldstr "value"
-		IL_00ee: ldloc.s 4
-		IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::Invoke(object[], object, object, object)
-		IL_00f5: pop
-		IL_00f6: ldnull
-		IL_00f7: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L5C30::__js_call__(object[], object)
-		IL_00fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_0102: ldc.i4.1
-		IL_0103: newarr [System.Runtime]System.Object
-		IL_0108: dup
-		IL_0109: ldc.i4.0
-		IL_010a: ldloc.0
-		IL_010b: stelem.ref
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0111: stloc.s 4
-		IL_0113: ldnull
-		IL_0114: ldftn object Modules.Import_ExportNamedFrom_LibB/__js2il_esm_export::__js_call__(object[], object, object, object)
-		IL_011a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
-		IL_011f: ldc.i4.1
-		IL_0120: newarr [System.Runtime]System.Object
-		IL_0125: dup
-		IL_0126: ldc.i4.0
-		IL_0127: ldloc.0
-		IL_0128: stelem.ref
-		IL_0129: ldnull
-		IL_012a: ldstr "doubled"
-		IL_012f: ldloc.s 4
-		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::Invoke(object[], object, object, object)
-		IL_0136: pop
-		IL_0137: ret
+		IL_00e9: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L5C30::__js_call__(object[], object)
+		IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_00f4: ldc.i4.1
+		IL_00f5: newarr [System.Runtime]System.Object
+		IL_00fa: dup
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldloc.0
+		IL_00fd: stelem.ref
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0103: stloc.s 4
+		IL_0105: ldnull
+		IL_0106: ldftn object Modules.Import_ExportNamedFrom_LibB/__js2il_esm_export::__js_call__(object[], object, object, object)
+		IL_010c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+		IL_0111: ldc.i4.1
+		IL_0112: newarr [System.Runtime]System.Object
+		IL_0117: dup
+		IL_0118: ldc.i4.0
+		IL_0119: ldloc.0
+		IL_011a: stelem.ref
+		IL_011b: ldnull
+		IL_011c: ldstr "doubled"
+		IL_0121: ldloc.s 4
+		IL_0123: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::Invoke(object[], object, object, object)
+		IL_0128: pop
+		IL_0129: ret
 	} // end of method Import_ExportNamedFrom_LibB::__js_module_init__
 
 } // end of class Modules.Import_ExportNamedFrom_LibB
@@ -1847,7 +1830,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bd9
+				// Method begins at RVA 0x2bc1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1868,7 +1851,7 @@
 				object x
 			) cil managed 
 		{
-			// Method begins at RVA 0x2ae1
+			// Method begins at RVA 0x2ac9
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -1890,7 +1873,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2bd0
+			// Method begins at RVA 0x2bb8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1914,7 +1897,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x22c0
+		// Method begins at RVA 0x22a8
 		// Header size: 12
 		// Code size: 93 (0x5d)
 		.maxstack 8
@@ -1967,7 +1950,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2be2
+		// Method begins at RVA 0x2bca
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
+++ b/Js2IL.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c8f
+					// Method begins at RVA 0x2c73
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c86
+				// Method begins at RVA 0x2c6a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -61,7 +61,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x246c
+			// Method begins at RVA 0x2450
 			// Header size: 12
 			// Code size: 159 (0x9f)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c98
+				// Method begins at RVA 0x2c7c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +162,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x2518
+			// Method begins at RVA 0x24fc
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -242,7 +242,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2caa
+					// Method begins at RVA 0x2c8e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -270,7 +270,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2cc5
+							// Method begins at RVA 0x2ca9
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -290,7 +290,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2cce
+							// Method begins at RVA 0x2cb2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -308,7 +308,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2cbc
+						// Method begins at RVA 0x2ca0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -326,7 +326,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2cb3
+					// Method begins at RVA 0x2c97
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -344,7 +344,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ca1
+				// Method begins at RVA 0x2c85
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -366,7 +366,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x25a0
+			// Method begins at RVA 0x2584
 			// Header size: 12
 			// Code size: 518 (0x206)
 			.maxstack 8
@@ -613,7 +613,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cd7
+				// Method begins at RVA 0x2cbb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -636,7 +636,7 @@
 				object getter
 			) cil managed 
 		{
-			// Method begins at RVA 0x27b4
+			// Method begins at RVA 0x2798
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -710,7 +710,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2c7d
+			// Method begins at RVA 0x2c61
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -736,7 +736,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 366 (0x16e)
+		// Code size: 352 (0x160)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom/Scope,
@@ -745,8 +745,7 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object,
-			[7] object[]
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFrom/Scope::.ctor()
@@ -807,73 +806,65 @@
 		IL_008d: stloc.s 6
 		IL_008f: ldloc.s 6
 		IL_0091: stloc.3
-		IL_0092: ldc.i4.1
-		IL_0093: newarr [System.Runtime]System.Object
-		IL_0098: dup
-		IL_0099: ldc.i4.0
-		IL_009a: ldnull
-		IL_009b: stelem.ref
-		IL_009c: stloc.s 7
-		IL_009e: ldarg.1
-		IL_009f: ldloc.s 7
-		IL_00a1: ldstr "./Import_ExportStarFrom_LibB.mjs"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00ab: stloc.s 6
-		IL_00ad: ldloc.s 6
-		IL_00af: stloc.s 4
-		IL_00b1: ldnull
-		IL_00b2: ldftn object Modules.Import_ExportStarFrom/__js2il_esm_namespace::__js_call__(object[], object, object)
-		IL_00b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_00bd: ldc.i4.1
-		IL_00be: newarr [System.Runtime]System.Object
-		IL_00c3: dup
-		IL_00c4: ldc.i4.0
-		IL_00c5: ldloc.0
-		IL_00c6: stelem.ref
-		IL_00c7: ldnull
-		IL_00c8: ldloc.s 4
-		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
-		IL_00cf: stloc.s 6
-		IL_00d1: ldloc.s 6
-		IL_00d3: stloc.s 5
-		IL_00d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00da: ldstr "own:"
-		IL_00df: ldloc.s 5
-		IL_00e1: ldstr "own"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00f0: pop
-		IL_00f1: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_00f6: ldstr "prototype"
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0100: ldstr "hasOwnProperty"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_010a: ldstr "call"
-		IL_010f: ldloc.s 5
-		IL_0111: ldstr "inherited"
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_011b: stloc.s 6
-		IL_011d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0122: ldstr "hasInherited:"
-		IL_0127: ldloc.s 6
-		IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_012e: pop
-		IL_012f: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_0134: ldstr "prototype"
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_013e: ldstr "hasOwnProperty"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0148: ldstr "call"
-		IL_014d: ldloc.s 5
-		IL_014f: ldstr "default"
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0159: stloc.s 6
-		IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0160: ldstr "hasDefault:"
-		IL_0165: ldloc.s 6
-		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_016c: pop
-		IL_016d: ret
+		IL_0092: ldarg.1
+		IL_0093: ldstr "./Import_ExportStarFrom_LibB.mjs"
+		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_009d: stloc.s 6
+		IL_009f: ldloc.s 6
+		IL_00a1: stloc.s 4
+		IL_00a3: ldnull
+		IL_00a4: ldftn object Modules.Import_ExportStarFrom/__js2il_esm_namespace::__js_call__(object[], object, object)
+		IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_00af: ldc.i4.1
+		IL_00b0: newarr [System.Runtime]System.Object
+		IL_00b5: dup
+		IL_00b6: ldc.i4.0
+		IL_00b7: ldloc.0
+		IL_00b8: stelem.ref
+		IL_00b9: ldnull
+		IL_00ba: ldloc.s 4
+		IL_00bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+		IL_00c1: stloc.s 6
+		IL_00c3: ldloc.s 6
+		IL_00c5: stloc.s 5
+		IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00cc: ldstr "own:"
+		IL_00d1: ldloc.s 5
+		IL_00d3: ldstr "own"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00e2: pop
+		IL_00e3: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_00e8: ldstr "prototype"
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00f2: ldstr "hasOwnProperty"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00fc: ldstr "call"
+		IL_0101: ldloc.s 5
+		IL_0103: ldstr "inherited"
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_010d: stloc.s 6
+		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0114: ldstr "hasInherited:"
+		IL_0119: ldloc.s 6
+		IL_011b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0120: pop
+		IL_0121: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0126: ldstr "prototype"
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0130: ldstr "hasOwnProperty"
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_013a: ldstr "call"
+		IL_013f: ldloc.s 5
+		IL_0141: ldstr "default"
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_014b: stloc.s 6
+		IL_014d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0152: ldstr "hasDefault:"
+		IL_0157: ldloc.s 6
+		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_015e: pop
+		IL_015f: ret
 	} // end of method Import_ExportStarFrom::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFrom
@@ -897,7 +888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d1f
+					// Method begins at RVA 0x2d03
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -915,7 +906,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d16
+				// Method begins at RVA 0x2cfa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -936,7 +927,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2830
+			// Method begins at RVA 0x2814
 			// Header size: 12
 			// Code size: 159 (0x9f)
 			.maxstack 8
@@ -1016,7 +1007,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d28
+				// Method begins at RVA 0x2d0c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1037,7 +1028,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x28dc
+			// Method begins at RVA 0x28c0
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1117,7 +1108,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d3a
+					// Method begins at RVA 0x2d1e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1145,7 +1136,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2d55
+							// Method begins at RVA 0x2d39
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1165,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2d5e
+							// Method begins at RVA 0x2d42
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1183,7 +1174,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2d4c
+						// Method begins at RVA 0x2d30
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1201,7 +1192,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d43
+					// Method begins at RVA 0x2d27
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1219,7 +1210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d31
+				// Method begins at RVA 0x2d15
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1241,7 +1232,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x2964
+			// Method begins at RVA 0x2948
 			// Header size: 12
 			// Code size: 518 (0x206)
 			.maxstack 8
@@ -1488,7 +1479,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d67
+				// Method begins at RVA 0x2d4b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1511,7 +1502,7 @@
 				object getter
 			) cil managed 
 		{
-			// Method begins at RVA 0x2b78
+			// Method begins at RVA 0x2b5c
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -1582,7 +1573,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d0d
+					// Method begins at RVA 0x2cf1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1603,7 +1594,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c59
+				// Method begins at RVA 0x2c3d
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -1638,7 +1629,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d04
+				// Method begins at RVA 0x2ce8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1660,7 +1651,7 @@
 				object __k
 			) cil managed 
 		{
-			// Method begins at RVA 0x2bf4
+			// Method begins at RVA 0x2bd8
 			// Header size: 12
 			// Code size: 89 (0x59)
 			.maxstack 8
@@ -1736,7 +1727,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2cf2
+					// Method begins at RVA 0x2cd6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1756,7 +1747,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2cfb
+					// Method begins at RVA 0x2cdf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1774,7 +1765,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ce9
+				// Method begins at RVA 0x2ccd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1800,7 +1791,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ce0
+			// Method begins at RVA 0x2cc4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1824,9 +1815,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21cc
+		// Method begins at RVA 0x21bc
 		// Header size: 12
-		// Code size: 516 (0x204)
+		// Code size: 502 (0x1f6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom_LibB/Scope,
@@ -1835,13 +1826,13 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object[],
-			[7] bool,
+			[6] bool,
+			[7] object,
 			[8] object,
 			[9] object,
 			[10] object,
 			[11] object,
-			[12] object
+			[12] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope::.ctor()
@@ -1903,146 +1894,138 @@
 		IL_008f: ldloc.0
 		IL_0090: ldloc.s 5
 		IL_0092: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__js2il_esm_export
-		IL_0097: ldc.i4.1
-		IL_0098: newarr [System.Runtime]System.Object
-		IL_009d: dup
-		IL_009e: ldc.i4.0
-		IL_009f: ldnull
-		IL_00a0: stelem.ref
-		IL_00a1: stloc.s 6
-		IL_00a3: ldarg.1
-		IL_00a4: ldloc.s 6
-		IL_00a6: ldstr "./Import_ExportStarFrom_LibA.cjs"
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00b0: stloc.s 5
-		IL_00b2: ldloc.0
-		IL_00b3: ldloc.s 5
-		IL_00b5: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__js2il_esm_mod_0
-		IL_00ba: ldloc.0
-		IL_00bb: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__js2il_esm_mod_0
-		IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
-		IL_00c5: stloc.3
-		// loop start (head: IL_00c6)
-			IL_00c6: ldloc.3
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-			IL_00cc: stloc.s 5
-			IL_00ce: ldloc.s 5
-			IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_00d5: stloc.s 7
-			IL_00d7: ldloc.s 7
-			IL_00d9: brtrue IL_0203
+		IL_0097: ldarg.1
+		IL_0098: ldstr "./Import_ExportStarFrom_LibA.cjs"
+		IL_009d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00a2: stloc.s 5
+		IL_00a4: ldloc.0
+		IL_00a5: ldloc.s 5
+		IL_00a7: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__js2il_esm_mod_0
+		IL_00ac: ldloc.0
+		IL_00ad: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__js2il_esm_mod_0
+		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
+		IL_00b7: stloc.3
+		// loop start (head: IL_00b8)
+			IL_00b8: ldloc.3
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+			IL_00be: stloc.s 5
+			IL_00c0: ldloc.s 5
+			IL_00c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_00c7: stloc.s 6
+			IL_00c9: ldloc.s 6
+			IL_00cb: brtrue IL_01f5
 
-			IL_00de: ldloc.s 5
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_00e5: stloc.s 5
-			IL_00e7: ldloc.s 5
-			IL_00e9: stloc.s 4
-			IL_00eb: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-			IL_00f0: ldstr "prototype"
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-			IL_00fa: ldstr "hasOwnProperty"
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-			IL_0104: ldstr "call"
-			IL_0109: ldloc.0
-			IL_010a: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__js2il_esm_mod_0
-			IL_010f: ldloc.s 4
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0116: stloc.s 5
-			IL_0118: ldloc.s 5
-			IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_011f: ldc.i4.0
-			IL_0120: ceq
-			IL_0122: stloc.s 7
-			IL_0124: ldloc.s 7
-			IL_0126: brfalse IL_0130
+			IL_00d0: ldloc.s 5
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_00d7: stloc.s 5
+			IL_00d9: ldloc.s 5
+			IL_00db: stloc.s 4
+			IL_00dd: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+			IL_00e2: ldstr "prototype"
+			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+			IL_00ec: ldstr "hasOwnProperty"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+			IL_00f6: ldstr "call"
+			IL_00fb: ldloc.0
+			IL_00fc: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__js2il_esm_mod_0
+			IL_0101: ldloc.s 4
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0108: stloc.s 5
+			IL_010a: ldloc.s 5
+			IL_010c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0111: ldc.i4.0
+			IL_0112: ceq
+			IL_0114: stloc.s 6
+			IL_0116: ldloc.s 6
+			IL_0118: brfalse IL_0122
 
-			IL_012b: br IL_01fe
+			IL_011d: br IL_01f0
 
-			IL_0130: ldloc.s 4
-			IL_0132: ldstr "default"
-			IL_0137: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_013c: stloc.s 7
-			IL_013e: ldloc.s 7
-			IL_0140: box [System.Runtime]System.Boolean
-			IL_0145: stloc.s 8
-			IL_0147: ldloc.s 8
-			IL_0149: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_014e: stloc.s 7
-			IL_0150: ldloc.s 7
-			IL_0152: brtrue IL_0177
+			IL_0122: ldloc.s 4
+			IL_0124: ldstr "default"
+			IL_0129: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_012e: stloc.s 6
+			IL_0130: ldloc.s 6
+			IL_0132: box [System.Runtime]System.Boolean
+			IL_0137: stloc.s 7
+			IL_0139: ldloc.s 7
+			IL_013b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0140: stloc.s 6
+			IL_0142: ldloc.s 6
+			IL_0144: brtrue IL_0169
 
-			IL_0157: ldloc.s 4
-			IL_0159: ldstr "__esModule"
-			IL_015e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0163: stloc.s 7
-			IL_0165: ldloc.s 7
-			IL_0167: box [System.Runtime]System.Boolean
-			IL_016c: stloc.s 9
-			IL_016e: ldloc.s 9
-			IL_0170: stloc.s 11
-			IL_0172: br IL_017b
+			IL_0149: ldloc.s 4
+			IL_014b: ldstr "__esModule"
+			IL_0150: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0155: stloc.s 6
+			IL_0157: ldloc.s 6
+			IL_0159: box [System.Runtime]System.Boolean
+			IL_015e: stloc.s 8
+			IL_0160: ldloc.s 8
+			IL_0162: stloc.s 10
+			IL_0164: br IL_016d
 
-			IL_0177: ldloc.s 8
-			IL_0179: stloc.s 11
+			IL_0169: ldloc.s 7
+			IL_016b: stloc.s 10
 
-			IL_017b: ldloc.s 11
-			IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0182: stloc.s 7
-			IL_0184: ldloc.s 7
-			IL_0186: brtrue IL_01ab
+			IL_016d: ldloc.s 10
+			IL_016f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0174: stloc.s 6
+			IL_0176: ldloc.s 6
+			IL_0178: brtrue IL_019d
 
-			IL_018b: ldloc.s 4
-			IL_018d: ldstr "module.exports"
-			IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0197: stloc.s 7
-			IL_0199: ldloc.s 7
-			IL_019b: box [System.Runtime]System.Boolean
-			IL_01a0: stloc.s 8
-			IL_01a2: ldloc.s 8
-			IL_01a4: stloc.s 11
-			IL_01a6: br IL_01ab
+			IL_017d: ldloc.s 4
+			IL_017f: ldstr "module.exports"
+			IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0189: stloc.s 6
+			IL_018b: ldloc.s 6
+			IL_018d: box [System.Runtime]System.Boolean
+			IL_0192: stloc.s 7
+			IL_0194: ldloc.s 7
+			IL_0196: stloc.s 10
+			IL_0198: br IL_019d
 
-			IL_01ab: ldloc.s 11
-			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 7
-			IL_01b4: ldloc.s 7
-			IL_01b6: brfalse IL_01c0
+			IL_019d: ldloc.s 10
+			IL_019f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01a4: stloc.s 6
+			IL_01a6: ldloc.s 6
+			IL_01a8: brfalse IL_01b2
 
-			IL_01bb: br IL_01fe
+			IL_01ad: br IL_01f0
 
-			IL_01c0: ldnull
-			IL_01c1: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L7C3::__js_call__(object[], object, object)
-			IL_01c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_01cc: ldc.i4.1
-			IL_01cd: newarr [System.Runtime]System.Object
-			IL_01d2: dup
-			IL_01d3: ldc.i4.0
-			IL_01d4: ldloc.0
-			IL_01d5: stelem.ref
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-			IL_01db: stloc.s 5
-			IL_01dd: ldc.i4.1
-			IL_01de: newarr [System.Runtime]System.Object
-			IL_01e3: dup
-			IL_01e4: ldc.i4.0
-			IL_01e5: ldloc.s 4
+			IL_01b2: ldnull
+			IL_01b3: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L7C3::__js_call__(object[], object, object)
+			IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_01be: ldc.i4.1
+			IL_01bf: newarr [System.Runtime]System.Object
+			IL_01c4: dup
+			IL_01c5: ldc.i4.0
+			IL_01c6: ldloc.0
+			IL_01c7: stelem.ref
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+			IL_01cd: stloc.s 5
+			IL_01cf: ldc.i4.1
+			IL_01d0: newarr [System.Runtime]System.Object
+			IL_01d5: dup
+			IL_01d6: ldc.i4.0
+			IL_01d7: ldloc.s 4
+			IL_01d9: stelem.ref
+			IL_01da: stloc.s 12
+			IL_01dc: ldloc.s 5
+			IL_01de: ldc.i4.1
+			IL_01df: newarr [System.Runtime]System.Object
+			IL_01e4: dup
+			IL_01e5: ldc.i4.0
+			IL_01e6: ldnull
 			IL_01e7: stelem.ref
-			IL_01e8: stloc.s 6
-			IL_01ea: ldloc.s 5
-			IL_01ec: ldc.i4.1
-			IL_01ed: newarr [System.Runtime]System.Object
-			IL_01f2: dup
-			IL_01f3: ldc.i4.0
-			IL_01f4: ldnull
-			IL_01f5: stelem.ref
-			IL_01f6: ldloc.s 6
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01fd: pop
+			IL_01e8: ldloc.s 12
+			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01ef: pop
 
-			IL_01fe: br IL_00c6
+			IL_01f0: br IL_00b8
 		// end loop
 
-		IL_0203: ret
+		IL_01f5: ret
 	} // end of method Import_ExportStarFrom_LibB::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFrom_LibB
@@ -2062,7 +2045,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d79
+				// Method begins at RVA 0x2d5d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2082,7 +2065,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2c7a
+			// Method begins at RVA 0x2c5e
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2107,7 +2090,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2d70
+			// Method begins at RVA 0x2d54
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2131,7 +2114,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x23dc
+		// Method begins at RVA 0x23c0
 		// Header size: 12
 		// Code size: 130 (0x82)
 		.maxstack 8
@@ -2198,7 +2181,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2d82
+		// Method begins at RVA 0x2d66
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/Js2IL.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26a1
+			// Method begins at RVA 0x2695
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,59 +40,50 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 144 (0x90)
+		// Code size: 132 (0x84)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_RequireEsmModule/Scope,
 			[1] object,
-			[2] object[],
-			[3] object
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_RequireEsmModule/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./Import_RequireEsmModule_Lib.mjs"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "./Import_RequireEsmModule_Lib.mjs"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0025: ldstr "default:"
-		IL_002a: ldloc.1
-		IL_002b: ldstr "default"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0035: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_003a: pop
-		IL_003b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0040: ldstr "named:"
-		IL_0045: ldloc.1
-		IL_0046: ldstr "named"
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0055: pop
-		IL_0056: ldloc.1
-		IL_0057: ldstr "sum"
-		IL_005c: ldc.r8 2
-		IL_0065: box [System.Runtime]System.Double
-		IL_006a: ldc.r8 3
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_007d: stloc.3
-		IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0083: ldstr "sum:"
-		IL_0088: ldloc.3
-		IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_008e: pop
-		IL_008f: ret
+		IL_0013: stloc.1
+		IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0019: ldstr "default:"
+		IL_001e: ldloc.1
+		IL_001f: ldstr "default"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_002e: pop
+		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0034: ldstr "named:"
+		IL_0039: ldloc.1
+		IL_003a: ldstr "named"
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0049: pop
+		IL_004a: ldloc.1
+		IL_004b: ldstr "sum"
+		IL_0050: ldc.r8 2
+		IL_0059: box [System.Runtime]System.Double
+		IL_005e: ldc.r8 3
+		IL_0067: box [System.Runtime]System.Double
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0071: stloc.2
+		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0077: ldstr "sum:"
+		IL_007c: ldloc.2
+		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0082: pop
+		IL_0083: ret
 	} // end of method Import_RequireEsmModule::__js_module_init__
 
 } // end of class Modules.Import_RequireEsmModule
@@ -112,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b3
+				// Method begins at RVA 0x26a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +124,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2297
+			// Method begins at RVA 0x228b
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -160,7 +151,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26bc
+				// Method begins at RVA 0x26b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +173,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x22ac
+			// Method begins at RVA 0x22a0
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -211,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c5
+				// Method begins at RVA 0x26b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -232,7 +223,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x22c2
+			// Method begins at RVA 0x22b6
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -258,7 +249,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26ce
+				// Method begins at RVA 0x26c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -279,7 +270,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x22d1
+			// Method begins at RVA 0x22c5
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -309,7 +300,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26e0
+					// Method begins at RVA 0x26d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +318,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26d7
+				// Method begins at RVA 0x26cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -348,7 +339,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22d4
 			// Header size: 12
 			// Code size: 159 (0x9f)
 			.maxstack 8
@@ -428,7 +419,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26e9
+				// Method begins at RVA 0x26dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -449,7 +440,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x238c
+			// Method begins at RVA 0x2380
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -529,7 +520,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26fb
+					// Method begins at RVA 0x26ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -557,7 +548,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2716
+							// Method begins at RVA 0x270a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -577,7 +568,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x271f
+							// Method begins at RVA 0x2713
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -595,7 +586,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x270d
+						// Method begins at RVA 0x2701
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -613,7 +604,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2704
+					// Method begins at RVA 0x26f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -631,7 +622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26f2
+				// Method begins at RVA 0x26e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -653,7 +644,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x2414
+			// Method begins at RVA 0x2408
 			// Header size: 12
 			// Code size: 518 (0x206)
 			.maxstack 8
@@ -900,7 +891,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2728
+				// Method begins at RVA 0x271c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -923,7 +914,7 @@
 				object getter
 			) cil managed 
 		{
-			// Method begins at RVA 0x2628
+			// Method begins at RVA 0x261c
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -1002,7 +993,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26aa
+			// Method begins at RVA 0x269e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1026,7 +1017,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20ec
+		// Method begins at RVA 0x20e0
 		// Header size: 12
 		// Code size: 415 (0x19f)
 		.maxstack 8
@@ -1205,7 +1196,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2731
+		// Method begins at RVA 0x2725
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/Js2IL.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ff
+					// Method begins at RVA 0x25e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f6
+				// Method begins at RVA 0x25da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -61,7 +61,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x2210
 			// Header size: 12
 			// Code size: 159 (0x9f)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2608
+				// Method begins at RVA 0x25ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +162,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x22d8
+			// Method begins at RVA 0x22bc
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -242,7 +242,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x261a
+					// Method begins at RVA 0x25fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -270,7 +270,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2635
+							// Method begins at RVA 0x2619
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -290,7 +290,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x263e
+							// Method begins at RVA 0x2622
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -308,7 +308,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x262c
+						// Method begins at RVA 0x2610
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -326,7 +326,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2623
+					// Method begins at RVA 0x2607
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -344,7 +344,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2611
+				// Method begins at RVA 0x25f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -366,7 +366,7 @@
 				object mod
 			) cil managed 
 		{
-			// Method begins at RVA 0x2360
+			// Method begins at RVA 0x2344
 			// Header size: 12
 			// Code size: 518 (0x206)
 			.maxstack 8
@@ -613,7 +613,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2647
+				// Method begins at RVA 0x262b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -636,7 +636,7 @@
 				object getter
 			) cil managed 
 		{
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2558
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -710,7 +710,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25ed
+			// Method begins at RVA 0x25d1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -736,7 +736,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 397 (0x18d)
+		// Code size: 369 (0x171)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_StaticImport_FromCjs/Scope,
@@ -748,8 +748,7 @@
 			[6] object,
 			[7] object,
 			[8] object,
-			[9] object,
-			[10] object[]
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_StaticImport_FromCjs/Scope::.ctor()
@@ -810,91 +809,75 @@
 		IL_008d: stloc.s 9
 		IL_008f: ldloc.s 9
 		IL_0091: stloc.3
-		IL_0092: ldc.i4.1
-		IL_0093: newarr [System.Runtime]System.Object
-		IL_0098: dup
-		IL_0099: ldc.i4.0
-		IL_009a: ldnull
-		IL_009b: stelem.ref
-		IL_009c: stloc.s 10
-		IL_009e: ldarg.1
-		IL_009f: ldloc.s 10
-		IL_00a1: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00ab: stloc.s 9
-		IL_00ad: ldloc.s 9
-		IL_00af: stloc.s 4
-		IL_00b1: ldnull
-		IL_00b2: ldftn object Modules.Import_StaticImport_FromCjs/__js2il_esm_default::__js_call__(object, object)
-		IL_00b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00bd: ldnull
-		IL_00be: ldloc.s 4
-		IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_00c5: stloc.s 9
-		IL_00c7: ldloc.s 9
-		IL_00c9: stloc.s 5
-		IL_00cb: ldloc.s 4
-		IL_00cd: ldstr "value"
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00d7: stloc.s 6
-		IL_00d9: ldc.i4.1
-		IL_00da: newarr [System.Runtime]System.Object
-		IL_00df: dup
-		IL_00e0: ldc.i4.0
-		IL_00e1: ldnull
-		IL_00e2: stelem.ref
-		IL_00e3: stloc.s 10
-		IL_00e5: ldarg.1
-		IL_00e6: ldloc.s 10
-		IL_00e8: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00f2: stloc.s 9
-		IL_00f4: ldloc.s 9
-		IL_00f6: stloc.s 7
-		IL_00f8: ldnull
-		IL_00f9: ldftn object Modules.Import_StaticImport_FromCjs/__js2il_esm_namespace::__js_call__(object[], object, object)
-		IL_00ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_0104: ldc.i4.1
-		IL_0105: newarr [System.Runtime]System.Object
-		IL_010a: dup
-		IL_010b: ldc.i4.0
-		IL_010c: ldloc.0
-		IL_010d: stelem.ref
-		IL_010e: ldnull
-		IL_010f: ldloc.s 7
-		IL_0111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
-		IL_0116: stloc.s 9
-		IL_0118: ldloc.s 9
-		IL_011a: stloc.s 8
+		IL_0092: ldarg.1
+		IL_0093: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
+		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_009d: stloc.s 9
+		IL_009f: ldloc.s 9
+		IL_00a1: stloc.s 4
+		IL_00a3: ldnull
+		IL_00a4: ldftn object Modules.Import_StaticImport_FromCjs/__js2il_esm_default::__js_call__(object, object)
+		IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00af: ldnull
+		IL_00b0: ldloc.s 4
+		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_00b7: stloc.s 9
+		IL_00b9: ldloc.s 9
+		IL_00bb: stloc.s 5
+		IL_00bd: ldloc.s 4
+		IL_00bf: ldstr "value"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00c9: stloc.s 6
+		IL_00cb: ldarg.1
+		IL_00cc: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
+		IL_00d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00d6: stloc.s 9
+		IL_00d8: ldloc.s 9
+		IL_00da: stloc.s 7
+		IL_00dc: ldnull
+		IL_00dd: ldftn object Modules.Import_StaticImport_FromCjs/__js2il_esm_namespace::__js_call__(object[], object, object)
+		IL_00e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_00e8: ldc.i4.1
+		IL_00e9: newarr [System.Runtime]System.Object
+		IL_00ee: dup
+		IL_00ef: ldc.i4.0
+		IL_00f0: ldloc.0
+		IL_00f1: stelem.ref
+		IL_00f2: ldnull
+		IL_00f3: ldloc.s 7
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+		IL_00fa: stloc.s 9
+		IL_00fc: ldloc.s 9
+		IL_00fe: stloc.s 8
+		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0105: ldstr "default.value:"
+		IL_010a: ldloc.s 5
+		IL_010c: ldstr "value"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_011b: pop
 		IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0121: ldstr "default.value:"
-		IL_0126: ldloc.s 5
-		IL_0128: ldstr "value"
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0137: pop
-		IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013d: ldstr "named:"
-		IL_0142: ldloc.s 6
-		IL_0144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0149: pop
-		IL_014a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014f: ldstr "namespace.default.value:"
-		IL_0154: ldloc.s 8
-		IL_0156: ldstr "default"
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0121: ldstr "named:"
+		IL_0126: ldloc.s 6
+		IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_012d: pop
+		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0133: ldstr "namespace.default.value:"
+		IL_0138: ldloc.s 8
+		IL_013a: ldstr "default"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0144: ldstr "value"
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0153: pop
+		IL_0154: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0159: ldstr "namespace.value:"
+		IL_015e: ldloc.s 8
 		IL_0160: ldstr "value"
 		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
 		IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 		IL_016f: pop
-		IL_0170: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0175: ldstr "namespace.value:"
-		IL_017a: ldloc.s 8
-		IL_017c: ldstr "value"
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_018b: pop
-		IL_018c: ret
+		IL_0170: ret
 	} // end of method Import_StaticImport_FromCjs::__js_module_init__
 
 } // end of class Modules.Import_StaticImport_FromCjs
@@ -910,7 +893,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2650
+			// Method begins at RVA 0x2634
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -934,7 +917,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21ec
+		// Method begins at RVA 0x21d0
 		// Header size: 12
 		// Code size: 50 (0x32)
 		.maxstack 8
@@ -967,7 +950,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2659
+		// Method begins at RVA 0x263d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f0e
+					// Method begins at RVA 0x2f02
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f05
+				// Method begins at RVA 0x2ef9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -74,7 +74,7 @@
 				object timeLimitSeconds
 			) cil managed 
 		{
-			// Method begins at RVA 0x2238
+			// Method begins at RVA 0x222c
 			// Header size: 12
 			// Code size: 211 (0xd3)
 			.maxstack 8
@@ -204,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f17
+				// Method begins at RVA 0x2f0b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -226,7 +226,7 @@
 				object $p0
 			) cil managed 
 		{
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x230c
 			// Header size: 12
 			// Code size: 436 (0x1b4)
 			.maxstack 8
@@ -430,7 +430,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e00
+				// Method begins at RVA 0x2df4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -450,7 +450,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e09
+				// Method begins at RVA 0x2dfd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -470,7 +470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e12
+				// Method begins at RVA 0x2e06
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -498,7 +498,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e2d
+						// Method begins at RVA 0x2e21
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -522,7 +522,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2e3f
+							// Method begins at RVA 0x2e33
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -540,7 +540,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e36
+						// Method begins at RVA 0x2e2a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -558,7 +558,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e24
+					// Method begins at RVA 0x2e18
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -586,7 +586,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2e5a
+							// Method begins at RVA 0x2e4e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -604,7 +604,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e51
+						// Method begins at RVA 0x2e45
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -622,7 +622,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e48
+					// Method begins at RVA 0x2e3c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -646,7 +646,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e6c
+						// Method begins at RVA 0x2e60
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -664,7 +664,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e63
+					// Method begins at RVA 0x2e57
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -682,7 +682,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e1b
+				// Method begins at RVA 0x2e0f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -702,7 +702,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e75
+				// Method begins at RVA 0x2e69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -726,7 +726,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e87
+					// Method begins at RVA 0x2e7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -744,7 +744,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e7e
+				// Method begins at RVA 0x2e72
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -769,7 +769,7 @@
 				object size
 			) cil managed 
 		{
-			// Method begins at RVA 0x254c
+			// Method begins at RVA 0x2540
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -815,7 +815,7 @@
 				object index
 			) cil managed 
 		{
-			// Method begins at RVA 0x2860
+			// Method begins at RVA 0x2854
 			// Header size: 12
 			// Code size: 95 (0x5f)
 			.maxstack 8
@@ -882,7 +882,7 @@
 				object range_stop
 			) cil managed 
 		{
-			// Method begins at RVA 0x25e0
+			// Method begins at RVA 0x25d4
 			// Header size: 12
 			// Code size: 625 (0x271)
 			.maxstack 8
@@ -1186,7 +1186,7 @@
 				object index
 			) cil managed 
 		{
-			// Method begins at RVA 0x28cc
+			// Method begins at RVA 0x28c0
 			// Header size: 12
 			// Code size: 82 (0x52)
 			.maxstack 8
@@ -1246,7 +1246,7 @@
 				object index
 			) cil managed 
 		{
-			// Method begins at RVA 0x259c
+			// Method begins at RVA 0x2590
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -1293,7 +1293,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e90
+				// Method begins at RVA 0x2e84
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1313,7 +1313,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e99
+				// Method begins at RVA 0x2e8d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1337,7 +1337,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2eab
+					// Method begins at RVA 0x2e9f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1355,7 +1355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ea2
+				// Method begins at RVA 0x2e96
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1375,7 +1375,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eb4
+				// Method begins at RVA 0x2ea8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1403,7 +1403,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ecf
+						// Method begins at RVA 0x2ec3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1421,7 +1421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ec6
+					// Method begins at RVA 0x2eba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1439,7 +1439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ebd
+				// Method begins at RVA 0x2eb1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1459,7 +1459,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ed8
+				// Method begins at RVA 0x2ecc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1483,7 +1483,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2eea
+					// Method begins at RVA 0x2ede
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1501,7 +1501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ee1
+				// Method begins at RVA 0x2ed5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1525,7 +1525,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2efc
+					// Method begins at RVA 0x2ef0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1543,7 +1543,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ef3
+				// Method begins at RVA 0x2ee7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1570,7 +1570,7 @@
 				object sieveSize
 			) cil managed 
 		{
-			// Method begins at RVA 0x24d8
+			// Method begins at RVA 0x24cc
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -1631,7 +1631,7 @@
 		.method public hidebysig 
 			instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve runSieve () cil managed 
 		{
-			// Method begins at RVA 0x292c
+			// Method begins at RVA 0x2920
 			// Header size: 12
 			// Code size: 207 (0xcf)
 			.maxstack 8
@@ -1727,7 +1727,7 @@
 		.method public hidebysig 
 			instance float64 countPrimes () cil managed 
 		{
-			// Method begins at RVA 0x2c98
+			// Method begins at RVA 0x2c8c
 			// Header size: 12
 			// Code size: 108 (0x6c)
 			.maxstack 8
@@ -1788,7 +1788,7 @@
 				object max
 			) cil managed 
 		{
-			// Method begins at RVA 0x2d10
+			// Method begins at RVA 0x2d04
 			// Header size: 12
 			// Code size: 219 (0xdb)
 			.maxstack 8
@@ -1889,7 +1889,7 @@
 				object verbose
 			) cil managed 
 		{
-			// Method begins at RVA 0x2a08
+			// Method begins at RVA 0x29fc
 			// Header size: 12
 			// Code size: 642 (0x282)
 			.maxstack 8
@@ -2138,7 +2138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2df7
+			// Method begins at RVA 0x2deb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2164,16 +2164,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 475 (0x1db)
+		// Code size: 461 (0x1cd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
 			[1] class [System.Linq.Expressions]System.Dynamic.ExpandoObject,
 			[2] object,
 			[3] object,
-			[4] object[],
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_PrimeJavaScript/Scope::.ctor()
@@ -2213,114 +2212,106 @@
 		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
 		IL_0093: pop
 		IL_0094: stloc.1
-		IL_0095: ldc.i4.1
-		IL_0096: newarr [System.Runtime]System.Object
-		IL_009b: dup
-		IL_009c: ldc.i4.0
-		IL_009d: ldnull
-		IL_009e: stelem.ref
-		IL_009f: stloc.s 4
-		IL_00a1: ldarg.1
+		IL_0095: ldarg.1
+		IL_0096: ldstr "perf_hooks"
+		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00a0: stloc.s 4
 		IL_00a2: ldloc.s 4
-		IL_00a4: ldstr "perf_hooks"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00ae: stloc.s 5
-		IL_00b0: ldloc.s 5
-		IL_00b2: brfalse IL_00c7
+		IL_00a4: brfalse IL_00b9
 
-		IL_00b7: ldloc.s 5
-		IL_00b9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00be: stloc.s 6
-		IL_00c0: ldloc.s 6
-		IL_00c2: brfalse IL_00d8
+		IL_00a9: ldloc.s 4
+		IL_00ab: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00b0: stloc.s 5
+		IL_00b2: ldloc.s 5
+		IL_00b4: brfalse IL_00ca
 
-		IL_00c7: ldloc.s 5
-		IL_00c9: ldstr ""
-		IL_00ce: ldstr "performance"
-		IL_00d3: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_00b9: ldloc.s 4
+		IL_00bb: ldstr ""
+		IL_00c0: ldstr "performance"
+		IL_00c5: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_00d8: ldloc.0
-		IL_00d9: ldloc.s 5
-		IL_00db: ldstr "performance"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00e5: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-		IL_00ea: ldstr "[\\\\/]"
-		IL_00ef: ldstr ""
-		IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00f9: stloc.s 5
-		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_0100: ldstr "argv"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_010a: ldc.r8 0.0
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-		IL_0118: ldstr "split"
-		IL_011d: ldloc.s 5
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0124: stloc.s 5
-		IL_0126: ldloc.s 5
-		IL_0128: stloc.2
-		IL_0129: ldloc.1
-		IL_012a: ldstr "runtime"
-		IL_012f: ldloc.2
-		IL_0130: ldloc.2
-		IL_0131: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_0136: ldc.r8 1
-		IL_013f: sub
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_014a: pop
-		IL_014b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_0150: ldstr "argv"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_015a: ldstr "includes"
-		IL_015f: ldstr "verbose"
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0169: stloc.s 5
-		IL_016b: ldloc.1
-		IL_016c: ldstr "verbose"
-		IL_0171: ldloc.s 5
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0178: pop
-		IL_0179: ldnull
-		IL_017a: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(object[], object, object, object)
-		IL_0180: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
-		IL_0185: ldc.i4.1
-		IL_0186: newarr [System.Runtime]System.Object
-		IL_018b: dup
-		IL_018c: ldc.i4.0
+		IL_00ca: ldloc.0
+		IL_00cb: ldloc.s 4
+		IL_00cd: ldstr "performance"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00d7: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+		IL_00dc: ldstr "[\\\\/]"
+		IL_00e1: ldstr ""
+		IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00eb: stloc.s 4
+		IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_00f2: ldstr "argv"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00fc: ldc.r8 0.0
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_010a: ldstr "split"
+		IL_010f: ldloc.s 4
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0116: stloc.s 4
+		IL_0118: ldloc.s 4
+		IL_011a: stloc.2
+		IL_011b: ldloc.1
+		IL_011c: ldstr "runtime"
+		IL_0121: ldloc.2
+		IL_0122: ldloc.2
+		IL_0123: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0128: ldc.r8 1
+		IL_0131: sub
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_013c: pop
+		IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_0142: ldstr "argv"
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_014c: ldstr "includes"
+		IL_0151: ldstr "verbose"
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_015b: stloc.s 4
+		IL_015d: ldloc.1
+		IL_015e: ldstr "verbose"
+		IL_0163: ldloc.s 4
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_016a: pop
+		IL_016b: ldnull
+		IL_016c: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(object[], object, object, object)
+		IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+		IL_0177: ldc.i4.1
+		IL_0178: newarr [System.Runtime]System.Object
+		IL_017d: dup
+		IL_017e: ldc.i4.0
+		IL_017f: ldloc.0
+		IL_0180: stelem.ref
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_018b: stloc.s 4
 		IL_018d: ldloc.0
-		IL_018e: stelem.ref
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0199: stloc.s 5
-		IL_019b: ldloc.0
-		IL_019c: ldloc.s 5
-		IL_019e: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_01a3: ldnull
-		IL_01a4: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(object[], object, object)
-		IL_01aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_01af: ldc.i4.1
-		IL_01b0: newarr [System.Runtime]System.Object
-		IL_01b5: dup
-		IL_01b6: ldc.i4.0
-		IL_01b7: ldloc.0
-		IL_01b8: stelem.ref
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01c3: stloc.s 5
-		IL_01c5: ldloc.s 5
-		IL_01c7: stloc.3
-		IL_01c8: ldloc.3
-		IL_01c9: ldc.i4.1
-		IL_01ca: newarr [System.Runtime]System.Object
-		IL_01cf: dup
-		IL_01d0: ldc.i4.0
-		IL_01d1: ldnull
-		IL_01d2: stelem.ref
-		IL_01d3: ldloc.1
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_01d9: pop
-		IL_01da: ret
+		IL_018e: ldloc.s 4
+		IL_0190: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_0195: ldnull
+		IL_0196: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(object[], object, object)
+		IL_019c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_01a1: ldc.i4.1
+		IL_01a2: newarr [System.Runtime]System.Object
+		IL_01a7: dup
+		IL_01a8: ldc.i4.0
+		IL_01a9: ldloc.0
+		IL_01aa: stelem.ref
+		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01b5: stloc.s 4
+		IL_01b7: ldloc.s 4
+		IL_01b9: stloc.3
+		IL_01ba: ldloc.3
+		IL_01bb: ldc.i4.1
+		IL_01bc: newarr [System.Runtime]System.Object
+		IL_01c1: dup
+		IL_01c2: ldc.i4.0
+		IL_01c3: ldnull
+		IL_01c4: stelem.ref
+		IL_01c5: ldloc.1
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_01cb: pop
+		IL_01cc: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -2332,7 +2323,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2f20
+		// Method begins at RVA 0x2f14
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32fd
+				// Method begins at RVA 0x32e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -40,7 +40,7 @@
 				object p
 			) cil managed 
 		{
-			// Method begins at RVA 0x2334
+			// Method begins at RVA 0x2318
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -75,7 +75,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3306
+				// Method begins at RVA 0x32ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 				object c
 			) cil managed 
 		{
-			// Method begins at RVA 0x2360
+			// Method begins at RVA 0x2344
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -131,7 +131,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x330f
+				// Method begins at RVA 0x32f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -152,7 +152,7 @@
 				object csprojText
 			) cil managed 
 		{
-			// Method begins at RVA 0x2384
+			// Method begins at RVA 0x2368
 			// Header size: 12
 			// Code size: 111 (0x6f)
 			.maxstack 8
@@ -229,7 +229,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3321
+					// Method begins at RVA 0x3305
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 					object n
 				) cil managed 
 			{
-				// Method begins at RVA 0x31d8
+				// Method begins at RVA 0x31bc
 				// Header size: 12
 				// Code size: 30 (0x1e)
 				.maxstack 8
@@ -290,7 +290,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x332a
+					// Method begins at RVA 0x330e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -311,7 +311,7 @@
 					object n
 				) cil managed 
 			{
-				// Method begins at RVA 0x3204
+				// Method begins at RVA 0x31e8
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -339,7 +339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3318
+				// Method begins at RVA 0x32fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -362,7 +362,7 @@
 				object kind
 			) cil managed 
 		{
-			// Method begins at RVA 0x2400
+			// Method begins at RVA 0x23e4
 			// Header size: 12
 			// Code size: 727 (0x2d7)
 			.maxstack 8
@@ -647,7 +647,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3333
+				// Method begins at RVA 0x3317
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -670,7 +670,7 @@
 				object current
 			) cil managed 
 		{
-			// Method begins at RVA 0x26e4
+			// Method begins at RVA 0x26c8
 			// Header size: 12
 			// Code size: 212 (0xd4)
 			.maxstack 8
@@ -789,7 +789,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3345
+					// Method begins at RVA 0x3329
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -807,7 +807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x333c
+				// Method begins at RVA 0x3320
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -829,7 +829,7 @@
 				object newVersion
 			) cil managed 
 		{
-			// Method begins at RVA 0x27c4
+			// Method begins at RVA 0x27a8
 			// Header size: 12
 			// Code size: 156 (0x9c)
 			.maxstack 8
@@ -916,7 +916,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3357
+					// Method begins at RVA 0x333b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -934,7 +934,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x334e
+				// Method begins at RVA 0x3332
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -956,7 +956,7 @@
 				object changelog
 			) cil managed 
 		{
-			// Method begins at RVA 0x286c
+			// Method begins at RVA 0x2850
 			// Header size: 12
 			// Code size: 474 (0x1da)
 			.maxstack 8
@@ -1147,7 +1147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3360
+				// Method begins at RVA 0x3344
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1168,7 +1168,7 @@
 				object line
 			) cil managed 
 		{
-			// Method begins at RVA 0x2a54
+			// Method begins at RVA 0x2a38
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -1217,7 +1217,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3372
+					// Method begins at RVA 0x3356
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1239,7 +1239,7 @@
 					object l
 				) cil managed 
 			{
-				// Method begins at RVA 0x3220
+				// Method begins at RVA 0x3204
 				// Header size: 12
 				// Code size: 99 (0x63)
 				.maxstack 8
@@ -1303,7 +1303,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3369
+				// Method begins at RVA 0x334d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1326,7 +1326,7 @@
 				object body
 			) cil managed 
 		{
-			// Method begins at RVA 0x2a8c
+			// Method begins at RVA 0x2a70
 			// Header size: 12
 			// Code size: 305 (0x131)
 			.maxstack 8
@@ -1471,7 +1471,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x338d
+					// Method begins at RVA 0x3371
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1493,7 +1493,7 @@
 					object l
 				) cil managed 
 			{
-				// Method begins at RVA 0x3290
+				// Method begins at RVA 0x3274
 				// Header size: 12
 				// Code size: 88 (0x58)
 				.maxstack 8
@@ -1559,7 +1559,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3384
+					// Method begins at RVA 0x3368
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1579,7 +1579,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3396
+					// Method begins at RVA 0x337a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1597,7 +1597,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x337b
+				// Method begins at RVA 0x335f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1618,7 +1618,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2bcc
+			// Method begins at RVA 0x2bb0
 			// Header size: 12
 			// Code size: 1536 (0x600)
 			.maxstack 8
@@ -2266,7 +2266,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x339f
+				// Method begins at RVA 0x3383
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2286,7 +2286,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33a8
+				// Method begins at RVA 0x338c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2320,7 +2320,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x32f4
+			// Method begins at RVA 0x32d8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2346,7 +2346,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 709 (0x2c5)
+		// Code size: 681 (0x2a9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_BumpVersion/Scope,
@@ -2357,8 +2357,7 @@
 			[5] object,
 			[6] object,
 			[7] object,
-			[8] object[],
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope::.ctor()
@@ -2502,138 +2501,122 @@
 		IL_016e: stloc.s 7
 		IL_0170: ldloc.s 7
 		IL_0172: stloc.1
-		IL_0173: ldc.i4.1
-		IL_0174: newarr [System.Runtime]System.Object
-		IL_0179: dup
-		IL_017a: ldc.i4.0
-		IL_017b: ldnull
-		IL_017c: stelem.ref
-		IL_017d: stloc.s 8
-		IL_017f: ldarg.1
-		IL_0180: ldloc.s 8
-		IL_0182: ldstr "fs"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_018c: stloc.s 7
-		IL_018e: ldloc.0
-		IL_018f: ldloc.s 7
-		IL_0191: stfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
-		IL_0196: ldc.i4.1
-		IL_0197: newarr [System.Runtime]System.Object
-		IL_019c: dup
-		IL_019d: ldc.i4.0
-		IL_019e: ldnull
-		IL_019f: stelem.ref
-		IL_01a0: stloc.s 8
-		IL_01a2: ldarg.1
-		IL_01a3: ldloc.s 8
-		IL_01a5: ldstr "path"
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_01af: stloc.s 7
-		IL_01b1: ldloc.s 7
-		IL_01b3: stloc.2
-		IL_01b4: ldloc.2
-		IL_01b5: ldstr "resolve"
-		IL_01ba: ldarg.s __dirname
-		IL_01bc: ldstr ".."
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01c6: stloc.s 7
+		IL_0173: ldarg.1
+		IL_0174: ldstr "fs"
+		IL_0179: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_017e: stloc.s 7
+		IL_0180: ldloc.0
+		IL_0181: ldloc.s 7
+		IL_0183: stfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
+		IL_0188: ldarg.1
+		IL_0189: ldstr "path"
+		IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0193: stloc.s 7
+		IL_0195: ldloc.s 7
+		IL_0197: stloc.2
+		IL_0198: ldloc.2
+		IL_0199: ldstr "resolve"
+		IL_019e: ldarg.s __dirname
+		IL_01a0: ldstr ".."
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01aa: stloc.s 7
+		IL_01ac: ldloc.s 7
+		IL_01ae: stloc.3
+		IL_01af: ldloc.2
+		IL_01b0: ldstr "join"
+		IL_01b5: ldloc.3
+		IL_01b6: ldstr "Js2IL"
+		IL_01bb: ldstr "Js2IL.csproj"
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_01c5: stloc.s 7
+		IL_01c7: ldloc.0
 		IL_01c8: ldloc.s 7
-		IL_01ca: stloc.3
-		IL_01cb: ldloc.2
-		IL_01cc: ldstr "join"
-		IL_01d1: ldloc.3
-		IL_01d2: ldstr "Js2IL"
-		IL_01d7: ldstr "Js2IL.csproj"
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_01e1: stloc.s 7
-		IL_01e3: ldloc.0
-		IL_01e4: ldloc.s 7
-		IL_01e6: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-		IL_01eb: ldloc.2
-		IL_01ec: ldstr "join"
-		IL_01f1: ldloc.3
-		IL_01f2: ldstr "JavaScriptRuntime"
-		IL_01f7: ldstr "JavaScriptRuntime.csproj"
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0201: stloc.s 7
-		IL_0203: ldloc.0
-		IL_0204: ldloc.s 7
-		IL_0206: stfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-		IL_020b: ldloc.2
-		IL_020c: ldstr "join"
-		IL_0211: ldloc.3
-		IL_0212: ldstr "CHANGELOG.md"
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_021c: stloc.s 7
-		IL_021e: ldloc.0
-		IL_021f: ldloc.s 7
-		IL_0221: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+		IL_01ca: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+		IL_01cf: ldloc.2
+		IL_01d0: ldstr "join"
+		IL_01d5: ldloc.3
+		IL_01d6: ldstr "JavaScriptRuntime"
+		IL_01db: ldstr "JavaScriptRuntime.csproj"
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_01e5: stloc.s 7
+		IL_01e7: ldloc.0
+		IL_01e8: ldloc.s 7
+		IL_01ea: stfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+		IL_01ef: ldloc.2
+		IL_01f0: ldstr "join"
+		IL_01f5: ldloc.3
+		IL_01f6: ldstr "CHANGELOG.md"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0200: stloc.s 7
+		IL_0202: ldloc.0
+		IL_0203: ldloc.s 7
+		IL_0205: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
 		.try
 		{
-			IL_0226: ldnull
-			IL_0227: ldftn object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(object[], object)
-			IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0232: ldc.i4.1
-			IL_0233: newarr [System.Runtime]System.Object
-			IL_0238: dup
-			IL_0239: ldc.i4.0
-			IL_023a: ldloc.0
-			IL_023b: stelem.ref
-			IL_023c: ldnull
-			IL_023d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
-			IL_0242: pop
-			IL_0243: leave IL_02c4
+			IL_020a: ldnull
+			IL_020b: ldftn object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(object[], object)
+			IL_0211: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0216: ldc.i4.1
+			IL_0217: newarr [System.Runtime]System.Object
+			IL_021c: dup
+			IL_021d: ldc.i4.0
+			IL_021e: ldloc.0
+			IL_021f: stelem.ref
+			IL_0220: ldnull
+			IL_0221: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
+			IL_0226: pop
+			IL_0227: leave IL_02a8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0248: stloc.s 4
-			IL_024a: ldloc.s 4
-			IL_024c: dup
-			IL_024d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0252: dup
-			IL_0253: brtrue IL_0269
+			IL_022c: stloc.s 4
+			IL_022e: ldloc.s 4
+			IL_0230: dup
+			IL_0231: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0236: dup
+			IL_0237: brtrue IL_024d
 
-			IL_0258: pop
-			IL_0259: dup
-			IL_025a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_025f: dup
-			IL_0260: brtrue IL_0276
+			IL_023c: pop
+			IL_023d: dup
+			IL_023e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0243: dup
+			IL_0244: brtrue IL_025a
 
-			IL_0265: pop
-			IL_0266: pop
-			IL_0267: rethrow
+			IL_0249: pop
+			IL_024a: pop
+			IL_024b: rethrow
 
-			IL_0269: pop
-			IL_026a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_026f: stloc.s 5
-			IL_0271: br IL_0279
+			IL_024d: pop
+			IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0253: stloc.s 5
+			IL_0255: br IL_025d
 
-			IL_0276: pop
-			IL_0277: stloc.s 5
+			IL_025a: pop
+			IL_025b: stloc.s 5
 
-			IL_0279: ldloc.s 5
-			IL_027b: stloc.s 7
-			IL_027d: ldloc.s 7
-			IL_027f: stloc.s 6
-			IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0286: ldstr "ERROR:"
-			IL_028b: ldloc.s 6
-			IL_028d: ldstr "message"
-			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-			IL_0297: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object, object)
-			IL_029c: pop
-			IL_029d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_02a2: stloc.s 9
-			IL_02a4: ldloc.s 9
-			IL_02a6: ldstr "exit"
-			IL_02ab: ldc.r8 1
-			IL_02b4: box [System.Runtime]System.Double
-			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02be: pop
-			IL_02bf: leave IL_02c4
+			IL_025d: ldloc.s 5
+			IL_025f: stloc.s 7
+			IL_0261: ldloc.s 7
+			IL_0263: stloc.s 6
+			IL_0265: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_026a: ldstr "ERROR:"
+			IL_026f: ldloc.s 6
+			IL_0271: ldstr "message"
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+			IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object, object)
+			IL_0280: pop
+			IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0286: stloc.s 8
+			IL_0288: ldloc.s 8
+			IL_028a: ldstr "exit"
+			IL_028f: ldc.r8 1
+			IL_0298: box [System.Runtime]System.Double
+			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02a2: pop
+			IL_02a3: leave IL_02a8
 		} // end handler
 
-		IL_02c4: ret
+		IL_02a8: ret
 	} // end of method Compile_Scripts_BumpVersion::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_BumpVersion
@@ -2645,7 +2628,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x33b1
+		// Method begins at RVA 0x3395
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fac
+				// Method begins at RVA 0x2f80
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fc7
+						// Method begins at RVA 0x2f9b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fd0
+						// Method begins at RVA 0x2fa4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fd9
+						// Method begins at RVA 0x2fad
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fe2
+						// Method begins at RVA 0x2fb6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fbe
+					// Method begins at RVA 0x2f92
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fb5
+				// Method begins at RVA 0x2f89
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +164,7 @@
 				object argv
 			) cil managed 
 		{
-			// Method begins at RVA 0x22ec
+			// Method begins at RVA 0x22c0
 			// Header size: 12
 			// Code size: 571 (0x23b)
 			.maxstack 8
@@ -412,7 +412,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ff4
+					// Method begins at RVA 0x2fc8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -434,7 +434,7 @@
 					object node
 				) cil managed 
 			{
-				// Method begins at RVA 0x2a20
+				// Method begins at RVA 0x29f4
 				// Header size: 12
 				// Code size: 404 (0x194)
 				.maxstack 8
@@ -609,7 +609,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ffd
+					// Method begins at RVA 0x2fd1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -630,7 +630,7 @@
 					object content
 				) cil managed 
 			{
-				// Method begins at RVA 0x2bc0
+				// Method begins at RVA 0x2b94
 				// Header size: 12
 				// Code size: 148 (0x94)
 				.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3006
+					// Method begins at RVA 0x2fda
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -735,7 +735,7 @@
 					object node
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c60
+				// Method begins at RVA 0x2c34
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -781,7 +781,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3018
+						// Method begins at RVA 0x2fec
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -802,7 +802,7 @@
 						object el
 					) cil managed 
 				{
-					// Method begins at RVA 0x2e90
+					// Method begins at RVA 0x2e64
 					// Header size: 12
 					// Code size: 209 (0xd1)
 					.maxstack 8
@@ -920,7 +920,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3021
+						// Method begins at RVA 0x2ff5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -938,7 +938,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x300f
+					// Method begins at RVA 0x2fe3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -961,7 +961,7 @@
 					object node
 				) cil managed 
 			{
-				// Method begins at RVA 0x2c8c
+				// Method begins at RVA 0x2c60
 				// Header size: 12
 				// Code size: 503 (0x1f7)
 				.maxstack 8
@@ -1193,7 +1193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2feb
+				// Method begins at RVA 0x2fbf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1215,7 +1215,7 @@
 				object html
 			) cil managed 
 		{
-			// Method begins at RVA 0x2534
+			// Method begins at RVA 0x2508
 			// Header size: 12
 			// Code size: 554 (0x22a)
 			.maxstack 8
@@ -1440,7 +1440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x302a
+				// Method begins at RVA 0x2ffe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1461,7 +1461,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x276c
+			// Method begins at RVA 0x2740
 			// Header size: 12
 			// Code size: 678 (0x2a6)
 			.maxstack 8
@@ -1746,7 +1746,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x303c
+					// Method begins at RVA 0x3010
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1766,7 +1766,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3045
+					// Method begins at RVA 0x3019
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1784,7 +1784,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3033
+				// Method begins at RVA 0x3007
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1810,7 +1810,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2fa3
+			// Method begins at RVA 0x2f77
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1836,7 +1836,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 473 (0x1d9)
+		// Code size: 431 (0x1af)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope,
@@ -1846,12 +1846,11 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object[],
-			[8] bool,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[7] bool,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[9] object,
 			[10] object,
-			[11] object,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::.ctor()
@@ -1897,159 +1896,135 @@
 		IL_006b: stloc.s 6
 		IL_006d: ldloc.s 6
 		IL_006f: stloc.1
-		IL_0070: ldc.i4.1
-		IL_0071: newarr [System.Runtime]System.Object
-		IL_0076: dup
-		IL_0077: ldc.i4.0
-		IL_0078: ldnull
-		IL_0079: stelem.ref
-		IL_007a: stloc.s 7
-		IL_007c: ldarg.1
-		IL_007d: ldloc.s 7
-		IL_007f: ldstr "fs"
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0089: stloc.s 6
-		IL_008b: ldloc.0
-		IL_008c: ldloc.s 6
-		IL_008e: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-		IL_0093: ldc.i4.1
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: dup
-		IL_009a: ldc.i4.0
-		IL_009b: ldnull
-		IL_009c: stelem.ref
-		IL_009d: stloc.s 7
-		IL_009f: ldarg.1
-		IL_00a0: ldloc.s 7
-		IL_00a2: ldstr "path"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00ac: stloc.s 6
-		IL_00ae: ldloc.0
-		IL_00af: ldloc.s 6
-		IL_00b1: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-		IL_00b6: ldc.i4.1
-		IL_00b7: newarr [System.Runtime]System.Object
-		IL_00bc: dup
-		IL_00bd: ldc.i4.0
-		IL_00be: ldnull
-		IL_00bf: stelem.ref
+		IL_0070: ldarg.1
+		IL_0071: ldstr "fs"
+		IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_007b: stloc.s 6
+		IL_007d: ldloc.0
+		IL_007e: ldloc.s 6
+		IL_0080: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+		IL_0085: ldarg.1
+		IL_0086: ldstr "path"
+		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0090: stloc.s 6
+		IL_0092: ldloc.0
+		IL_0093: ldloc.s 6
+		IL_0095: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+		IL_009a: ldarg.1
+		IL_009b: ldstr "turndown"
+		IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00a5: stloc.s 6
+		IL_00a7: ldloc.0
+		IL_00a8: ldloc.s 6
+		IL_00aa: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::TurndownService
+		IL_00af: ldarg.1
+		IL_00b0: ldstr "main"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00ba: ldarg.2
+		IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_00c0: stloc.s 7
-		IL_00c2: ldarg.1
-		IL_00c3: ldloc.s 7
-		IL_00c5: ldstr "turndown"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00cf: stloc.s 6
-		IL_00d1: ldloc.0
-		IL_00d2: ldloc.s 6
-		IL_00d4: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::TurndownService
-		IL_00d9: ldarg.1
-		IL_00da: ldstr "main"
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00e4: ldarg.2
-		IL_00e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00ea: stloc.s 8
-		IL_00ec: ldloc.s 8
-		IL_00ee: brfalse IL_01d8
+		IL_00c2: ldloc.s 7
+		IL_00c4: brfalse IL_01ae
 		.try
 		{
-			IL_00f3: ldnull
-			IL_00f4: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(object[], object)
-			IL_00fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00ff: ldc.i4.1
-			IL_0100: newarr [System.Runtime]System.Object
-			IL_0105: dup
-			IL_0106: ldc.i4.0
-			IL_0107: ldloc.0
-			IL_0108: stelem.ref
-			IL_0109: ldnull
-			IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
-			IL_010f: pop
-			IL_0110: leave IL_01d8
+			IL_00c9: ldnull
+			IL_00ca: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(object[], object)
+			IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00d5: ldc.i4.1
+			IL_00d6: newarr [System.Runtime]System.Object
+			IL_00db: dup
+			IL_00dc: ldc.i4.0
+			IL_00dd: ldloc.0
+			IL_00de: stelem.ref
+			IL_00df: ldnull
+			IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
+			IL_00e5: pop
+			IL_00e6: leave IL_01ae
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0115: stloc.2
-			IL_0116: ldloc.2
-			IL_0117: dup
-			IL_0118: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_011d: dup
-			IL_011e: brtrue IL_0134
+			IL_00eb: stloc.2
+			IL_00ec: ldloc.2
+			IL_00ed: dup
+			IL_00ee: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00f3: dup
+			IL_00f4: brtrue IL_010a
 
-			IL_0123: pop
-			IL_0124: dup
-			IL_0125: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_012a: dup
-			IL_012b: brtrue IL_0140
+			IL_00f9: pop
+			IL_00fa: dup
+			IL_00fb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0100: dup
+			IL_0101: brtrue IL_0116
 
-			IL_0130: pop
-			IL_0131: pop
-			IL_0132: rethrow
+			IL_0106: pop
+			IL_0107: pop
+			IL_0108: rethrow
 
-			IL_0134: pop
-			IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_013a: stloc.3
-			IL_013b: br IL_0142
+			IL_010a: pop
+			IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0110: stloc.3
+			IL_0111: br IL_0118
 
-			IL_0140: pop
-			IL_0141: stloc.3
+			IL_0116: pop
+			IL_0117: stloc.3
 
-			IL_0142: ldloc.3
-			IL_0143: stloc.s 6
-			IL_0145: ldloc.s 6
-			IL_0147: stloc.s 4
-			IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_014e: stloc.s 9
-			IL_0150: ldloc.s 4
-			IL_0152: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0157: stloc.s 8
-			IL_0159: ldloc.s 8
-			IL_015b: brfalse IL_0173
+			IL_0118: ldloc.3
+			IL_0119: stloc.s 6
+			IL_011b: ldloc.s 6
+			IL_011d: stloc.s 4
+			IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0124: stloc.s 8
+			IL_0126: ldloc.s 4
+			IL_0128: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_012d: stloc.s 7
+			IL_012f: ldloc.s 7
+			IL_0131: brfalse IL_0149
 
-			IL_0160: ldloc.s 4
-			IL_0162: ldstr "message"
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-			IL_016c: stloc.s 11
-			IL_016e: br IL_0177
+			IL_0136: ldloc.s 4
+			IL_0138: ldstr "message"
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+			IL_0142: stloc.s 10
+			IL_0144: br IL_014d
 
-			IL_0173: ldloc.s 4
-			IL_0175: stloc.s 11
+			IL_0149: ldloc.s 4
+			IL_014b: stloc.s 10
 
-			IL_0177: ldloc.s 11
-			IL_0179: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_017e: stloc.s 8
-			IL_0180: ldloc.s 8
-			IL_0182: brfalse IL_019a
+			IL_014d: ldloc.s 10
+			IL_014f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0154: stloc.s 7
+			IL_0156: ldloc.s 7
+			IL_0158: brfalse IL_0170
 
-			IL_0187: ldloc.s 4
-			IL_0189: ldstr "message"
-			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-			IL_0193: stloc.s 5
-			IL_0195: br IL_019e
+			IL_015d: ldloc.s 4
+			IL_015f: ldstr "message"
+			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+			IL_0169: stloc.s 5
+			IL_016b: br IL_0174
 
-			IL_019a: ldloc.s 4
-			IL_019c: stloc.s 5
+			IL_0170: ldloc.s 4
+			IL_0172: stloc.s 5
 
-			IL_019e: ldloc.s 9
-			IL_01a0: ldc.i4.1
-			IL_01a1: newarr [System.Runtime]System.Object
-			IL_01a6: dup
-			IL_01a7: ldc.i4.0
-			IL_01a8: ldloc.s 5
-			IL_01aa: stelem.ref
-			IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object[])
-			IL_01b0: pop
-			IL_01b1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_01b6: stloc.s 12
-			IL_01b8: ldloc.s 12
-			IL_01ba: ldstr "exitCode"
-			IL_01bf: ldc.r8 1
-			IL_01c8: box [System.Runtime]System.Double
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-			IL_01d2: pop
-			IL_01d3: leave IL_01d8
+			IL_0174: ldloc.s 8
+			IL_0176: ldc.i4.1
+			IL_0177: newarr [System.Runtime]System.Object
+			IL_017c: dup
+			IL_017d: ldc.i4.0
+			IL_017e: ldloc.s 5
+			IL_0180: stelem.ref
+			IL_0181: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object[])
+			IL_0186: pop
+			IL_0187: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_018c: stloc.s 11
+			IL_018e: ldloc.s 11
+			IL_0190: ldstr "exitCode"
+			IL_0195: ldc.r8 1
+			IL_019e: box [System.Runtime]System.Double
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+			IL_01a8: pop
+			IL_01a9: leave IL_01ae
 		} // end handler
 
-		IL_01d8: ret
+		IL_01ae: ret
 	} // end of method Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
@@ -2069,7 +2044,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3057
+				// Method begins at RVA 0x302b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2089,7 +2064,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2f6d
+			// Method begins at RVA 0x2f41
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2118,7 +2093,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3060
+				// Method begins at RVA 0x3034
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2140,7 +2115,7 @@
 				object _rule
 			) cil managed 
 		{
-			// Method begins at RVA 0x2f70
+			// Method begins at RVA 0x2f44
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2169,7 +2144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3069
+				// Method begins at RVA 0x303d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2190,7 +2165,7 @@
 				object html
 			) cil managed 
 		{
-			// Method begins at RVA 0x2f74
+			// Method begins at RVA 0x2f48
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -2238,7 +2213,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x304e
+			// Method begins at RVA 0x3022
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2262,7 +2237,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2248
+		// Method begins at RVA 0x221c
 		// Header size: 12
 		// Code size: 152 (0x98)
 		.maxstack 8
@@ -2340,7 +2315,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3072
+		// Method begins at RVA 0x3046
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e77
+				// Method begins at RVA 0x2e3f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -39,7 +39,7 @@
 				object testName
 			) cil managed 
 		{
-			// Method begins at RVA 0x21d0
+			// Method begins at RVA 0x2198
 			// Header size: 12
 			// Code size: 148 (0x94)
 			.maxstack 8
@@ -126,7 +126,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e92
+					// Method begins at RVA 0x2e5a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -147,7 +147,7 @@
 					object d
 				) cil managed 
 			{
-				// Method begins at RVA 0x2e10
+				// Method begins at RVA 0x2dd8
 				// Header size: 12
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -182,7 +182,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e9b
+					// Method begins at RVA 0x2e63
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -204,7 +204,7 @@
 					object d
 				) cil managed 
 			{
-				// Method begins at RVA 0x2e2c
+				// Method begins at RVA 0x2df4
 				// Header size: 12
 				// Code size: 54 (0x36)
 				.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e89
+					// Method begins at RVA 0x2e51
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -276,7 +276,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e80
+				// Method begins at RVA 0x2e48
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -304,7 +304,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2eb6
+						// Method begins at RVA 0x2e7e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -322,7 +322,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ead
+					// Method begins at RVA 0x2e75
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -340,7 +340,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ea4
+				// Method begins at RVA 0x2e6c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -363,7 +363,7 @@
 				object assemblyFileBaseName
 			) cil managed 
 		{
-			// Method begins at RVA 0x2270
+			// Method begins at RVA 0x2238
 			// Header size: 12
 			// Code size: 693 (0x2b5)
 			.maxstack 8
@@ -675,7 +675,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ed1
+						// Method begins at RVA 0x2e99
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -693,7 +693,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ec8
+					// Method begins at RVA 0x2e90
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -711,7 +711,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ebf
+				// Method begins at RVA 0x2e87
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -733,7 +733,7 @@
 				object startDir
 			) cil managed 
 		{
-			// Method begins at RVA 0x2544
+			// Method begins at RVA 0x250c
 			// Header size: 12
 			// Code size: 360 (0x168)
 			.maxstack 8
@@ -916,7 +916,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eda
+				// Method begins at RVA 0x2ea2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -938,7 +938,7 @@
 				object assemblyPath
 			) cil managed 
 		{
-			// Method begins at RVA 0x26b8
+			// Method begins at RVA 0x2680
 			// Header size: 12
 			// Code size: 153 (0x99)
 			.maxstack 8
@@ -1024,7 +1024,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2eec
+					// Method begins at RVA 0x2eb4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1048,7 +1048,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2efe
+						// Method begins at RVA 0x2ec6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1066,7 +1066,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ef5
+					// Method begins at RVA 0x2ebd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1086,7 +1086,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f07
+					// Method begins at RVA 0x2ecf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1106,7 +1106,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f10
+					// Method begins at RVA 0x2ed8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1126,7 +1126,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f19
+					// Method begins at RVA 0x2ee1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1144,7 +1144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ee3
+				// Method begins at RVA 0x2eab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1165,7 +1165,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2760
+			// Method begins at RVA 0x2728
 			// Header size: 12
 			// Code size: 1684 (0x694)
 			.maxstack 8
@@ -1818,7 +1818,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2e6e
+			// Method begins at RVA 0x2e36
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1844,14 +1844,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 371 (0x173)
+		// Code size: 315 (0x13b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_DecompileGeneratorTest/Scope,
 			[1] object,
 			[2] object,
-			[3] object,
-			[4] object[]
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/Scope::.ctor()
@@ -1924,95 +1923,63 @@
 		IL_00a8: stloc.3
 		IL_00a9: ldloc.3
 		IL_00aa: stloc.2
-		IL_00ab: ldc.i4.1
-		IL_00ac: newarr [System.Runtime]System.Object
-		IL_00b1: dup
-		IL_00b2: ldc.i4.0
-		IL_00b3: ldnull
-		IL_00b4: stelem.ref
-		IL_00b5: stloc.s 4
-		IL_00b7: ldarg.1
-		IL_00b8: ldloc.s 4
-		IL_00ba: ldstr "node:child_process"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00c4: stloc.3
-		IL_00c5: ldloc.0
-		IL_00c6: ldloc.3
-		IL_00c7: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-		IL_00cc: ldc.i4.1
-		IL_00cd: newarr [System.Runtime]System.Object
-		IL_00d2: dup
-		IL_00d3: ldc.i4.0
-		IL_00d4: ldnull
-		IL_00d5: stelem.ref
-		IL_00d6: stloc.s 4
-		IL_00d8: ldarg.1
-		IL_00d9: ldloc.s 4
-		IL_00db: ldstr "node:fs"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00e5: stloc.3
-		IL_00e6: ldloc.0
-		IL_00e7: ldloc.3
-		IL_00e8: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-		IL_00ed: ldc.i4.1
-		IL_00ee: newarr [System.Runtime]System.Object
-		IL_00f3: dup
-		IL_00f4: ldc.i4.0
-		IL_00f5: ldnull
-		IL_00f6: stelem.ref
-		IL_00f7: stloc.s 4
-		IL_00f9: ldarg.1
-		IL_00fa: ldloc.s 4
-		IL_00fc: ldstr "node:path"
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0106: stloc.3
-		IL_0107: ldloc.0
-		IL_0108: ldloc.3
-		IL_0109: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-		IL_010e: ldc.i4.1
-		IL_010f: newarr [System.Runtime]System.Object
-		IL_0114: dup
-		IL_0115: ldc.i4.0
-		IL_0116: ldnull
-		IL_0117: stelem.ref
-		IL_0118: stloc.s 4
-		IL_011a: ldarg.1
-		IL_011b: ldloc.s 4
-		IL_011d: ldstr "node:os"
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0127: stloc.3
-		IL_0128: ldloc.0
-		IL_0129: ldloc.3
-		IL_012a: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
-		IL_012f: ldnull
-		IL_0130: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(object[], object, object)
-		IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_013b: ldc.i4.1
-		IL_013c: newarr [System.Runtime]System.Object
-		IL_0141: dup
-		IL_0142: ldc.i4.0
-		IL_0143: ldloc.0
-		IL_0144: stelem.ref
-		IL_0145: ldnull
-		IL_0146: ldarg.s __dirname
-		IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
-		IL_014d: stloc.3
-		IL_014e: ldloc.0
-		IL_014f: ldloc.3
-		IL_0150: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-		IL_0155: ldnull
-		IL_0156: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(object[], object)
-		IL_015c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_0161: ldc.i4.1
-		IL_0162: newarr [System.Runtime]System.Object
-		IL_0167: dup
-		IL_0168: ldc.i4.0
-		IL_0169: ldloc.0
-		IL_016a: stelem.ref
-		IL_016b: ldnull
-		IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
-		IL_0171: pop
-		IL_0172: ret
+		IL_00ab: ldarg.1
+		IL_00ac: ldstr "node:child_process"
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00b6: stloc.3
+		IL_00b7: ldloc.0
+		IL_00b8: ldloc.3
+		IL_00b9: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+		IL_00be: ldarg.1
+		IL_00bf: ldstr "node:fs"
+		IL_00c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00c9: stloc.3
+		IL_00ca: ldloc.0
+		IL_00cb: ldloc.3
+		IL_00cc: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+		IL_00d1: ldarg.1
+		IL_00d2: ldstr "node:path"
+		IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00dc: stloc.3
+		IL_00dd: ldloc.0
+		IL_00de: ldloc.3
+		IL_00df: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+		IL_00e4: ldarg.1
+		IL_00e5: ldstr "node:os"
+		IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00ef: stloc.3
+		IL_00f0: ldloc.0
+		IL_00f1: ldloc.3
+		IL_00f2: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
+		IL_00f7: ldnull
+		IL_00f8: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(object[], object, object)
+		IL_00fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_0103: ldc.i4.1
+		IL_0104: newarr [System.Runtime]System.Object
+		IL_0109: dup
+		IL_010a: ldc.i4.0
+		IL_010b: ldloc.0
+		IL_010c: stelem.ref
+		IL_010d: ldnull
+		IL_010e: ldarg.s __dirname
+		IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+		IL_0115: stloc.3
+		IL_0116: ldloc.0
+		IL_0117: ldloc.3
+		IL_0118: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+		IL_011d: ldnull
+		IL_011e: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(object[], object)
+		IL_0124: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0129: ldc.i4.1
+		IL_012a: newarr [System.Runtime]System.Object
+		IL_012f: dup
+		IL_0130: ldc.i4.0
+		IL_0131: ldloc.0
+		IL_0132: stelem.ref
+		IL_0133: ldnull
+		IL_0134: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
+		IL_0139: pop
+		IL_013a: ret
 	} // end of method Compile_Scripts_DecompileGeneratorTest::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_DecompileGeneratorTest
@@ -2024,7 +1991,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2f22
+		// Method begins at RVA 0x2eea
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37ae
+				// Method begins at RVA 0x3796
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -40,7 +40,7 @@
 				object p
 			) cil managed 
 		{
-			// Method begins at RVA 0x2268
+			// Method begins at RVA 0x2250
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37b7
+				// Method begins at RVA 0x379f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,7 +99,7 @@
 				object v
 			) cil managed 
 		{
-			// Method begins at RVA 0x229c
+			// Method begins at RVA 0x2284
 			// Header size: 12
 			// Code size: 69 (0x45)
 			.maxstack 8
@@ -159,7 +159,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37c0
+				// Method begins at RVA 0x37a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +180,7 @@
 				object s
 			) cil managed 
 		{
-			// Method begins at RVA 0x22f0
+			// Method begins at RVA 0x22d8
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -228,7 +228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37c9
+				// Method begins at RVA 0x37b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 				object text
 			) cil managed 
 		{
-			// Method begins at RVA 0x2330
+			// Method begins at RVA 0x2318
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -342,7 +342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37d2
+				// Method begins at RVA 0x37ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -364,7 +364,7 @@
 				object ns
 			) cil managed 
 		{
-			// Method begins at RVA 0x23d0
+			// Method begins at RVA 0x23b8
 			// Header size: 12
 			// Code size: 306 (0x132)
 			.maxstack 8
@@ -520,7 +520,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37e4
+					// Method begins at RVA 0x37cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -542,7 +542,7 @@
 					object p
 				) cil managed 
 			{
-				// Method begins at RVA 0x3770
+				// Method begins at RVA 0x3758
 				// Header size: 12
 				// Code size: 41 (0x29)
 				.maxstack 8
@@ -578,7 +578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37db
+				// Method begins at RVA 0x37c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -600,7 +600,7 @@
 				object impl
 			) cil managed 
 		{
-			// Method begins at RVA 0x2510
+			// Method begins at RVA 0x24f8
 			// Header size: 12
 			// Code size: 126 (0x7e)
 			.maxstack 8
@@ -679,7 +679,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37ed
+				// Method begins at RVA 0x37d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -703,7 +703,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37ff
+					// Method begins at RVA 0x37e7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -721,7 +721,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37f6
+				// Method begins at RVA 0x37de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -743,7 +743,7 @@
 				object apis
 			) cil managed 
 		{
-			// Method begins at RVA 0x259c
+			// Method begins at RVA 0x2584
 			// Header size: 12
 			// Code size: 640 (0x280)
 			.maxstack 8
@@ -1034,7 +1034,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3808
+				// Method begins at RVA 0x37f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1058,7 +1058,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x381a
+					// Method begins at RVA 0x3802
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1082,7 +1082,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x382c
+						// Method begins at RVA 0x3814
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1100,7 +1100,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3823
+					// Method begins at RVA 0x380b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1118,7 +1118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3811
+				// Method begins at RVA 0x37f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1140,7 +1140,7 @@
 				object apis
 			) cil managed 
 		{
-			// Method begins at RVA 0x2844
+			// Method begins at RVA 0x282c
 			// Header size: 12
 			// Code size: 757 (0x2f5)
 			.maxstack 8
@@ -1487,7 +1487,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3835
+				// Method begins at RVA 0x381d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1515,7 +1515,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3850
+						// Method begins at RVA 0x3838
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1535,7 +1535,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3859
+						// Method begins at RVA 0x3841
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1555,7 +1555,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3862
+						// Method begins at RVA 0x384a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1573,7 +1573,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3847
+					// Method begins at RVA 0x382f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1591,7 +1591,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x383e
+				// Method begins at RVA 0x3826
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1613,7 +1613,7 @@
 				object ns
 			) cil managed 
 		{
-			// Method begins at RVA 0x2b7c
+			// Method begins at RVA 0x2b64
 			// Header size: 12
 			// Code size: 861 (0x35d)
 			.maxstack 8
@@ -2006,7 +2006,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x386b
+				// Method begins at RVA 0x3853
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2034,7 +2034,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3886
+						// Method begins at RVA 0x386e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2054,7 +2054,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x388f
+						// Method begins at RVA 0x3877
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2074,7 +2074,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3898
+						// Method begins at RVA 0x3880
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2098,7 +2098,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x38aa
+							// Method begins at RVA 0x3892
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2116,7 +2116,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x38a1
+						// Method begins at RVA 0x3889
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2134,7 +2134,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x387d
+					// Method begins at RVA 0x3865
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2152,7 +2152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3874
+				// Method begins at RVA 0x385c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2174,7 +2174,7 @@
 				object ns
 			) cil managed 
 		{
-			// Method begins at RVA 0x2f04
+			// Method begins at RVA 0x2eec
 			// Header size: 12
 			// Code size: 1110 (0x456)
 			.maxstack 8
@@ -2650,7 +2650,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38b3
+				// Method begins at RVA 0x389b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2670,7 +2670,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38bc
+				// Method begins at RVA 0x38a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2691,7 +2691,7 @@
 				object ns
 			) cil managed 
 		{
-			// Method begins at RVA 0x339c
+			// Method begins at RVA 0x3384
 			// Header size: 12
 			// Code size: 315 (0x13b)
 			.maxstack 8
@@ -2865,7 +2865,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38c5
+				// Method begins at RVA 0x38ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2886,7 +2886,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x34f4
+			// Method begins at RVA 0x34dc
 			// Header size: 12
 			// Code size: 621 (0x26d)
 			.maxstack 8
@@ -3205,7 +3205,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x37a5
+			// Method begins at RVA 0x378d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3231,13 +3231,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 521 (0x209)
+		// Code size: 497 (0x1f1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::.ctor()
@@ -3412,49 +3411,33 @@
 		IL_01aa: stloc.2
 		IL_01ab: ldloc.2
 		IL_01ac: stloc.1
-		IL_01ad: ldc.i4.1
-		IL_01ae: newarr [System.Runtime]System.Object
-		IL_01b3: dup
-		IL_01b4: ldc.i4.0
-		IL_01b5: ldnull
-		IL_01b6: stelem.ref
-		IL_01b7: stloc.3
-		IL_01b8: ldarg.1
-		IL_01b9: ldloc.3
-		IL_01ba: ldstr "fs"
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_01c4: stloc.2
-		IL_01c5: ldloc.0
-		IL_01c6: ldloc.2
-		IL_01c7: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-		IL_01cc: ldc.i4.1
-		IL_01cd: newarr [System.Runtime]System.Object
-		IL_01d2: dup
-		IL_01d3: ldc.i4.0
-		IL_01d4: ldnull
-		IL_01d5: stelem.ref
-		IL_01d6: stloc.3
-		IL_01d7: ldarg.1
-		IL_01d8: ldloc.3
-		IL_01d9: ldstr "path"
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_01e3: stloc.2
-		IL_01e4: ldloc.0
-		IL_01e5: ldloc.2
-		IL_01e6: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-		IL_01eb: ldnull
-		IL_01ec: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(object[], object)
-		IL_01f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_01f7: ldc.i4.1
-		IL_01f8: newarr [System.Runtime]System.Object
-		IL_01fd: dup
-		IL_01fe: ldc.i4.0
-		IL_01ff: ldloc.0
-		IL_0200: stelem.ref
-		IL_0201: ldnull
-		IL_0202: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
-		IL_0207: pop
-		IL_0208: ret
+		IL_01ad: ldarg.1
+		IL_01ae: ldstr "fs"
+		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_01b8: stloc.2
+		IL_01b9: ldloc.0
+		IL_01ba: ldloc.2
+		IL_01bb: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+		IL_01c0: ldarg.1
+		IL_01c1: ldstr "path"
+		IL_01c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_01cb: stloc.2
+		IL_01cc: ldloc.0
+		IL_01cd: ldloc.2
+		IL_01ce: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+		IL_01d3: ldnull
+		IL_01d4: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(object[], object)
+		IL_01da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_01df: ldc.i4.1
+		IL_01e0: newarr [System.Runtime]System.Object
+		IL_01e5: dup
+		IL_01e6: ldc.i4.0
+		IL_01e7: ldloc.0
+		IL_01e8: stelem.ref
+		IL_01e9: ldnull
+		IL_01ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
+		IL_01ef: pop
+		IL_01f0: ret
 	} // end of method Compile_Scripts_GenerateNodeSupportMd::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_GenerateNodeSupportMd
@@ -3466,7 +3449,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x38ce
+		// Method begins at RVA 0x38b6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e79
+				// Method begins at RVA 0x2e69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e94
+						// Method begins at RVA 0x2e84
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e8b
+					// Method begins at RVA 0x2e7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e82
+				// Method begins at RVA 0x2e72
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,7 +113,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x218c
 			// Header size: 12
 			// Code size: 1107 (0x453)
 			.maxstack 8
@@ -616,7 +616,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2eaf
+						// Method begins at RVA 0x2e9f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -640,7 +640,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2ec1
+							// Method begins at RVA 0x2eb1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -658,7 +658,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2eb8
+						// Method begins at RVA 0x2ea8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -678,7 +678,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2eca
+						// Method begins at RVA 0x2eba
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -702,7 +702,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ea6
+					// Method begins at RVA 0x2e96
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -723,7 +723,7 @@
 					object newTarget
 				) cil managed 
 			{
-				// Method begins at RVA 0x2b14
+				// Method begins at RVA 0x2b04
 				// Header size: 12
 				// Code size: 848 (0x350)
 				.maxstack 8
@@ -1128,7 +1128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e9d
+				// Method begins at RVA 0x2e8d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1149,7 +1149,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x25fc
+			// Method begins at RVA 0x25ec
 			// Header size: 12
 			// Code size: 381 (0x17d)
 			.maxstack 8
@@ -1350,7 +1350,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ed3
+				// Method begins at RVA 0x2ec3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1371,7 +1371,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2788
+			// Method begins at RVA 0x2778
 			// Header size: 12
 			// Code size: 437 (0x1b5)
 			.maxstack 8
@@ -1584,7 +1584,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ee5
+					// Method begins at RVA 0x2ed5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1604,7 +1604,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2eee
+					// Method begins at RVA 0x2ede
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1628,7 +1628,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2edc
+				// Method begins at RVA 0x2ecc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1649,7 +1649,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x294c
+			// Method begins at RVA 0x293c
 			// Header size: 12
 			// Code size: 413 (0x19d)
 			.maxstack 8
@@ -1847,7 +1847,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ef7
+				// Method begins at RVA 0x2ee7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1867,7 +1867,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2af5
+			// Method begins at RVA 0x2ae5
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -1916,7 +1916,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2e70
+			// Method begins at RVA 0x2e60
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1942,7 +1942,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 318 (0x13e)
+		// Code size: 304 (0x130)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_AsyncHelpers_On_Once/Scope,
@@ -1951,8 +1951,7 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object[],
-			[7] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Events_AsyncHelpers_On_Once/Scope::.ctor()
@@ -2009,72 +2008,64 @@
 		IL_0081: stloc.s 5
 		IL_0083: ldloc.s 5
 		IL_0085: stloc.s 4
-		IL_0087: ldc.i4.1
-		IL_0088: newarr [System.Runtime]System.Object
-		IL_008d: dup
-		IL_008e: ldc.i4.0
-		IL_008f: ldnull
-		IL_0090: stelem.ref
-		IL_0091: stloc.s 6
-		IL_0093: ldarg.1
-		IL_0094: ldloc.s 6
-		IL_0096: ldstr "node:events"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00a0: stloc.s 5
-		IL_00a2: ldloc.0
-		IL_00a3: ldloc.s 5
-		IL_00a5: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-		IL_00aa: ldloc.0
-		IL_00ab: ldloc.0
-		IL_00ac: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-		IL_00b1: ldstr "EventEmitter"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00bb: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-		IL_00c0: ldnull
-		IL_00c1: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
-		IL_00c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_00cc: ldc.i4.1
-		IL_00cd: newarr [System.Runtime]System.Object
-		IL_00d2: dup
-		IL_00d3: ldc.i4.0
-		IL_00d4: ldloc.0
-		IL_00d5: stelem.ref
-		IL_00d6: ldnull
-		IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
-		IL_00dc: stloc.s 5
-		IL_00de: ldloc.s 5
-		IL_00e0: ldstr "then"
-		IL_00e5: ldloc.2
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00eb: stloc.s 5
-		IL_00ed: ldloc.s 5
-		IL_00ef: ldstr "then"
-		IL_00f4: ldloc.3
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.s 5
-		IL_00fe: ldstr "then"
-		IL_0103: ldloc.s 4
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010a: stloc.s 5
-		IL_010c: ldnull
-		IL_010d: ldftn object Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9::__js_call__(object)
-		IL_0113: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0118: ldc.i4.1
-		IL_0119: newarr [System.Runtime]System.Object
-		IL_011e: dup
-		IL_011f: ldc.i4.0
-		IL_0120: ldloc.0
-		IL_0121: stelem.ref
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_012c: stloc.s 7
-		IL_012e: ldloc.s 5
-		IL_0130: ldstr "then"
-		IL_0135: ldloc.s 7
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_013c: pop
-		IL_013d: ret
+		IL_0087: ldarg.1
+		IL_0088: ldstr "node:events"
+		IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0092: stloc.s 5
+		IL_0094: ldloc.0
+		IL_0095: ldloc.s 5
+		IL_0097: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+		IL_009c: ldloc.0
+		IL_009d: ldloc.0
+		IL_009e: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+		IL_00a3: ldstr "EventEmitter"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00ad: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
+		IL_00b2: ldnull
+		IL_00b3: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
+		IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_00be: ldc.i4.1
+		IL_00bf: newarr [System.Runtime]System.Object
+		IL_00c4: dup
+		IL_00c5: ldc.i4.0
+		IL_00c6: ldloc.0
+		IL_00c7: stelem.ref
+		IL_00c8: ldnull
+		IL_00c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::Invoke(object[], object)
+		IL_00ce: stloc.s 5
+		IL_00d0: ldloc.s 5
+		IL_00d2: ldstr "then"
+		IL_00d7: ldloc.2
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00dd: stloc.s 5
+		IL_00df: ldloc.s 5
+		IL_00e1: ldstr "then"
+		IL_00e6: ldloc.3
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ec: stloc.s 5
+		IL_00ee: ldloc.s 5
+		IL_00f0: ldstr "then"
+		IL_00f5: ldloc.s 4
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00fc: stloc.s 5
+		IL_00fe: ldnull
+		IL_00ff: ldftn object Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9::__js_call__(object)
+		IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_010a: ldc.i4.1
+		IL_010b: newarr [System.Runtime]System.Object
+		IL_0110: dup
+		IL_0111: ldc.i4.0
+		IL_0112: ldloc.0
+		IL_0113: stelem.ref
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_011e: stloc.s 6
+		IL_0120: ldloc.s 5
+		IL_0122: ldstr "then"
+		IL_0127: ldloc.s 6
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_012e: pop
+		IL_012f: ret
 	} // end of method Events_AsyncHelpers_On_Once::__js_module_init__
 
 } // end of class Modules.Events_AsyncHelpers_On_Once
@@ -2086,7 +2077,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2f00
+		// Method begins at RVA 0x2ef0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
+++ b/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x281c
+				// Method begins at RVA 0x2810
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2728
+			// Method begins at RVA 0x271a
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2825
+				// Method begins at RVA 0x2819
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -80,7 +80,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x272b
+			// Method begins at RVA 0x271d
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x282e
+				// Method begins at RVA 0x2822
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +122,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x272e
+			// Method begins at RVA 0x2720
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -144,7 +144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2837
+				// Method begins at RVA 0x282b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +164,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2731
+			// Method begins at RVA 0x2723
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -186,7 +186,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2840
+				// Method begins at RVA 0x2834
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -207,7 +207,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2734
+			// Method begins at RVA 0x2728
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -246,7 +246,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2849
+				// Method begins at RVA 0x283d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -267,7 +267,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2768
+			// Method begins at RVA 0x275c
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -306,7 +306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2852
+				// Method begins at RVA 0x2846
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -327,7 +327,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x279c
+			// Method begins at RVA 0x2790
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -366,7 +366,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x285b
+				// Method begins at RVA 0x284f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -387,7 +387,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x27d0
+			// Method begins at RVA 0x27c4
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -426,7 +426,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2864
+				// Method begins at RVA 0x2858
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -446,7 +446,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2804
+			// Method begins at RVA 0x27f8
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -468,7 +468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x286d
+				// Method begins at RVA 0x2861
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -488,7 +488,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2807
+			// Method begins at RVA 0x27fb
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -510,7 +510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2876
+				// Method begins at RVA 0x286a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -530,7 +530,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x280a
+			// Method begins at RVA 0x27fe
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -552,7 +552,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x287f
+				// Method begins at RVA 0x2873
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x280d
+			// Method begins at RVA 0x2801
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -594,7 +594,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2888
+				// Method begins at RVA 0x287c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -614,7 +614,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2810
+			// Method begins at RVA 0x2804
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -647,7 +647,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2813
+			// Method begins at RVA 0x2807
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -673,7 +673,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1740 (0x6cc)
+		// Code size: 1726 (0x6be)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_Complete/Scope,
@@ -696,10 +696,9 @@
 			[17] object,
 			[18] object,
 			[19] object,
-			[20] object[],
-			[21] object,
-			[22] bool,
-			[23] object
+			[20] object,
+			[21] bool,
+			[22] object
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_Complete/Scope::.ctor()
@@ -730,574 +729,566 @@
 		IL_0041: stloc.s 19
 		IL_0043: ldloc.s 19
 		IL_0045: stloc.2
-		IL_0046: ldc.i4.1
-		IL_0047: newarr [System.Runtime]System.Object
-		IL_004c: dup
-		IL_004d: ldc.i4.0
-		IL_004e: ldnull
-		IL_004f: stelem.ref
-		IL_0050: stloc.s 20
-		IL_0052: ldarg.1
-		IL_0053: ldloc.s 20
-		IL_0055: ldstr "node:events"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_005f: stloc.s 19
-		IL_0061: ldloc.s 19
-		IL_0063: stloc.3
-		IL_0064: ldloc.3
-		IL_0065: ldstr "EventEmitter"
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_006f: stloc.s 4
-		IL_0071: ldloc.s 4
-		IL_0073: ldc.i4.0
-		IL_0074: newarr [System.Runtime]System.Object
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_007e: stloc.s 19
-		IL_0080: ldloc.s 19
-		IL_0082: stloc.s 5
-		IL_0084: ldloc.s 5
-		IL_0086: ldstr "eventNames"
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0090: stloc.s 19
-		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0097: ldc.i4.1
-		IL_0098: newarr [System.Runtime]System.Object
-		IL_009d: dup
-		IL_009e: ldc.i4.0
-		IL_009f: ldloc.s 19
-		IL_00a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_00a6: box [System.Runtime]System.Double
-		IL_00ab: stelem.ref
-		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00b1: pop
-		IL_00b2: ldnull
-		IL_00b3: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19::__js_call__(object)
-		IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00be: ldc.i4.1
-		IL_00bf: newarr [System.Runtime]System.Object
-		IL_00c4: dup
-		IL_00c5: ldc.i4.0
-		IL_00c6: ldloc.0
-		IL_00c7: stelem.ref
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_00cd: stloc.s 19
-		IL_00cf: ldloc.s 5
-		IL_00d1: ldstr "on"
-		IL_00d6: ldstr "foo"
-		IL_00db: ldloc.s 19
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00e2: pop
-		IL_00e3: ldnull
-		IL_00e4: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19::__js_call__(object)
-		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ef: ldc.i4.1
-		IL_00f0: newarr [System.Runtime]System.Object
-		IL_00f5: dup
-		IL_00f6: ldc.i4.0
-		IL_00f7: ldloc.0
-		IL_00f8: stelem.ref
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_00fe: stloc.s 19
-		IL_0100: ldloc.s 5
-		IL_0102: ldstr "on"
-		IL_0107: ldstr "bar"
-		IL_010c: ldloc.s 19
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0113: pop
-		IL_0114: ldloc.s 5
-		IL_0116: ldstr "eventNames"
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0120: stloc.s 19
-		IL_0122: ldloc.s 19
-		IL_0124: stloc.s 6
-		IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012b: ldc.i4.1
-		IL_012c: newarr [System.Runtime]System.Object
-		IL_0131: dup
-		IL_0132: ldc.i4.0
-		IL_0133: ldloc.s 6
-		IL_0135: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_013a: box [System.Runtime]System.Double
-		IL_013f: stelem.ref
-		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0145: pop
-		IL_0146: ldloc.s 4
-		IL_0148: ldc.i4.0
-		IL_0149: newarr [System.Runtime]System.Object
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0153: stloc.s 19
-		IL_0155: ldloc.s 19
-		IL_0157: stloc.s 7
-		IL_0159: ldloc.s 7
-		IL_015b: ldstr "listeners"
-		IL_0160: ldstr "test"
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_016a: stloc.s 19
-		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0171: ldc.i4.1
-		IL_0172: newarr [System.Runtime]System.Object
-		IL_0177: dup
-		IL_0178: ldc.i4.0
-		IL_0179: ldloc.s 19
-		IL_017b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_0180: box [System.Runtime]System.Double
-		IL_0185: stelem.ref
-		IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_018b: pop
-		IL_018c: ldloc.s 7
-		IL_018e: ldstr "on"
-		IL_0193: ldstr "test"
-		IL_0198: ldloc.1
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_019e: pop
-		IL_019f: ldloc.s 7
-		IL_01a1: ldstr "on"
-		IL_01a6: ldstr "test"
-		IL_01ab: ldloc.2
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01b1: pop
-		IL_01b2: ldloc.s 7
-		IL_01b4: ldstr "listeners"
-		IL_01b9: ldstr "test"
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01c3: stloc.s 19
-		IL_01c5: ldloc.s 19
-		IL_01c7: stloc.s 8
-		IL_01c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ce: ldc.i4.1
-		IL_01cf: newarr [System.Runtime]System.Object
-		IL_01d4: dup
-		IL_01d5: ldc.i4.0
-		IL_01d6: ldloc.s 8
-		IL_01d8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_01dd: box [System.Runtime]System.Double
-		IL_01e2: stelem.ref
-		IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_01e8: pop
-		IL_01e9: ldloc.s 4
-		IL_01eb: ldc.i4.0
-		IL_01ec: newarr [System.Runtime]System.Object
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_01f6: stloc.s 19
-		IL_01f8: ldloc.s 19
-		IL_01fa: stloc.s 9
-		IL_01fc: ldloc.0
-		IL_01fd: ldstr ""
-		IL_0202: stfld object Modules.Events_EventEmitter_Complete/Scope::order
-		IL_0207: ldnull
-		IL_0208: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21::__js_call__(object[], object)
-		IL_020e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_0213: ldc.i4.1
-		IL_0214: newarr [System.Runtime]System.Object
-		IL_0219: dup
-		IL_021a: ldc.i4.0
-		IL_021b: ldloc.0
-		IL_021c: stelem.ref
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0222: stloc.s 19
-		IL_0224: ldloc.s 9
-		IL_0226: ldstr "on"
-		IL_022b: ldstr "event"
-		IL_0230: ldloc.s 19
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0237: pop
-		IL_0238: ldnull
-		IL_0239: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34::__js_call__(object[], object)
-		IL_023f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_0244: ldc.i4.1
-		IL_0245: newarr [System.Runtime]System.Object
-		IL_024a: dup
-		IL_024b: ldc.i4.0
-		IL_024c: ldloc.0
-		IL_024d: stelem.ref
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0253: stloc.s 19
-		IL_0255: ldloc.s 9
-		IL_0257: ldstr "prependListener"
-		IL_025c: ldstr "event"
-		IL_0261: ldloc.s 19
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0268: pop
-		IL_0269: ldloc.s 9
-		IL_026b: ldstr "emit"
-		IL_0270: ldstr "event"
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_027a: pop
-		IL_027b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0280: ldc.i4.1
-		IL_0281: newarr [System.Runtime]System.Object
-		IL_0286: dup
-		IL_0287: ldc.i4.0
-		IL_0288: ldloc.0
-		IL_0289: ldfld object Modules.Events_EventEmitter_Complete/Scope::order
-		IL_028e: stelem.ref
-		IL_028f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0294: pop
-		IL_0295: ldloc.s 4
-		IL_0297: ldc.i4.0
-		IL_0298: newarr [System.Runtime]System.Object
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_02a2: stloc.s 19
-		IL_02a4: ldloc.s 19
-		IL_02a6: stloc.s 10
-		IL_02a8: ldloc.0
-		IL_02a9: ldstr ""
-		IL_02ae: stfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-		IL_02b3: ldnull
-		IL_02b4: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20::__js_call__(object[], object)
-		IL_02ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_02bf: ldc.i4.1
-		IL_02c0: newarr [System.Runtime]System.Object
-		IL_02c5: dup
-		IL_02c6: ldc.i4.0
-		IL_02c7: ldloc.0
-		IL_02c8: stelem.ref
-		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_02ce: stloc.s 19
-		IL_02d0: ldloc.s 10
-		IL_02d2: ldstr "on"
-		IL_02d7: ldstr "tick"
-		IL_02dc: ldloc.s 19
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_02e3: pop
-		IL_02e4: ldnull
-		IL_02e5: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37::__js_call__(object[], object)
-		IL_02eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_02f0: ldc.i4.1
-		IL_02f1: newarr [System.Runtime]System.Object
-		IL_02f6: dup
-		IL_02f7: ldc.i4.0
-		IL_02f8: ldloc.0
-		IL_02f9: stelem.ref
-		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_02ff: stloc.s 19
-		IL_0301: ldloc.s 10
-		IL_0303: ldstr "prependOnceListener"
-		IL_0308: ldstr "tick"
-		IL_030d: ldloc.s 19
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0314: pop
-		IL_0315: ldloc.s 10
-		IL_0317: ldstr "emit"
-		IL_031c: ldstr "tick"
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0326: pop
-		IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_032c: ldc.i4.1
-		IL_032d: newarr [System.Runtime]System.Object
-		IL_0332: dup
-		IL_0333: ldc.i4.0
-		IL_0334: ldloc.0
-		IL_0335: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-		IL_033a: stelem.ref
-		IL_033b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0340: pop
-		IL_0341: ldloc.s 10
-		IL_0343: ldstr "emit"
-		IL_0348: ldstr "tick"
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0352: pop
-		IL_0353: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0358: ldc.i4.1
-		IL_0359: newarr [System.Runtime]System.Object
-		IL_035e: dup
-		IL_035f: ldc.i4.0
-		IL_0360: ldloc.0
-		IL_0361: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-		IL_0366: stelem.ref
-		IL_0367: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_036c: pop
-		IL_036d: ldloc.s 4
-		IL_036f: ldc.i4.0
-		IL_0370: newarr [System.Runtime]System.Object
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_037a: stloc.s 19
-		IL_037c: ldloc.s 19
-		IL_037e: stloc.s 11
-		IL_0380: ldloc.s 11
-		IL_0382: ldstr "getMaxListeners"
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_038c: stloc.s 19
-		IL_038e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0393: ldc.i4.1
-		IL_0394: newarr [System.Runtime]System.Object
-		IL_0399: dup
-		IL_039a: ldc.i4.0
-		IL_039b: ldloc.s 19
-		IL_039d: stelem.ref
-		IL_039e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_03a3: pop
-		IL_03a4: ldloc.s 11
-		IL_03a6: ldstr "setMaxListeners"
-		IL_03ab: ldc.r8 20
-		IL_03b4: box [System.Runtime]System.Double
-		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03be: pop
-		IL_03bf: ldloc.s 11
-		IL_03c1: ldstr "getMaxListeners"
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_03cb: stloc.s 19
-		IL_03cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03d2: ldc.i4.1
-		IL_03d3: newarr [System.Runtime]System.Object
-		IL_03d8: dup
-		IL_03d9: ldc.i4.0
-		IL_03da: ldloc.s 19
-		IL_03dc: stelem.ref
-		IL_03dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_03e2: pop
-		IL_03e3: ldloc.s 11
-		IL_03e5: ldstr "setMaxListeners"
-		IL_03ea: ldc.r8 5
-		IL_03f3: box [System.Runtime]System.Double
-		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03fd: pop
-		IL_03fe: ldloc.s 11
-		IL_0400: ldstr "getMaxListeners"
-		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_040a: stloc.s 19
-		IL_040c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0411: ldc.i4.1
-		IL_0412: newarr [System.Runtime]System.Object
-		IL_0417: dup
-		IL_0418: ldc.i4.0
-		IL_0419: ldloc.s 19
-		IL_041b: stelem.ref
-		IL_041c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0421: pop
-		IL_0422: ldloc.s 4
-		IL_0424: ldc.i4.0
-		IL_0425: newarr [System.Runtime]System.Object
-		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_042f: stloc.s 19
-		IL_0431: ldloc.s 19
-		IL_0433: stloc.s 12
-		IL_0435: ldnull
-		IL_0436: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19::__js_call__(object)
-		IL_043c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0441: ldc.i4.1
-		IL_0442: newarr [System.Runtime]System.Object
-		IL_0447: dup
-		IL_0448: ldc.i4.0
-		IL_0449: ldloc.0
-		IL_044a: stelem.ref
-		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0450: stloc.s 19
-		IL_0452: ldloc.s 12
-		IL_0454: ldstr "on"
-		IL_0459: ldstr "raw"
-		IL_045e: ldloc.s 19
-		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0465: pop
-		IL_0466: ldnull
-		IL_0467: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21::__js_call__(object)
-		IL_046d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0472: ldc.i4.1
-		IL_0473: newarr [System.Runtime]System.Object
-		IL_0478: dup
-		IL_0479: ldc.i4.0
-		IL_047a: ldloc.0
-		IL_047b: stelem.ref
-		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0481: stloc.s 19
-		IL_0483: ldloc.s 12
-		IL_0485: ldstr "once"
-		IL_048a: ldstr "raw"
-		IL_048f: ldloc.s 19
-		IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0496: pop
-		IL_0497: ldloc.s 12
-		IL_0499: ldstr "rawListeners"
-		IL_049e: ldstr "raw"
-		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04a8: stloc.s 19
-		IL_04aa: ldloc.s 19
-		IL_04ac: stloc.s 13
-		IL_04ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b3: ldc.i4.1
-		IL_04b4: newarr [System.Runtime]System.Object
-		IL_04b9: dup
-		IL_04ba: ldc.i4.0
-		IL_04bb: ldloc.s 13
-		IL_04bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_04c2: box [System.Runtime]System.Double
-		IL_04c7: stelem.ref
-		IL_04c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_04cd: pop
-		IL_04ce: ldloc.s 4
-		IL_04d0: ldc.i4.0
-		IL_04d1: newarr [System.Runtime]System.Object
-		IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_04db: stloc.s 19
-		IL_04dd: ldloc.s 19
-		IL_04df: stloc.s 14
-		IL_04e1: ldnull
-		IL_04e2: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_result::__js_call__(object)
-		IL_04e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_04ed: ldc.i4.1
-		IL_04ee: newarr [System.Runtime]System.Object
-		IL_04f3: dup
-		IL_04f4: ldc.i4.0
-		IL_04f5: ldloc.0
-		IL_04f6: stelem.ref
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_04fc: stloc.s 19
-		IL_04fe: ldloc.s 14
-		IL_0500: ldstr "on"
-		IL_0505: ldstr "a"
-		IL_050a: ldloc.s 19
-		IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0511: stloc.s 19
-		IL_0513: ldnull
-		IL_0514: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24::__js_call__(object)
-		IL_051a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_051f: ldc.i4.1
-		IL_0520: newarr [System.Runtime]System.Object
-		IL_0525: dup
-		IL_0526: ldc.i4.0
-		IL_0527: ldloc.0
-		IL_0528: stelem.ref
-		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_052e: stloc.s 21
-		IL_0530: ldloc.s 19
-		IL_0532: ldstr "prependListener"
-		IL_0537: ldstr "b"
-		IL_053c: ldloc.s 21
-		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0543: stloc.s 21
-		IL_0545: ldloc.s 21
-		IL_0547: ldstr "setMaxListeners"
-		IL_054c: ldc.r8 15
-		IL_0555: box [System.Runtime]System.Double
-		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_055f: stloc.s 21
-		IL_0561: ldloc.s 21
-		IL_0563: ldstr "removeAllListeners"
-		IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_056d: stloc.s 21
-		IL_056f: ldloc.s 21
-		IL_0571: stloc.s 15
-		IL_0573: ldloc.s 15
-		IL_0575: ldloc.s 14
-		IL_0577: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_057c: stloc.s 22
-		IL_057e: ldloc.s 22
-		IL_0580: box [System.Runtime]System.Boolean
-		IL_0585: stloc.s 23
-		IL_0587: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_058c: ldc.i4.1
-		IL_058d: newarr [System.Runtime]System.Object
-		IL_0592: dup
-		IL_0593: ldc.i4.0
-		IL_0594: ldloc.s 23
-		IL_0596: stelem.ref
-		IL_0597: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_059c: pop
-		IL_059d: ldloc.s 14
-		IL_059f: ldstr "eventNames"
-		IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_05a9: stloc.s 21
-		IL_05ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05b0: ldc.i4.1
-		IL_05b1: newarr [System.Runtime]System.Object
-		IL_05b6: dup
-		IL_05b7: ldc.i4.0
-		IL_05b8: ldloc.s 21
-		IL_05ba: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_05bf: box [System.Runtime]System.Double
-		IL_05c4: stelem.ref
-		IL_05c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_05ca: pop
-		IL_05cb: ldloc.s 14
-		IL_05cd: ldstr "getMaxListeners"
-		IL_05d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_05d7: stloc.s 21
-		IL_05d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05de: ldc.i4.1
-		IL_05df: newarr [System.Runtime]System.Object
-		IL_05e4: dup
-		IL_05e5: ldc.i4.0
-		IL_05e6: ldloc.s 21
-		IL_05e8: stelem.ref
-		IL_05e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_05ee: pop
-		IL_05ef: ldloc.s 4
-		IL_05f1: ldc.i4.0
-		IL_05f2: newarr [System.Runtime]System.Object
-		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_05fc: stloc.s 21
-		IL_05fe: ldloc.s 21
-		IL_0600: stloc.s 16
-		IL_0602: ldnull
-		IL_0603: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20::__js_call__(object)
-		IL_0609: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_060e: ldc.i4.1
-		IL_060f: newarr [System.Runtime]System.Object
-		IL_0614: dup
-		IL_0615: ldc.i4.0
-		IL_0616: ldloc.0
-		IL_0617: stelem.ref
-		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_061d: stloc.s 21
-		IL_061f: ldloc.s 16
-		IL_0621: ldstr "on"
-		IL_0626: ldstr "copy"
-		IL_062b: ldloc.s 21
-		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0632: pop
-		IL_0633: ldloc.s 16
-		IL_0635: ldstr "listeners"
-		IL_063a: ldstr "copy"
-		IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0644: stloc.s 21
-		IL_0646: ldloc.s 21
-		IL_0648: stloc.s 17
-		IL_064a: ldloc.s 16
-		IL_064c: ldstr "listeners"
-		IL_0651: ldstr "copy"
-		IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_065b: stloc.s 21
-		IL_065d: ldloc.s 21
-		IL_065f: stloc.s 18
-		IL_0661: ldloc.s 17
-		IL_0663: ldloc.s 18
-		IL_0665: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_066a: stloc.s 22
-		IL_066c: ldloc.s 22
-		IL_066e: box [System.Runtime]System.Boolean
-		IL_0673: stloc.s 23
-		IL_0675: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_067a: ldc.i4.1
-		IL_067b: newarr [System.Runtime]System.Object
-		IL_0680: dup
-		IL_0681: ldc.i4.0
-		IL_0682: ldloc.s 23
-		IL_0684: stelem.ref
-		IL_0685: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_068a: pop
-		IL_068b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0690: ldc.i4.1
-		IL_0691: newarr [System.Runtime]System.Object
-		IL_0696: dup
-		IL_0697: ldc.i4.0
-		IL_0698: ldloc.s 17
-		IL_069a: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_069f: box [System.Runtime]System.Double
-		IL_06a4: stelem.ref
-		IL_06a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_06aa: pop
-		IL_06ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06b0: ldc.i4.1
-		IL_06b1: newarr [System.Runtime]System.Object
-		IL_06b6: dup
-		IL_06b7: ldc.i4.0
-		IL_06b8: ldloc.s 18
-		IL_06ba: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_06bf: box [System.Runtime]System.Double
-		IL_06c4: stelem.ref
-		IL_06c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_06ca: pop
-		IL_06cb: ret
+		IL_0046: ldarg.1
+		IL_0047: ldstr "node:events"
+		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0051: stloc.s 19
+		IL_0053: ldloc.s 19
+		IL_0055: stloc.3
+		IL_0056: ldloc.3
+		IL_0057: ldstr "EventEmitter"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0061: stloc.s 4
+		IL_0063: ldloc.s 4
+		IL_0065: ldc.i4.0
+		IL_0066: newarr [System.Runtime]System.Object
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0070: stloc.s 19
+		IL_0072: ldloc.s 19
+		IL_0074: stloc.s 5
+		IL_0076: ldloc.s 5
+		IL_0078: ldstr "eventNames"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0082: stloc.s 19
+		IL_0084: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0089: ldc.i4.1
+		IL_008a: newarr [System.Runtime]System.Object
+		IL_008f: dup
+		IL_0090: ldc.i4.0
+		IL_0091: ldloc.s 19
+		IL_0093: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0098: box [System.Runtime]System.Double
+		IL_009d: stelem.ref
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00a3: pop
+		IL_00a4: ldnull
+		IL_00a5: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19::__js_call__(object)
+		IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00b0: ldc.i4.1
+		IL_00b1: newarr [System.Runtime]System.Object
+		IL_00b6: dup
+		IL_00b7: ldc.i4.0
+		IL_00b8: ldloc.0
+		IL_00b9: stelem.ref
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00bf: stloc.s 19
+		IL_00c1: ldloc.s 5
+		IL_00c3: ldstr "on"
+		IL_00c8: ldstr "foo"
+		IL_00cd: ldloc.s 19
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00d4: pop
+		IL_00d5: ldnull
+		IL_00d6: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19::__js_call__(object)
+		IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00e1: ldc.i4.1
+		IL_00e2: newarr [System.Runtime]System.Object
+		IL_00e7: dup
+		IL_00e8: ldc.i4.0
+		IL_00e9: ldloc.0
+		IL_00ea: stelem.ref
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00f0: stloc.s 19
+		IL_00f2: ldloc.s 5
+		IL_00f4: ldstr "on"
+		IL_00f9: ldstr "bar"
+		IL_00fe: ldloc.s 19
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0105: pop
+		IL_0106: ldloc.s 5
+		IL_0108: ldstr "eventNames"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0112: stloc.s 19
+		IL_0114: ldloc.s 19
+		IL_0116: stloc.s 6
+		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011d: ldc.i4.1
+		IL_011e: newarr [System.Runtime]System.Object
+		IL_0123: dup
+		IL_0124: ldc.i4.0
+		IL_0125: ldloc.s 6
+		IL_0127: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_012c: box [System.Runtime]System.Double
+		IL_0131: stelem.ref
+		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0137: pop
+		IL_0138: ldloc.s 4
+		IL_013a: ldc.i4.0
+		IL_013b: newarr [System.Runtime]System.Object
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0145: stloc.s 19
+		IL_0147: ldloc.s 19
+		IL_0149: stloc.s 7
+		IL_014b: ldloc.s 7
+		IL_014d: ldstr "listeners"
+		IL_0152: ldstr "test"
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_015c: stloc.s 19
+		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0163: ldc.i4.1
+		IL_0164: newarr [System.Runtime]System.Object
+		IL_0169: dup
+		IL_016a: ldc.i4.0
+		IL_016b: ldloc.s 19
+		IL_016d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0172: box [System.Runtime]System.Double
+		IL_0177: stelem.ref
+		IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_017d: pop
+		IL_017e: ldloc.s 7
+		IL_0180: ldstr "on"
+		IL_0185: ldstr "test"
+		IL_018a: ldloc.1
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0190: pop
+		IL_0191: ldloc.s 7
+		IL_0193: ldstr "on"
+		IL_0198: ldstr "test"
+		IL_019d: ldloc.2
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01a3: pop
+		IL_01a4: ldloc.s 7
+		IL_01a6: ldstr "listeners"
+		IL_01ab: ldstr "test"
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01b5: stloc.s 19
+		IL_01b7: ldloc.s 19
+		IL_01b9: stloc.s 8
+		IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c0: ldc.i4.1
+		IL_01c1: newarr [System.Runtime]System.Object
+		IL_01c6: dup
+		IL_01c7: ldc.i4.0
+		IL_01c8: ldloc.s 8
+		IL_01ca: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_01cf: box [System.Runtime]System.Double
+		IL_01d4: stelem.ref
+		IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_01da: pop
+		IL_01db: ldloc.s 4
+		IL_01dd: ldc.i4.0
+		IL_01de: newarr [System.Runtime]System.Object
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_01e8: stloc.s 19
+		IL_01ea: ldloc.s 19
+		IL_01ec: stloc.s 9
+		IL_01ee: ldloc.0
+		IL_01ef: ldstr ""
+		IL_01f4: stfld object Modules.Events_EventEmitter_Complete/Scope::order
+		IL_01f9: ldnull
+		IL_01fa: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21::__js_call__(object[], object)
+		IL_0200: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0205: ldc.i4.1
+		IL_0206: newarr [System.Runtime]System.Object
+		IL_020b: dup
+		IL_020c: ldc.i4.0
+		IL_020d: ldloc.0
+		IL_020e: stelem.ref
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0214: stloc.s 19
+		IL_0216: ldloc.s 9
+		IL_0218: ldstr "on"
+		IL_021d: ldstr "event"
+		IL_0222: ldloc.s 19
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0229: pop
+		IL_022a: ldnull
+		IL_022b: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34::__js_call__(object[], object)
+		IL_0231: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0236: ldc.i4.1
+		IL_0237: newarr [System.Runtime]System.Object
+		IL_023c: dup
+		IL_023d: ldc.i4.0
+		IL_023e: ldloc.0
+		IL_023f: stelem.ref
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0245: stloc.s 19
+		IL_0247: ldloc.s 9
+		IL_0249: ldstr "prependListener"
+		IL_024e: ldstr "event"
+		IL_0253: ldloc.s 19
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_025a: pop
+		IL_025b: ldloc.s 9
+		IL_025d: ldstr "emit"
+		IL_0262: ldstr "event"
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_026c: pop
+		IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0272: ldc.i4.1
+		IL_0273: newarr [System.Runtime]System.Object
+		IL_0278: dup
+		IL_0279: ldc.i4.0
+		IL_027a: ldloc.0
+		IL_027b: ldfld object Modules.Events_EventEmitter_Complete/Scope::order
+		IL_0280: stelem.ref
+		IL_0281: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0286: pop
+		IL_0287: ldloc.s 4
+		IL_0289: ldc.i4.0
+		IL_028a: newarr [System.Runtime]System.Object
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0294: stloc.s 19
+		IL_0296: ldloc.s 19
+		IL_0298: stloc.s 10
+		IL_029a: ldloc.0
+		IL_029b: ldstr ""
+		IL_02a0: stfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
+		IL_02a5: ldnull
+		IL_02a6: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20::__js_call__(object[], object)
+		IL_02ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_02b1: ldc.i4.1
+		IL_02b2: newarr [System.Runtime]System.Object
+		IL_02b7: dup
+		IL_02b8: ldc.i4.0
+		IL_02b9: ldloc.0
+		IL_02ba: stelem.ref
+		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_02c0: stloc.s 19
+		IL_02c2: ldloc.s 10
+		IL_02c4: ldstr "on"
+		IL_02c9: ldstr "tick"
+		IL_02ce: ldloc.s 19
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_02d5: pop
+		IL_02d6: ldnull
+		IL_02d7: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37::__js_call__(object[], object)
+		IL_02dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_02e2: ldc.i4.1
+		IL_02e3: newarr [System.Runtime]System.Object
+		IL_02e8: dup
+		IL_02e9: ldc.i4.0
+		IL_02ea: ldloc.0
+		IL_02eb: stelem.ref
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_02f1: stloc.s 19
+		IL_02f3: ldloc.s 10
+		IL_02f5: ldstr "prependOnceListener"
+		IL_02fa: ldstr "tick"
+		IL_02ff: ldloc.s 19
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0306: pop
+		IL_0307: ldloc.s 10
+		IL_0309: ldstr "emit"
+		IL_030e: ldstr "tick"
+		IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0318: pop
+		IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_031e: ldc.i4.1
+		IL_031f: newarr [System.Runtime]System.Object
+		IL_0324: dup
+		IL_0325: ldc.i4.0
+		IL_0326: ldloc.0
+		IL_0327: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
+		IL_032c: stelem.ref
+		IL_032d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0332: pop
+		IL_0333: ldloc.s 10
+		IL_0335: ldstr "emit"
+		IL_033a: ldstr "tick"
+		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0344: pop
+		IL_0345: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_034a: ldc.i4.1
+		IL_034b: newarr [System.Runtime]System.Object
+		IL_0350: dup
+		IL_0351: ldc.i4.0
+		IL_0352: ldloc.0
+		IL_0353: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
+		IL_0358: stelem.ref
+		IL_0359: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_035e: pop
+		IL_035f: ldloc.s 4
+		IL_0361: ldc.i4.0
+		IL_0362: newarr [System.Runtime]System.Object
+		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_036c: stloc.s 19
+		IL_036e: ldloc.s 19
+		IL_0370: stloc.s 11
+		IL_0372: ldloc.s 11
+		IL_0374: ldstr "getMaxListeners"
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_037e: stloc.s 19
+		IL_0380: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0385: ldc.i4.1
+		IL_0386: newarr [System.Runtime]System.Object
+		IL_038b: dup
+		IL_038c: ldc.i4.0
+		IL_038d: ldloc.s 19
+		IL_038f: stelem.ref
+		IL_0390: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0395: pop
+		IL_0396: ldloc.s 11
+		IL_0398: ldstr "setMaxListeners"
+		IL_039d: ldc.r8 20
+		IL_03a6: box [System.Runtime]System.Double
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03b0: pop
+		IL_03b1: ldloc.s 11
+		IL_03b3: ldstr "getMaxListeners"
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_03bd: stloc.s 19
+		IL_03bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03c4: ldc.i4.1
+		IL_03c5: newarr [System.Runtime]System.Object
+		IL_03ca: dup
+		IL_03cb: ldc.i4.0
+		IL_03cc: ldloc.s 19
+		IL_03ce: stelem.ref
+		IL_03cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_03d4: pop
+		IL_03d5: ldloc.s 11
+		IL_03d7: ldstr "setMaxListeners"
+		IL_03dc: ldc.r8 5
+		IL_03e5: box [System.Runtime]System.Double
+		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03ef: pop
+		IL_03f0: ldloc.s 11
+		IL_03f2: ldstr "getMaxListeners"
+		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_03fc: stloc.s 19
+		IL_03fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0403: ldc.i4.1
+		IL_0404: newarr [System.Runtime]System.Object
+		IL_0409: dup
+		IL_040a: ldc.i4.0
+		IL_040b: ldloc.s 19
+		IL_040d: stelem.ref
+		IL_040e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0413: pop
+		IL_0414: ldloc.s 4
+		IL_0416: ldc.i4.0
+		IL_0417: newarr [System.Runtime]System.Object
+		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0421: stloc.s 19
+		IL_0423: ldloc.s 19
+		IL_0425: stloc.s 12
+		IL_0427: ldnull
+		IL_0428: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19::__js_call__(object)
+		IL_042e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0433: ldc.i4.1
+		IL_0434: newarr [System.Runtime]System.Object
+		IL_0439: dup
+		IL_043a: ldc.i4.0
+		IL_043b: ldloc.0
+		IL_043c: stelem.ref
+		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0442: stloc.s 19
+		IL_0444: ldloc.s 12
+		IL_0446: ldstr "on"
+		IL_044b: ldstr "raw"
+		IL_0450: ldloc.s 19
+		IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0457: pop
+		IL_0458: ldnull
+		IL_0459: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21::__js_call__(object)
+		IL_045f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0464: ldc.i4.1
+		IL_0465: newarr [System.Runtime]System.Object
+		IL_046a: dup
+		IL_046b: ldc.i4.0
+		IL_046c: ldloc.0
+		IL_046d: stelem.ref
+		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0473: stloc.s 19
+		IL_0475: ldloc.s 12
+		IL_0477: ldstr "once"
+		IL_047c: ldstr "raw"
+		IL_0481: ldloc.s 19
+		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0488: pop
+		IL_0489: ldloc.s 12
+		IL_048b: ldstr "rawListeners"
+		IL_0490: ldstr "raw"
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_049a: stloc.s 19
+		IL_049c: ldloc.s 19
+		IL_049e: stloc.s 13
+		IL_04a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04a5: ldc.i4.1
+		IL_04a6: newarr [System.Runtime]System.Object
+		IL_04ab: dup
+		IL_04ac: ldc.i4.0
+		IL_04ad: ldloc.s 13
+		IL_04af: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_04b4: box [System.Runtime]System.Double
+		IL_04b9: stelem.ref
+		IL_04ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_04bf: pop
+		IL_04c0: ldloc.s 4
+		IL_04c2: ldc.i4.0
+		IL_04c3: newarr [System.Runtime]System.Object
+		IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_04cd: stloc.s 19
+		IL_04cf: ldloc.s 19
+		IL_04d1: stloc.s 14
+		IL_04d3: ldnull
+		IL_04d4: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_result::__js_call__(object)
+		IL_04da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_04df: ldc.i4.1
+		IL_04e0: newarr [System.Runtime]System.Object
+		IL_04e5: dup
+		IL_04e6: ldc.i4.0
+		IL_04e7: ldloc.0
+		IL_04e8: stelem.ref
+		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_04ee: stloc.s 19
+		IL_04f0: ldloc.s 14
+		IL_04f2: ldstr "on"
+		IL_04f7: ldstr "a"
+		IL_04fc: ldloc.s 19
+		IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0503: stloc.s 19
+		IL_0505: ldnull
+		IL_0506: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24::__js_call__(object)
+		IL_050c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0511: ldc.i4.1
+		IL_0512: newarr [System.Runtime]System.Object
+		IL_0517: dup
+		IL_0518: ldc.i4.0
+		IL_0519: ldloc.0
+		IL_051a: stelem.ref
+		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0520: stloc.s 20
+		IL_0522: ldloc.s 19
+		IL_0524: ldstr "prependListener"
+		IL_0529: ldstr "b"
+		IL_052e: ldloc.s 20
+		IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0535: stloc.s 20
+		IL_0537: ldloc.s 20
+		IL_0539: ldstr "setMaxListeners"
+		IL_053e: ldc.r8 15
+		IL_0547: box [System.Runtime]System.Double
+		IL_054c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0551: stloc.s 20
+		IL_0553: ldloc.s 20
+		IL_0555: ldstr "removeAllListeners"
+		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_055f: stloc.s 20
+		IL_0561: ldloc.s 20
+		IL_0563: stloc.s 15
+		IL_0565: ldloc.s 15
+		IL_0567: ldloc.s 14
+		IL_0569: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_056e: stloc.s 21
+		IL_0570: ldloc.s 21
+		IL_0572: box [System.Runtime]System.Boolean
+		IL_0577: stloc.s 22
+		IL_0579: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_057e: ldc.i4.1
+		IL_057f: newarr [System.Runtime]System.Object
+		IL_0584: dup
+		IL_0585: ldc.i4.0
+		IL_0586: ldloc.s 22
+		IL_0588: stelem.ref
+		IL_0589: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_058e: pop
+		IL_058f: ldloc.s 14
+		IL_0591: ldstr "eventNames"
+		IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_059b: stloc.s 20
+		IL_059d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05a2: ldc.i4.1
+		IL_05a3: newarr [System.Runtime]System.Object
+		IL_05a8: dup
+		IL_05a9: ldc.i4.0
+		IL_05aa: ldloc.s 20
+		IL_05ac: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_05b1: box [System.Runtime]System.Double
+		IL_05b6: stelem.ref
+		IL_05b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_05bc: pop
+		IL_05bd: ldloc.s 14
+		IL_05bf: ldstr "getMaxListeners"
+		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_05c9: stloc.s 20
+		IL_05cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05d0: ldc.i4.1
+		IL_05d1: newarr [System.Runtime]System.Object
+		IL_05d6: dup
+		IL_05d7: ldc.i4.0
+		IL_05d8: ldloc.s 20
+		IL_05da: stelem.ref
+		IL_05db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_05e0: pop
+		IL_05e1: ldloc.s 4
+		IL_05e3: ldc.i4.0
+		IL_05e4: newarr [System.Runtime]System.Object
+		IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_05ee: stloc.s 20
+		IL_05f0: ldloc.s 20
+		IL_05f2: stloc.s 16
+		IL_05f4: ldnull
+		IL_05f5: ldftn object Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20::__js_call__(object)
+		IL_05fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0600: ldc.i4.1
+		IL_0601: newarr [System.Runtime]System.Object
+		IL_0606: dup
+		IL_0607: ldc.i4.0
+		IL_0608: ldloc.0
+		IL_0609: stelem.ref
+		IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_060f: stloc.s 20
+		IL_0611: ldloc.s 16
+		IL_0613: ldstr "on"
+		IL_0618: ldstr "copy"
+		IL_061d: ldloc.s 20
+		IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0624: pop
+		IL_0625: ldloc.s 16
+		IL_0627: ldstr "listeners"
+		IL_062c: ldstr "copy"
+		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0636: stloc.s 20
+		IL_0638: ldloc.s 20
+		IL_063a: stloc.s 17
+		IL_063c: ldloc.s 16
+		IL_063e: ldstr "listeners"
+		IL_0643: ldstr "copy"
+		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_064d: stloc.s 20
+		IL_064f: ldloc.s 20
+		IL_0651: stloc.s 18
+		IL_0653: ldloc.s 17
+		IL_0655: ldloc.s 18
+		IL_0657: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_065c: stloc.s 21
+		IL_065e: ldloc.s 21
+		IL_0660: box [System.Runtime]System.Boolean
+		IL_0665: stloc.s 22
+		IL_0667: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_066c: ldc.i4.1
+		IL_066d: newarr [System.Runtime]System.Object
+		IL_0672: dup
+		IL_0673: ldc.i4.0
+		IL_0674: ldloc.s 22
+		IL_0676: stelem.ref
+		IL_0677: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_067c: pop
+		IL_067d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0682: ldc.i4.1
+		IL_0683: newarr [System.Runtime]System.Object
+		IL_0688: dup
+		IL_0689: ldc.i4.0
+		IL_068a: ldloc.s 17
+		IL_068c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_0691: box [System.Runtime]System.Double
+		IL_0696: stelem.ref
+		IL_0697: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_069c: pop
+		IL_069d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06a2: ldc.i4.1
+		IL_06a3: newarr [System.Runtime]System.Object
+		IL_06a8: dup
+		IL_06a9: ldc.i4.0
+		IL_06aa: ldloc.s 18
+		IL_06ac: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_06b1: box [System.Runtime]System.Double
+		IL_06b6: stelem.ref
+		IL_06b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_06bc: pop
+		IL_06bd: ret
 	} // end of method Events_EventEmitter_Complete::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_Complete
@@ -1309,7 +1300,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2891
+		// Method begins at RVA 0x2885
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Emit_Args.verified.txt
+++ b/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Emit_Args.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ae
+				// Method begins at RVA 0x229e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x2248
+			// Method begins at RVA 0x2238
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b7
+				// Method begins at RVA 0x22a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 				object c
 			) cil managed 
 		{
-			// Method begins at RVA 0x226c
+			// Method begins at RVA 0x225c
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -148,7 +148,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22a5
+			// Method begins at RVA 0x2295
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -174,177 +174,168 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 490 (0x1ea)
+		// Code size: 476 (0x1dc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_Emit_Args/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object[],
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_Emit_Args/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 4
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "node:events"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 4
 		IL_0013: ldloc.s 4
-		IL_0015: ldstr "node:events"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 5
-		IL_0021: ldloc.s 5
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "EventEmitter"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldloc.2
-		IL_0031: ldc.i4.0
-		IL_0032: newarr [System.Runtime]System.Object
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_003c: stloc.s 5
-		IL_003e: ldloc.s 5
-		IL_0040: stloc.3
-		IL_0041: ldloc.0
-		IL_0042: ldc.r8 0.0
-		IL_004b: box [System.Runtime]System.Double
-		IL_0050: stfld object Modules.Events_EventEmitter_Emit_Args/Scope::sum
-		IL_0055: ldloc.0
-		IL_0056: ldc.r8 0.0
-		IL_005f: box [System.Runtime]System.Double
-		IL_0064: stfld object Modules.Events_EventEmitter_Emit_Args/Scope::product
-		IL_0069: ldnull
-		IL_006a: ldftn object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18::__js_call__(object[], object, object, object)
-		IL_0070: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
-		IL_0075: ldc.i4.1
-		IL_0076: newarr [System.Runtime]System.Object
-		IL_007b: dup
-		IL_007c: ldc.i4.0
-		IL_007d: ldloc.0
-		IL_007e: stelem.ref
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0084: stloc.s 5
-		IL_0086: ldloc.3
-		IL_0087: ldstr "on"
-		IL_008c: ldstr "sum"
-		IL_0091: ldloc.s 5
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0098: pop
-		IL_0099: ldnull
-		IL_009a: ldftn object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22::__js_call__(object[], object, object, object, object)
-		IL_00a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc3::.ctor(object, native int)
-		IL_00a5: ldc.i4.1
-		IL_00a6: newarr [System.Runtime]System.Object
-		IL_00ab: dup
-		IL_00ac: ldc.i4.0
-		IL_00ad: ldloc.0
-		IL_00ae: stelem.ref
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_00b4: stloc.s 5
-		IL_00b6: ldloc.3
-		IL_00b7: ldstr "on"
-		IL_00bc: ldstr "product"
-		IL_00c1: ldloc.s 5
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00c8: pop
-		IL_00c9: ldloc.3
-		IL_00ca: ldstr "emit"
-		IL_00cf: ldstr "sum"
-		IL_00d4: ldc.r8 2
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "EventEmitter"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldc.i4.0
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_002e: stloc.s 4
+		IL_0030: ldloc.s 4
+		IL_0032: stloc.3
+		IL_0033: ldloc.0
+		IL_0034: ldc.r8 0.0
+		IL_003d: box [System.Runtime]System.Double
+		IL_0042: stfld object Modules.Events_EventEmitter_Emit_Args/Scope::sum
+		IL_0047: ldloc.0
+		IL_0048: ldc.r8 0.0
+		IL_0051: box [System.Runtime]System.Double
+		IL_0056: stfld object Modules.Events_EventEmitter_Emit_Args/Scope::product
+		IL_005b: ldnull
+		IL_005c: ldftn object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18::__js_call__(object[], object, object, object)
+		IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+		IL_0067: ldc.i4.1
+		IL_0068: newarr [System.Runtime]System.Object
+		IL_006d: dup
+		IL_006e: ldc.i4.0
+		IL_006f: ldloc.0
+		IL_0070: stelem.ref
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0076: stloc.s 4
+		IL_0078: ldloc.3
+		IL_0079: ldstr "on"
+		IL_007e: ldstr "sum"
+		IL_0083: ldloc.s 4
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_008a: pop
+		IL_008b: ldnull
+		IL_008c: ldftn object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22::__js_call__(object[], object, object, object, object)
+		IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc3::.ctor(object, native int)
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00a6: stloc.s 4
+		IL_00a8: ldloc.3
+		IL_00a9: ldstr "on"
+		IL_00ae: ldstr "product"
+		IL_00b3: ldloc.s 4
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00ba: pop
+		IL_00bb: ldloc.3
+		IL_00bc: ldstr "emit"
+		IL_00c1: ldstr "sum"
+		IL_00c6: ldc.r8 2
+		IL_00cf: box [System.Runtime]System.Double
+		IL_00d4: ldc.r8 5
 		IL_00dd: box [System.Runtime]System.Double
-		IL_00e2: ldc.r8 5
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00f5: stloc.s 5
-		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fc: ldc.i4.1
-		IL_00fd: newarr [System.Runtime]System.Object
-		IL_0102: dup
-		IL_0103: ldc.i4.0
-		IL_0104: ldloc.s 5
-		IL_0106: stelem.ref
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_010c: pop
-		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: ldfld object Modules.Events_EventEmitter_Emit_Args/Scope::sum
-		IL_0120: stelem.ref
-		IL_0121: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0126: pop
-		IL_0127: ldloc.3
-		IL_0128: ldstr "emit"
-		IL_012d: ldc.i4.4
-		IL_012e: newarr [System.Runtime]System.Object
-		IL_0133: dup
-		IL_0134: ldc.i4.0
-		IL_0135: ldstr "product"
-		IL_013a: stelem.ref
-		IL_013b: dup
-		IL_013c: ldc.i4.1
-		IL_013d: ldc.r8 2
-		IL_0146: box [System.Runtime]System.Double
-		IL_014b: stelem.ref
-		IL_014c: dup
-		IL_014d: ldc.i4.2
-		IL_014e: ldc.r8 3
-		IL_0157: box [System.Runtime]System.Double
-		IL_015c: stelem.ref
-		IL_015d: dup
-		IL_015e: ldc.i4.3
-		IL_015f: ldc.r8 4
-		IL_0168: box [System.Runtime]System.Double
-		IL_016d: stelem.ref
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_0173: stloc.s 5
-		IL_0175: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017a: ldc.i4.1
-		IL_017b: newarr [System.Runtime]System.Object
-		IL_0180: dup
-		IL_0181: ldc.i4.0
-		IL_0182: ldloc.s 5
-		IL_0184: stelem.ref
-		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_018a: pop
-		IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0190: ldc.i4.1
-		IL_0191: newarr [System.Runtime]System.Object
-		IL_0196: dup
-		IL_0197: ldc.i4.0
-		IL_0198: ldloc.0
-		IL_0199: ldfld object Modules.Events_EventEmitter_Emit_Args/Scope::product
-		IL_019e: stelem.ref
-		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_01a4: pop
-		IL_01a5: ldloc.3
-		IL_01a6: ldstr "emit"
-		IL_01ab: ldstr "missing"
-		IL_01b0: ldc.r8 1
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00e7: stloc.s 4
+		IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ee: ldc.i4.1
+		IL_00ef: newarr [System.Runtime]System.Object
+		IL_00f4: dup
+		IL_00f5: ldc.i4.0
+		IL_00f6: ldloc.s 4
+		IL_00f8: stelem.ref
+		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00fe: pop
+		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0104: ldc.i4.1
+		IL_0105: newarr [System.Runtime]System.Object
+		IL_010a: dup
+		IL_010b: ldc.i4.0
+		IL_010c: ldloc.0
+		IL_010d: ldfld object Modules.Events_EventEmitter_Emit_Args/Scope::sum
+		IL_0112: stelem.ref
+		IL_0113: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0118: pop
+		IL_0119: ldloc.3
+		IL_011a: ldstr "emit"
+		IL_011f: ldc.i4.4
+		IL_0120: newarr [System.Runtime]System.Object
+		IL_0125: dup
+		IL_0126: ldc.i4.0
+		IL_0127: ldstr "product"
+		IL_012c: stelem.ref
+		IL_012d: dup
+		IL_012e: ldc.i4.1
+		IL_012f: ldc.r8 2
+		IL_0138: box [System.Runtime]System.Double
+		IL_013d: stelem.ref
+		IL_013e: dup
+		IL_013f: ldc.i4.2
+		IL_0140: ldc.r8 3
+		IL_0149: box [System.Runtime]System.Double
+		IL_014e: stelem.ref
+		IL_014f: dup
+		IL_0150: ldc.i4.3
+		IL_0151: ldc.r8 4
+		IL_015a: box [System.Runtime]System.Double
+		IL_015f: stelem.ref
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0165: stloc.s 4
+		IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016c: ldc.i4.1
+		IL_016d: newarr [System.Runtime]System.Object
+		IL_0172: dup
+		IL_0173: ldc.i4.0
+		IL_0174: ldloc.s 4
+		IL_0176: stelem.ref
+		IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_017c: pop
+		IL_017d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0182: ldc.i4.1
+		IL_0183: newarr [System.Runtime]System.Object
+		IL_0188: dup
+		IL_0189: ldc.i4.0
+		IL_018a: ldloc.0
+		IL_018b: ldfld object Modules.Events_EventEmitter_Emit_Args/Scope::product
+		IL_0190: stelem.ref
+		IL_0191: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0196: pop
+		IL_0197: ldloc.3
+		IL_0198: ldstr "emit"
+		IL_019d: ldstr "missing"
+		IL_01a2: ldc.r8 1
+		IL_01ab: box [System.Runtime]System.Double
+		IL_01b0: ldc.r8 2
 		IL_01b9: box [System.Runtime]System.Double
-		IL_01be: ldc.r8 2
-		IL_01c7: box [System.Runtime]System.Double
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_01d1: stloc.s 5
-		IL_01d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d8: ldc.i4.1
-		IL_01d9: newarr [System.Runtime]System.Object
-		IL_01de: dup
-		IL_01df: ldc.i4.0
-		IL_01e0: ldloc.s 5
-		IL_01e2: stelem.ref
-		IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_01e8: pop
-		IL_01e9: ret
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_01c3: stloc.s 4
+		IL_01c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ca: ldc.i4.1
+		IL_01cb: newarr [System.Runtime]System.Object
+		IL_01d0: dup
+		IL_01d1: ldc.i4.0
+		IL_01d2: ldloc.s 4
+		IL_01d4: stelem.ref
+		IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_01da: pop
+		IL_01db: ret
 	} // end of method Events_EventEmitter_Emit_Args::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_Emit_Args
@@ -356,7 +347,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22c0
+		// Method begins at RVA 0x22b0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
+++ b/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c8
+				// Method begins at RVA 0x22b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -39,7 +39,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2218
+			// Method begins at RVA 0x2208
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d1
+				// Method begins at RVA 0x22c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2254
+			// Method begins at RVA 0x2244
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22da
+				// Method begins at RVA 0x22ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -161,7 +161,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2290
+			// Method begins at RVA 0x2280
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -199,7 +199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e3
+				// Method begins at RVA 0x22d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -219,7 +219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ec
+				// Method begins at RVA 0x22dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -237,7 +237,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22bf
+			// Method begins at RVA 0x22af
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -263,7 +263,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 425 (0x1a9)
+		// Code size: 411 (0x19b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_ErrorMonitor/Scope,
@@ -274,177 +274,168 @@
 			[5] class [System.Runtime]System.Exception,
 			[6] object,
 			[7] object,
-			[8] object[],
-			[9] object,
-			[10] object
+			[8] object,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 8
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "node:events"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 8
 		IL_0013: ldloc.s 8
-		IL_0015: ldstr "node:events"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 9
-		IL_0021: ldloc.s 9
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "EventEmitter"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldloc.2
-		IL_0031: ldc.i4.0
-		IL_0032: newarr [System.Runtime]System.Object
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_003c: stloc.s 9
-		IL_003e: ldloc.s 9
-		IL_0040: stloc.3
-		IL_0041: ldloc.1
-		IL_0042: ldstr "errorMonitor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_004c: stloc.s 9
-		IL_004e: ldnull
-		IL_004f: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
-		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_005a: ldc.i4.1
-		IL_005b: newarr [System.Runtime]System.Object
-		IL_0060: dup
-		IL_0061: ldc.i4.0
-		IL_0062: ldloc.0
-		IL_0063: stelem.ref
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0069: stloc.s 10
-		IL_006b: ldloc.3
-		IL_006c: ldstr "on"
-		IL_0071: ldloc.s 9
-		IL_0073: ldloc.s 10
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_007a: pop
-		IL_007b: ldnull
-		IL_007c: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
-		IL_0082: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0087: ldc.i4.1
-		IL_0088: newarr [System.Runtime]System.Object
-		IL_008d: dup
-		IL_008e: ldc.i4.0
-		IL_008f: ldloc.0
-		IL_0090: stelem.ref
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0096: stloc.s 10
-		IL_0098: ldloc.3
-		IL_0099: ldstr "on"
-		IL_009e: ldstr "error"
-		IL_00a3: ldloc.s 10
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00aa: pop
-		IL_00ab: ldstr "boom"
-		IL_00b0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-		IL_00ba: stloc.s 10
-		IL_00bc: ldloc.3
-		IL_00bd: ldstr "emit"
-		IL_00c2: ldstr "error"
-		IL_00c7: ldloc.s 10
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00ce: pop
-		IL_00cf: ldloc.2
-		IL_00d0: ldc.i4.0
-		IL_00d1: newarr [System.Runtime]System.Object
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_00db: stloc.s 10
-		IL_00dd: ldloc.s 10
-		IL_00df: stloc.s 4
-		IL_00e1: ldloc.1
-		IL_00e2: ldstr "errorMonitor"
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00ec: stloc.s 10
-		IL_00ee: ldnull
-		IL_00ef: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00fa: ldc.i4.1
-		IL_00fb: newarr [System.Runtime]System.Object
-		IL_0100: dup
-		IL_0101: ldc.i4.0
-		IL_0102: ldloc.0
-		IL_0103: stelem.ref
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0109: stloc.s 9
-		IL_010b: ldloc.s 4
-		IL_010d: ldstr "on"
-		IL_0112: ldloc.s 10
-		IL_0114: ldloc.s 9
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_011b: pop
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "EventEmitter"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldc.i4.0
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_002e: stloc.s 8
+		IL_0030: ldloc.s 8
+		IL_0032: stloc.3
+		IL_0033: ldloc.1
+		IL_0034: ldstr "errorMonitor"
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_003e: stloc.s 8
+		IL_0040: ldnull
+		IL_0041: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
+		IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_004c: ldc.i4.1
+		IL_004d: newarr [System.Runtime]System.Object
+		IL_0052: dup
+		IL_0053: ldc.i4.0
+		IL_0054: ldloc.0
+		IL_0055: stelem.ref
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_005b: stloc.s 9
+		IL_005d: ldloc.3
+		IL_005e: ldstr "on"
+		IL_0063: ldloc.s 8
+		IL_0065: ldloc.s 9
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_006c: pop
+		IL_006d: ldnull
+		IL_006e: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
+		IL_0074: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0079: ldc.i4.1
+		IL_007a: newarr [System.Runtime]System.Object
+		IL_007f: dup
+		IL_0080: ldc.i4.0
+		IL_0081: ldloc.0
+		IL_0082: stelem.ref
+		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0088: stloc.s 9
+		IL_008a: ldloc.3
+		IL_008b: ldstr "on"
+		IL_0090: ldstr "error"
+		IL_0095: ldloc.s 9
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_009c: pop
+		IL_009d: ldstr "boom"
+		IL_00a2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_00ac: stloc.s 9
+		IL_00ae: ldloc.3
+		IL_00af: ldstr "emit"
+		IL_00b4: ldstr "error"
+		IL_00b9: ldloc.s 9
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00c0: pop
+		IL_00c1: ldloc.2
+		IL_00c2: ldc.i4.0
+		IL_00c3: newarr [System.Runtime]System.Object
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_00cd: stloc.s 9
+		IL_00cf: ldloc.s 9
+		IL_00d1: stloc.s 4
+		IL_00d3: ldloc.1
+		IL_00d4: ldstr "errorMonitor"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00de: stloc.s 9
+		IL_00e0: ldnull
+		IL_00e1: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
+		IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00ec: ldc.i4.1
+		IL_00ed: newarr [System.Runtime]System.Object
+		IL_00f2: dup
+		IL_00f3: ldc.i4.0
+		IL_00f4: ldloc.0
+		IL_00f5: stelem.ref
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00fb: stloc.s 8
+		IL_00fd: ldloc.s 4
+		IL_00ff: ldstr "on"
+		IL_0104: ldloc.s 9
+		IL_0106: ldloc.s 8
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_010d: pop
 		.try
 		{
-			IL_011c: ldloc.s 4
-			IL_011e: ldstr "emit"
-			IL_0123: ldstr "error"
-			IL_0128: ldstr "fatal"
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0132: pop
-			IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0138: ldc.i4.1
-			IL_0139: newarr [System.Runtime]System.Object
-			IL_013e: dup
-			IL_013f: ldc.i4.0
-			IL_0140: ldstr "NO_THROW"
-			IL_0145: stelem.ref
-			IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_014b: pop
-			IL_014c: leave IL_01a8
+			IL_010e: ldloc.s 4
+			IL_0110: ldstr "emit"
+			IL_0115: ldstr "error"
+			IL_011a: ldstr "fatal"
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0124: pop
+			IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012a: ldc.i4.1
+			IL_012b: newarr [System.Runtime]System.Object
+			IL_0130: dup
+			IL_0131: ldc.i4.0
+			IL_0132: ldstr "NO_THROW"
+			IL_0137: stelem.ref
+			IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_013d: pop
+			IL_013e: leave IL_019a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0151: stloc.s 5
-			IL_0153: ldloc.s 5
-			IL_0155: dup
-			IL_0156: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_015b: dup
-			IL_015c: brtrue IL_0172
+			IL_0143: stloc.s 5
+			IL_0145: ldloc.s 5
+			IL_0147: dup
+			IL_0148: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_014d: dup
+			IL_014e: brtrue IL_0164
 
+			IL_0153: pop
+			IL_0154: dup
+			IL_0155: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_015a: dup
+			IL_015b: brtrue IL_0171
+
+			IL_0160: pop
 			IL_0161: pop
-			IL_0162: dup
-			IL_0163: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0168: dup
-			IL_0169: brtrue IL_017f
+			IL_0162: rethrow
 
-			IL_016e: pop
-			IL_016f: pop
-			IL_0170: rethrow
+			IL_0164: pop
+			IL_0165: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_016a: stloc.s 6
+			IL_016c: br IL_0174
 
-			IL_0172: pop
-			IL_0173: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0178: stloc.s 6
-			IL_017a: br IL_0182
+			IL_0171: pop
+			IL_0172: stloc.s 6
 
-			IL_017f: pop
-			IL_0180: stloc.s 6
-
-			IL_0182: ldloc.s 6
-			IL_0184: stloc.s 9
-			IL_0186: ldloc.s 9
-			IL_0188: stloc.s 7
-			IL_018a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_018f: ldc.i4.1
-			IL_0190: newarr [System.Runtime]System.Object
-			IL_0195: dup
-			IL_0196: ldc.i4.0
-			IL_0197: ldstr "thrown"
-			IL_019c: stelem.ref
-			IL_019d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_01a2: pop
-			IL_01a3: leave IL_01a8
+			IL_0174: ldloc.s 6
+			IL_0176: stloc.s 8
+			IL_0178: ldloc.s 8
+			IL_017a: stloc.s 7
+			IL_017c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0181: ldc.i4.1
+			IL_0182: newarr [System.Runtime]System.Object
+			IL_0187: dup
+			IL_0188: ldc.i4.0
+			IL_0189: ldstr "thrown"
+			IL_018e: stelem.ref
+			IL_018f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_0194: pop
+			IL_0195: leave IL_019a
 		} // end handler
 
-		IL_01a8: ret
+		IL_019a: ret
 	} // end of method Events_EventEmitter_ErrorMonitor::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_ErrorMonitor
@@ -456,7 +447,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22f5
+		// Method begins at RVA 0x22e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
+++ b/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ff
+				// Method begins at RVA 0x23ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -39,7 +39,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2380
+			// Method begins at RVA 0x2370
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2408
+				// Method begins at RVA 0x23f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,7 +99,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x23b8
+			// Method begins at RVA 0x23a8
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -138,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2411
+				// Method begins at RVA 0x2401
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x23f0
+			// Method begins at RVA 0x23e0
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -180,7 +180,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241a
+				// Method begins at RVA 0x240a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -200,7 +200,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x23f3
+			// Method begins at RVA 0x23e3
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -229,7 +229,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23f6
+			// Method begins at RVA 0x23e6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -255,7 +255,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 802 (0x322)
+		// Code size: 788 (0x314)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_On_Off_Once/Scope,
@@ -263,8 +263,7 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object,
-			[6] object[]
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_On_Off_Once/Scope::.ctor()
@@ -282,268 +281,260 @@
 		IL_0021: stloc.s 5
 		IL_0023: ldloc.s 5
 		IL_0025: stloc.1
-		IL_0026: ldc.i4.1
-		IL_0027: newarr [System.Runtime]System.Object
-		IL_002c: dup
-		IL_002d: ldc.i4.0
-		IL_002e: ldnull
-		IL_002f: stelem.ref
-		IL_0030: stloc.s 6
-		IL_0032: ldarg.1
-		IL_0033: ldloc.s 6
-		IL_0035: ldstr "node:events"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003f: stloc.s 5
-		IL_0041: ldloc.s 5
-		IL_0043: stloc.2
-		IL_0044: ldloc.2
-		IL_0045: ldstr "EventEmitter"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_004f: stloc.3
-		IL_0050: ldloc.3
-		IL_0051: ldc.i4.0
-		IL_0052: newarr [System.Runtime]System.Object
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_005c: stloc.s 5
-		IL_005e: ldloc.s 5
-		IL_0060: stloc.s 4
-		IL_0062: ldloc.0
-		IL_0063: ldc.r8 0.0
-		IL_006c: box [System.Runtime]System.Double
-		IL_0071: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
-		IL_0076: ldloc.s 4
-		IL_0078: ldstr "emit"
-		IL_007d: ldstr "data"
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0087: stloc.s 5
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008e: ldc.i4.1
-		IL_008f: newarr [System.Runtime]System.Object
-		IL_0094: dup
-		IL_0095: ldc.i4.0
-		IL_0096: ldloc.s 5
-		IL_0098: stelem.ref
-		IL_0099: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_009e: pop
-		IL_009f: ldloc.s 4
-		IL_00a1: ldstr "on"
-		IL_00a6: ldstr "data"
-		IL_00ab: ldloc.1
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00b1: pop
-		IL_00b2: ldloc.s 4
-		IL_00b4: ldstr "emit"
-		IL_00b9: ldstr "data"
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c3: stloc.s 5
-		IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ca: ldc.i4.1
-		IL_00cb: newarr [System.Runtime]System.Object
-		IL_00d0: dup
-		IL_00d1: ldc.i4.0
-		IL_00d2: ldloc.s 5
-		IL_00d4: stelem.ref
-		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00da: pop
-		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e0: ldc.i4.1
-		IL_00e1: newarr [System.Runtime]System.Object
-		IL_00e6: dup
-		IL_00e7: ldc.i4.0
-		IL_00e8: ldloc.0
-		IL_00e9: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
-		IL_00ee: stelem.ref
-		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00f4: pop
-		IL_00f5: ldloc.s 4
-		IL_00f7: ldstr "listenerCount"
-		IL_00fc: ldstr "data"
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0106: stloc.s 5
-		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010d: ldc.i4.1
-		IL_010e: newarr [System.Runtime]System.Object
-		IL_0113: dup
-		IL_0114: ldc.i4.0
-		IL_0115: ldloc.s 5
-		IL_0117: stelem.ref
-		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_011d: pop
-		IL_011e: ldloc.s 4
-		IL_0120: ldstr "off"
-		IL_0125: ldstr "data"
-		IL_012a: ldloc.1
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0130: pop
-		IL_0131: ldloc.s 4
-		IL_0133: ldstr "emit"
-		IL_0138: ldstr "data"
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0142: stloc.s 5
-		IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0149: ldc.i4.1
-		IL_014a: newarr [System.Runtime]System.Object
-		IL_014f: dup
-		IL_0150: ldc.i4.0
-		IL_0151: ldloc.s 5
-		IL_0153: stelem.ref
-		IL_0154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0159: pop
-		IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015f: ldc.i4.1
-		IL_0160: newarr [System.Runtime]System.Object
-		IL_0165: dup
-		IL_0166: ldc.i4.0
-		IL_0167: ldloc.0
-		IL_0168: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
-		IL_016d: stelem.ref
-		IL_016e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0173: pop
-		IL_0174: ldloc.0
-		IL_0175: ldc.r8 0.0
-		IL_017e: box [System.Runtime]System.Double
-		IL_0183: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
-		IL_0188: ldnull
-		IL_0189: ldftn object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21::__js_call__(object[], object)
-		IL_018f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_0194: ldc.i4.1
-		IL_0195: newarr [System.Runtime]System.Object
-		IL_019a: dup
-		IL_019b: ldc.i4.0
-		IL_019c: ldloc.0
-		IL_019d: stelem.ref
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_01a3: stloc.s 5
-		IL_01a5: ldloc.s 4
-		IL_01a7: ldstr "once"
-		IL_01ac: ldstr "tick"
-		IL_01b1: ldloc.s 5
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01b8: pop
-		IL_01b9: ldloc.s 4
-		IL_01bb: ldstr "listenerCount"
-		IL_01c0: ldstr "tick"
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01ca: stloc.s 5
-		IL_01cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d1: ldc.i4.1
-		IL_01d2: newarr [System.Runtime]System.Object
-		IL_01d7: dup
-		IL_01d8: ldc.i4.0
-		IL_01d9: ldloc.s 5
-		IL_01db: stelem.ref
-		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_01e1: pop
-		IL_01e2: ldloc.s 4
-		IL_01e4: ldstr "emit"
-		IL_01e9: ldstr "tick"
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01f3: stloc.s 5
-		IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fa: ldc.i4.1
-		IL_01fb: newarr [System.Runtime]System.Object
-		IL_0200: dup
-		IL_0201: ldc.i4.0
-		IL_0202: ldloc.s 5
-		IL_0204: stelem.ref
-		IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_020a: pop
-		IL_020b: ldloc.s 4
-		IL_020d: ldstr "emit"
-		IL_0212: ldstr "tick"
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_021c: stloc.s 5
-		IL_021e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0223: ldc.i4.1
-		IL_0224: newarr [System.Runtime]System.Object
-		IL_0229: dup
-		IL_022a: ldc.i4.0
-		IL_022b: ldloc.s 5
-		IL_022d: stelem.ref
-		IL_022e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0233: pop
-		IL_0234: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0239: ldc.i4.1
-		IL_023a: newarr [System.Runtime]System.Object
-		IL_023f: dup
-		IL_0240: ldc.i4.0
-		IL_0241: ldloc.0
-		IL_0242: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
-		IL_0247: stelem.ref
-		IL_0248: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_024d: pop
-		IL_024e: ldnull
-		IL_024f: ldftn object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20::__js_call__(object)
-		IL_0255: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_025a: ldc.i4.1
-		IL_025b: newarr [System.Runtime]System.Object
-		IL_0260: dup
-		IL_0261: ldc.i4.0
-		IL_0262: ldloc.0
-		IL_0263: stelem.ref
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0269: stloc.s 5
-		IL_026b: ldloc.s 4
-		IL_026d: ldstr "on"
-		IL_0272: ldstr "alpha"
-		IL_0277: ldloc.s 5
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_027e: pop
-		IL_027f: ldnull
-		IL_0280: ldftn object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19::__js_call__(object)
-		IL_0286: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_028b: ldc.i4.1
-		IL_028c: newarr [System.Runtime]System.Object
-		IL_0291: dup
-		IL_0292: ldc.i4.0
-		IL_0293: ldloc.0
-		IL_0294: stelem.ref
-		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_029a: stloc.s 5
-		IL_029c: ldloc.s 4
-		IL_029e: ldstr "on"
-		IL_02a3: ldstr "beta"
-		IL_02a8: ldloc.s 5
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_02af: pop
-		IL_02b0: ldloc.s 4
-		IL_02b2: ldstr "removeAllListeners"
-		IL_02b7: ldstr "alpha"
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02c1: pop
-		IL_02c2: ldloc.s 4
-		IL_02c4: ldstr "listenerCount"
-		IL_02c9: ldstr "alpha"
-		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02d3: stloc.s 5
-		IL_02d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02da: ldc.i4.1
-		IL_02db: newarr [System.Runtime]System.Object
-		IL_02e0: dup
-		IL_02e1: ldc.i4.0
-		IL_02e2: ldloc.s 5
-		IL_02e4: stelem.ref
-		IL_02e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_02ea: pop
-		IL_02eb: ldloc.s 4
-		IL_02ed: ldstr "removeAllListeners"
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_02f7: pop
-		IL_02f8: ldloc.s 4
-		IL_02fa: ldstr "listenerCount"
-		IL_02ff: ldstr "beta"
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0309: stloc.s 5
-		IL_030b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0310: ldc.i4.1
-		IL_0311: newarr [System.Runtime]System.Object
-		IL_0316: dup
-		IL_0317: ldc.i4.0
-		IL_0318: ldloc.s 5
-		IL_031a: stelem.ref
-		IL_031b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0320: pop
-		IL_0321: ret
+		IL_0026: ldarg.1
+		IL_0027: ldstr "node:events"
+		IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0031: stloc.s 5
+		IL_0033: ldloc.s 5
+		IL_0035: stloc.2
+		IL_0036: ldloc.2
+		IL_0037: ldstr "EventEmitter"
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0041: stloc.3
+		IL_0042: ldloc.3
+		IL_0043: ldc.i4.0
+		IL_0044: newarr [System.Runtime]System.Object
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_004e: stloc.s 5
+		IL_0050: ldloc.s 5
+		IL_0052: stloc.s 4
+		IL_0054: ldloc.0
+		IL_0055: ldc.r8 0.0
+		IL_005e: box [System.Runtime]System.Double
+		IL_0063: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
+		IL_0068: ldloc.s 4
+		IL_006a: ldstr "emit"
+		IL_006f: ldstr "data"
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0079: stloc.s 5
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldc.i4.1
+		IL_0081: newarr [System.Runtime]System.Object
+		IL_0086: dup
+		IL_0087: ldc.i4.0
+		IL_0088: ldloc.s 5
+		IL_008a: stelem.ref
+		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0090: pop
+		IL_0091: ldloc.s 4
+		IL_0093: ldstr "on"
+		IL_0098: ldstr "data"
+		IL_009d: ldloc.1
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00a3: pop
+		IL_00a4: ldloc.s 4
+		IL_00a6: ldstr "emit"
+		IL_00ab: ldstr "data"
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b5: stloc.s 5
+		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bc: ldc.i4.1
+		IL_00bd: newarr [System.Runtime]System.Object
+		IL_00c2: dup
+		IL_00c3: ldc.i4.0
+		IL_00c4: ldloc.s 5
+		IL_00c6: stelem.ref
+		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00cc: pop
+		IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d2: ldc.i4.1
+		IL_00d3: newarr [System.Runtime]System.Object
+		IL_00d8: dup
+		IL_00d9: ldc.i4.0
+		IL_00da: ldloc.0
+		IL_00db: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
+		IL_00e0: stelem.ref
+		IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00e6: pop
+		IL_00e7: ldloc.s 4
+		IL_00e9: ldstr "listenerCount"
+		IL_00ee: ldstr "data"
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f8: stloc.s 5
+		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ff: ldc.i4.1
+		IL_0100: newarr [System.Runtime]System.Object
+		IL_0105: dup
+		IL_0106: ldc.i4.0
+		IL_0107: ldloc.s 5
+		IL_0109: stelem.ref
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_010f: pop
+		IL_0110: ldloc.s 4
+		IL_0112: ldstr "off"
+		IL_0117: ldstr "data"
+		IL_011c: ldloc.1
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0122: pop
+		IL_0123: ldloc.s 4
+		IL_0125: ldstr "emit"
+		IL_012a: ldstr "data"
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0134: stloc.s 5
+		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013b: ldc.i4.1
+		IL_013c: newarr [System.Runtime]System.Object
+		IL_0141: dup
+		IL_0142: ldc.i4.0
+		IL_0143: ldloc.s 5
+		IL_0145: stelem.ref
+		IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_014b: pop
+		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0151: ldc.i4.1
+		IL_0152: newarr [System.Runtime]System.Object
+		IL_0157: dup
+		IL_0158: ldc.i4.0
+		IL_0159: ldloc.0
+		IL_015a: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
+		IL_015f: stelem.ref
+		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0165: pop
+		IL_0166: ldloc.0
+		IL_0167: ldc.r8 0.0
+		IL_0170: box [System.Runtime]System.Double
+		IL_0175: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
+		IL_017a: ldnull
+		IL_017b: ldftn object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21::__js_call__(object[], object)
+		IL_0181: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0186: ldc.i4.1
+		IL_0187: newarr [System.Runtime]System.Object
+		IL_018c: dup
+		IL_018d: ldc.i4.0
+		IL_018e: ldloc.0
+		IL_018f: stelem.ref
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0195: stloc.s 5
+		IL_0197: ldloc.s 4
+		IL_0199: ldstr "once"
+		IL_019e: ldstr "tick"
+		IL_01a3: ldloc.s 5
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01aa: pop
+		IL_01ab: ldloc.s 4
+		IL_01ad: ldstr "listenerCount"
+		IL_01b2: ldstr "tick"
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01bc: stloc.s 5
+		IL_01be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c3: ldc.i4.1
+		IL_01c4: newarr [System.Runtime]System.Object
+		IL_01c9: dup
+		IL_01ca: ldc.i4.0
+		IL_01cb: ldloc.s 5
+		IL_01cd: stelem.ref
+		IL_01ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_01d3: pop
+		IL_01d4: ldloc.s 4
+		IL_01d6: ldstr "emit"
+		IL_01db: ldstr "tick"
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01e5: stloc.s 5
+		IL_01e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ec: ldc.i4.1
+		IL_01ed: newarr [System.Runtime]System.Object
+		IL_01f2: dup
+		IL_01f3: ldc.i4.0
+		IL_01f4: ldloc.s 5
+		IL_01f6: stelem.ref
+		IL_01f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_01fc: pop
+		IL_01fd: ldloc.s 4
+		IL_01ff: ldstr "emit"
+		IL_0204: ldstr "tick"
+		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_020e: stloc.s 5
+		IL_0210: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0215: ldc.i4.1
+		IL_0216: newarr [System.Runtime]System.Object
+		IL_021b: dup
+		IL_021c: ldc.i4.0
+		IL_021d: ldloc.s 5
+		IL_021f: stelem.ref
+		IL_0220: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0225: pop
+		IL_0226: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_022b: ldc.i4.1
+		IL_022c: newarr [System.Runtime]System.Object
+		IL_0231: dup
+		IL_0232: ldc.i4.0
+		IL_0233: ldloc.0
+		IL_0234: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
+		IL_0239: stelem.ref
+		IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_023f: pop
+		IL_0240: ldnull
+		IL_0241: ldftn object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20::__js_call__(object)
+		IL_0247: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_024c: ldc.i4.1
+		IL_024d: newarr [System.Runtime]System.Object
+		IL_0252: dup
+		IL_0253: ldc.i4.0
+		IL_0254: ldloc.0
+		IL_0255: stelem.ref
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_025b: stloc.s 5
+		IL_025d: ldloc.s 4
+		IL_025f: ldstr "on"
+		IL_0264: ldstr "alpha"
+		IL_0269: ldloc.s 5
+		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0270: pop
+		IL_0271: ldnull
+		IL_0272: ldftn object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19::__js_call__(object)
+		IL_0278: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_027d: ldc.i4.1
+		IL_027e: newarr [System.Runtime]System.Object
+		IL_0283: dup
+		IL_0284: ldc.i4.0
+		IL_0285: ldloc.0
+		IL_0286: stelem.ref
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_028c: stloc.s 5
+		IL_028e: ldloc.s 4
+		IL_0290: ldstr "on"
+		IL_0295: ldstr "beta"
+		IL_029a: ldloc.s 5
+		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_02a1: pop
+		IL_02a2: ldloc.s 4
+		IL_02a4: ldstr "removeAllListeners"
+		IL_02a9: ldstr "alpha"
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02b3: pop
+		IL_02b4: ldloc.s 4
+		IL_02b6: ldstr "listenerCount"
+		IL_02bb: ldstr "alpha"
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02c5: stloc.s 5
+		IL_02c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02cc: ldc.i4.1
+		IL_02cd: newarr [System.Runtime]System.Object
+		IL_02d2: dup
+		IL_02d3: ldc.i4.0
+		IL_02d4: ldloc.s 5
+		IL_02d6: stelem.ref
+		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_02dc: pop
+		IL_02dd: ldloc.s 4
+		IL_02df: ldstr "removeAllListeners"
+		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_02e9: pop
+		IL_02ea: ldloc.s 4
+		IL_02ec: ldstr "listenerCount"
+		IL_02f1: ldstr "beta"
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02fb: stloc.s 5
+		IL_02fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0302: ldc.i4.1
+		IL_0303: newarr [System.Runtime]System.Object
+		IL_0308: dup
+		IL_0309: ldc.i4.0
+		IL_030a: ldloc.s 5
+		IL_030c: stelem.ref
+		IL_030d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0312: pop
+		IL_0313: ret
 	} // end of method Events_EventEmitter_On_Off_Once::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_On_Off_Once
@@ -555,7 +546,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2423
+		// Method begins at RVA 0x2413
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_SetMaxListeners_Validation.verified.txt
+++ b/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_SetMaxListeners_Validation.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e5
+				// Method begins at RVA 0x22d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ee
+				// Method begins at RVA 0x22e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f7
+				// Method begins at RVA 0x22eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2300
+				// Method begins at RVA 0x22f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x22d0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 611 (0x263)
+		// Code size: 597 (0x255)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope,
@@ -138,252 +138,243 @@
 			[10] class [System.Runtime]System.Exception,
 			[11] object,
 			[12] object,
-			[13] object[],
-			[14] object
+			[13] object
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 13
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "node:events"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 13
 		IL_0013: ldloc.s 13
-		IL_0015: ldstr "node:events"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 14
-		IL_0021: ldloc.s 14
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "EventEmitter"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldloc.2
-		IL_0031: ldc.i4.0
-		IL_0032: newarr [System.Runtime]System.Object
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_003c: stloc.s 14
-		IL_003e: ldloc.s 14
-		IL_0040: stloc.3
-		IL_0041: ldloc.3
-		IL_0042: ldstr "getMaxListeners"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_004c: stloc.s 14
-		IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0053: ldc.i4.1
-		IL_0054: newarr [System.Runtime]System.Object
-		IL_0059: dup
-		IL_005a: ldc.i4.0
-		IL_005b: ldloc.s 14
-		IL_005d: stelem.ref
-		IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0063: pop
-		IL_0064: ldloc.3
-		IL_0065: ldstr "setMaxListeners"
-		IL_006a: ldc.r8 20
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_007d: pop
-		IL_007e: ldloc.3
-		IL_007f: ldstr "getMaxListeners"
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0089: stloc.s 14
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0090: ldc.i4.1
-		IL_0091: newarr [System.Runtime]System.Object
-		IL_0096: dup
-		IL_0097: ldc.i4.0
-		IL_0098: ldloc.s 14
-		IL_009a: stelem.ref
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00a0: pop
-		IL_00a1: ldloc.3
-		IL_00a2: ldstr "setMaxListeners"
-		IL_00a7: ldc.r8 0.0
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ba: pop
-		IL_00bb: ldloc.3
-		IL_00bc: ldstr "getMaxListeners"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00c6: stloc.s 14
-		IL_00c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cd: ldc.i4.1
-		IL_00ce: newarr [System.Runtime]System.Object
-		IL_00d3: dup
-		IL_00d4: ldc.i4.0
-		IL_00d5: ldloc.s 14
-		IL_00d7: stelem.ref
-		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00dd: pop
-		IL_00de: ldloc.2
-		IL_00df: ldc.i4.0
-		IL_00e0: newarr [System.Runtime]System.Object
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_00ea: stloc.s 14
-		IL_00ec: ldloc.s 14
-		IL_00ee: stloc.s 4
-		IL_00f0: ldloc.s 4
-		IL_00f2: ldstr "setMaxListeners"
-		IL_00f7: ldstr "15"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0101: pop
-		IL_0102: ldloc.s 4
-		IL_0104: ldstr "getMaxListeners"
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_010e: stloc.s 14
-		IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0115: ldc.i4.1
-		IL_0116: newarr [System.Runtime]System.Object
-		IL_011b: dup
-		IL_011c: ldc.i4.0
-		IL_011d: ldloc.s 14
-		IL_011f: stelem.ref
-		IL_0120: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0125: pop
-		IL_0126: ldloc.2
-		IL_0127: ldc.i4.0
-		IL_0128: newarr [System.Runtime]System.Object
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0132: stloc.s 14
-		IL_0134: ldloc.s 14
-		IL_0136: stloc.s 5
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "EventEmitter"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldc.i4.0
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_002e: stloc.s 13
+		IL_0030: ldloc.s 13
+		IL_0032: stloc.3
+		IL_0033: ldloc.3
+		IL_0034: ldstr "getMaxListeners"
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_003e: stloc.s 13
+		IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0045: ldc.i4.1
+		IL_0046: newarr [System.Runtime]System.Object
+		IL_004b: dup
+		IL_004c: ldc.i4.0
+		IL_004d: ldloc.s 13
+		IL_004f: stelem.ref
+		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0055: pop
+		IL_0056: ldloc.3
+		IL_0057: ldstr "setMaxListeners"
+		IL_005c: ldc.r8 20
+		IL_0065: box [System.Runtime]System.Double
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_006f: pop
+		IL_0070: ldloc.3
+		IL_0071: ldstr "getMaxListeners"
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_007b: stloc.s 13
+		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0082: ldc.i4.1
+		IL_0083: newarr [System.Runtime]System.Object
+		IL_0088: dup
+		IL_0089: ldc.i4.0
+		IL_008a: ldloc.s 13
+		IL_008c: stelem.ref
+		IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0092: pop
+		IL_0093: ldloc.3
+		IL_0094: ldstr "setMaxListeners"
+		IL_0099: ldc.r8 0.0
+		IL_00a2: box [System.Runtime]System.Double
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ac: pop
+		IL_00ad: ldloc.3
+		IL_00ae: ldstr "getMaxListeners"
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00b8: stloc.s 13
+		IL_00ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bf: ldc.i4.1
+		IL_00c0: newarr [System.Runtime]System.Object
+		IL_00c5: dup
+		IL_00c6: ldc.i4.0
+		IL_00c7: ldloc.s 13
+		IL_00c9: stelem.ref
+		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00cf: pop
+		IL_00d0: ldloc.2
+		IL_00d1: ldc.i4.0
+		IL_00d2: newarr [System.Runtime]System.Object
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_00dc: stloc.s 13
+		IL_00de: ldloc.s 13
+		IL_00e0: stloc.s 4
+		IL_00e2: ldloc.s 4
+		IL_00e4: ldstr "setMaxListeners"
+		IL_00e9: ldstr "15"
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f3: pop
+		IL_00f4: ldloc.s 4
+		IL_00f6: ldstr "getMaxListeners"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0100: stloc.s 13
+		IL_0102: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0107: ldc.i4.1
+		IL_0108: newarr [System.Runtime]System.Object
+		IL_010d: dup
+		IL_010e: ldc.i4.0
+		IL_010f: ldloc.s 13
+		IL_0111: stelem.ref
+		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0117: pop
+		IL_0118: ldloc.2
+		IL_0119: ldc.i4.0
+		IL_011a: newarr [System.Runtime]System.Object
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0124: stloc.s 13
+		IL_0126: ldloc.s 13
+		IL_0128: stloc.s 5
 		.try
 		{
-			IL_0138: ldloc.s 5
-			IL_013a: ldstr "setMaxListeners"
-			IL_013f: ldc.r8 5
-			IL_0148: neg
-			IL_0149: box [System.Runtime]System.Double
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0153: pop
-			IL_0154: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0159: ldc.i4.1
-			IL_015a: newarr [System.Runtime]System.Object
-			IL_015f: dup
-			IL_0160: ldc.i4.0
-			IL_0161: ldstr "SHOULD NOT REACH HERE"
-			IL_0166: stelem.ref
-			IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_016c: pop
-			IL_016d: leave IL_01c9
+			IL_012a: ldloc.s 5
+			IL_012c: ldstr "setMaxListeners"
+			IL_0131: ldc.r8 5
+			IL_013a: neg
+			IL_013b: box [System.Runtime]System.Double
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0145: pop
+			IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_014b: ldc.i4.1
+			IL_014c: newarr [System.Runtime]System.Object
+			IL_0151: dup
+			IL_0152: ldc.i4.0
+			IL_0153: ldstr "SHOULD NOT REACH HERE"
+			IL_0158: stelem.ref
+			IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_015e: pop
+			IL_015f: leave IL_01bb
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0172: stloc.s 6
-			IL_0174: ldloc.s 6
-			IL_0176: dup
-			IL_0177: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_017c: dup
-			IL_017d: brtrue IL_0193
+			IL_0164: stloc.s 6
+			IL_0166: ldloc.s 6
+			IL_0168: dup
+			IL_0169: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_016e: dup
+			IL_016f: brtrue IL_0185
 
+			IL_0174: pop
+			IL_0175: dup
+			IL_0176: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_017b: dup
+			IL_017c: brtrue IL_0192
+
+			IL_0181: pop
 			IL_0182: pop
-			IL_0183: dup
-			IL_0184: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0189: dup
-			IL_018a: brtrue IL_01a0
+			IL_0183: rethrow
 
-			IL_018f: pop
-			IL_0190: pop
-			IL_0191: rethrow
+			IL_0185: pop
+			IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_018b: stloc.s 7
+			IL_018d: br IL_0195
 
-			IL_0193: pop
-			IL_0194: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0199: stloc.s 7
-			IL_019b: br IL_01a3
+			IL_0192: pop
+			IL_0193: stloc.s 7
 
-			IL_01a0: pop
-			IL_01a1: stloc.s 7
-
-			IL_01a3: ldloc.s 7
-			IL_01a5: stloc.s 14
-			IL_01a7: ldloc.s 14
-			IL_01a9: stloc.s 8
-			IL_01ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01b0: ldc.i4.1
-			IL_01b1: newarr [System.Runtime]System.Object
-			IL_01b6: dup
-			IL_01b7: ldc.i4.0
-			IL_01b8: ldstr "Caught error for negative value"
-			IL_01bd: stelem.ref
-			IL_01be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_01c3: pop
-			IL_01c4: leave IL_01c9
+			IL_0195: ldloc.s 7
+			IL_0197: stloc.s 13
+			IL_0199: ldloc.s 13
+			IL_019b: stloc.s 8
+			IL_019d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01a2: ldc.i4.1
+			IL_01a3: newarr [System.Runtime]System.Object
+			IL_01a8: dup
+			IL_01a9: ldc.i4.0
+			IL_01aa: ldstr "Caught error for negative value"
+			IL_01af: stelem.ref
+			IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_01b5: pop
+			IL_01b6: leave IL_01bb
 		} // end handler
 
-		IL_01c9: ldloc.2
-		IL_01ca: ldc.i4.0
-		IL_01cb: newarr [System.Runtime]System.Object
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_01d5: stloc.s 14
-		IL_01d7: ldloc.s 14
-		IL_01d9: stloc.s 9
+		IL_01bb: ldloc.2
+		IL_01bc: ldc.i4.0
+		IL_01bd: newarr [System.Runtime]System.Object
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_01c7: stloc.s 13
+		IL_01c9: ldloc.s 13
+		IL_01cb: stloc.s 9
 		.try
 		{
-			IL_01db: ldloc.s 9
-			IL_01dd: ldstr "setMaxListeners"
-			IL_01e2: ldstr "invalid"
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ec: pop
-			IL_01ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01f2: ldc.i4.1
-			IL_01f3: newarr [System.Runtime]System.Object
-			IL_01f8: dup
-			IL_01f9: ldc.i4.0
-			IL_01fa: ldstr "SHOULD NOT REACH HERE"
-			IL_01ff: stelem.ref
-			IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_0205: pop
-			IL_0206: leave IL_0262
+			IL_01cd: ldloc.s 9
+			IL_01cf: ldstr "setMaxListeners"
+			IL_01d4: ldstr "invalid"
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01de: pop
+			IL_01df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01e4: ldc.i4.1
+			IL_01e5: newarr [System.Runtime]System.Object
+			IL_01ea: dup
+			IL_01eb: ldc.i4.0
+			IL_01ec: ldstr "SHOULD NOT REACH HERE"
+			IL_01f1: stelem.ref
+			IL_01f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_01f7: pop
+			IL_01f8: leave IL_0254
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_020b: stloc.s 10
-			IL_020d: ldloc.s 10
-			IL_020f: dup
-			IL_0210: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0215: dup
-			IL_0216: brtrue IL_022c
+			IL_01fd: stloc.s 10
+			IL_01ff: ldloc.s 10
+			IL_0201: dup
+			IL_0202: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0207: dup
+			IL_0208: brtrue IL_021e
 
+			IL_020d: pop
+			IL_020e: dup
+			IL_020f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0214: dup
+			IL_0215: brtrue IL_022b
+
+			IL_021a: pop
 			IL_021b: pop
-			IL_021c: dup
-			IL_021d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0222: dup
-			IL_0223: brtrue IL_0239
+			IL_021c: rethrow
 
-			IL_0228: pop
-			IL_0229: pop
-			IL_022a: rethrow
+			IL_021e: pop
+			IL_021f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0224: stloc.s 11
+			IL_0226: br IL_022e
 
-			IL_022c: pop
-			IL_022d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0232: stloc.s 11
-			IL_0234: br IL_023c
+			IL_022b: pop
+			IL_022c: stloc.s 11
 
-			IL_0239: pop
-			IL_023a: stloc.s 11
-
-			IL_023c: ldloc.s 11
-			IL_023e: stloc.s 14
-			IL_0240: ldloc.s 14
-			IL_0242: stloc.s 12
-			IL_0244: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0249: ldc.i4.1
-			IL_024a: newarr [System.Runtime]System.Object
-			IL_024f: dup
-			IL_0250: ldc.i4.0
-			IL_0251: ldstr "Caught error for NaN"
-			IL_0256: stelem.ref
-			IL_0257: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_025c: pop
-			IL_025d: leave IL_0262
+			IL_022e: ldloc.s 11
+			IL_0230: stloc.s 13
+			IL_0232: ldloc.s 13
+			IL_0234: stloc.s 12
+			IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_023b: ldc.i4.1
+			IL_023c: newarr [System.Runtime]System.Object
+			IL_0241: dup
+			IL_0242: ldc.i4.0
+			IL_0243: ldstr "Caught error for NaN"
+			IL_0248: stelem.ref
+			IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_024e: pop
+			IL_024f: leave IL_0254
 		} // end handler
 
-		IL_0262: ret
+		IL_0254: ret
 	} // end of method Events_EventEmitter_SetMaxListeners_Validation::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_SetMaxListeners_Validation
@@ -395,7 +386,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2309
+		// Method begins at RVA 0x22fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ce
+				// Method begins at RVA 0x21a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2166
+			// Method begins at RVA 0x213c
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d7
+				// Method begins at RVA 0x21ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -97,7 +97,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2184
+			// Method begins at RVA 0x2158
 			// Header size: 12
 			// Code size: 53 (0x35)
 			.maxstack 8
@@ -134,7 +134,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c5
+			// Method begins at RVA 0x2199
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -160,7 +160,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 266 (0x10a)
+		// Code size: 224 (0xe0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_MissingDir_Rejects/Scope,
@@ -168,114 +168,89 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object[],
+			[5] object,
 			[6] object,
-			[7] object,
-			[8] object
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.FSPromises_Readdir_MissingDir_Rejects/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 5
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "fs/promises"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 5
 		IL_0013: ldloc.s 5
-		IL_0015: ldstr "fs/promises"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 6
-		IL_0021: ldloc.s 6
-		IL_0023: stloc.1
-		IL_0024: ldc.i4.1
-		IL_0025: newarr [System.Runtime]System.Object
-		IL_002a: dup
-		IL_002b: ldc.i4.0
-		IL_002c: ldnull
-		IL_002d: stelem.ref
-		IL_002e: stloc.s 5
-		IL_0030: ldarg.1
-		IL_0031: ldloc.s 5
-		IL_0033: ldstr "path"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003d: stloc.s 6
-		IL_003f: ldloc.s 6
-		IL_0041: stloc.2
-		IL_0042: ldc.i4.1
-		IL_0043: newarr [System.Runtime]System.Object
-		IL_0048: dup
-		IL_0049: ldc.i4.0
-		IL_004a: ldnull
-		IL_004b: stelem.ref
-		IL_004c: stloc.s 5
-		IL_004e: ldarg.1
-		IL_004f: ldloc.s 5
-		IL_0051: ldstr "os"
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_005b: stloc.s 6
-		IL_005d: ldloc.s 6
-		IL_005f: stloc.3
-		IL_0060: ldloc.3
-		IL_0061: ldstr "tmpdir"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_006b: stloc.s 6
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-		IL_0072: stloc.s 7
-		IL_0074: ldstr "js2il-readdir-missing-does-not-exist-"
-		IL_0079: ldloc.s 7
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0080: stloc.s 8
-		IL_0082: ldloc.2
-		IL_0083: ldstr "join"
-		IL_0088: ldloc.s 6
-		IL_008a: ldloc.s 8
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0091: stloc.s 6
-		IL_0093: ldloc.s 6
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.1
-		IL_0098: ldstr "readdir"
-		IL_009d: ldloc.s 4
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a4: stloc.s 6
-		IL_00a6: ldnull
-		IL_00a7: ldftn object Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L9C11::__js_call__(object)
-		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00b2: ldc.i4.1
-		IL_00b3: newarr [System.Runtime]System.Object
-		IL_00b8: dup
-		IL_00b9: ldc.i4.0
-		IL_00ba: ldloc.0
-		IL_00bb: stelem.ref
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00c6: stloc.s 7
-		IL_00c8: ldloc.s 6
-		IL_00ca: ldstr "then"
-		IL_00cf: ldloc.s 7
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d6: stloc.s 7
-		IL_00d8: ldnull
-		IL_00d9: ldftn object Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L12C12::__js_call__(object, object)
-		IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00e4: ldc.i4.1
-		IL_00e5: newarr [System.Runtime]System.Object
-		IL_00ea: dup
-		IL_00eb: ldc.i4.0
-		IL_00ec: ldloc.0
-		IL_00ed: stelem.ref
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00f8: stloc.s 6
-		IL_00fa: ldloc.s 7
-		IL_00fc: ldstr "catch"
-		IL_0101: ldloc.s 6
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0108: pop
-		IL_0109: ret
+		IL_0015: stloc.1
+		IL_0016: ldarg.1
+		IL_0017: ldstr "path"
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0021: stloc.s 5
+		IL_0023: ldloc.s 5
+		IL_0025: stloc.2
+		IL_0026: ldarg.1
+		IL_0027: ldstr "os"
+		IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0031: stloc.s 5
+		IL_0033: ldloc.s 5
+		IL_0035: stloc.3
+		IL_0036: ldloc.3
+		IL_0037: ldstr "tmpdir"
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0041: stloc.s 5
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+		IL_0048: stloc.s 6
+		IL_004a: ldstr "js2il-readdir-missing-does-not-exist-"
+		IL_004f: ldloc.s 6
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0056: stloc.s 7
+		IL_0058: ldloc.2
+		IL_0059: ldstr "join"
+		IL_005e: ldloc.s 5
+		IL_0060: ldloc.s 7
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0067: stloc.s 5
+		IL_0069: ldloc.s 5
+		IL_006b: stloc.s 4
+		IL_006d: ldloc.1
+		IL_006e: ldstr "readdir"
+		IL_0073: ldloc.s 4
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007a: stloc.s 5
+		IL_007c: ldnull
+		IL_007d: ldftn object Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L9C11::__js_call__(object)
+		IL_0083: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0088: ldc.i4.1
+		IL_0089: newarr [System.Runtime]System.Object
+		IL_008e: dup
+		IL_008f: ldc.i4.0
+		IL_0090: ldloc.0
+		IL_0091: stelem.ref
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_009c: stloc.s 6
+		IL_009e: ldloc.s 5
+		IL_00a0: ldstr "then"
+		IL_00a5: ldloc.s 6
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ac: stloc.s 6
+		IL_00ae: ldnull
+		IL_00af: ldftn object Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L12C12::__js_call__(object, object)
+		IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00ba: ldc.i4.1
+		IL_00bb: newarr [System.Runtime]System.Object
+		IL_00c0: dup
+		IL_00c1: ldc.i4.0
+		IL_00c2: ldloc.0
+		IL_00c3: stelem.ref
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00ce: stloc.s 5
+		IL_00d0: ldloc.s 6
+		IL_00d2: ldstr "catch"
+		IL_00d7: ldloc.s 5
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00de: pop
+		IL_00df: ret
 	} // end of method FSPromises_Readdir_MissingDir_Rejects::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_MissingDir_Rejects
@@ -287,7 +262,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e0
+		// Method begins at RVA 0x21b4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23b9
+					// Method begins at RVA 0x2381
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,7 +49,7 @@
 					object e
 				) cil managed 
 			{
-				// Method begins at RVA 0x2384
+				// Method begins at RVA 0x234c
 				// Header size: 12
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -86,7 +86,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b0
+				// Method begins at RVA 0x2378
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,7 +107,7 @@
 				object entries
 			) cil managed 
 		{
-			// Method begins at RVA 0x22a8
+			// Method begins at RVA 0x2270
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -170,7 +170,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c2
+				// Method begins at RVA 0x238a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +191,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2304
+			// Method begins at RVA 0x22cc
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -220,7 +220,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23cb
+				// Method begins at RVA 0x2393
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -241,7 +241,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2324
+			// Method begins at RVA 0x22ec
 			// Header size: 12
 			// Code size: 84 (0x54)
 			.maxstack 8
@@ -302,7 +302,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23a7
+			// Method begins at RVA 0x236f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -328,228 +328,195 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 586 (0x24a)
+		// Code size: 530 (0x212)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_Names/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object[],
+			[4] object,
 			[5] object,
-			[6] object,
-			[7] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.FSPromises_Readdir_Names/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 4
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "fs/promises"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 4
 		IL_0013: ldloc.s 4
-		IL_0015: ldstr "fs/promises"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 5
-		IL_0021: ldloc.s 5
-		IL_0023: stloc.1
-		IL_0024: ldc.i4.1
-		IL_0025: newarr [System.Runtime]System.Object
-		IL_002a: dup
-		IL_002b: ldc.i4.0
-		IL_002c: ldnull
-		IL_002d: stelem.ref
-		IL_002e: stloc.s 4
-		IL_0030: ldarg.1
-		IL_0031: ldloc.s 4
-		IL_0033: ldstr "fs"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003d: stloc.s 5
-		IL_003f: ldloc.0
-		IL_0040: ldloc.s 5
-		IL_0042: stfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_0047: ldc.i4.1
-		IL_0048: newarr [System.Runtime]System.Object
-		IL_004d: dup
-		IL_004e: ldc.i4.0
-		IL_004f: ldnull
-		IL_0050: stelem.ref
-		IL_0051: stloc.s 4
-		IL_0053: ldarg.1
-		IL_0054: ldloc.s 4
-		IL_0056: ldstr "path"
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0060: stloc.s 5
-		IL_0062: ldloc.s 5
-		IL_0064: stloc.2
-		IL_0065: ldc.i4.1
-		IL_0066: newarr [System.Runtime]System.Object
-		IL_006b: dup
-		IL_006c: ldc.i4.0
-		IL_006d: ldnull
-		IL_006e: stelem.ref
-		IL_006f: stloc.s 4
-		IL_0071: ldarg.1
-		IL_0072: ldloc.s 4
-		IL_0074: ldstr "os"
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_007e: stloc.s 5
-		IL_0080: ldloc.s 5
-		IL_0082: stloc.3
-		IL_0083: ldloc.3
-		IL_0084: ldstr "tmpdir"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_008e: stloc.s 5
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-		IL_0095: stloc.s 6
-		IL_0097: ldstr "js2il-readdir-names-"
-		IL_009c: ldloc.s 6
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00a3: stloc.s 7
-		IL_00a5: ldloc.2
-		IL_00a6: ldstr "join"
-		IL_00ab: ldloc.s 5
-		IL_00ad: ldloc.s 7
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00b4: stloc.s 5
-		IL_00b6: ldloc.0
-		IL_00b7: ldloc.s 5
-		IL_00b9: stfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_00be: ldloc.0
-		IL_00bf: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_00c4: stloc.s 5
-		IL_00c6: ldloc.0
-		IL_00c7: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_00cc: stloc.s 6
-		IL_00ce: ldloc.s 5
-		IL_00d0: ldstr "mkdirSync"
-		IL_00d5: ldloc.s 6
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00dc: dup
-		IL_00dd: ldstr "recursive"
-		IL_00e2: ldc.i4.1
-		IL_00e3: box [System.Runtime]System.Boolean
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_00ed: pop
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00f3: pop
-		IL_00f4: ldloc.0
-		IL_00f5: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_00fa: stloc.s 6
-		IL_00fc: ldloc.0
-		IL_00fd: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_0102: stloc.s 5
-		IL_0104: ldloc.2
-		IL_0105: ldstr "join"
-		IL_010a: ldloc.s 5
-		IL_010c: ldstr "alpha.txt"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0116: stloc.s 5
-		IL_0118: ldloc.s 6
-		IL_011a: ldstr "writeFileSync"
-		IL_011f: ldloc.s 5
-		IL_0121: ldstr ""
-		IL_0126: ldstr "utf8"
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0130: pop
-		IL_0131: ldloc.0
-		IL_0132: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_0137: stloc.s 5
-		IL_0139: ldloc.0
-		IL_013a: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_013f: stloc.s 6
-		IL_0141: ldloc.2
-		IL_0142: ldstr "join"
-		IL_0147: ldloc.s 6
-		IL_0149: ldstr "beta.txt"
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0153: stloc.s 6
-		IL_0155: ldloc.s 5
-		IL_0157: ldstr "writeFileSync"
-		IL_015c: ldloc.s 6
-		IL_015e: ldstr ""
-		IL_0163: ldstr "utf8"
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_016d: pop
-		IL_016e: ldloc.0
-		IL_016f: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_0174: stloc.s 6
-		IL_0176: ldloc.0
-		IL_0177: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_017c: stloc.s 5
-		IL_017e: ldloc.2
-		IL_017f: ldstr "join"
-		IL_0184: ldloc.s 5
-		IL_0186: ldstr "subdir"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0190: stloc.s 5
-		IL_0192: ldloc.s 6
-		IL_0194: ldstr "mkdirSync"
-		IL_0199: ldloc.s 5
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01a0: pop
-		IL_01a1: ldloc.1
-		IL_01a2: ldstr "readdir"
-		IL_01a7: ldloc.0
-		IL_01a8: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01b2: stloc.s 5
-		IL_01b4: ldnull
-		IL_01b5: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11::__js_call__(object, object)
-		IL_01bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01c0: ldc.i4.1
-		IL_01c1: newarr [System.Runtime]System.Object
-		IL_01c6: dup
-		IL_01c7: ldc.i4.0
-		IL_01c8: ldloc.0
-		IL_01c9: stelem.ref
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01d4: stloc.s 6
-		IL_01d6: ldloc.s 5
-		IL_01d8: ldstr "then"
-		IL_01dd: ldloc.s 6
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01e4: stloc.s 6
-		IL_01e6: ldnull
-		IL_01e7: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12::__js_call__(object, object)
-		IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01f2: ldc.i4.1
-		IL_01f3: newarr [System.Runtime]System.Object
-		IL_01f8: dup
-		IL_01f9: ldc.i4.0
-		IL_01fa: ldloc.0
-		IL_01fb: stelem.ref
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0206: stloc.s 5
-		IL_0208: ldloc.s 6
-		IL_020a: ldstr "catch"
-		IL_020f: ldloc.s 5
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0216: stloc.s 5
-		IL_0218: ldnull
-		IL_0219: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14::__js_call__(object[], object)
-		IL_021f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_0224: ldc.i4.1
-		IL_0225: newarr [System.Runtime]System.Object
-		IL_022a: dup
-		IL_022b: ldc.i4.0
-		IL_022c: ldloc.0
-		IL_022d: stelem.ref
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0238: stloc.s 6
-		IL_023a: ldloc.s 5
-		IL_023c: ldstr "finally"
-		IL_0241: ldloc.s 6
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0248: pop
-		IL_0249: ret
+		IL_0015: stloc.1
+		IL_0016: ldarg.1
+		IL_0017: ldstr "fs"
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0021: stloc.s 4
+		IL_0023: ldloc.0
+		IL_0024: ldloc.s 4
+		IL_0026: stfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_002b: ldarg.1
+		IL_002c: ldstr "path"
+		IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0036: stloc.s 4
+		IL_0038: ldloc.s 4
+		IL_003a: stloc.2
+		IL_003b: ldarg.1
+		IL_003c: ldstr "os"
+		IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0046: stloc.s 4
+		IL_0048: ldloc.s 4
+		IL_004a: stloc.3
+		IL_004b: ldloc.3
+		IL_004c: ldstr "tmpdir"
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0056: stloc.s 4
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+		IL_005d: stloc.s 5
+		IL_005f: ldstr "js2il-readdir-names-"
+		IL_0064: ldloc.s 5
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_006b: stloc.s 6
+		IL_006d: ldloc.2
+		IL_006e: ldstr "join"
+		IL_0073: ldloc.s 4
+		IL_0075: ldloc.s 6
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_007c: stloc.s 4
+		IL_007e: ldloc.0
+		IL_007f: ldloc.s 4
+		IL_0081: stfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0086: ldloc.0
+		IL_0087: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_008c: stloc.s 4
+		IL_008e: ldloc.0
+		IL_008f: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0094: stloc.s 5
+		IL_0096: ldloc.s 4
+		IL_0098: ldstr "mkdirSync"
+		IL_009d: ldloc.s 5
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a4: dup
+		IL_00a5: ldstr "recursive"
+		IL_00aa: ldc.i4.1
+		IL_00ab: box [System.Runtime]System.Boolean
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_00b5: pop
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00bb: pop
+		IL_00bc: ldloc.0
+		IL_00bd: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_00c2: stloc.s 5
+		IL_00c4: ldloc.0
+		IL_00c5: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_00ca: stloc.s 4
+		IL_00cc: ldloc.2
+		IL_00cd: ldstr "join"
+		IL_00d2: ldloc.s 4
+		IL_00d4: ldstr "alpha.txt"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00de: stloc.s 4
+		IL_00e0: ldloc.s 5
+		IL_00e2: ldstr "writeFileSync"
+		IL_00e7: ldloc.s 4
+		IL_00e9: ldstr ""
+		IL_00ee: ldstr "utf8"
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00f8: pop
+		IL_00f9: ldloc.0
+		IL_00fa: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_00ff: stloc.s 4
+		IL_0101: ldloc.0
+		IL_0102: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0107: stloc.s 5
+		IL_0109: ldloc.2
+		IL_010a: ldstr "join"
+		IL_010f: ldloc.s 5
+		IL_0111: ldstr "beta.txt"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_011b: stloc.s 5
+		IL_011d: ldloc.s 4
+		IL_011f: ldstr "writeFileSync"
+		IL_0124: ldloc.s 5
+		IL_0126: ldstr ""
+		IL_012b: ldstr "utf8"
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0135: pop
+		IL_0136: ldloc.0
+		IL_0137: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_013c: stloc.s 5
+		IL_013e: ldloc.0
+		IL_013f: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0144: stloc.s 4
+		IL_0146: ldloc.2
+		IL_0147: ldstr "join"
+		IL_014c: ldloc.s 4
+		IL_014e: ldstr "subdir"
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0158: stloc.s 4
+		IL_015a: ldloc.s 5
+		IL_015c: ldstr "mkdirSync"
+		IL_0161: ldloc.s 4
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0168: pop
+		IL_0169: ldloc.1
+		IL_016a: ldstr "readdir"
+		IL_016f: ldloc.0
+		IL_0170: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_017a: stloc.s 4
+		IL_017c: ldnull
+		IL_017d: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11::__js_call__(object, object)
+		IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0188: ldc.i4.1
+		IL_0189: newarr [System.Runtime]System.Object
+		IL_018e: dup
+		IL_018f: ldc.i4.0
+		IL_0190: ldloc.0
+		IL_0191: stelem.ref
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_019c: stloc.s 5
+		IL_019e: ldloc.s 4
+		IL_01a0: ldstr "then"
+		IL_01a5: ldloc.s 5
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01ac: stloc.s 5
+		IL_01ae: ldnull
+		IL_01af: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12::__js_call__(object, object)
+		IL_01b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01ba: ldc.i4.1
+		IL_01bb: newarr [System.Runtime]System.Object
+		IL_01c0: dup
+		IL_01c1: ldc.i4.0
+		IL_01c2: ldloc.0
+		IL_01c3: stelem.ref
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01ce: stloc.s 4
+		IL_01d0: ldloc.s 5
+		IL_01d2: ldstr "catch"
+		IL_01d7: ldloc.s 4
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01de: stloc.s 4
+		IL_01e0: ldnull
+		IL_01e1: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14::__js_call__(object[], object)
+		IL_01e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_01ec: ldc.i4.1
+		IL_01ed: newarr [System.Runtime]System.Object
+		IL_01f2: dup
+		IL_01f3: ldc.i4.0
+		IL_01f4: ldloc.0
+		IL_01f5: stelem.ref
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0200: stloc.s 5
+		IL_0202: ldloc.s 4
+		IL_0204: ldstr "finally"
+		IL_0209: ldloc.s 5
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0210: pop
+		IL_0211: ret
 	} // end of method FSPromises_Readdir_Names::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_Names
@@ -561,7 +528,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23d4
+		// Method begins at RVA 0x239c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x240d
+					// Method begins at RVA 0x23d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,7 +49,7 @@
 					object e
 				) cil managed 
 			{
-				// Method begins at RVA 0x2380
+				// Method begins at RVA 0x2348
 				// Header size: 12
 				// Code size: 74 (0x4a)
 				.maxstack 8
@@ -110,7 +110,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2416
+					// Method begins at RVA 0x23de
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -131,7 +131,7 @@
 					object l
 				) cil managed 
 			{
-				// Method begins at RVA 0x23d8
+				// Method begins at RVA 0x23a0
 				// Header size: 12
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -168,7 +168,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2404
+				// Method begins at RVA 0x23cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -189,7 +189,7 @@
 				object entries
 			) cil managed 
 		{
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x224c
 			// Header size: 12
 			// Code size: 114 (0x72)
 			.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241f
+				// Method begins at RVA 0x23e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +286,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2302
+			// Method begins at RVA 0x22ca
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -315,7 +315,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2428
+				// Method begins at RVA 0x23f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2320
+			// Method begins at RVA 0x22e8
 			// Header size: 12
 			// Code size: 84 (0x54)
 			.maxstack 8
@@ -397,7 +397,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23fb
+			// Method begins at RVA 0x23c3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -423,218 +423,185 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 552 (0x228)
+		// Code size: 496 (0x1f0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_WithFileTypes/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object[],
+			[4] object,
 			[5] object,
-			[6] object,
-			[7] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.FSPromises_Readdir_WithFileTypes/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 4
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "fs/promises"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 4
 		IL_0013: ldloc.s 4
-		IL_0015: ldstr "fs/promises"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 5
-		IL_0021: ldloc.s 5
-		IL_0023: stloc.1
-		IL_0024: ldc.i4.1
-		IL_0025: newarr [System.Runtime]System.Object
-		IL_002a: dup
-		IL_002b: ldc.i4.0
-		IL_002c: ldnull
-		IL_002d: stelem.ref
-		IL_002e: stloc.s 4
-		IL_0030: ldarg.1
-		IL_0031: ldloc.s 4
-		IL_0033: ldstr "fs"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003d: stloc.s 5
-		IL_003f: ldloc.0
-		IL_0040: ldloc.s 5
-		IL_0042: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_0047: ldc.i4.1
-		IL_0048: newarr [System.Runtime]System.Object
-		IL_004d: dup
-		IL_004e: ldc.i4.0
-		IL_004f: ldnull
-		IL_0050: stelem.ref
-		IL_0051: stloc.s 4
-		IL_0053: ldarg.1
-		IL_0054: ldloc.s 4
-		IL_0056: ldstr "path"
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0060: stloc.s 5
-		IL_0062: ldloc.s 5
-		IL_0064: stloc.2
-		IL_0065: ldc.i4.1
-		IL_0066: newarr [System.Runtime]System.Object
-		IL_006b: dup
-		IL_006c: ldc.i4.0
-		IL_006d: ldnull
-		IL_006e: stelem.ref
-		IL_006f: stloc.s 4
-		IL_0071: ldarg.1
-		IL_0072: ldloc.s 4
-		IL_0074: ldstr "os"
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_007e: stloc.s 5
-		IL_0080: ldloc.s 5
-		IL_0082: stloc.3
-		IL_0083: ldloc.3
-		IL_0084: ldstr "tmpdir"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_008e: stloc.s 5
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-		IL_0095: stloc.s 6
-		IL_0097: ldstr "js2il-readdir-types-"
-		IL_009c: ldloc.s 6
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00a3: stloc.s 7
-		IL_00a5: ldloc.2
-		IL_00a6: ldstr "join"
-		IL_00ab: ldloc.s 5
-		IL_00ad: ldloc.s 7
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00b4: stloc.s 5
-		IL_00b6: ldloc.0
-		IL_00b7: ldloc.s 5
-		IL_00b9: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_00be: ldloc.0
-		IL_00bf: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_00c4: stloc.s 5
-		IL_00c6: ldloc.0
-		IL_00c7: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_00cc: stloc.s 6
-		IL_00ce: ldloc.s 5
-		IL_00d0: ldstr "mkdirSync"
-		IL_00d5: ldloc.s 6
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00dc: dup
-		IL_00dd: ldstr "recursive"
-		IL_00e2: ldc.i4.1
-		IL_00e3: box [System.Runtime]System.Boolean
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_00ed: pop
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00f3: pop
-		IL_00f4: ldloc.0
-		IL_00f5: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_00fa: stloc.s 6
-		IL_00fc: ldloc.0
-		IL_00fd: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_0102: stloc.s 5
-		IL_0104: ldloc.2
-		IL_0105: ldstr "join"
-		IL_010a: ldloc.s 5
-		IL_010c: ldstr "alpha.txt"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0116: stloc.s 5
-		IL_0118: ldloc.s 6
-		IL_011a: ldstr "writeFileSync"
-		IL_011f: ldloc.s 5
-		IL_0121: ldstr ""
-		IL_0126: ldstr "utf8"
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0130: pop
-		IL_0131: ldloc.0
-		IL_0132: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_0137: stloc.s 5
-		IL_0139: ldloc.0
-		IL_013a: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_013f: stloc.s 6
-		IL_0141: ldloc.2
-		IL_0142: ldstr "join"
-		IL_0147: ldloc.s 6
-		IL_0149: ldstr "subdir"
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0153: stloc.s 6
-		IL_0155: ldloc.s 5
-		IL_0157: ldstr "mkdirSync"
-		IL_015c: ldloc.s 6
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0163: pop
-		IL_0164: ldloc.0
-		IL_0165: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_016a: stloc.s 6
-		IL_016c: ldloc.1
-		IL_016d: ldstr "readdir"
-		IL_0172: ldloc.s 6
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0179: dup
-		IL_017a: ldstr "withFileTypes"
-		IL_017f: ldc.i4.1
-		IL_0180: box [System.Runtime]System.Boolean
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_018a: pop
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0190: stloc.s 6
-		IL_0192: ldnull
-		IL_0193: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11::__js_call__(object, object)
-		IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_019e: ldc.i4.1
-		IL_019f: newarr [System.Runtime]System.Object
-		IL_01a4: dup
-		IL_01a5: ldc.i4.0
-		IL_01a6: ldloc.0
-		IL_01a7: stelem.ref
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01b2: stloc.s 5
-		IL_01b4: ldloc.s 6
-		IL_01b6: ldstr "then"
-		IL_01bb: ldloc.s 5
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01c2: stloc.s 5
-		IL_01c4: ldnull
-		IL_01c5: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12::__js_call__(object, object)
-		IL_01cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01d0: ldc.i4.1
-		IL_01d1: newarr [System.Runtime]System.Object
-		IL_01d6: dup
-		IL_01d7: ldc.i4.0
-		IL_01d8: ldloc.0
-		IL_01d9: stelem.ref
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01e4: stloc.s 6
-		IL_01e6: ldloc.s 5
-		IL_01e8: ldstr "catch"
-		IL_01ed: ldloc.s 6
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01f4: stloc.s 6
-		IL_01f6: ldnull
-		IL_01f7: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14::__js_call__(object[], object)
-		IL_01fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_0202: ldc.i4.1
-		IL_0203: newarr [System.Runtime]System.Object
-		IL_0208: dup
-		IL_0209: ldc.i4.0
-		IL_020a: ldloc.0
-		IL_020b: stelem.ref
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0216: stloc.s 5
-		IL_0218: ldloc.s 6
-		IL_021a: ldstr "finally"
-		IL_021f: ldloc.s 5
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0226: pop
-		IL_0227: ret
+		IL_0015: stloc.1
+		IL_0016: ldarg.1
+		IL_0017: ldstr "fs"
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0021: stloc.s 4
+		IL_0023: ldloc.0
+		IL_0024: ldloc.s 4
+		IL_0026: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_002b: ldarg.1
+		IL_002c: ldstr "path"
+		IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0036: stloc.s 4
+		IL_0038: ldloc.s 4
+		IL_003a: stloc.2
+		IL_003b: ldarg.1
+		IL_003c: ldstr "os"
+		IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0046: stloc.s 4
+		IL_0048: ldloc.s 4
+		IL_004a: stloc.3
+		IL_004b: ldloc.3
+		IL_004c: ldstr "tmpdir"
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0056: stloc.s 4
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+		IL_005d: stloc.s 5
+		IL_005f: ldstr "js2il-readdir-types-"
+		IL_0064: ldloc.s 5
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_006b: stloc.s 6
+		IL_006d: ldloc.2
+		IL_006e: ldstr "join"
+		IL_0073: ldloc.s 4
+		IL_0075: ldloc.s 6
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_007c: stloc.s 4
+		IL_007e: ldloc.0
+		IL_007f: ldloc.s 4
+		IL_0081: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_0086: ldloc.0
+		IL_0087: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_008c: stloc.s 4
+		IL_008e: ldloc.0
+		IL_008f: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_0094: stloc.s 5
+		IL_0096: ldloc.s 4
+		IL_0098: ldstr "mkdirSync"
+		IL_009d: ldloc.s 5
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a4: dup
+		IL_00a5: ldstr "recursive"
+		IL_00aa: ldc.i4.1
+		IL_00ab: box [System.Runtime]System.Boolean
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_00b5: pop
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00bb: pop
+		IL_00bc: ldloc.0
+		IL_00bd: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_00c2: stloc.s 5
+		IL_00c4: ldloc.0
+		IL_00c5: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_00ca: stloc.s 4
+		IL_00cc: ldloc.2
+		IL_00cd: ldstr "join"
+		IL_00d2: ldloc.s 4
+		IL_00d4: ldstr "alpha.txt"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00de: stloc.s 4
+		IL_00e0: ldloc.s 5
+		IL_00e2: ldstr "writeFileSync"
+		IL_00e7: ldloc.s 4
+		IL_00e9: ldstr ""
+		IL_00ee: ldstr "utf8"
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00f8: pop
+		IL_00f9: ldloc.0
+		IL_00fa: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_00ff: stloc.s 4
+		IL_0101: ldloc.0
+		IL_0102: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_0107: stloc.s 5
+		IL_0109: ldloc.2
+		IL_010a: ldstr "join"
+		IL_010f: ldloc.s 5
+		IL_0111: ldstr "subdir"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_011b: stloc.s 5
+		IL_011d: ldloc.s 4
+		IL_011f: ldstr "mkdirSync"
+		IL_0124: ldloc.s 5
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_012b: pop
+		IL_012c: ldloc.0
+		IL_012d: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_0132: stloc.s 5
+		IL_0134: ldloc.1
+		IL_0135: ldstr "readdir"
+		IL_013a: ldloc.s 5
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0141: dup
+		IL_0142: ldstr "withFileTypes"
+		IL_0147: ldc.i4.1
+		IL_0148: box [System.Runtime]System.Boolean
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0152: pop
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0158: stloc.s 5
+		IL_015a: ldnull
+		IL_015b: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11::__js_call__(object, object)
+		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0166: ldc.i4.1
+		IL_0167: newarr [System.Runtime]System.Object
+		IL_016c: dup
+		IL_016d: ldc.i4.0
+		IL_016e: ldloc.0
+		IL_016f: stelem.ref
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_017a: stloc.s 4
+		IL_017c: ldloc.s 5
+		IL_017e: ldstr "then"
+		IL_0183: ldloc.s 4
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_018a: stloc.s 4
+		IL_018c: ldnull
+		IL_018d: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12::__js_call__(object, object)
+		IL_0193: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0198: ldc.i4.1
+		IL_0199: newarr [System.Runtime]System.Object
+		IL_019e: dup
+		IL_019f: ldc.i4.0
+		IL_01a0: ldloc.0
+		IL_01a1: stelem.ref
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01ac: stloc.s 5
+		IL_01ae: ldloc.s 4
+		IL_01b0: ldstr "catch"
+		IL_01b5: ldloc.s 5
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01bc: stloc.s 5
+		IL_01be: ldnull
+		IL_01bf: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14::__js_call__(object[], object)
+		IL_01c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_01ca: ldc.i4.1
+		IL_01cb: newarr [System.Runtime]System.Object
+		IL_01d0: dup
+		IL_01d1: ldc.i4.0
+		IL_01d2: ldloc.0
+		IL_01d3: stelem.ref
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01de: stloc.s 4
+		IL_01e0: ldloc.s 5
+		IL_01e2: ldstr "finally"
+		IL_01e7: ldloc.s 4
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01ee: pop
+		IL_01ef: ret
 	} // end of method FSPromises_Readdir_WithFileTypes::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_WithFileTypes
@@ -646,7 +613,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2431
+		// Method begins at RVA 0x23f9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_ReadWrite_Buffer.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_ReadWrite_Buffer.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21fc
+			// Method begins at RVA 0x21e0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 416 (0x1a0)
+		// Code size: 388 (0x184)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_ReadWrite_Buffer/Scope,
@@ -50,161 +50,144 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 			[5] object,
 			[6] object,
-			[7] object[],
-			[8] object,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[10] bool,
-			[11] object
+			[7] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[9] bool,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.FS_ReadWrite_Buffer/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 7
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "fs"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 7
 		IL_0013: ldloc.s 7
-		IL_0015: ldstr "fs"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 8
-		IL_0021: ldloc.s 8
-		IL_0023: stloc.1
-		IL_0024: ldc.i4.1
-		IL_0025: newarr [System.Runtime]System.Object
-		IL_002a: dup
-		IL_002b: ldc.i4.0
-		IL_002c: ldnull
-		IL_002d: stelem.ref
-		IL_002e: stloc.s 7
-		IL_0030: ldarg.1
-		IL_0031: ldloc.s 7
-		IL_0033: ldstr "path"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003d: stloc.s 8
-		IL_003f: ldloc.s 8
-		IL_0041: stloc.2
-		IL_0042: ldloc.2
-		IL_0043: ldstr "join"
-		IL_0048: ldarg.s __dirname
-		IL_004a: ldstr "tmp-buffer.bin"
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0054: stloc.s 8
-		IL_0056: ldloc.s 8
-		IL_0058: stloc.3
-		IL_0059: ldc.i4.3
-		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_005f: dup
-		IL_0060: ldc.r8 97
-		IL_0069: box [System.Runtime]System.Double
-		IL_006e: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0073: dup
-		IL_0074: ldc.r8 98
-		IL_007d: box [System.Runtime]System.Double
-		IL_0082: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0087: dup
-		IL_0088: ldc.r8 99
-		IL_0091: box [System.Runtime]System.Double
-		IL_0096: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_00a0: stloc.s 9
-		IL_00a2: ldloc.s 9
-		IL_00a4: stloc.s 4
-		IL_00a6: ldloc.1
-		IL_00a7: ldstr "writeFileSync"
-		IL_00ac: ldloc.3
-		IL_00ad: ldloc.s 4
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00b4: pop
-		IL_00b5: ldloc.1
-		IL_00b6: ldstr "readFileSync"
-		IL_00bb: ldloc.3
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c1: stloc.s 8
-		IL_00c3: ldloc.s 8
-		IL_00c5: stloc.s 5
-		IL_00c7: ldloc.s 5
-		IL_00c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_00ce: stloc.s 10
-		IL_00d0: ldloc.s 10
-		IL_00d2: box [System.Runtime]System.Boolean
-		IL_00d7: stloc.s 11
-		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.s 11
-		IL_00e8: stelem.ref
-		IL_00e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00ee: pop
-		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f4: ldc.i4.1
-		IL_00f5: newarr [System.Runtime]System.Object
-		IL_00fa: dup
-		IL_00fb: ldc.i4.0
-		IL_00fc: ldloc.s 5
-		IL_00fe: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_0103: box [System.Runtime]System.Double
-		IL_0108: stelem.ref
-		IL_0109: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_010e: pop
-		IL_010f: ldloc.s 5
-		IL_0111: ldstr "toString"
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_011b: stloc.s 8
-		IL_011d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0122: ldc.i4.1
-		IL_0123: newarr [System.Runtime]System.Object
-		IL_0128: dup
-		IL_0129: ldc.i4.0
-		IL_012a: ldloc.s 8
-		IL_012c: stelem.ref
-		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0132: pop
-		IL_0133: ldloc.1
-		IL_0134: ldstr "readFileSync"
-		IL_0139: ldloc.3
-		IL_013a: ldstr "utf8"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0144: stloc.s 8
-		IL_0146: ldloc.s 8
-		IL_0148: stloc.s 6
-		IL_014a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014f: ldc.i4.1
-		IL_0150: newarr [System.Runtime]System.Object
-		IL_0155: dup
-		IL_0156: ldc.i4.0
-		IL_0157: ldloc.s 6
-		IL_0159: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_015e: stelem.ref
-		IL_015f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0164: pop
-		IL_0165: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016a: ldc.i4.1
-		IL_016b: newarr [System.Runtime]System.Object
-		IL_0170: dup
-		IL_0171: ldc.i4.0
-		IL_0172: ldloc.s 6
-		IL_0174: stelem.ref
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_017a: pop
-		IL_017b: ldloc.1
-		IL_017c: ldstr "rmSync"
-		IL_0181: ldloc.3
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0187: dup
-		IL_0188: ldstr "force"
-		IL_018d: ldc.i4.1
-		IL_018e: box [System.Runtime]System.Boolean
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0198: pop
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_019e: pop
-		IL_019f: ret
+		IL_0015: stloc.1
+		IL_0016: ldarg.1
+		IL_0017: ldstr "path"
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0021: stloc.s 7
+		IL_0023: ldloc.s 7
+		IL_0025: stloc.2
+		IL_0026: ldloc.2
+		IL_0027: ldstr "join"
+		IL_002c: ldarg.s __dirname
+		IL_002e: ldstr "tmp-buffer.bin"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0038: stloc.s 7
+		IL_003a: ldloc.s 7
+		IL_003c: stloc.3
+		IL_003d: ldc.i4.3
+		IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0043: dup
+		IL_0044: ldc.r8 97
+		IL_004d: box [System.Runtime]System.Double
+		IL_0052: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0057: dup
+		IL_0058: ldc.r8 98
+		IL_0061: box [System.Runtime]System.Double
+		IL_0066: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_006b: dup
+		IL_006c: ldc.r8 99
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0084: stloc.s 8
+		IL_0086: ldloc.s 8
+		IL_0088: stloc.s 4
+		IL_008a: ldloc.1
+		IL_008b: ldstr "writeFileSync"
+		IL_0090: ldloc.3
+		IL_0091: ldloc.s 4
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0098: pop
+		IL_0099: ldloc.1
+		IL_009a: ldstr "readFileSync"
+		IL_009f: ldloc.3
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00a5: stloc.s 7
+		IL_00a7: ldloc.s 7
+		IL_00a9: stloc.s 5
+		IL_00ab: ldloc.s 5
+		IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_00b2: stloc.s 9
+		IL_00b4: ldloc.s 9
+		IL_00b6: box [System.Runtime]System.Boolean
+		IL_00bb: stloc.s 10
+		IL_00bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c2: ldc.i4.1
+		IL_00c3: newarr [System.Runtime]System.Object
+		IL_00c8: dup
+		IL_00c9: ldc.i4.0
+		IL_00ca: ldloc.s 10
+		IL_00cc: stelem.ref
+		IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00d2: pop
+		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d8: ldc.i4.1
+		IL_00d9: newarr [System.Runtime]System.Object
+		IL_00de: dup
+		IL_00df: ldc.i4.0
+		IL_00e0: ldloc.s 5
+		IL_00e2: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_00e7: box [System.Runtime]System.Double
+		IL_00ec: stelem.ref
+		IL_00ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f2: pop
+		IL_00f3: ldloc.s 5
+		IL_00f5: ldstr "toString"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00ff: stloc.s 7
+		IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0106: ldc.i4.1
+		IL_0107: newarr [System.Runtime]System.Object
+		IL_010c: dup
+		IL_010d: ldc.i4.0
+		IL_010e: ldloc.s 7
+		IL_0110: stelem.ref
+		IL_0111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0116: pop
+		IL_0117: ldloc.1
+		IL_0118: ldstr "readFileSync"
+		IL_011d: ldloc.3
+		IL_011e: ldstr "utf8"
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0128: stloc.s 7
+		IL_012a: ldloc.s 7
+		IL_012c: stloc.s 6
+		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0133: ldc.i4.1
+		IL_0134: newarr [System.Runtime]System.Object
+		IL_0139: dup
+		IL_013a: ldc.i4.0
+		IL_013b: ldloc.s 6
+		IL_013d: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0142: stelem.ref
+		IL_0143: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0148: pop
+		IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014e: ldc.i4.1
+		IL_014f: newarr [System.Runtime]System.Object
+		IL_0154: dup
+		IL_0155: ldc.i4.0
+		IL_0156: ldloc.s 6
+		IL_0158: stelem.ref
+		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_015e: pop
+		IL_015f: ldloc.1
+		IL_0160: ldstr "rmSync"
+		IL_0165: ldloc.3
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_016b: dup
+		IL_016c: ldstr "force"
+		IL_0171: ldc.i4.1
+		IL_0172: box [System.Runtime]System.Boolean
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_017c: pop
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0182: pop
+		IL_0183: ret
 	} // end of method FS_ReadWrite_Buffer::__js_module_init__
 
 } // end of class Modules.FS_ReadWrite_Buffer
@@ -216,7 +199,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2205
+		// Method begins at RVA 0x21e9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_ReadWrite_Utf8.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_ReadWrite_Utf8.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fa
+			// Method begins at RVA 0x20de
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 158 (0x9e)
+		// Code size: 130 (0x82)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_ReadWrite_Utf8/Scope,
@@ -48,73 +48,56 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object[],
-			[6] object
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.FS_ReadWrite_Utf8/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 5
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "fs"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 5
 		IL_0013: ldloc.s 5
-		IL_0015: ldstr "fs"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 6
-		IL_0021: ldloc.s 6
-		IL_0023: stloc.1
-		IL_0024: ldc.i4.1
-		IL_0025: newarr [System.Runtime]System.Object
-		IL_002a: dup
-		IL_002b: ldc.i4.0
-		IL_002c: ldnull
-		IL_002d: stelem.ref
-		IL_002e: stloc.s 5
-		IL_0030: ldarg.1
-		IL_0031: ldloc.s 5
-		IL_0033: ldstr "path"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003d: stloc.s 6
-		IL_003f: ldloc.s 6
-		IL_0041: stloc.2
-		IL_0042: ldloc.2
-		IL_0043: ldstr "join"
-		IL_0048: ldarg.s __dirname
-		IL_004a: ldstr "tmp.txt"
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0054: stloc.s 6
-		IL_0056: ldloc.s 6
-		IL_0058: stloc.3
-		IL_0059: ldloc.1
-		IL_005a: ldstr "writeFileSync"
-		IL_005f: ldloc.3
-		IL_0060: ldstr "hello"
-		IL_0065: ldstr "utf8"
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_006f: pop
-		IL_0070: ldloc.1
-		IL_0071: ldstr "readFileSync"
-		IL_0076: ldloc.3
-		IL_0077: ldstr "utf8"
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0081: stloc.s 6
-		IL_0083: ldloc.s 6
-		IL_0085: stloc.s 4
-		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008c: ldc.i4.1
-		IL_008d: newarr [System.Runtime]System.Object
-		IL_0092: dup
-		IL_0093: ldc.i4.0
-		IL_0094: ldloc.s 4
-		IL_0096: stelem.ref
-		IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_009c: pop
-		IL_009d: ret
+		IL_0015: stloc.1
+		IL_0016: ldarg.1
+		IL_0017: ldstr "path"
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0021: stloc.s 5
+		IL_0023: ldloc.s 5
+		IL_0025: stloc.2
+		IL_0026: ldloc.2
+		IL_0027: ldstr "join"
+		IL_002c: ldarg.s __dirname
+		IL_002e: ldstr "tmp.txt"
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0038: stloc.s 5
+		IL_003a: ldloc.s 5
+		IL_003c: stloc.3
+		IL_003d: ldloc.1
+		IL_003e: ldstr "writeFileSync"
+		IL_0043: ldloc.3
+		IL_0044: ldstr "hello"
+		IL_0049: ldstr "utf8"
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0053: pop
+		IL_0054: ldloc.1
+		IL_0055: ldstr "readFileSync"
+		IL_005a: ldloc.3
+		IL_005b: ldstr "utf8"
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0065: stloc.s 5
+		IL_0067: ldloc.s 5
+		IL_0069: stloc.s 4
+		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0070: ldc.i4.1
+		IL_0071: newarr [System.Runtime]System.Object
+		IL_0076: dup
+		IL_0077: ldc.i4.0
+		IL_0078: ldloc.s 4
+		IL_007a: stelem.ref
+		IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0080: pop
+		IL_0081: ret
 	} // end of method FS_ReadWrite_Utf8::__js_module_init__
 
 } // end of class Modules.FS_ReadWrite_Utf8
@@ -126,7 +109,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2103
+		// Method begins at RVA 0x20e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Delimiter.verified.txt
+++ b/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Delimiter.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20e6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,80 +40,71 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 152 (0x98)
+		// Code size: 138 (0x8a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Delimiter/Scope,
 			[1] object,
-			[2] object[],
-			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[5] bool,
+			[2] object,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[4] bool,
+			[5] object,
 			[6] object,
 			[7] object,
-			[8] object,
-			[9] object
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Delimiter/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "path"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "path"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0025: stloc.s 4
-		IL_0027: ldloc.1
-		IL_0028: ldstr "delimiter"
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0032: ldstr ":"
-		IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_003c: stloc.s 5
-		IL_003e: ldloc.s 5
-		IL_0040: box [System.Runtime]System.Boolean
-		IL_0045: stloc.s 6
-		IL_0047: ldloc.s 6
-		IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_004e: stloc.s 5
-		IL_0050: ldloc.s 5
-		IL_0052: brtrue IL_0080
+		IL_0013: stloc.1
+		IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0019: stloc.3
+		IL_001a: ldloc.1
+		IL_001b: ldstr "delimiter"
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0025: ldstr ":"
+		IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_002f: stloc.s 4
+		IL_0031: ldloc.s 4
+		IL_0033: box [System.Runtime]System.Boolean
+		IL_0038: stloc.s 5
+		IL_003a: ldloc.s 5
+		IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0041: stloc.s 4
+		IL_0043: ldloc.s 4
+		IL_0045: brtrue IL_0073
 
-		IL_0057: ldloc.1
-		IL_0058: ldstr "delimiter"
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0062: ldstr ";"
-		IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_006c: stloc.s 5
-		IL_006e: ldloc.s 5
-		IL_0070: box [System.Runtime]System.Boolean
-		IL_0075: stloc.s 7
-		IL_0077: ldloc.s 7
-		IL_0079: stloc.s 9
-		IL_007b: br IL_0084
+		IL_004a: ldloc.1
+		IL_004b: ldstr "delimiter"
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0055: ldstr ";"
+		IL_005a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_005f: stloc.s 4
+		IL_0061: ldloc.s 4
+		IL_0063: box [System.Runtime]System.Boolean
+		IL_0068: stloc.s 6
+		IL_006a: ldloc.s 6
+		IL_006c: stloc.s 8
+		IL_006e: br IL_0077
 
-		IL_0080: ldloc.s 6
-		IL_0082: stloc.s 9
+		IL_0073: ldloc.s 5
+		IL_0075: stloc.s 8
 
-		IL_0084: ldloc.s 4
-		IL_0086: ldc.i4.1
-		IL_0087: newarr [System.Runtime]System.Object
-		IL_008c: dup
-		IL_008d: ldc.i4.0
-		IL_008e: ldloc.s 9
-		IL_0090: stelem.ref
-		IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0096: pop
-		IL_0097: ret
+		IL_0077: ldloc.3
+		IL_0078: ldc.i4.1
+		IL_0079: newarr [System.Runtime]System.Object
+		IL_007e: dup
+		IL_007f: ldc.i4.0
+		IL_0080: ldloc.s 8
+		IL_0082: stelem.ref
+		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0088: pop
+		IL_0089: ret
 	} // end of method Require_Path_Delimiter::__js_module_init__
 
 } // end of class Modules.Require_Path_Delimiter
@@ -125,7 +116,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20fd
+		// Method begins at RVA 0x20ef
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Extname_And_IsAbsolute.verified.txt
+++ b/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Extname_And_IsAbsolute.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2187
+			// Method begins at RVA 0x217b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,130 +40,121 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 299 (0x12b)
+		// Code size: 287 (0x11f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Extname_And_IsAbsolute/Scope,
 			[1] object,
-			[2] object[],
-			[3] object
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Extname_And_IsAbsolute/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "path"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "path"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: ldloc.1
-		IL_0021: ldstr "extname"
-		IL_0026: ldstr "index.html"
-		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0030: stloc.3
-		IL_0031: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0036: ldc.i4.1
-		IL_0037: newarr [System.Runtime]System.Object
-		IL_003c: dup
-		IL_003d: ldc.i4.0
-		IL_003e: ldloc.3
-		IL_003f: stelem.ref
-		IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0045: pop
-		IL_0046: ldloc.1
-		IL_0047: ldstr "extname"
-		IL_004c: ldstr "index."
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0056: stloc.3
-		IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005c: ldc.i4.1
-		IL_005d: newarr [System.Runtime]System.Object
-		IL_0062: dup
-		IL_0063: ldc.i4.0
-		IL_0064: ldloc.3
-		IL_0065: stelem.ref
-		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_006b: pop
-		IL_006c: ldloc.1
-		IL_006d: ldstr "extname"
-		IL_0072: ldstr "index"
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_007c: stloc.3
-		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0082: ldc.i4.1
-		IL_0083: newarr [System.Runtime]System.Object
-		IL_0088: dup
-		IL_0089: ldc.i4.0
-		IL_008a: ldloc.3
-		IL_008b: stelem.ref
-		IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0091: pop
-		IL_0092: ldloc.1
-		IL_0093: ldstr "extname"
-		IL_0098: ldstr ".bashrc"
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a2: stloc.3
-		IL_00a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a8: ldc.i4.1
-		IL_00a9: newarr [System.Runtime]System.Object
-		IL_00ae: dup
-		IL_00af: ldc.i4.0
-		IL_00b0: ldloc.3
-		IL_00b1: stelem.ref
-		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00b7: pop
-		IL_00b8: ldloc.1
-		IL_00b9: ldstr "extname"
-		IL_00be: ldstr "/a/b/archive.tar.gz"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c8: stloc.3
-		IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ce: ldc.i4.1
-		IL_00cf: newarr [System.Runtime]System.Object
-		IL_00d4: dup
-		IL_00d5: ldc.i4.0
-		IL_00d6: ldloc.3
-		IL_00d7: stelem.ref
-		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00dd: pop
-		IL_00de: ldloc.1
-		IL_00df: ldstr "isAbsolute"
-		IL_00e4: ldstr "/foo/bar"
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ee: stloc.3
-		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f4: ldc.i4.1
-		IL_00f5: newarr [System.Runtime]System.Object
-		IL_00fa: dup
-		IL_00fb: ldc.i4.0
-		IL_00fc: ldloc.3
-		IL_00fd: stelem.ref
-		IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0103: pop
-		IL_0104: ldloc.1
-		IL_0105: ldstr "isAbsolute"
-		IL_010a: ldstr "foo/bar"
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0114: stloc.3
-		IL_0115: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011a: ldc.i4.1
-		IL_011b: newarr [System.Runtime]System.Object
-		IL_0120: dup
-		IL_0121: ldc.i4.0
-		IL_0122: ldloc.3
-		IL_0123: stelem.ref
-		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0129: pop
-		IL_012a: ret
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: ldstr "extname"
+		IL_001a: ldstr "index.html"
+		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0024: stloc.2
+		IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.2
+		IL_0033: stelem.ref
+		IL_0034: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0039: pop
+		IL_003a: ldloc.1
+		IL_003b: ldstr "extname"
+		IL_0040: ldstr "index."
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_004a: stloc.2
+		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0050: ldc.i4.1
+		IL_0051: newarr [System.Runtime]System.Object
+		IL_0056: dup
+		IL_0057: ldc.i4.0
+		IL_0058: ldloc.2
+		IL_0059: stelem.ref
+		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_005f: pop
+		IL_0060: ldloc.1
+		IL_0061: ldstr "extname"
+		IL_0066: ldstr "index"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0070: stloc.2
+		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.2
+		IL_007f: stelem.ref
+		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0085: pop
+		IL_0086: ldloc.1
+		IL_0087: ldstr "extname"
+		IL_008c: ldstr ".bashrc"
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0096: stloc.2
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldc.i4.1
+		IL_009d: newarr [System.Runtime]System.Object
+		IL_00a2: dup
+		IL_00a3: ldc.i4.0
+		IL_00a4: ldloc.2
+		IL_00a5: stelem.ref
+		IL_00a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00ab: pop
+		IL_00ac: ldloc.1
+		IL_00ad: ldstr "extname"
+		IL_00b2: ldstr "/a/b/archive.tar.gz"
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00bc: stloc.2
+		IL_00bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c2: ldc.i4.1
+		IL_00c3: newarr [System.Runtime]System.Object
+		IL_00c8: dup
+		IL_00c9: ldc.i4.0
+		IL_00ca: ldloc.2
+		IL_00cb: stelem.ref
+		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00d1: pop
+		IL_00d2: ldloc.1
+		IL_00d3: ldstr "isAbsolute"
+		IL_00d8: ldstr "/foo/bar"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e2: stloc.2
+		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e8: ldc.i4.1
+		IL_00e9: newarr [System.Runtime]System.Object
+		IL_00ee: dup
+		IL_00ef: ldc.i4.0
+		IL_00f0: ldloc.2
+		IL_00f1: stelem.ref
+		IL_00f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f7: pop
+		IL_00f8: ldloc.1
+		IL_00f9: ldstr "isAbsolute"
+		IL_00fe: ldstr "foo/bar"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0108: stloc.2
+		IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010e: ldc.i4.1
+		IL_010f: newarr [System.Runtime]System.Object
+		IL_0114: dup
+		IL_0115: ldc.i4.0
+		IL_0116: ldloc.2
+		IL_0117: stelem.ref
+		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_011d: pop
+		IL_011e: ret
 	} // end of method Require_Path_Extname_And_IsAbsolute::__js_module_init__
 
 } // end of class Modules.Require_Path_Extname_And_IsAbsolute
@@ -175,7 +166,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2190
+		// Method begins at RVA 0x2184
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20c6
+			// Method begins at RVA 0x20b4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,56 +40,47 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 106 (0x6a)
+		// Code size: 88 (0x58)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Join_Basic/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Join_Basic/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.3
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "path"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.3
 		IL_0012: ldloc.3
-		IL_0013: ldstr "path"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.s 4
-		IL_001f: ldloc.s 4
-		IL_0021: stloc.1
-		IL_0022: ldloc.1
-		IL_0023: ldstr "join"
-		IL_0028: ldstr "a"
-		IL_002d: ldstr "b"
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0037: stloc.s 4
-		IL_0039: ldloc.s 4
-		IL_003b: ldstr "replace"
-		IL_0040: ldstr "\\"
-		IL_0045: ldstr "/"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_004f: stloc.s 4
-		IL_0051: ldloc.s 4
-		IL_0053: stloc.2
-		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0059: ldc.i4.1
-		IL_005a: newarr [System.Runtime]System.Object
-		IL_005f: dup
-		IL_0060: ldc.i4.0
-		IL_0061: ldloc.2
-		IL_0062: stelem.ref
-		IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0068: pop
-		IL_0069: ret
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: ldstr "join"
+		IL_001a: ldstr "a"
+		IL_001f: ldstr "b"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0029: stloc.3
+		IL_002a: ldloc.3
+		IL_002b: ldstr "replace"
+		IL_0030: ldstr "\\"
+		IL_0035: ldstr "/"
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_003f: stloc.3
+		IL_0040: ldloc.3
+		IL_0041: stloc.2
+		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0047: ldc.i4.1
+		IL_0048: newarr [System.Runtime]System.Object
+		IL_004d: dup
+		IL_004e: ldc.i4.0
+		IL_004f: ldloc.2
+		IL_0050: stelem.ref
+		IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0056: pop
+		IL_0057: ret
 	} // end of method Require_Path_Join_Basic::__js_module_init__
 
 } // end of class Modules.Require_Path_Join_Basic
@@ -101,7 +92,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20cf
+		// Method begins at RVA 0x20bd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2129
+				// Method begins at RVA 0x2119
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x20f8
+			// Method begins at RVA 0x20e8
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -81,7 +81,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2110
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -107,14 +107,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 154 (0x9a)
+		// Code size: 140 (0x8c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Join_NestedFunction/Scope,
 			[1] object,
 			[2] object,
-			[3] object,
-			[4] object[]
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Join_NestedFunction/Scope::.ctor()
@@ -132,53 +131,45 @@
 		IL_0021: stloc.3
 		IL_0022: ldloc.3
 		IL_0023: stloc.1
-		IL_0024: ldc.i4.1
-		IL_0025: newarr [System.Runtime]System.Object
-		IL_002a: dup
-		IL_002b: ldc.i4.0
-		IL_002c: ldnull
-		IL_002d: stelem.ref
-		IL_002e: stloc.s 4
-		IL_0030: ldarg.1
-		IL_0031: ldloc.s 4
-		IL_0033: ldstr "path"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003d: stloc.3
-		IL_003e: ldloc.0
-		IL_003f: ldloc.3
-		IL_0040: stfld object Modules.Require_Path_Join_NestedFunction/Scope::path
-		IL_0045: ldnull
-		IL_0046: ldftn object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(object[], object, object, object)
-		IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
-		IL_0051: ldc.i4.1
-		IL_0052: newarr [System.Runtime]System.Object
-		IL_0057: dup
-		IL_0058: ldc.i4.0
-		IL_0059: ldloc.0
-		IL_005a: stelem.ref
-		IL_005b: ldnull
-		IL_005c: ldstr "a"
-		IL_0061: ldstr "b"
-		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::Invoke(object[], object, object, object)
-		IL_006b: stloc.3
-		IL_006c: ldloc.3
-		IL_006d: ldstr "replace"
-		IL_0072: ldstr "\\"
-		IL_0077: ldstr "/"
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0081: stloc.3
-		IL_0082: ldloc.3
-		IL_0083: stloc.2
-		IL_0084: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0089: ldc.i4.1
-		IL_008a: newarr [System.Runtime]System.Object
-		IL_008f: dup
-		IL_0090: ldc.i4.0
-		IL_0091: ldloc.2
-		IL_0092: stelem.ref
-		IL_0093: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0098: pop
-		IL_0099: ret
+		IL_0024: ldarg.1
+		IL_0025: ldstr "path"
+		IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_002f: stloc.3
+		IL_0030: ldloc.0
+		IL_0031: ldloc.3
+		IL_0032: stfld object Modules.Require_Path_Join_NestedFunction/Scope::path
+		IL_0037: ldnull
+		IL_0038: ldftn object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(object[], object, object, object)
+		IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+		IL_0043: ldc.i4.1
+		IL_0044: newarr [System.Runtime]System.Object
+		IL_0049: dup
+		IL_004a: ldc.i4.0
+		IL_004b: ldloc.0
+		IL_004c: stelem.ref
+		IL_004d: ldnull
+		IL_004e: ldstr "a"
+		IL_0053: ldstr "b"
+		IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::Invoke(object[], object, object, object)
+		IL_005d: stloc.3
+		IL_005e: ldloc.3
+		IL_005f: ldstr "replace"
+		IL_0064: ldstr "\\"
+		IL_0069: ldstr "/"
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0073: stloc.3
+		IL_0074: ldloc.3
+		IL_0075: stloc.2
+		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007b: ldc.i4.1
+		IL_007c: newarr [System.Runtime]System.Object
+		IL_0081: dup
+		IL_0082: ldc.i4.0
+		IL_0083: ldloc.2
+		IL_0084: stelem.ref
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_008a: pop
+		IL_008b: ret
 	} // end of method Require_Path_Join_NestedFunction::__js_module_init__
 
 } // end of class Modules.Require_Path_Join_NestedFunction
@@ -190,7 +181,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2132
+		// Method begins at RVA 0x2122
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Normalize_And_Sep.verified.txt
+++ b/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Normalize_And_Sep.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2248
+			// Method begins at RVA 0x223a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 492 (0x1ec)
+		// Code size: 478 (0x1de)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Normalize_And_Sep/Scope,
@@ -48,190 +48,181 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object[],
+			[5] object,
 			[6] object,
-			[7] object,
-			[8] bool,
-			[9] object,
-			[10] string
+			[7] bool,
+			[8] object,
+			[9] string
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Normalize_And_Sep/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 5
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "path"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 5
 		IL_0013: ldloc.s 5
-		IL_0015: ldstr "path"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 6
-		IL_0021: ldloc.s 6
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "sep"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldstr "a"
-		IL_0035: ldloc.2
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_003b: stloc.s 7
-		IL_003d: ldloc.s 7
-		IL_003f: ldloc.2
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "sep"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldstr "a"
+		IL_0027: ldloc.2
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_002d: stloc.s 6
+		IL_002f: ldloc.s 6
+		IL_0031: ldloc.2
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0037: stloc.s 6
+		IL_0039: ldloc.s 6
+		IL_003b: ldstr "b"
 		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0045: stloc.s 7
-		IL_0047: ldloc.s 7
-		IL_0049: ldstr "b"
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0053: stloc.s 7
-		IL_0055: ldloc.s 7
-		IL_0057: ldloc.2
+		IL_0045: stloc.s 6
+		IL_0047: ldloc.s 6
+		IL_0049: ldloc.2
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_004f: stloc.s 6
+		IL_0051: ldloc.s 6
+		IL_0053: ldstr ".."
 		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_005d: stloc.s 7
-		IL_005f: ldloc.s 7
-		IL_0061: ldstr ".."
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_006b: stloc.s 7
-		IL_006d: ldloc.s 7
-		IL_006f: ldloc.2
+		IL_005d: stloc.s 6
+		IL_005f: ldloc.s 6
+		IL_0061: ldloc.2
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0067: stloc.s 6
+		IL_0069: ldloc.s 6
+		IL_006b: ldstr "c"
 		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0075: stloc.s 7
-		IL_0077: ldloc.s 7
-		IL_0079: ldstr "c"
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0083: stloc.s 7
-		IL_0085: ldloc.1
-		IL_0086: ldstr "normalize"
-		IL_008b: ldloc.s 7
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0092: stloc.s 6
-		IL_0094: ldloc.s 6
-		IL_0096: stloc.3
-		IL_0097: ldloc.2
-		IL_0098: ldstr "tmp"
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00a2: stloc.s 7
-		IL_00a4: ldloc.s 7
-		IL_00a6: ldloc.2
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00ac: stloc.s 7
-		IL_00ae: ldloc.s 7
-		IL_00b0: ldloc.2
+		IL_0075: stloc.s 6
+		IL_0077: ldloc.1
+		IL_0078: ldstr "normalize"
+		IL_007d: ldloc.s 6
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0084: stloc.s 5
+		IL_0086: ldloc.s 5
+		IL_0088: stloc.3
+		IL_0089: ldloc.2
+		IL_008a: ldstr "tmp"
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0094: stloc.s 6
+		IL_0096: ldloc.s 6
+		IL_0098: ldloc.2
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_009e: stloc.s 6
+		IL_00a0: ldloc.s 6
+		IL_00a2: ldloc.2
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00a8: stloc.s 6
+		IL_00aa: ldloc.s 6
+		IL_00ac: ldstr "x"
 		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00b6: stloc.s 7
-		IL_00b8: ldloc.s 7
-		IL_00ba: ldstr "x"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00c4: stloc.s 7
-		IL_00c6: ldloc.s 7
-		IL_00c8: ldloc.2
+		IL_00b6: stloc.s 6
+		IL_00b8: ldloc.s 6
+		IL_00ba: ldloc.2
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00c0: stloc.s 6
+		IL_00c2: ldloc.s 6
+		IL_00c4: ldstr "."
 		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00ce: stloc.s 7
-		IL_00d0: ldloc.s 7
-		IL_00d2: ldstr "."
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00dc: stloc.s 7
-		IL_00de: ldloc.s 7
-		IL_00e0: ldloc.2
+		IL_00ce: stloc.s 6
+		IL_00d0: ldloc.s 6
+		IL_00d2: ldloc.2
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00d8: stloc.s 6
+		IL_00da: ldloc.s 6
+		IL_00dc: ldstr "y"
 		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00e6: stloc.s 7
-		IL_00e8: ldloc.s 7
-		IL_00ea: ldstr "y"
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00f4: stloc.s 7
-		IL_00f6: ldloc.1
-		IL_00f7: ldstr "normalize"
-		IL_00fc: ldloc.s 7
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0103: stloc.s 6
-		IL_0105: ldloc.s 6
-		IL_0107: stloc.s 4
-		IL_0109: ldstr "a"
-		IL_010e: ldloc.2
+		IL_00e6: stloc.s 6
+		IL_00e8: ldloc.1
+		IL_00e9: ldstr "normalize"
+		IL_00ee: ldloc.s 6
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f5: stloc.s 5
+		IL_00f7: ldloc.s 5
+		IL_00f9: stloc.s 4
+		IL_00fb: ldstr "a"
+		IL_0100: ldloc.2
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0106: stloc.s 6
+		IL_0108: ldloc.s 6
+		IL_010a: ldstr "c"
 		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0114: stloc.s 7
-		IL_0116: ldloc.s 7
-		IL_0118: ldstr "c"
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0122: stloc.s 7
-		IL_0124: ldloc.3
-		IL_0125: ldloc.s 7
-		IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_012c: stloc.s 8
-		IL_012e: ldloc.s 8
-		IL_0130: box [System.Runtime]System.Boolean
-		IL_0135: stloc.s 9
-		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013c: ldc.i4.1
-		IL_013d: newarr [System.Runtime]System.Object
-		IL_0142: dup
-		IL_0143: ldc.i4.0
-		IL_0144: ldloc.s 9
-		IL_0146: stelem.ref
-		IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_014c: pop
-		IL_014d: ldc.i4.3
-		IL_014e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0153: dup
-		IL_0154: ldstr "tmp"
-		IL_0159: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_015e: dup
-		IL_015f: ldstr "x"
-		IL_0164: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0169: dup
-		IL_016a: ldstr "y"
-		IL_016f: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0174: ldc.i4.1
-		IL_0175: newarr [System.Runtime]System.Object
-		IL_017a: dup
-		IL_017b: ldc.i4.0
-		IL_017c: ldloc.2
-		IL_017d: stelem.ref
-		IL_017e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0183: stloc.s 10
-		IL_0185: ldloc.2
-		IL_0186: ldloc.s 10
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_018d: stloc.s 7
-		IL_018f: ldloc.s 4
-		IL_0191: ldloc.s 7
-		IL_0193: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0198: stloc.s 8
-		IL_019a: ldloc.s 8
-		IL_019c: box [System.Runtime]System.Boolean
-		IL_01a1: stloc.s 9
-		IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a8: ldc.i4.1
-		IL_01a9: newarr [System.Runtime]System.Object
-		IL_01ae: dup
-		IL_01af: ldc.i4.0
-		IL_01b0: ldloc.s 9
-		IL_01b2: stelem.ref
-		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_01b8: pop
-		IL_01b9: ldloc.1
-		IL_01ba: ldstr "sep"
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_01c4: ldloc.2
-		IL_01c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01ca: stloc.s 8
-		IL_01cc: ldloc.s 8
-		IL_01ce: box [System.Runtime]System.Boolean
-		IL_01d3: stloc.s 9
-		IL_01d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01da: ldc.i4.1
-		IL_01db: newarr [System.Runtime]System.Object
-		IL_01e0: dup
-		IL_01e1: ldc.i4.0
-		IL_01e2: ldloc.s 9
-		IL_01e4: stelem.ref
-		IL_01e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_01ea: pop
-		IL_01eb: ret
+		IL_0114: stloc.s 6
+		IL_0116: ldloc.3
+		IL_0117: ldloc.s 6
+		IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_011e: stloc.s 7
+		IL_0120: ldloc.s 7
+		IL_0122: box [System.Runtime]System.Boolean
+		IL_0127: stloc.s 8
+		IL_0129: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012e: ldc.i4.1
+		IL_012f: newarr [System.Runtime]System.Object
+		IL_0134: dup
+		IL_0135: ldc.i4.0
+		IL_0136: ldloc.s 8
+		IL_0138: stelem.ref
+		IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_013e: pop
+		IL_013f: ldc.i4.3
+		IL_0140: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0145: dup
+		IL_0146: ldstr "tmp"
+		IL_014b: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0150: dup
+		IL_0151: ldstr "x"
+		IL_0156: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_015b: dup
+		IL_015c: ldstr "y"
+		IL_0161: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0166: ldc.i4.1
+		IL_0167: newarr [System.Runtime]System.Object
+		IL_016c: dup
+		IL_016d: ldc.i4.0
+		IL_016e: ldloc.2
+		IL_016f: stelem.ref
+		IL_0170: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0175: stloc.s 9
+		IL_0177: ldloc.2
+		IL_0178: ldloc.s 9
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_017f: stloc.s 6
+		IL_0181: ldloc.s 4
+		IL_0183: ldloc.s 6
+		IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_018a: stloc.s 7
+		IL_018c: ldloc.s 7
+		IL_018e: box [System.Runtime]System.Boolean
+		IL_0193: stloc.s 8
+		IL_0195: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019a: ldc.i4.1
+		IL_019b: newarr [System.Runtime]System.Object
+		IL_01a0: dup
+		IL_01a1: ldc.i4.0
+		IL_01a2: ldloc.s 8
+		IL_01a4: stelem.ref
+		IL_01a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_01aa: pop
+		IL_01ab: ldloc.1
+		IL_01ac: ldstr "sep"
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_01b6: ldloc.2
+		IL_01b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01bc: stloc.s 7
+		IL_01be: ldloc.s 7
+		IL_01c0: box [System.Runtime]System.Boolean
+		IL_01c5: stloc.s 8
+		IL_01c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cc: ldc.i4.1
+		IL_01cd: newarr [System.Runtime]System.Object
+		IL_01d2: dup
+		IL_01d3: ldc.i4.0
+		IL_01d4: ldloc.s 8
+		IL_01d6: stelem.ref
+		IL_01d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_01dc: pop
+		IL_01dd: ret
 	} // end of method Require_Path_Normalize_And_Sep::__js_module_init__
 
 } // end of class Modules.Require_Path_Normalize_And_Sep
@@ -243,7 +234,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2251
+		// Method begins at RVA 0x2243
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Parse_And_Format.verified.txt
+++ b/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Parse_And_Format.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2486
+			// Method begins at RVA 0x2478
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1066 (0x42a)
+		// Code size: 1052 (0x41c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Parse_And_Format/Scope,
@@ -52,395 +52,386 @@
 			[6] object,
 			[7] object,
 			[8] object,
-			[9] object[],
-			[10] object,
-			[11] string,
-			[12] object,
-			[13] bool,
+			[9] object,
+			[10] string,
+			[11] object,
+			[12] bool,
+			[13] object,
 			[14] object,
-			[15] object,
-			[16] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[15] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[16] object,
 			[17] object,
-			[18] object,
-			[19] class [System.Linq.Expressions]System.Dynamic.ExpandoObject
+			[18] class [System.Linq.Expressions]System.Dynamic.ExpandoObject
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Parse_And_Format/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 9
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "path"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 9
 		IL_0013: ldloc.s 9
-		IL_0015: ldstr "path"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 10
-		IL_0021: ldloc.s 10
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "sep"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldc.i4.4
-		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0036: dup
-		IL_0037: ldstr "home"
-		IL_003c: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0041: dup
-		IL_0042: ldstr "user"
-		IL_0047: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_004c: dup
-		IL_004d: ldstr "dir"
-		IL_0052: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0057: dup
-		IL_0058: ldstr "file.txt"
-		IL_005d: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0062: ldc.i4.1
-		IL_0063: newarr [System.Runtime]System.Object
-		IL_0068: dup
-		IL_0069: ldc.i4.0
-		IL_006a: ldloc.2
-		IL_006b: stelem.ref
-		IL_006c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0071: stloc.s 11
-		IL_0073: ldloc.2
-		IL_0074: ldloc.s 11
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_007b: stloc.s 12
-		IL_007d: ldloc.s 12
-		IL_007f: stloc.3
-		IL_0080: ldloc.1
-		IL_0081: ldstr "parse"
-		IL_0086: ldloc.3
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_008c: stloc.s 10
-		IL_008e: ldloc.s 10
-		IL_0090: stloc.s 4
-		IL_0092: ldloc.s 4
-		IL_0094: ldstr "dir"
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_009e: stloc.s 10
-		IL_00a0: ldloc.s 10
-		IL_00a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "sep"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldc.i4.4
+		IL_0023: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0028: dup
+		IL_0029: ldstr "home"
+		IL_002e: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0033: dup
+		IL_0034: ldstr "user"
+		IL_0039: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_003e: dup
+		IL_003f: ldstr "dir"
+		IL_0044: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0049: dup
+		IL_004a: ldstr "file.txt"
+		IL_004f: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0054: ldc.i4.1
+		IL_0055: newarr [System.Runtime]System.Object
+		IL_005a: dup
+		IL_005b: ldc.i4.0
+		IL_005c: ldloc.2
+		IL_005d: stelem.ref
+		IL_005e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0063: stloc.s 10
+		IL_0065: ldloc.2
+		IL_0066: ldloc.s 10
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_006d: stloc.s 11
+		IL_006f: ldloc.s 11
+		IL_0071: stloc.3
+		IL_0072: ldloc.1
+		IL_0073: ldstr "parse"
+		IL_0078: ldloc.3
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007e: stloc.s 9
+		IL_0080: ldloc.s 9
+		IL_0082: stloc.s 4
+		IL_0084: ldloc.s 4
+		IL_0086: ldstr "dir"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0090: stloc.s 9
+		IL_0092: ldloc.s 9
+		IL_0094: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0099: stloc.s 12
+		IL_009b: ldloc.s 12
+		IL_009d: brtrue IL_00ae
+
+		IL_00a2: ldstr ""
 		IL_00a7: stloc.s 13
-		IL_00a9: ldloc.s 13
-		IL_00ab: brtrue IL_00bc
+		IL_00a9: br IL_00b2
 
-		IL_00b0: ldstr ""
-		IL_00b5: stloc.s 14
-		IL_00b7: br IL_00c0
+		IL_00ae: ldloc.s 9
+		IL_00b0: stloc.s 13
 
-		IL_00bc: ldloc.s 10
-		IL_00be: stloc.s 14
+		IL_00b2: ldloc.s 13
+		IL_00b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_00b9: stloc.s 10
+		IL_00bb: ldloc.s 10
+		IL_00bd: stloc.s 5
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "base"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00cb: ldstr "file.txt"
+		IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00d5: stloc.s 12
+		IL_00d7: ldloc.s 12
+		IL_00d9: box [System.Runtime]System.Boolean
+		IL_00de: stloc.s 14
+		IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e5: ldc.i4.1
+		IL_00e6: newarr [System.Runtime]System.Object
+		IL_00eb: dup
+		IL_00ec: ldc.i4.0
+		IL_00ed: ldloc.s 14
+		IL_00ef: stelem.ref
+		IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f5: pop
+		IL_00f6: ldloc.s 4
+		IL_00f8: ldstr "ext"
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0102: ldstr ".txt"
+		IL_0107: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_010c: stloc.s 12
+		IL_010e: ldloc.s 12
+		IL_0110: box [System.Runtime]System.Boolean
+		IL_0115: stloc.s 14
+		IL_0117: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011c: ldc.i4.1
+		IL_011d: newarr [System.Runtime]System.Object
+		IL_0122: dup
+		IL_0123: ldc.i4.0
+		IL_0124: ldloc.s 14
+		IL_0126: stelem.ref
+		IL_0127: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_012c: pop
+		IL_012d: ldloc.s 4
+		IL_012f: ldstr "name"
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0139: ldstr "file"
+		IL_013e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0143: stloc.s 12
+		IL_0145: ldloc.s 12
+		IL_0147: box [System.Runtime]System.Boolean
+		IL_014c: stloc.s 14
+		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0153: ldc.i4.1
+		IL_0154: newarr [System.Runtime]System.Object
+		IL_0159: dup
+		IL_015a: ldc.i4.0
+		IL_015b: ldloc.s 14
+		IL_015d: stelem.ref
+		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0163: pop
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0169: stloc.s 15
+		IL_016b: ldloc.s 4
+		IL_016d: ldstr "root"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0177: ldloc.2
+		IL_0178: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_017d: stloc.s 12
+		IL_017f: ldloc.s 12
+		IL_0181: box [System.Runtime]System.Boolean
+		IL_0186: stloc.s 14
+		IL_0188: ldloc.s 14
+		IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_018f: stloc.s 12
+		IL_0191: ldloc.s 12
+		IL_0193: brtrue IL_01c2
 
-		IL_00c0: ldloc.s 14
-		IL_00c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00c7: stloc.s 11
-		IL_00c9: ldloc.s 11
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.s 4
-		IL_00cf: ldstr "base"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00d9: ldstr "file.txt"
-		IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00e3: stloc.s 13
-		IL_00e5: ldloc.s 13
-		IL_00e7: box [System.Runtime]System.Boolean
-		IL_00ec: stloc.s 15
-		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f3: ldc.i4.1
-		IL_00f4: newarr [System.Runtime]System.Object
-		IL_00f9: dup
-		IL_00fa: ldc.i4.0
-		IL_00fb: ldloc.s 15
-		IL_00fd: stelem.ref
-		IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0103: pop
-		IL_0104: ldloc.s 4
-		IL_0106: ldstr "ext"
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0110: ldstr ".txt"
-		IL_0115: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_011a: stloc.s 13
-		IL_011c: ldloc.s 13
-		IL_011e: box [System.Runtime]System.Boolean
-		IL_0123: stloc.s 15
-		IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012a: ldc.i4.1
-		IL_012b: newarr [System.Runtime]System.Object
-		IL_0130: dup
-		IL_0131: ldc.i4.0
-		IL_0132: ldloc.s 15
-		IL_0134: stelem.ref
-		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_013a: pop
-		IL_013b: ldloc.s 4
-		IL_013d: ldstr "name"
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0147: ldstr "file"
-		IL_014c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0151: stloc.s 13
-		IL_0153: ldloc.s 13
-		IL_0155: box [System.Runtime]System.Boolean
-		IL_015a: stloc.s 15
-		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0161: ldc.i4.1
-		IL_0162: newarr [System.Runtime]System.Object
-		IL_0167: dup
-		IL_0168: ldc.i4.0
-		IL_0169: ldloc.s 15
-		IL_016b: stelem.ref
-		IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0171: pop
-		IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0177: stloc.s 16
-		IL_0179: ldloc.s 4
-		IL_017b: ldstr "root"
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0185: ldloc.2
-		IL_0186: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_018b: stloc.s 13
-		IL_018d: ldloc.s 13
-		IL_018f: box [System.Runtime]System.Boolean
-		IL_0194: stloc.s 15
-		IL_0196: ldloc.s 15
-		IL_0198: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_019d: stloc.s 13
-		IL_019f: ldloc.s 13
-		IL_01a1: brtrue IL_01d0
+		IL_0198: ldloc.s 4
+		IL_019a: ldstr "root"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_01a4: ldstr ""
+		IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01ae: stloc.s 12
+		IL_01b0: ldloc.s 12
+		IL_01b2: box [System.Runtime]System.Boolean
+		IL_01b7: stloc.s 16
+		IL_01b9: ldloc.s 16
+		IL_01bb: stloc.s 17
+		IL_01bd: br IL_01c6
 
-		IL_01a6: ldloc.s 4
-		IL_01a8: ldstr "root"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_01b2: ldstr ""
-		IL_01b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01bc: stloc.s 13
-		IL_01be: ldloc.s 13
-		IL_01c0: box [System.Runtime]System.Boolean
-		IL_01c5: stloc.s 17
-		IL_01c7: ldloc.s 17
-		IL_01c9: stloc.s 18
-		IL_01cb: br IL_01d4
+		IL_01c2: ldloc.s 14
+		IL_01c4: stloc.s 17
 
-		IL_01d0: ldloc.s 15
-		IL_01d2: stloc.s 18
-
-		IL_01d4: ldloc.s 16
-		IL_01d6: ldc.i4.1
-		IL_01d7: newarr [System.Runtime]System.Object
-		IL_01dc: dup
-		IL_01dd: ldc.i4.0
-		IL_01de: ldloc.s 18
-		IL_01e0: stelem.ref
-		IL_01e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_01e6: pop
-		IL_01e7: ldc.i4.3
-		IL_01e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01ed: dup
-		IL_01ee: ldstr "home"
-		IL_01f3: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_01f8: dup
-		IL_01f9: ldstr "user"
-		IL_01fe: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0203: dup
-		IL_0204: ldstr "dir"
-		IL_0209: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_020e: ldc.i4.1
-		IL_020f: newarr [System.Runtime]System.Object
-		IL_0214: dup
-		IL_0215: ldc.i4.0
-		IL_0216: ldloc.2
-		IL_0217: stelem.ref
-		IL_0218: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_021d: stloc.s 11
-		IL_021f: ldloc.2
-		IL_0220: ldloc.s 11
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0227: stloc.s 18
-		IL_0229: ldloc.s 5
-		IL_022b: ldstr "endsWith"
-		IL_0230: ldloc.s 18
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0237: stloc.s 10
-		IL_0239: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_023e: ldc.i4.1
-		IL_023f: newarr [System.Runtime]System.Object
-		IL_0244: dup
-		IL_0245: ldc.i4.0
-		IL_0246: ldloc.s 10
-		IL_0248: stelem.ref
-		IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_024e: pop
-		IL_024f: ldloc.1
-		IL_0250: ldstr "format"
-		IL_0255: ldloc.s 4
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_025c: stloc.s 10
-		IL_025e: ldloc.s 10
-		IL_0260: stloc.s 6
-		IL_0262: ldc.i4.2
-		IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0268: dup
-		IL_0269: ldstr "tmp"
-		IL_026e: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0273: dup
-		IL_0274: ldstr "demo"
-		IL_0279: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_027e: ldc.i4.1
-		IL_027f: newarr [System.Runtime]System.Object
-		IL_0284: dup
-		IL_0285: ldc.i4.0
-		IL_0286: ldloc.2
-		IL_0287: stelem.ref
-		IL_0288: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_028d: stloc.s 11
-		IL_028f: ldloc.2
-		IL_0290: ldloc.s 11
-		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0297: stloc.s 18
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01c6: ldloc.s 15
+		IL_01c8: ldc.i4.1
+		IL_01c9: newarr [System.Runtime]System.Object
+		IL_01ce: dup
+		IL_01cf: ldc.i4.0
+		IL_01d0: ldloc.s 17
+		IL_01d2: stelem.ref
+		IL_01d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_01d8: pop
+		IL_01d9: ldc.i4.3
+		IL_01da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01df: dup
+		IL_01e0: ldstr "home"
+		IL_01e5: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_01ea: dup
+		IL_01eb: ldstr "user"
+		IL_01f0: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_01f5: dup
+		IL_01f6: ldstr "dir"
+		IL_01fb: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0200: ldc.i4.1
+		IL_0201: newarr [System.Runtime]System.Object
+		IL_0206: dup
+		IL_0207: ldc.i4.0
+		IL_0208: ldloc.2
+		IL_0209: stelem.ref
+		IL_020a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_020f: stloc.s 10
+		IL_0211: ldloc.2
+		IL_0212: ldloc.s 10
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0219: stloc.s 17
+		IL_021b: ldloc.s 5
+		IL_021d: ldstr "endsWith"
+		IL_0222: ldloc.s 17
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0229: stloc.s 9
+		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0230: ldc.i4.1
+		IL_0231: newarr [System.Runtime]System.Object
+		IL_0236: dup
+		IL_0237: ldc.i4.0
+		IL_0238: ldloc.s 9
+		IL_023a: stelem.ref
+		IL_023b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0240: pop
+		IL_0241: ldloc.1
+		IL_0242: ldstr "format"
+		IL_0247: ldloc.s 4
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_024e: stloc.s 9
+		IL_0250: ldloc.s 9
+		IL_0252: stloc.s 6
+		IL_0254: ldc.i4.2
+		IL_0255: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_025a: dup
+		IL_025b: ldstr "tmp"
+		IL_0260: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0265: dup
+		IL_0266: ldstr "demo"
+		IL_026b: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0270: ldc.i4.1
+		IL_0271: newarr [System.Runtime]System.Object
+		IL_0276: dup
+		IL_0277: ldc.i4.0
+		IL_0278: ldloc.2
+		IL_0279: stelem.ref
+		IL_027a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_027f: stloc.s 10
+		IL_0281: ldloc.2
+		IL_0282: ldloc.s 10
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0289: stloc.s 17
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0290: dup
+		IL_0291: ldstr "dir"
+		IL_0296: ldloc.s 17
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_029d: pop
 		IL_029e: dup
-		IL_029f: ldstr "dir"
-		IL_02a4: ldloc.s 18
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_02ab: pop
-		IL_02ac: dup
-		IL_02ad: ldstr "name"
-		IL_02b2: ldstr "archive"
-		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_02bc: pop
-		IL_02bd: dup
-		IL_02be: ldstr "ext"
-		IL_02c3: ldstr ".tar"
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_02cd: pop
-		IL_02ce: stloc.s 19
-		IL_02d0: ldloc.1
-		IL_02d1: ldstr "format"
-		IL_02d6: ldloc.s 19
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02dd: stloc.s 10
-		IL_02df: ldloc.s 10
-		IL_02e1: stloc.s 7
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02e8: dup
-		IL_02e9: ldstr "root"
-		IL_02ee: ldloc.2
-		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_02f4: pop
-		IL_02f5: dup
-		IL_02f6: ldstr "base"
-		IL_02fb: ldstr "index.js"
-		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0305: pop
-		IL_0306: stloc.s 19
-		IL_0308: ldloc.1
-		IL_0309: ldstr "format"
-		IL_030e: ldloc.s 19
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0315: stloc.s 10
-		IL_0317: ldloc.s 10
-		IL_0319: stloc.s 8
-		IL_031b: ldc.i4.4
-		IL_031c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0321: dup
-		IL_0322: ldstr "home"
-		IL_0327: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_032c: dup
-		IL_032d: ldstr "user"
-		IL_0332: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0337: dup
-		IL_0338: ldstr "dir"
-		IL_033d: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0342: dup
-		IL_0343: ldstr "file.txt"
-		IL_0348: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_034d: ldc.i4.1
-		IL_034e: newarr [System.Runtime]System.Object
-		IL_0353: dup
-		IL_0354: ldc.i4.0
-		IL_0355: ldloc.2
-		IL_0356: stelem.ref
-		IL_0357: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_035c: stloc.s 11
-		IL_035e: ldloc.2
-		IL_035f: ldloc.s 11
-		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0366: stloc.s 18
-		IL_0368: ldloc.s 6
-		IL_036a: ldstr "endsWith"
-		IL_036f: ldloc.s 18
-		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0376: stloc.s 10
-		IL_0378: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_037d: ldc.i4.1
-		IL_037e: newarr [System.Runtime]System.Object
-		IL_0383: dup
-		IL_0384: ldc.i4.0
-		IL_0385: ldloc.s 10
-		IL_0387: stelem.ref
-		IL_0388: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_038d: pop
-		IL_038e: ldc.i4.3
-		IL_038f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0394: dup
-		IL_0395: ldstr "tmp"
-		IL_039a: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_039f: dup
-		IL_03a0: ldstr "demo"
-		IL_03a5: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_03aa: dup
-		IL_03ab: ldstr "archive.tar"
-		IL_03b0: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_03b5: ldc.i4.1
-		IL_03b6: newarr [System.Runtime]System.Object
-		IL_03bb: dup
-		IL_03bc: ldc.i4.0
-		IL_03bd: ldloc.2
-		IL_03be: stelem.ref
-		IL_03bf: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_03c4: stloc.s 11
-		IL_03c6: ldloc.2
-		IL_03c7: ldloc.s 11
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03ce: stloc.s 18
-		IL_03d0: ldloc.s 7
-		IL_03d2: ldstr "endsWith"
-		IL_03d7: ldloc.s 18
-		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03de: stloc.s 10
-		IL_03e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03e5: ldc.i4.1
-		IL_03e6: newarr [System.Runtime]System.Object
-		IL_03eb: dup
-		IL_03ec: ldc.i4.0
-		IL_03ed: ldloc.s 10
-		IL_03ef: stelem.ref
-		IL_03f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_03f5: pop
-		IL_03f6: ldloc.2
-		IL_03f7: ldstr "index.js"
-		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0401: stloc.s 18
-		IL_0403: ldloc.s 8
-		IL_0405: ldstr "endsWith"
-		IL_040a: ldloc.s 18
-		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0411: stloc.s 10
-		IL_0413: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0418: ldc.i4.1
-		IL_0419: newarr [System.Runtime]System.Object
-		IL_041e: dup
-		IL_041f: ldc.i4.0
-		IL_0420: ldloc.s 10
-		IL_0422: stelem.ref
-		IL_0423: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0428: pop
-		IL_0429: ret
+		IL_029f: ldstr "name"
+		IL_02a4: ldstr "archive"
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_02ae: pop
+		IL_02af: dup
+		IL_02b0: ldstr "ext"
+		IL_02b5: ldstr ".tar"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_02bf: pop
+		IL_02c0: stloc.s 18
+		IL_02c2: ldloc.1
+		IL_02c3: ldstr "format"
+		IL_02c8: ldloc.s 18
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02cf: stloc.s 9
+		IL_02d1: ldloc.s 9
+		IL_02d3: stloc.s 7
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02da: dup
+		IL_02db: ldstr "root"
+		IL_02e0: ldloc.2
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_02e6: pop
+		IL_02e7: dup
+		IL_02e8: ldstr "base"
+		IL_02ed: ldstr "index.js"
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_02f7: pop
+		IL_02f8: stloc.s 18
+		IL_02fa: ldloc.1
+		IL_02fb: ldstr "format"
+		IL_0300: ldloc.s 18
+		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0307: stloc.s 9
+		IL_0309: ldloc.s 9
+		IL_030b: stloc.s 8
+		IL_030d: ldc.i4.4
+		IL_030e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0313: dup
+		IL_0314: ldstr "home"
+		IL_0319: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_031e: dup
+		IL_031f: ldstr "user"
+		IL_0324: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0329: dup
+		IL_032a: ldstr "dir"
+		IL_032f: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0334: dup
+		IL_0335: ldstr "file.txt"
+		IL_033a: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_033f: ldc.i4.1
+		IL_0340: newarr [System.Runtime]System.Object
+		IL_0345: dup
+		IL_0346: ldc.i4.0
+		IL_0347: ldloc.2
+		IL_0348: stelem.ref
+		IL_0349: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_034e: stloc.s 10
+		IL_0350: ldloc.2
+		IL_0351: ldloc.s 10
+		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0358: stloc.s 17
+		IL_035a: ldloc.s 6
+		IL_035c: ldstr "endsWith"
+		IL_0361: ldloc.s 17
+		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0368: stloc.s 9
+		IL_036a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_036f: ldc.i4.1
+		IL_0370: newarr [System.Runtime]System.Object
+		IL_0375: dup
+		IL_0376: ldc.i4.0
+		IL_0377: ldloc.s 9
+		IL_0379: stelem.ref
+		IL_037a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_037f: pop
+		IL_0380: ldc.i4.3
+		IL_0381: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0386: dup
+		IL_0387: ldstr "tmp"
+		IL_038c: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0391: dup
+		IL_0392: ldstr "demo"
+		IL_0397: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_039c: dup
+		IL_039d: ldstr "archive.tar"
+		IL_03a2: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_03a7: ldc.i4.1
+		IL_03a8: newarr [System.Runtime]System.Object
+		IL_03ad: dup
+		IL_03ae: ldc.i4.0
+		IL_03af: ldloc.2
+		IL_03b0: stelem.ref
+		IL_03b1: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_03b6: stloc.s 10
+		IL_03b8: ldloc.2
+		IL_03b9: ldloc.s 10
+		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03c0: stloc.s 17
+		IL_03c2: ldloc.s 7
+		IL_03c4: ldstr "endsWith"
+		IL_03c9: ldloc.s 17
+		IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03d0: stloc.s 9
+		IL_03d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03d7: ldc.i4.1
+		IL_03d8: newarr [System.Runtime]System.Object
+		IL_03dd: dup
+		IL_03de: ldc.i4.0
+		IL_03df: ldloc.s 9
+		IL_03e1: stelem.ref
+		IL_03e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_03e7: pop
+		IL_03e8: ldloc.2
+		IL_03e9: ldstr "index.js"
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03f3: stloc.s 17
+		IL_03f5: ldloc.s 8
+		IL_03f7: ldstr "endsWith"
+		IL_03fc: ldloc.s 17
+		IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0403: stloc.s 9
+		IL_0405: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_040a: ldc.i4.1
+		IL_040b: newarr [System.Runtime]System.Object
+		IL_0410: dup
+		IL_0411: ldc.i4.0
+		IL_0412: ldloc.s 9
+		IL_0414: stelem.ref
+		IL_0415: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_041a: pop
+		IL_041b: ret
 	} // end of method Require_Path_Parse_And_Format::__js_module_init__
 
 } // end of class Modules.Require_Path_Parse_And_Format
@@ -452,7 +443,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x248f
+		// Method begins at RVA 0x2481
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Relative_SamePath_EmptyString.verified.txt
+++ b/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Relative_SamePath_EmptyString.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20ae
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,57 +40,48 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 100 (0x64)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Relative_SamePath_EmptyString/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Relative_SamePath_EmptyString/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.3
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "path"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.3
 		IL_0012: ldloc.3
-		IL_0013: ldstr "path"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.s 4
-		IL_001f: ldloc.s 4
-		IL_0021: stloc.1
-		IL_0022: ldloc.1
-		IL_0023: ldstr "resolve"
-		IL_0028: ldarg.s __dirname
-		IL_002a: ldstr "a"
-		IL_002f: ldstr "b"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0039: stloc.s 4
-		IL_003b: ldloc.s 4
-		IL_003d: stloc.2
-		IL_003e: ldloc.1
-		IL_003f: ldstr "relative"
-		IL_0044: ldloc.2
-		IL_0045: ldloc.2
-		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_004b: stloc.s 4
-		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0052: ldc.i4.1
-		IL_0053: newarr [System.Runtime]System.Object
-		IL_0058: dup
-		IL_0059: ldc.i4.0
-		IL_005a: ldloc.s 4
-		IL_005c: stelem.ref
-		IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0062: pop
-		IL_0063: ret
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: ldstr "resolve"
+		IL_001a: ldarg.s __dirname
+		IL_001c: ldstr "a"
+		IL_0021: ldstr "b"
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_002b: stloc.3
+		IL_002c: ldloc.3
+		IL_002d: stloc.2
+		IL_002e: ldloc.1
+		IL_002f: ldstr "relative"
+		IL_0034: ldloc.2
+		IL_0035: ldloc.2
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_003b: stloc.3
+		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0041: ldc.i4.1
+		IL_0042: newarr [System.Runtime]System.Object
+		IL_0047: dup
+		IL_0048: ldc.i4.0
+		IL_0049: ldloc.3
+		IL_004a: stelem.ref
+		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0050: pop
+		IL_0051: ret
 	} // end of method Require_Path_Relative_SamePath_EmptyString::__js_module_init__
 
 } // end of class Modules.Require_Path_Relative_SamePath_EmptyString
@@ -102,7 +93,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c9
+		// Method begins at RVA 0x20b7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_ToNamespacedPath.verified.txt
+++ b/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_ToNamespacedPath.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2173
+			// Method begins at RVA 0x2165
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 279 (0x117)
+		// Code size: 265 (0x109)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_ToNamespacedPath/Scope,
@@ -48,120 +48,111 @@
 			[2] object,
 			[3] object,
 			[4] string,
-			[5] object[],
-			[6] object,
-			[7] string,
-			[8] object,
-			[9] bool,
-			[10] object
+			[5] object,
+			[6] string,
+			[7] object,
+			[8] bool,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_ToNamespacedPath/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 5
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "path"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 5
 		IL_0013: ldloc.s 5
-		IL_0015: ldstr "path"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 6
-		IL_0021: ldloc.s 6
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "sep"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldc.i4.3
-		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0036: dup
-		IL_0037: ldstr "tmp"
-		IL_003c: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0041: dup
-		IL_0042: ldstr "a"
-		IL_0047: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_004c: dup
-		IL_004d: ldstr "b"
-		IL_0052: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0057: ldc.i4.1
-		IL_0058: newarr [System.Runtime]System.Object
-		IL_005d: dup
-		IL_005e: ldc.i4.0
-		IL_005f: ldloc.2
-		IL_0060: stelem.ref
-		IL_0061: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0066: stloc.s 7
-		IL_0068: ldloc.2
-		IL_0069: ldloc.s 7
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0070: stloc.s 8
-		IL_0072: ldloc.s 8
-		IL_0074: stloc.3
-		IL_0075: ldc.i4.2
-		IL_0076: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_007b: dup
-		IL_007c: ldstr "relative"
-		IL_0081: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0086: dup
-		IL_0087: ldstr "path"
-		IL_008c: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0091: ldc.i4.1
-		IL_0092: newarr [System.Runtime]System.Object
-		IL_0097: dup
-		IL_0098: ldc.i4.0
-		IL_0099: ldloc.2
-		IL_009a: stelem.ref
-		IL_009b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00a0: stloc.s 7
-		IL_00a2: ldloc.s 7
-		IL_00a4: stloc.s 4
-		IL_00a6: ldloc.1
-		IL_00a7: ldstr "toNamespacedPath"
-		IL_00ac: ldloc.3
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00b2: stloc.s 6
-		IL_00b4: ldloc.s 6
-		IL_00b6: ldloc.3
-		IL_00b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00bc: stloc.s 9
-		IL_00be: ldloc.s 9
-		IL_00c0: box [System.Runtime]System.Boolean
-		IL_00c5: stloc.s 10
-		IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cc: ldc.i4.1
-		IL_00cd: newarr [System.Runtime]System.Object
-		IL_00d2: dup
-		IL_00d3: ldc.i4.0
-		IL_00d4: ldloc.s 10
-		IL_00d6: stelem.ref
-		IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00dc: pop
-		IL_00dd: ldloc.1
-		IL_00de: ldstr "toNamespacedPath"
-		IL_00e3: ldloc.s 4
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ea: stloc.s 6
-		IL_00ec: ldloc.s 6
-		IL_00ee: ldloc.s 4
-		IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f5: stloc.s 9
-		IL_00f7: ldloc.s 9
-		IL_00f9: box [System.Runtime]System.Boolean
-		IL_00fe: stloc.s 10
-		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0105: ldc.i4.1
-		IL_0106: newarr [System.Runtime]System.Object
-		IL_010b: dup
-		IL_010c: ldc.i4.0
-		IL_010d: ldloc.s 10
-		IL_010f: stelem.ref
-		IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0115: pop
-		IL_0116: ret
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "sep"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldc.i4.3
+		IL_0023: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0028: dup
+		IL_0029: ldstr "tmp"
+		IL_002e: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0033: dup
+		IL_0034: ldstr "a"
+		IL_0039: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_003e: dup
+		IL_003f: ldstr "b"
+		IL_0044: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0049: ldc.i4.1
+		IL_004a: newarr [System.Runtime]System.Object
+		IL_004f: dup
+		IL_0050: ldc.i4.0
+		IL_0051: ldloc.2
+		IL_0052: stelem.ref
+		IL_0053: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0058: stloc.s 6
+		IL_005a: ldloc.2
+		IL_005b: ldloc.s 6
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0062: stloc.s 7
+		IL_0064: ldloc.s 7
+		IL_0066: stloc.3
+		IL_0067: ldc.i4.2
+		IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_006d: dup
+		IL_006e: ldstr "relative"
+		IL_0073: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0078: dup
+		IL_0079: ldstr "path"
+		IL_007e: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0083: ldc.i4.1
+		IL_0084: newarr [System.Runtime]System.Object
+		IL_0089: dup
+		IL_008a: ldc.i4.0
+		IL_008b: ldloc.2
+		IL_008c: stelem.ref
+		IL_008d: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0092: stloc.s 6
+		IL_0094: ldloc.s 6
+		IL_0096: stloc.s 4
+		IL_0098: ldloc.1
+		IL_0099: ldstr "toNamespacedPath"
+		IL_009e: ldloc.3
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00a4: stloc.s 5
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldloc.3
+		IL_00a9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00ae: stloc.s 8
+		IL_00b0: ldloc.s 8
+		IL_00b2: box [System.Runtime]System.Boolean
+		IL_00b7: stloc.s 9
+		IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00be: ldc.i4.1
+		IL_00bf: newarr [System.Runtime]System.Object
+		IL_00c4: dup
+		IL_00c5: ldc.i4.0
+		IL_00c6: ldloc.s 9
+		IL_00c8: stelem.ref
+		IL_00c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00ce: pop
+		IL_00cf: ldloc.1
+		IL_00d0: ldstr "toNamespacedPath"
+		IL_00d5: ldloc.s 4
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00dc: stloc.s 5
+		IL_00de: ldloc.s 5
+		IL_00e0: ldloc.s 4
+		IL_00e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00e7: stloc.s 8
+		IL_00e9: ldloc.s 8
+		IL_00eb: box [System.Runtime]System.Boolean
+		IL_00f0: stloc.s 9
+		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f7: ldc.i4.1
+		IL_00f8: newarr [System.Runtime]System.Object
+		IL_00fd: dup
+		IL_00fe: ldc.i4.0
+		IL_00ff: ldloc.s 9
+		IL_0101: stelem.ref
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0107: pop
+		IL_0108: ret
 	} // end of method Require_Path_ToNamespacedPath::__js_module_init__
 
 } // end of class Modules.Require_Path_ToNamespacedPath
@@ -173,7 +164,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x217c
+		// Method begins at RVA 0x216e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.Global___dirname_PrintsDirectory.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.Global___dirname_PrintsDirectory.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x2094
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,46 +40,37 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 68 (0x44)
+		// Code size: 56 (0x38)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Global___dirname_PrintsDirectory/Scope,
 			[1] object,
-			[2] object[],
-			[3] object
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.Global___dirname_PrintsDirectory/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "path"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "path"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: ldloc.1
-		IL_0021: ldstr "dirname"
-		IL_0026: ldarg.s __dirname
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_002d: stloc.3
-		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.3
-		IL_003c: stelem.ref
-		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0042: pop
-		IL_0043: ret
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: ldstr "dirname"
+		IL_001a: ldarg.s __dirname
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0021: stloc.2
+		IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0027: ldc.i4.1
+		IL_0028: newarr [System.Runtime]System.Object
+		IL_002d: dup
+		IL_002e: ldc.i4.0
+		IL_002f: ldloc.2
+		IL_0030: stelem.ref
+		IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0036: pop
+		IL_0037: ret
 	} // end of method Global___dirname_PrintsDirectory::__js_module_init__
 
 } // end of class Modules.Global___dirname_PrintsDirectory
@@ -91,7 +82,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20a9
+		// Method begins at RVA 0x209d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Snapshots/GeneratorTests.PerfHooks_PerformanceNow_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Snapshots/GeneratorTests.PerfHooks_PerformanceNow_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f1
+				// Method begins at RVA 0x21e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fa
+				// Method begins at RVA 0x21ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2203
+				// Method begins at RVA 0x21f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x21dc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -102,7 +102,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 380 (0x17c)
+		// Code size: 366 (0x16e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.PerfHooks_PerformanceNow_Basic/Scope,
@@ -116,167 +116,158 @@
 			[8] object,
 			[9] object,
 			[10] float64,
-			[11] object[],
+			[11] object,
 			[12] object,
-			[13] object,
-			[14] float64,
-			[15] bool,
-			[16] float64,
-			[17] object
+			[13] float64,
+			[14] bool,
+			[15] float64,
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.PerfHooks_PerformanceNow_Basic/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 11
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "perf_hooks"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 11
 		IL_0013: ldloc.s 11
-		IL_0015: ldstr "perf_hooks"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 12
-		IL_0021: ldloc.s 12
-		IL_0023: brfalse IL_0038
+		IL_0015: brfalse IL_002a
 
-		IL_0028: ldloc.s 12
-		IL_002a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_002f: stloc.s 13
-		IL_0031: ldloc.s 13
-		IL_0033: brfalse IL_0049
+		IL_001a: ldloc.s 11
+		IL_001c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0021: stloc.s 12
+		IL_0023: ldloc.s 12
+		IL_0025: brfalse IL_003b
 
-		IL_0038: ldloc.s 12
-		IL_003a: ldstr ""
-		IL_003f: ldstr "performance"
-		IL_0044: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_002a: ldloc.s 11
+		IL_002c: ldstr ""
+		IL_0031: ldstr "performance"
+		IL_0036: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_0049: ldloc.s 12
-		IL_004b: ldstr "performance"
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0055: stloc.1
-		IL_0056: ldloc.1
-		IL_0057: ldstr "now"
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0061: stloc.s 12
-		IL_0063: ldloc.s 12
-		IL_0065: stloc.2
-		IL_0066: ldc.r8 0.0
-		IL_006f: stloc.3
-		IL_0070: ldc.r8 0.0
-		IL_0079: stloc.s 4
-		// loop start (head: IL_007b)
-			IL_007b: ldloc.s 4
-			IL_007d: ldc.r8 10000
-			IL_0086: clt
-			IL_0088: brfalse IL_00ad
+		IL_003b: ldloc.s 11
+		IL_003d: ldstr "performance"
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0047: stloc.1
+		IL_0048: ldloc.1
+		IL_0049: ldstr "now"
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0053: stloc.s 11
+		IL_0055: ldloc.s 11
+		IL_0057: stloc.2
+		IL_0058: ldc.r8 0.0
+		IL_0061: stloc.3
+		IL_0062: ldc.r8 0.0
+		IL_006b: stloc.s 4
+		// loop start (head: IL_006d)
+			IL_006d: ldloc.s 4
+			IL_006f: ldc.r8 10000
+			IL_0078: clt
+			IL_007a: brfalse IL_009f
 
-			IL_008d: ldloc.3
-			IL_008e: ldloc.s 4
-			IL_0090: add
-			IL_0091: stloc.s 14
-			IL_0093: ldloc.s 14
-			IL_0095: stloc.3
-			IL_0096: ldloc.s 4
-			IL_0098: ldc.r8 1
-			IL_00a1: add
-			IL_00a2: stloc.s 14
-			IL_00a4: ldloc.s 14
-			IL_00a6: stloc.s 4
-			IL_00a8: br IL_007b
+			IL_007f: ldloc.3
+			IL_0080: ldloc.s 4
+			IL_0082: add
+			IL_0083: stloc.s 13
+			IL_0085: ldloc.s 13
+			IL_0087: stloc.3
+			IL_0088: ldloc.s 4
+			IL_008a: ldc.r8 1
+			IL_0093: add
+			IL_0094: stloc.s 13
+			IL_0096: ldloc.s 13
+			IL_0098: stloc.s 4
+			IL_009a: br IL_006d
 		// end loop
 
-		IL_00ad: ldloc.1
-		IL_00ae: ldstr "now"
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00b8: stloc.s 12
-		IL_00ba: ldloc.s 12
-		IL_00bc: stloc.s 5
-		IL_00be: ldc.i4.1
-		IL_00bf: stloc.s 6
+		IL_009f: ldloc.1
+		IL_00a0: ldstr "now"
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00aa: stloc.s 11
+		IL_00ac: ldloc.s 11
+		IL_00ae: stloc.s 5
+		IL_00b0: ldc.i4.1
+		IL_00b1: stloc.s 6
 		.try
 		{
-			IL_00c1: ldloc.1
-			IL_00c2: ldstr "now"
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00cc: pop
-			IL_00cd: leave IL_0117
+			IL_00b3: ldloc.1
+			IL_00b4: ldstr "now"
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00be: pop
+			IL_00bf: leave IL_0109
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00d2: stloc.s 7
-			IL_00d4: ldloc.s 7
-			IL_00d6: dup
-			IL_00d7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00dc: dup
-			IL_00dd: brtrue IL_00f3
+			IL_00c4: stloc.s 7
+			IL_00c6: ldloc.s 7
+			IL_00c8: dup
+			IL_00c9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00ce: dup
+			IL_00cf: brtrue IL_00e5
 
+			IL_00d4: pop
+			IL_00d5: dup
+			IL_00d6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00db: dup
+			IL_00dc: brtrue IL_00f2
+
+			IL_00e1: pop
 			IL_00e2: pop
-			IL_00e3: dup
-			IL_00e4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00e9: dup
-			IL_00ea: brtrue IL_0100
+			IL_00e3: rethrow
 
-			IL_00ef: pop
-			IL_00f0: pop
-			IL_00f1: rethrow
+			IL_00e5: pop
+			IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00eb: stloc.s 8
+			IL_00ed: br IL_00f5
 
-			IL_00f3: pop
-			IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00f9: stloc.s 8
-			IL_00fb: br IL_0103
+			IL_00f2: pop
+			IL_00f3: stloc.s 8
 
-			IL_0100: pop
-			IL_0101: stloc.s 8
-
-			IL_0103: ldloc.s 8
-			IL_0105: stloc.s 12
-			IL_0107: ldloc.s 12
-			IL_0109: stloc.s 9
-			IL_010b: ldc.i4.0
-			IL_010c: stloc.s 15
-			IL_010e: ldloc.s 15
-			IL_0110: stloc.s 6
-			IL_0112: leave IL_0117
+			IL_00f5: ldloc.s 8
+			IL_00f7: stloc.s 11
+			IL_00f9: ldloc.s 11
+			IL_00fb: stloc.s 9
+			IL_00fd: ldc.i4.0
+			IL_00fe: stloc.s 14
+			IL_0100: ldloc.s 14
+			IL_0102: stloc.s 6
+			IL_0104: leave IL_0109
 		} // end handler
 
-		IL_0117: ldloc.s 5
-		IL_0119: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_011e: stloc.s 14
-		IL_0120: ldloc.2
-		IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0126: stloc.s 16
-		IL_0128: ldloc.s 14
-		IL_012a: ldloc.s 16
-		IL_012c: sub
-		IL_012d: stloc.s 16
-		IL_012f: ldloc.s 16
-		IL_0131: stloc.s 10
-		IL_0133: ldloc.s 6
-		IL_0135: box [System.Runtime]System.Boolean
-		IL_013a: stloc.s 17
-		IL_013c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0141: ldstr "hasNow="
-		IL_0146: ldloc.s 17
-		IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_014d: pop
-		IL_014e: ldloc.s 10
-		IL_0150: ldc.r8 0.0
-		IL_0159: clt
-		IL_015b: ldc.i4.0
-		IL_015c: ceq
-		IL_015e: stloc.s 15
-		IL_0160: ldloc.s 15
-		IL_0162: box [System.Runtime]System.Boolean
-		IL_0167: stloc.s 17
-		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016e: ldstr "elapsedMsNonNegative="
-		IL_0173: ldloc.s 17
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_017a: pop
-		IL_017b: ret
+		IL_0109: ldloc.s 5
+		IL_010b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0110: stloc.s 13
+		IL_0112: ldloc.2
+		IL_0113: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0118: stloc.s 15
+		IL_011a: ldloc.s 13
+		IL_011c: ldloc.s 15
+		IL_011e: sub
+		IL_011f: stloc.s 15
+		IL_0121: ldloc.s 15
+		IL_0123: stloc.s 10
+		IL_0125: ldloc.s 6
+		IL_0127: box [System.Runtime]System.Boolean
+		IL_012c: stloc.s 16
+		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0133: ldstr "hasNow="
+		IL_0138: ldloc.s 16
+		IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_013f: pop
+		IL_0140: ldloc.s 10
+		IL_0142: ldc.r8 0.0
+		IL_014b: clt
+		IL_014d: ldc.i4.0
+		IL_014e: ceq
+		IL_0150: stloc.s 14
+		IL_0152: ldloc.s 14
+		IL_0154: box [System.Runtime]System.Boolean
+		IL_0159: stloc.s 16
+		IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0160: ldstr "elapsedMsNonNegative="
+		IL_0165: ldloc.s 16
+		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_016c: pop
+		IL_016d: ret
 	} // end of method PerfHooks_PerformanceNow_Basic::__js_module_init__
 
 } // end of class Modules.PerfHooks_PerformanceNow_Basic
@@ -288,7 +279,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220c
+		// Method begins at RVA 0x2200
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2222
+				// Method begins at RVA 0x2214
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -40,7 +40,7 @@
 				object chunk
 			) cil managed 
 		{
-			// Method begins at RVA 0x21fd
+			// Method begins at RVA 0x21ef
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -75,7 +75,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2219
+			// Method begins at RVA 0x220b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2234
+				// Method begins at RVA 0x2226
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -117,7 +117,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x222b
+			// Method begins at RVA 0x221d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -143,7 +143,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 417 (0x1a1)
+		// Code size: 403 (0x193)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipe_Basic/Scope,
@@ -153,154 +153,145 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object[],
-			[8] object,
+			[7] object,
+			[8] float64,
 			[9] float64,
-			[10] float64,
-			[11] object,
-			[12] object
+			[10] object,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipe_Basic/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 7
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "node:stream"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 7
 		IL_0013: ldloc.s 7
-		IL_0015: ldstr "node:stream"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 8
-		IL_0021: ldloc.s 8
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "Readable"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldloc.1
-		IL_0031: ldstr "Writable"
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_003b: stloc.3
-		IL_003c: ldloc.2
-		IL_003d: ldc.i4.0
-		IL_003e: newarr [System.Runtime]System.Object
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0048: stloc.s 8
-		IL_004a: ldloc.s 8
-		IL_004c: stloc.s 4
-		IL_004e: ldloc.3
-		IL_004f: ldc.i4.0
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_005a: stloc.s 8
-		IL_005c: ldloc.s 8
-		IL_005e: stloc.s 5
-		IL_0060: ldloc.0
-		IL_0061: ldc.i4.0
-		IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0067: stfld object Modules.Stream_Pipe_Basic/Scope::writtenData
-		IL_006c: ldnull
-		IL_006d: ldftn object Modules.Stream_Pipe_Basic/FunctionExpression_L13C18::__js_call__(object[], object, object)
-		IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_0078: ldc.i4.1
-		IL_0079: newarr [System.Runtime]System.Object
-		IL_007e: dup
-		IL_007f: ldc.i4.0
-		IL_0080: ldloc.0
-		IL_0081: stelem.ref
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0087: stloc.s 8
-		IL_0089: ldloc.s 5
-		IL_008b: ldstr "_write"
-		IL_0090: ldloc.s 8
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0097: pop
-		IL_0098: ldloc.s 4
-		IL_009a: ldstr "pipe"
-		IL_009f: ldloc.s 5
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a6: pop
-		IL_00a7: ldloc.s 4
-		IL_00a9: ldstr "push"
-		IL_00ae: ldstr "data1"
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00b8: pop
-		IL_00b9: ldloc.s 4
-		IL_00bb: ldstr "push"
-		IL_00c0: ldstr "data2"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ca: pop
-		IL_00cb: ldloc.s 4
-		IL_00cd: ldstr "push"
-		IL_00d2: ldstr "data3"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00dc: pop
-		IL_00dd: ldloc.s 4
-		IL_00df: ldstr "push"
-		IL_00e4: ldc.i4.0
-		IL_00e5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ef: pop
-		IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f5: ldstr "Written data count:"
-		IL_00fa: ldloc.0
-		IL_00fb: ldfld object Modules.Stream_Pipe_Basic/Scope::writtenData
-		IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_0105: box [System.Runtime]System.Double
-		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_010f: pop
-		IL_0110: ldc.r8 0.0
-		IL_0119: box [System.Runtime]System.Double
-		IL_011e: stloc.s 6
-		// loop start (head: IL_0120)
-			IL_0120: ldloc.0
-			IL_0121: ldfld object Modules.Stream_Pipe_Basic/Scope::writtenData
-			IL_0126: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_012b: stloc.s 9
-			IL_012d: ldloc.s 6
-			IL_012f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0134: stloc.s 10
-			IL_0136: ldloc.s 10
-			IL_0138: ldloc.s 9
-			IL_013a: clt
-			IL_013c: brfalse IL_01a0
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "Readable"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldloc.1
+		IL_0023: ldstr "Writable"
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_002d: stloc.3
+		IL_002e: ldloc.2
+		IL_002f: ldc.i4.0
+		IL_0030: newarr [System.Runtime]System.Object
+		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_003a: stloc.s 7
+		IL_003c: ldloc.s 7
+		IL_003e: stloc.s 4
+		IL_0040: ldloc.3
+		IL_0041: ldc.i4.0
+		IL_0042: newarr [System.Runtime]System.Object
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_004c: stloc.s 7
+		IL_004e: ldloc.s 7
+		IL_0050: stloc.s 5
+		IL_0052: ldloc.0
+		IL_0053: ldc.i4.0
+		IL_0054: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0059: stfld object Modules.Stream_Pipe_Basic/Scope::writtenData
+		IL_005e: ldnull
+		IL_005f: ldftn object Modules.Stream_Pipe_Basic/FunctionExpression_L13C18::__js_call__(object[], object, object)
+		IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_006a: ldc.i4.1
+		IL_006b: newarr [System.Runtime]System.Object
+		IL_0070: dup
+		IL_0071: ldc.i4.0
+		IL_0072: ldloc.0
+		IL_0073: stelem.ref
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0079: stloc.s 7
+		IL_007b: ldloc.s 5
+		IL_007d: ldstr "_write"
+		IL_0082: ldloc.s 7
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0089: pop
+		IL_008a: ldloc.s 4
+		IL_008c: ldstr "pipe"
+		IL_0091: ldloc.s 5
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0098: pop
+		IL_0099: ldloc.s 4
+		IL_009b: ldstr "push"
+		IL_00a0: ldstr "data1"
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00aa: pop
+		IL_00ab: ldloc.s 4
+		IL_00ad: ldstr "push"
+		IL_00b2: ldstr "data2"
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00bc: pop
+		IL_00bd: ldloc.s 4
+		IL_00bf: ldstr "push"
+		IL_00c4: ldstr "data3"
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ce: pop
+		IL_00cf: ldloc.s 4
+		IL_00d1: ldstr "push"
+		IL_00d6: ldc.i4.0
+		IL_00d7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e1: pop
+		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e7: ldstr "Written data count:"
+		IL_00ec: ldloc.0
+		IL_00ed: ldfld object Modules.Stream_Pipe_Basic/Scope::writtenData
+		IL_00f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_00f7: box [System.Runtime]System.Double
+		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0101: pop
+		IL_0102: ldc.r8 0.0
+		IL_010b: box [System.Runtime]System.Double
+		IL_0110: stloc.s 6
+		// loop start (head: IL_0112)
+			IL_0112: ldloc.0
+			IL_0113: ldfld object Modules.Stream_Pipe_Basic/Scope::writtenData
+			IL_0118: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_011d: stloc.s 8
+			IL_011f: ldloc.s 6
+			IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0126: stloc.s 9
+			IL_0128: ldloc.s 9
+			IL_012a: ldloc.s 8
+			IL_012c: clt
+			IL_012e: brfalse IL_0192
 
-			IL_0141: ldstr "Chunk "
-			IL_0146: ldloc.s 6
+			IL_0133: ldstr "Chunk "
+			IL_0138: ldloc.s 6
+			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_013f: stloc.s 10
+			IL_0141: ldloc.s 10
+			IL_0143: ldstr ":"
 			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_014d: stloc.s 11
-			IL_014f: ldloc.s 11
-			IL_0151: ldstr ":"
-			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_015b: stloc.s 11
-			IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0162: ldloc.s 11
-			IL_0164: ldloc.0
-			IL_0165: ldfld object Modules.Stream_Pipe_Basic/Scope::writtenData
-			IL_016a: ldloc.s 6
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-			IL_0171: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0176: pop
-			IL_0177: ldloc.s 6
-			IL_0179: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_017e: stloc.s 9
-			IL_0180: ldloc.s 9
-			IL_0182: ldc.r8 1
-			IL_018b: add
-			IL_018c: stloc.s 9
-			IL_018e: ldloc.s 9
-			IL_0190: box [System.Runtime]System.Double
-			IL_0195: stloc.s 12
-			IL_0197: ldloc.s 12
-			IL_0199: stloc.s 6
-			IL_019b: br IL_0120
+			IL_014d: stloc.s 10
+			IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0154: ldloc.s 10
+			IL_0156: ldloc.0
+			IL_0157: ldfld object Modules.Stream_Pipe_Basic/Scope::writtenData
+			IL_015c: ldloc.s 6
+			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+			IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0168: pop
+			IL_0169: ldloc.s 6
+			IL_016b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0170: stloc.s 8
+			IL_0172: ldloc.s 8
+			IL_0174: ldc.r8 1
+			IL_017d: add
+			IL_017e: stloc.s 8
+			IL_0180: ldloc.s 8
+			IL_0182: box [System.Runtime]System.Double
+			IL_0187: stloc.s 11
+			IL_0189: ldloc.s 11
+			IL_018b: stloc.s 6
+			IL_018d: br IL_0112
 		// end loop
 
-		IL_01a0: ret
+		IL_0192: ret
 	} // end of method Stream_Pipe_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipe_Basic
@@ -312,7 +303,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x223d
+		// Method begins at RVA 0x222f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220a
+				// Method begins at RVA 0x21fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -40,7 +40,7 @@
 				object chunk
 			) cil managed 
 		{
-			// Method begins at RVA 0x2198
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 65 (0x41)
 			.maxstack 8
@@ -81,7 +81,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2213
+				// Method begins at RVA 0x2203
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x21e5
+			// Method begins at RVA 0x21d5
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -136,7 +136,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2201
+			// Method begins at RVA 0x21f1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -162,123 +162,114 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 314 (0x13a)
+		// Code size: 300 (0x12c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Readable_Basic/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object[],
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Readable_Basic/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 4
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "node:stream"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 4
 		IL_0013: ldloc.s 4
-		IL_0015: ldstr "node:stream"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 5
-		IL_0021: ldloc.s 5
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "Readable"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldloc.2
-		IL_0031: ldc.i4.0
-		IL_0032: newarr [System.Runtime]System.Object
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_003c: stloc.s 5
-		IL_003e: ldloc.s 5
-		IL_0040: stloc.3
-		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0046: ldc.i4.1
-		IL_0047: newarr [System.Runtime]System.Object
-		IL_004c: dup
-		IL_004d: ldc.i4.0
-		IL_004e: ldloc.3
-		IL_004f: ldstr "readable"
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0059: stelem.ref
-		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_005f: pop
-		IL_0060: ldloc.0
-		IL_0061: ldc.r8 0.0
-		IL_006a: box [System.Runtime]System.Double
-		IL_006f: stfld object Modules.Stream_Readable_Basic/Scope::dataReceived
-		IL_0074: ldnull
-		IL_0075: ldftn object Modules.Stream_Readable_Basic/FunctionExpression_L13C20::__js_call__(object[], object, object)
-		IL_007b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_0080: ldc.i4.1
-		IL_0081: newarr [System.Runtime]System.Object
-		IL_0086: dup
-		IL_0087: ldc.i4.0
-		IL_0088: ldloc.0
-		IL_0089: stelem.ref
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.3
-		IL_0092: ldstr "on"
-		IL_0097: ldstr "data"
-		IL_009c: ldloc.s 5
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00a3: pop
-		IL_00a4: ldnull
-		IL_00a5: ldftn object Modules.Stream_Readable_Basic/FunctionExpression_L18C19::__js_call__(object)
-		IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00b0: ldc.i4.1
-		IL_00b1: newarr [System.Runtime]System.Object
-		IL_00b6: dup
-		IL_00b7: ldc.i4.0
-		IL_00b8: ldloc.0
-		IL_00b9: stelem.ref
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_00bf: stloc.s 5
-		IL_00c1: ldloc.3
-		IL_00c2: ldstr "on"
-		IL_00c7: ldstr "end"
-		IL_00cc: ldloc.s 5
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00d3: pop
-		IL_00d4: ldloc.3
-		IL_00d5: ldstr "push"
-		IL_00da: ldstr "chunk1"
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e4: pop
-		IL_00e5: ldloc.3
-		IL_00e6: ldstr "push"
-		IL_00eb: ldstr "chunk2"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f5: pop
-		IL_00f6: ldloc.3
-		IL_00f7: ldstr "push"
-		IL_00fc: ldc.i4.0
-		IL_00fd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0107: pop
-		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010d: ldstr "Data events:"
-		IL_0112: ldloc.0
-		IL_0113: ldfld object Modules.Stream_Readable_Basic/Scope::dataReceived
-		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_011d: pop
-		IL_011e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0123: ldstr "Readable after end:"
-		IL_0128: ldloc.3
-		IL_0129: ldstr "readable"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0138: pop
-		IL_0139: ret
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "Readable"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldc.i4.0
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_002e: stloc.s 4
+		IL_0030: ldloc.s 4
+		IL_0032: stloc.3
+		IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0038: ldc.i4.1
+		IL_0039: newarr [System.Runtime]System.Object
+		IL_003e: dup
+		IL_003f: ldc.i4.0
+		IL_0040: ldloc.3
+		IL_0041: ldstr "readable"
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_004b: stelem.ref
+		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0051: pop
+		IL_0052: ldloc.0
+		IL_0053: ldc.r8 0.0
+		IL_005c: box [System.Runtime]System.Double
+		IL_0061: stfld object Modules.Stream_Readable_Basic/Scope::dataReceived
+		IL_0066: ldnull
+		IL_0067: ldftn object Modules.Stream_Readable_Basic/FunctionExpression_L13C20::__js_call__(object[], object, object)
+		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_0072: ldc.i4.1
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldloc.0
+		IL_007b: stelem.ref
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0081: stloc.s 4
+		IL_0083: ldloc.3
+		IL_0084: ldstr "on"
+		IL_0089: ldstr "data"
+		IL_008e: ldloc.s 4
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0095: pop
+		IL_0096: ldnull
+		IL_0097: ldftn object Modules.Stream_Readable_Basic/FunctionExpression_L18C19::__js_call__(object)
+		IL_009d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a2: ldc.i4.1
+		IL_00a3: newarr [System.Runtime]System.Object
+		IL_00a8: dup
+		IL_00a9: ldc.i4.0
+		IL_00aa: ldloc.0
+		IL_00ab: stelem.ref
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00b1: stloc.s 4
+		IL_00b3: ldloc.3
+		IL_00b4: ldstr "on"
+		IL_00b9: ldstr "end"
+		IL_00be: ldloc.s 4
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00c5: pop
+		IL_00c6: ldloc.3
+		IL_00c7: ldstr "push"
+		IL_00cc: ldstr "chunk1"
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00d6: pop
+		IL_00d7: ldloc.3
+		IL_00d8: ldstr "push"
+		IL_00dd: ldstr "chunk2"
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e7: pop
+		IL_00e8: ldloc.3
+		IL_00e9: ldstr "push"
+		IL_00ee: ldc.i4.0
+		IL_00ef: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f9: pop
+		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ff: ldstr "Data events:"
+		IL_0104: ldloc.0
+		IL_0105: ldfld object Modules.Stream_Readable_Basic/Scope::dataReceived
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_010f: pop
+		IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0115: ldstr "Readable after end:"
+		IL_011a: ldloc.3
+		IL_011b: ldstr "readable"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_012a: pop
+		IL_012b: ret
 	} // end of method Stream_Readable_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Readable_Basic
@@ -290,7 +281,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221c
+		// Method begins at RVA 0x220c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2199
+			// Method begins at RVA 0x218b
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -89,7 +89,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x21b5
+			// Method begins at RVA 0x21a7
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -116,7 +116,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d1
+			// Method begins at RVA 0x21c3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -142,130 +142,121 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 317 (0x13d)
+		// Code size: 303 (0x12f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Writable_Basic/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object[],
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Writable_Basic/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 4
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "node:stream"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 4
 		IL_0013: ldloc.s 4
-		IL_0015: ldstr "node:stream"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 5
-		IL_0021: ldloc.s 5
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "Writable"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldloc.2
-		IL_0031: ldc.i4.0
-		IL_0032: newarr [System.Runtime]System.Object
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_003c: stloc.s 5
-		IL_003e: ldloc.s 5
-		IL_0040: stloc.3
-		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0046: ldc.i4.1
-		IL_0047: newarr [System.Runtime]System.Object
-		IL_004c: dup
-		IL_004d: ldc.i4.0
-		IL_004e: ldloc.3
-		IL_004f: ldstr "writable"
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0059: stelem.ref
-		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_005f: pop
-		IL_0060: ldnull
-		IL_0061: ldftn object Modules.Stream_Writable_Basic/FunctionExpression_L12C21::__js_call__(object)
-		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_006c: ldc.i4.1
-		IL_006d: newarr [System.Runtime]System.Object
-		IL_0072: dup
-		IL_0073: ldc.i4.0
-		IL_0074: ldloc.0
-		IL_0075: stelem.ref
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_007b: stloc.s 5
-		IL_007d: ldloc.3
-		IL_007e: ldstr "on"
-		IL_0083: ldstr "drain"
-		IL_0088: ldloc.s 5
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_008f: pop
-		IL_0090: ldnull
-		IL_0091: ldftn object Modules.Stream_Writable_Basic/FunctionExpression_L17C22::__js_call__(object)
-		IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_00ab: stloc.s 5
-		IL_00ad: ldloc.3
-		IL_00ae: ldstr "on"
-		IL_00b3: ldstr "finish"
-		IL_00b8: ldloc.s 5
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00bf: pop
-		IL_00c0: ldloc.3
-		IL_00c1: ldstr "write"
-		IL_00c6: ldstr "chunk1"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d0: stloc.s 5
-		IL_00d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d7: ldc.i4.1
-		IL_00d8: newarr [System.Runtime]System.Object
-		IL_00dd: dup
-		IL_00de: ldc.i4.0
-		IL_00df: ldloc.s 5
-		IL_00e1: stelem.ref
-		IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00e7: pop
-		IL_00e8: ldloc.3
-		IL_00e9: ldstr "write"
-		IL_00ee: ldstr "chunk2"
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f8: stloc.s 5
-		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ff: ldc.i4.1
-		IL_0100: newarr [System.Runtime]System.Object
-		IL_0105: dup
-		IL_0106: ldc.i4.0
-		IL_0107: ldloc.s 5
-		IL_0109: stelem.ref
-		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_010f: pop
-		IL_0110: ldloc.3
-		IL_0111: ldstr "end"
-		IL_0116: ldstr "final chunk"
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0120: pop
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0126: ldstr "Writable after end:"
-		IL_012b: ldloc.3
-		IL_012c: ldstr "writable"
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_013b: pop
-		IL_013c: ret
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "Writable"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldc.i4.0
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_002e: stloc.s 4
+		IL_0030: ldloc.s 4
+		IL_0032: stloc.3
+		IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0038: ldc.i4.1
+		IL_0039: newarr [System.Runtime]System.Object
+		IL_003e: dup
+		IL_003f: ldc.i4.0
+		IL_0040: ldloc.3
+		IL_0041: ldstr "writable"
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_004b: stelem.ref
+		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0051: pop
+		IL_0052: ldnull
+		IL_0053: ldftn object Modules.Stream_Writable_Basic/FunctionExpression_L12C21::__js_call__(object)
+		IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_005e: ldc.i4.1
+		IL_005f: newarr [System.Runtime]System.Object
+		IL_0064: dup
+		IL_0065: ldc.i4.0
+		IL_0066: ldloc.0
+		IL_0067: stelem.ref
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_006d: stloc.s 4
+		IL_006f: ldloc.3
+		IL_0070: ldstr "on"
+		IL_0075: ldstr "drain"
+		IL_007a: ldloc.s 4
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0081: pop
+		IL_0082: ldnull
+		IL_0083: ldftn object Modules.Stream_Writable_Basic/FunctionExpression_L17C22::__js_call__(object)
+		IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_008e: ldc.i4.1
+		IL_008f: newarr [System.Runtime]System.Object
+		IL_0094: dup
+		IL_0095: ldc.i4.0
+		IL_0096: ldloc.0
+		IL_0097: stelem.ref
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_009d: stloc.s 4
+		IL_009f: ldloc.3
+		IL_00a0: ldstr "on"
+		IL_00a5: ldstr "finish"
+		IL_00aa: ldloc.s 4
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00b1: pop
+		IL_00b2: ldloc.3
+		IL_00b3: ldstr "write"
+		IL_00b8: ldstr "chunk1"
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c2: stloc.s 4
+		IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.s 4
+		IL_00d3: stelem.ref
+		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00d9: pop
+		IL_00da: ldloc.3
+		IL_00db: ldstr "write"
+		IL_00e0: ldstr "chunk2"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ea: stloc.s 4
+		IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f1: ldc.i4.1
+		IL_00f2: newarr [System.Runtime]System.Object
+		IL_00f7: dup
+		IL_00f8: ldc.i4.0
+		IL_00f9: ldloc.s 4
+		IL_00fb: stelem.ref
+		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0101: pop
+		IL_0102: ldloc.3
+		IL_0103: ldstr "end"
+		IL_0108: ldstr "final chunk"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0112: pop
+		IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0118: ldstr "Writable after end:"
+		IL_011d: ldloc.3
+		IL_011e: ldstr "writable"
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_012d: pop
+		IL_012e: ret
 	} // end of method Stream_Writable_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Writable_Basic
@@ -277,7 +268,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ec
+		// Method begins at RVA 0x21de
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
+++ b/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e9
+				// Method begins at RVA 0x21db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -40,7 +40,7 @@
 				object chunk
 			) cil managed 
 		{
-			// Method begins at RVA 0x21b3
+			// Method begins at RVA 0x21a5
 			// Header size: 1
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e0
+			// Method begins at RVA 0x21d2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -104,7 +104,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fb
+				// Method begins at RVA 0x21ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +122,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f2
+			// Method begins at RVA 0x21e4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -148,7 +148,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 343 (0x157)
+		// Code size: 329 (0x149)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Writable_CustomWrite/Scope,
@@ -156,131 +156,122 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object[],
-			[6] object,
+			[5] object,
+			[6] float64,
 			[7] float64,
-			[8] float64,
-			[9] object,
-			[10] object
+			[8] object,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Writable_CustomWrite/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 5
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "node:stream"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 5
 		IL_0013: ldloc.s 5
-		IL_0015: ldstr "node:stream"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 6
-		IL_0021: ldloc.s 6
-		IL_0023: stloc.1
-		IL_0024: ldloc.1
-		IL_0025: ldstr "Writable"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_002f: stloc.2
-		IL_0030: ldloc.2
-		IL_0031: ldc.i4.0
-		IL_0032: newarr [System.Runtime]System.Object
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_003c: stloc.s 6
-		IL_003e: ldloc.s 6
-		IL_0040: stloc.3
-		IL_0041: ldloc.0
-		IL_0042: ldc.i4.0
-		IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0048: stfld object Modules.Stream_Writable_CustomWrite/Scope::writtenData
-		IL_004d: ldnull
-		IL_004e: ldftn object Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18::__js_call__(object[], object, object)
-		IL_0054: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_0059: ldc.i4.1
-		IL_005a: newarr [System.Runtime]System.Object
-		IL_005f: dup
-		IL_0060: ldc.i4.0
-		IL_0061: ldloc.0
-		IL_0062: stelem.ref
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_0068: stloc.s 6
+		IL_0015: stloc.1
+		IL_0016: ldloc.1
+		IL_0017: ldstr "Writable"
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0021: stloc.2
+		IL_0022: ldloc.2
+		IL_0023: ldc.i4.0
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_002e: stloc.s 5
+		IL_0030: ldloc.s 5
+		IL_0032: stloc.3
+		IL_0033: ldloc.0
+		IL_0034: ldc.i4.0
+		IL_0035: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_003a: stfld object Modules.Stream_Writable_CustomWrite/Scope::writtenData
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18::__js_call__(object[], object, object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_005a: stloc.s 5
+		IL_005c: ldloc.3
+		IL_005d: ldstr "_write"
+		IL_0062: ldloc.s 5
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0069: pop
 		IL_006a: ldloc.3
-		IL_006b: ldstr "_write"
-		IL_0070: ldloc.s 6
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0077: pop
-		IL_0078: ldloc.3
-		IL_0079: ldstr "write"
-		IL_007e: ldstr "test1"
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0088: pop
-		IL_0089: ldloc.3
-		IL_008a: ldstr "write"
-		IL_008f: ldstr "test2"
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0099: pop
-		IL_009a: ldloc.3
-		IL_009b: ldstr "end"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00a5: pop
-		IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ab: ldstr "Written data count:"
-		IL_00b0: ldloc.0
-		IL_00b1: ldfld object Modules.Stream_Writable_CustomWrite/Scope::writtenData
-		IL_00b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_00bb: box [System.Runtime]System.Double
-		IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00c5: pop
-		IL_00c6: ldc.r8 0.0
-		IL_00cf: box [System.Runtime]System.Double
-		IL_00d4: stloc.s 4
-		// loop start (head: IL_00d6)
-			IL_00d6: ldloc.0
-			IL_00d7: ldfld object Modules.Stream_Writable_CustomWrite/Scope::writtenData
-			IL_00dc: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00e1: stloc.s 7
-			IL_00e3: ldloc.s 4
-			IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ea: stloc.s 8
-			IL_00ec: ldloc.s 8
-			IL_00ee: ldloc.s 7
-			IL_00f0: clt
-			IL_00f2: brfalse IL_0156
+		IL_006b: ldstr "write"
+		IL_0070: ldstr "test1"
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007a: pop
+		IL_007b: ldloc.3
+		IL_007c: ldstr "write"
+		IL_0081: ldstr "test2"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008b: pop
+		IL_008c: ldloc.3
+		IL_008d: ldstr "end"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0097: pop
+		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009d: ldstr "Written data count:"
+		IL_00a2: ldloc.0
+		IL_00a3: ldfld object Modules.Stream_Writable_CustomWrite/Scope::writtenData
+		IL_00a8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+		IL_00ad: box [System.Runtime]System.Double
+		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b7: pop
+		IL_00b8: ldc.r8 0.0
+		IL_00c1: box [System.Runtime]System.Double
+		IL_00c6: stloc.s 4
+		// loop start (head: IL_00c8)
+			IL_00c8: ldloc.0
+			IL_00c9: ldfld object Modules.Stream_Writable_CustomWrite/Scope::writtenData
+			IL_00ce: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00d3: stloc.s 6
+			IL_00d5: ldloc.s 4
+			IL_00d7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00dc: stloc.s 7
+			IL_00de: ldloc.s 7
+			IL_00e0: ldloc.s 6
+			IL_00e2: clt
+			IL_00e4: brfalse IL_0148
 
-			IL_00f7: ldstr "Chunk "
-			IL_00fc: ldloc.s 4
+			IL_00e9: ldstr "Chunk "
+			IL_00ee: ldloc.s 4
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00f5: stloc.s 8
+			IL_00f7: ldloc.s 8
+			IL_00f9: ldstr ":"
 			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0103: stloc.s 9
-			IL_0105: ldloc.s 9
-			IL_0107: ldstr ":"
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0111: stloc.s 9
-			IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0118: ldloc.s 9
-			IL_011a: ldloc.0
-			IL_011b: ldfld object Modules.Stream_Writable_CustomWrite/Scope::writtenData
-			IL_0120: ldloc.s 4
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-			IL_0127: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_012c: pop
-			IL_012d: ldloc.s 4
-			IL_012f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0134: stloc.s 7
-			IL_0136: ldloc.s 7
-			IL_0138: ldc.r8 1
-			IL_0141: add
-			IL_0142: stloc.s 7
-			IL_0144: ldloc.s 7
-			IL_0146: box [System.Runtime]System.Double
-			IL_014b: stloc.s 10
-			IL_014d: ldloc.s 10
-			IL_014f: stloc.s 4
-			IL_0151: br IL_00d6
+			IL_0103: stloc.s 8
+			IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_010a: ldloc.s 8
+			IL_010c: ldloc.0
+			IL_010d: ldfld object Modules.Stream_Writable_CustomWrite/Scope::writtenData
+			IL_0112: ldloc.s 4
+			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+			IL_0119: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_011e: pop
+			IL_011f: ldloc.s 4
+			IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0126: stloc.s 6
+			IL_0128: ldloc.s 6
+			IL_012a: ldc.r8 1
+			IL_0133: add
+			IL_0134: stloc.s 6
+			IL_0136: ldloc.s 6
+			IL_0138: box [System.Runtime]System.Double
+			IL_013d: stloc.s 9
+			IL_013f: ldloc.s 9
+			IL_0141: stloc.s 4
+			IL_0143: br IL_00c8
 		// end loop
 
-		IL_0156: ret
+		IL_0148: ret
 	} // end of method Stream_Writable_CustomWrite::__js_module_init__
 
 } // end of class Modules.Stream_Writable_CustomWrite
@@ -292,7 +283,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2204
+		// Method begins at RVA 0x21f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221e
+				// Method begins at RVA 0x220e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -39,7 +39,7 @@
 				object name
 			) cil managed 
 		{
-			// Method begins at RVA 0x21b1
+			// Method begins at RVA 0x21a3
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -66,7 +66,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2227
+				// Method begins at RVA 0x2217
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,7 +86,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x21c8
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -117,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2230
+				// Method begins at RVA 0x2220
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -139,7 +139,7 @@
 				object breed
 			) cil managed 
 		{
-			// Method begins at RVA 0x21f0
+			// Method begins at RVA 0x21e0
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2215
+			// Method begins at RVA 0x2205
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,7 +202,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 341 (0x155)
+		// Code size: 327 (0x147)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Inherits_Basic/Scope,
@@ -211,9 +211,8 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object[],
-			[7] bool,
-			[8] object
+			[6] bool,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Util_Inherits_Basic/Scope::.ctor()
@@ -244,109 +243,101 @@
 		IL_0041: stloc.s 5
 		IL_0043: ldloc.s 5
 		IL_0045: stloc.2
-		IL_0046: ldc.i4.1
-		IL_0047: newarr [System.Runtime]System.Object
-		IL_004c: dup
-		IL_004d: ldc.i4.0
-		IL_004e: ldnull
-		IL_004f: stelem.ref
-		IL_0050: stloc.s 6
-		IL_0052: ldarg.1
-		IL_0053: ldloc.s 6
-		IL_0055: ldstr "util"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_005f: stloc.s 5
-		IL_0061: ldloc.s 5
-		IL_0063: stloc.3
-		IL_0064: ldnull
-		IL_0065: ldftn object Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25::__js_call__(object)
-		IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0070: ldc.i4.1
-		IL_0071: newarr [System.Runtime]System.Object
-		IL_0076: dup
-		IL_0077: ldc.i4.0
-		IL_0078: ldloc.0
-		IL_0079: stelem.ref
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-		IL_007f: stloc.s 5
-		IL_0081: ldloc.1
-		IL_0082: ldstr "prototype"
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_008c: ldstr "speak"
-		IL_0091: ldloc.s 5
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0046: ldarg.1
+		IL_0047: ldstr "util"
+		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0051: stloc.s 5
+		IL_0053: ldloc.s 5
+		IL_0055: stloc.3
+		IL_0056: ldnull
+		IL_0057: ldftn object Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25::__js_call__(object)
+		IL_005d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.0
+		IL_006b: stelem.ref
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0071: stloc.s 5
+		IL_0073: ldloc.1
+		IL_0074: ldstr "prototype"
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_007e: ldstr "speak"
+		IL_0083: ldloc.s 5
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_008a: pop
+		IL_008b: ldloc.3
+		IL_008c: ldstr "inherits"
+		IL_0091: ldloc.2
+		IL_0092: ldloc.1
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0098: pop
-		IL_0099: ldloc.3
-		IL_009a: ldstr "inherits"
-		IL_009f: ldloc.2
-		IL_00a0: ldloc.1
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00a6: pop
-		IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ac: ldc.i4.1
-		IL_00ad: newarr [System.Runtime]System.Object
-		IL_00b2: dup
-		IL_00b3: ldc.i4.0
-		IL_00b4: ldstr "inherits completed"
-		IL_00b9: stelem.ref
-		IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00bf: pop
-		IL_00c0: ldloc.2
-		IL_00c1: ldstr "super_"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00cb: ldloc.1
-		IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00d1: stloc.s 7
-		IL_00d3: ldloc.s 7
-		IL_00d5: box [System.Runtime]System.Boolean
-		IL_00da: stloc.s 8
-		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e1: ldc.i4.1
-		IL_00e2: newarr [System.Runtime]System.Object
-		IL_00e7: dup
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldloc.s 8
-		IL_00eb: stelem.ref
-		IL_00ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00f1: pop
-		IL_00f2: ldloc.2
-		IL_00f3: ldc.i4.2
-		IL_00f4: newarr [System.Runtime]System.Object
-		IL_00f9: dup
-		IL_00fa: ldc.i4.0
-		IL_00fb: ldstr "Buddy"
-		IL_0100: stelem.ref
-		IL_0101: dup
-		IL_0102: ldc.i4.1
-		IL_0103: ldstr "Golden Retriever"
-		IL_0108: stelem.ref
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_010e: stloc.s 5
-		IL_0110: ldloc.s 5
-		IL_0112: stloc.s 4
-		IL_0114: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0119: ldc.i4.1
-		IL_011a: newarr [System.Runtime]System.Object
-		IL_011f: dup
-		IL_0120: ldc.i4.0
-		IL_0121: ldloc.s 4
-		IL_0123: ldstr "name"
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_012d: stelem.ref
-		IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0133: pop
-		IL_0134: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0139: ldc.i4.1
-		IL_013a: newarr [System.Runtime]System.Object
-		IL_013f: dup
-		IL_0140: ldc.i4.0
-		IL_0141: ldloc.s 4
-		IL_0143: ldstr "breed"
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_014d: stelem.ref
-		IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0153: pop
-		IL_0154: ret
+		IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009e: ldc.i4.1
+		IL_009f: newarr [System.Runtime]System.Object
+		IL_00a4: dup
+		IL_00a5: ldc.i4.0
+		IL_00a6: ldstr "inherits completed"
+		IL_00ab: stelem.ref
+		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00b1: pop
+		IL_00b2: ldloc.2
+		IL_00b3: ldstr "super_"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00bd: ldloc.1
+		IL_00be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00c3: stloc.s 6
+		IL_00c5: ldloc.s 6
+		IL_00c7: box [System.Runtime]System.Boolean
+		IL_00cc: stloc.s 7
+		IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d3: ldc.i4.1
+		IL_00d4: newarr [System.Runtime]System.Object
+		IL_00d9: dup
+		IL_00da: ldc.i4.0
+		IL_00db: ldloc.s 7
+		IL_00dd: stelem.ref
+		IL_00de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00e3: pop
+		IL_00e4: ldloc.2
+		IL_00e5: ldc.i4.2
+		IL_00e6: newarr [System.Runtime]System.Object
+		IL_00eb: dup
+		IL_00ec: ldc.i4.0
+		IL_00ed: ldstr "Buddy"
+		IL_00f2: stelem.ref
+		IL_00f3: dup
+		IL_00f4: ldc.i4.1
+		IL_00f5: ldstr "Golden Retriever"
+		IL_00fa: stelem.ref
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0100: stloc.s 5
+		IL_0102: ldloc.s 5
+		IL_0104: stloc.s 4
+		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010b: ldc.i4.1
+		IL_010c: newarr [System.Runtime]System.Object
+		IL_0111: dup
+		IL_0112: ldc.i4.0
+		IL_0113: ldloc.s 4
+		IL_0115: ldstr "name"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_011f: stelem.ref
+		IL_0120: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0125: pop
+		IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012b: ldc.i4.1
+		IL_012c: newarr [System.Runtime]System.Object
+		IL_0131: dup
+		IL_0132: ldc.i4.0
+		IL_0133: ldloc.s 4
+		IL_0135: ldstr "breed"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_013f: stelem.ref
+		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0145: pop
+		IL_0146: ret
 	} // end of method Require_Util_Inherits_Basic::__js_module_init__
 
 } // end of class Modules.Require_Util_Inherits_Basic
@@ -358,7 +349,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2239
+		// Method begins at RVA 0x2229
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a5
+			// Method begins at RVA 0x2199
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,132 +40,123 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 329 (0x149)
+		// Code size: 317 (0x13d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Inspect_Basic/Scope,
 			[1] object,
-			[2] object[],
-			[3] object
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Util_Inspect_Basic/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.2
-		IL_0011: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "util"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: ldstr "util"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: stloc.1
-		IL_0020: ldloc.1
-		IL_0021: ldstr "inspect"
-		IL_0026: ldc.r8 42
-		IL_002f: box [System.Runtime]System.Double
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0039: stloc.3
-		IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.3
-		IL_0048: stelem.ref
-		IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_004e: pop
-		IL_004f: ldloc.1
-		IL_0050: ldstr "inspect"
-		IL_0055: ldstr "hello"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_005f: stloc.3
-		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0065: ldc.i4.1
-		IL_0066: newarr [System.Runtime]System.Object
-		IL_006b: dup
-		IL_006c: ldc.i4.0
-		IL_006d: ldloc.3
-		IL_006e: stelem.ref
-		IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0074: pop
-		IL_0075: ldloc.1
-		IL_0076: ldstr "inspect"
-		IL_007b: ldc.i4.1
-		IL_007c: box [System.Runtime]System.Boolean
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0086: stloc.3
-		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008c: ldc.i4.1
-		IL_008d: newarr [System.Runtime]System.Object
-		IL_0092: dup
-		IL_0093: ldc.i4.0
-		IL_0094: ldloc.3
-		IL_0095: stelem.ref
-		IL_0096: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_009b: pop
-		IL_009c: ldloc.1
-		IL_009d: ldstr "inspect"
-		IL_00a2: ldc.i4.0
-		IL_00a3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ad: stloc.3
-		IL_00ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b3: ldc.i4.1
-		IL_00b4: newarr [System.Runtime]System.Object
-		IL_00b9: dup
-		IL_00ba: ldc.i4.0
-		IL_00bb: ldloc.3
-		IL_00bc: stelem.ref
-		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00c2: pop
-		IL_00c3: ldloc.1
-		IL_00c4: ldstr "inspect"
-		IL_00c9: ldnull
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00cf: stloc.3
-		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d5: ldc.i4.1
-		IL_00d6: newarr [System.Runtime]System.Object
-		IL_00db: dup
-		IL_00dc: ldc.i4.0
-		IL_00dd: ldloc.3
-		IL_00de: stelem.ref
-		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00e4: pop
-		IL_00e5: ldloc.1
-		IL_00e6: ldstr "inspect"
-		IL_00eb: ldc.i4.3
-		IL_00ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00f1: dup
-		IL_00f2: ldc.r8 1
-		IL_00fb: box [System.Runtime]System.Double
-		IL_0100: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0105: dup
-		IL_0106: ldc.r8 2
-		IL_010f: box [System.Runtime]System.Double
-		IL_0114: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0119: dup
-		IL_011a: ldc.r8 3
-		IL_0123: box [System.Runtime]System.Double
-		IL_0128: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0132: stloc.3
-		IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0138: ldc.i4.1
-		IL_0139: newarr [System.Runtime]System.Object
-		IL_013e: dup
-		IL_013f: ldc.i4.0
-		IL_0140: ldloc.3
-		IL_0141: stelem.ref
-		IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0147: pop
-		IL_0148: ret
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: ldstr "inspect"
+		IL_001a: ldc.r8 42
+		IL_0023: box [System.Runtime]System.Double
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_002d: stloc.2
+		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.2
+		IL_003c: stelem.ref
+		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0042: pop
+		IL_0043: ldloc.1
+		IL_0044: ldstr "inspect"
+		IL_0049: ldstr "hello"
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0053: stloc.2
+		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0059: ldc.i4.1
+		IL_005a: newarr [System.Runtime]System.Object
+		IL_005f: dup
+		IL_0060: ldc.i4.0
+		IL_0061: ldloc.2
+		IL_0062: stelem.ref
+		IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0068: pop
+		IL_0069: ldloc.1
+		IL_006a: ldstr "inspect"
+		IL_006f: ldc.i4.1
+		IL_0070: box [System.Runtime]System.Boolean
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007a: stloc.2
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldc.i4.1
+		IL_0081: newarr [System.Runtime]System.Object
+		IL_0086: dup
+		IL_0087: ldc.i4.0
+		IL_0088: ldloc.2
+		IL_0089: stelem.ref
+		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_008f: pop
+		IL_0090: ldloc.1
+		IL_0091: ldstr "inspect"
+		IL_0096: ldc.i4.0
+		IL_0097: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00a1: stloc.2
+		IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a7: ldc.i4.1
+		IL_00a8: newarr [System.Runtime]System.Object
+		IL_00ad: dup
+		IL_00ae: ldc.i4.0
+		IL_00af: ldloc.2
+		IL_00b0: stelem.ref
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00b6: pop
+		IL_00b7: ldloc.1
+		IL_00b8: ldstr "inspect"
+		IL_00bd: ldnull
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c3: stloc.2
+		IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.2
+		IL_00d2: stelem.ref
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00d8: pop
+		IL_00d9: ldloc.1
+		IL_00da: ldstr "inspect"
+		IL_00df: ldc.i4.3
+		IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00e5: dup
+		IL_00e6: ldc.r8 1
+		IL_00ef: box [System.Runtime]System.Double
+		IL_00f4: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_00f9: dup
+		IL_00fa: ldc.r8 2
+		IL_0103: box [System.Runtime]System.Double
+		IL_0108: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_010d: dup
+		IL_010e: ldc.r8 3
+		IL_0117: box [System.Runtime]System.Double
+		IL_011c: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0126: stloc.2
+		IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012c: ldc.i4.1
+		IL_012d: newarr [System.Runtime]System.Object
+		IL_0132: dup
+		IL_0133: ldc.i4.0
+		IL_0134: ldloc.2
+		IL_0135: stelem.ref
+		IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_013b: pop
+		IL_013c: ret
 	} // end of method Require_Util_Inspect_Basic::__js_module_init__
 
 } // end of class Modules.Require_Util_Inspect_Basic
@@ -177,7 +168,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ae
+		// Method begins at RVA 0x21a2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_Object.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_Object.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x215f
+			// Method begins at RVA 0x2151
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,104 +40,95 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 259 (0x103)
+		// Code size: 245 (0xf5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Inspect_Object/Scope,
 			[1] object,
 			[2] class [System.Linq.Expressions]System.Dynamic.ExpandoObject,
 			[3] class [System.Linq.Expressions]System.Dynamic.ExpandoObject,
-			[4] object[],
-			[5] object
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Util_Inspect_Object/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 4
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "util"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 4
 		IL_0013: ldloc.s 4
-		IL_0015: ldstr "util"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 5
-		IL_0021: ldloc.s 5
-		IL_0023: stloc.1
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0029: dup
-		IL_002a: ldstr "name"
-		IL_002f: ldstr "John"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0039: pop
-		IL_003a: dup
-		IL_003b: ldstr "age"
-		IL_0040: ldc.r8 30
-		IL_0049: box [System.Runtime]System.Double
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0053: pop
-		IL_0054: dup
-		IL_0055: ldstr "active"
-		IL_005a: ldc.i4.1
-		IL_005b: box [System.Runtime]System.Boolean
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0065: pop
-		IL_0066: stloc.2
-		IL_0067: ldloc.1
-		IL_0068: ldstr "inspect"
-		IL_006d: ldloc.2
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0073: stloc.s 5
-		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007a: ldc.i4.1
-		IL_007b: newarr [System.Runtime]System.Object
-		IL_0080: dup
-		IL_0081: ldc.i4.0
-		IL_0082: ldloc.s 5
-		IL_0084: stelem.ref
-		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_008a: pop
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0090: dup
-		IL_0091: ldstr "person"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_009b: dup
-		IL_009c: ldstr "name"
-		IL_00a1: ldstr "Jane"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_00ab: pop
-		IL_00ac: dup
-		IL_00ad: ldstr "age"
-		IL_00b2: ldc.r8 25
-		IL_00bb: box [System.Runtime]System.Double
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_00c5: pop
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_00cb: pop
-		IL_00cc: dup
-		IL_00cd: ldstr "city"
-		IL_00d2: ldstr "NYC"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_00dc: pop
-		IL_00dd: stloc.3
-		IL_00de: ldloc.1
-		IL_00df: ldstr "inspect"
-		IL_00e4: ldloc.3
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ea: stloc.s 5
-		IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f1: ldc.i4.1
-		IL_00f2: newarr [System.Runtime]System.Object
-		IL_00f7: dup
-		IL_00f8: ldc.i4.0
-		IL_00f9: ldloc.s 5
-		IL_00fb: stelem.ref
-		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0101: pop
-		IL_0102: ret
+		IL_0015: stloc.1
+		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_001b: dup
+		IL_001c: ldstr "name"
+		IL_0021: ldstr "John"
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_002b: pop
+		IL_002c: dup
+		IL_002d: ldstr "age"
+		IL_0032: ldc.r8 30
+		IL_003b: box [System.Runtime]System.Double
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0045: pop
+		IL_0046: dup
+		IL_0047: ldstr "active"
+		IL_004c: ldc.i4.1
+		IL_004d: box [System.Runtime]System.Boolean
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0057: pop
+		IL_0058: stloc.2
+		IL_0059: ldloc.1
+		IL_005a: ldstr "inspect"
+		IL_005f: ldloc.2
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0065: stloc.s 4
+		IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006c: ldc.i4.1
+		IL_006d: newarr [System.Runtime]System.Object
+		IL_0072: dup
+		IL_0073: ldc.i4.0
+		IL_0074: ldloc.s 4
+		IL_0076: stelem.ref
+		IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_007c: pop
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0082: dup
+		IL_0083: ldstr "person"
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_008d: dup
+		IL_008e: ldstr "name"
+		IL_0093: ldstr "Jane"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_009d: pop
+		IL_009e: dup
+		IL_009f: ldstr "age"
+		IL_00a4: ldc.r8 25
+		IL_00ad: box [System.Runtime]System.Double
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_00b7: pop
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_00bd: pop
+		IL_00be: dup
+		IL_00bf: ldstr "city"
+		IL_00c4: ldstr "NYC"
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_00ce: pop
+		IL_00cf: stloc.3
+		IL_00d0: ldloc.1
+		IL_00d1: ldstr "inspect"
+		IL_00d6: ldloc.3
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00dc: stloc.s 4
+		IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e3: ldc.i4.1
+		IL_00e4: newarr [System.Runtime]System.Object
+		IL_00e9: dup
+		IL_00ea: ldc.i4.0
+		IL_00eb: ldloc.s 4
+		IL_00ed: stelem.ref
+		IL_00ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00f3: pop
+		IL_00f4: ret
 	} // end of method Require_Util_Inspect_Object::__js_module_init__
 
 } // end of class Modules.Require_Util_Inspect_Object
@@ -149,7 +140,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2168
+		// Method begins at RVA 0x215a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2165
+				// Method begins at RVA 0x2159
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -40,7 +40,7 @@
 				object callback
 			) cil managed 
 		{
-			// Method begins at RVA 0x2108
+			// Method begins at RVA 0x20fc
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -90,7 +90,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216e
+				// Method begins at RVA 0x2162
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,7 +111,7 @@
 				object result
 			) cil managed 
 		{
-			// Method begins at RVA 0x2144
+			// Method begins at RVA 0x2138
 			// Header size: 1
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -146,7 +146,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x215c
+			// Method begins at RVA 0x2150
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -172,7 +172,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 171 (0xab)
+		// Code size: 157 (0x9d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Promisify_Basic/Scope,
@@ -199,58 +199,50 @@
 		IL_0021: stloc.s 4
 		IL_0023: ldloc.s 4
 		IL_0025: stloc.1
-		IL_0026: ldc.i4.1
-		IL_0027: newarr [System.Runtime]System.Object
-		IL_002c: dup
-		IL_002d: ldc.i4.0
-		IL_002e: ldnull
-		IL_002f: stelem.ref
-		IL_0030: stloc.s 5
-		IL_0032: ldarg.1
-		IL_0033: ldloc.s 5
-		IL_0035: ldstr "util"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003f: stloc.s 4
-		IL_0041: ldloc.s 4
-		IL_0043: stloc.2
-		IL_0044: ldloc.2
-		IL_0045: ldstr "promisify"
-		IL_004a: ldloc.1
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0050: stloc.s 4
-		IL_0052: ldloc.s 4
-		IL_0054: stloc.3
-		IL_0055: ldc.i4.1
-		IL_0056: newarr [System.Runtime]System.Object
-		IL_005b: dup
-		IL_005c: ldc.i4.0
-		IL_005d: ldnull
-		IL_005e: stelem.ref
-		IL_005f: stloc.s 5
-		IL_0061: ldloc.3
-		IL_0062: ldloc.s 5
-		IL_0064: ldc.r8 5
-		IL_006d: box [System.Runtime]System.Double
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0077: stloc.s 4
-		IL_0079: ldnull
-		IL_007a: ldftn object Modules.Require_Util_Promisify_Basic/ArrowFunction_L15C21::__js_call__(object, object)
-		IL_0080: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0085: ldc.i4.1
-		IL_0086: newarr [System.Runtime]System.Object
-		IL_008b: dup
-		IL_008c: ldc.i4.0
-		IL_008d: ldloc.0
-		IL_008e: stelem.ref
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0099: stloc.s 6
-		IL_009b: ldloc.s 4
-		IL_009d: ldstr "then"
-		IL_00a2: ldloc.s 6
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a9: pop
-		IL_00aa: ret
+		IL_0026: ldarg.1
+		IL_0027: ldstr "util"
+		IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0031: stloc.s 4
+		IL_0033: ldloc.s 4
+		IL_0035: stloc.2
+		IL_0036: ldloc.2
+		IL_0037: ldstr "promisify"
+		IL_003c: ldloc.1
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0042: stloc.s 4
+		IL_0044: ldloc.s 4
+		IL_0046: stloc.3
+		IL_0047: ldc.i4.1
+		IL_0048: newarr [System.Runtime]System.Object
+		IL_004d: dup
+		IL_004e: ldc.i4.0
+		IL_004f: ldnull
+		IL_0050: stelem.ref
+		IL_0051: stloc.s 5
+		IL_0053: ldloc.3
+		IL_0054: ldloc.s 5
+		IL_0056: ldc.r8 5
+		IL_005f: box [System.Runtime]System.Double
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_0069: stloc.s 4
+		IL_006b: ldnull
+		IL_006c: ldftn object Modules.Require_Util_Promisify_Basic/ArrowFunction_L15C21::__js_call__(object, object)
+		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_008b: stloc.s 6
+		IL_008d: ldloc.s 4
+		IL_008f: ldstr "then"
+		IL_0094: ldloc.s 6
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_009b: pop
+		IL_009c: ret
 	} // end of method Require_Util_Promisify_Basic::__js_module_init__
 
 } // end of class Modules.Require_Util_Promisify_Basic
@@ -262,7 +254,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2177
+		// Method begins at RVA 0x216b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2288
+					// Method begins at RVA 0x227c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2291
+					// Method begins at RVA 0x2285
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227f
+				// Method begins at RVA 0x2273
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				object callback
 			) cil managed 
 		{
-			// Method begins at RVA 0x21b0
+			// Method begins at RVA 0x21a4
 			// Header size: 12
 			// Code size: 86 (0x56)
 			.maxstack 8
@@ -155,7 +155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229a
+				// Method begins at RVA 0x228e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 				object result
 			) cil managed 
 		{
-			// Method begins at RVA 0x2212
+			// Method begins at RVA 0x2206
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a3
+				// Method begins at RVA 0x2297
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -231,7 +231,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2226
+			// Method begins at RVA 0x221a
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -267,7 +267,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ac
+				// Method begins at RVA 0x22a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -288,7 +288,7 @@
 				object result
 			) cil managed 
 		{
-			// Method begins at RVA 0x2244
+			// Method begins at RVA 0x2238
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b5
+				// Method begins at RVA 0x22a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -343,7 +343,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2258
+			// Method begins at RVA 0x224c
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -376,7 +376,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2276
+			// Method begins at RVA 0x226a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -402,7 +402,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 340 (0x154)
+		// Code size: 326 (0x146)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Promisify_ErrorHandling/Scope,
@@ -429,122 +429,114 @@
 		IL_0021: stloc.s 4
 		IL_0023: ldloc.s 4
 		IL_0025: stloc.1
-		IL_0026: ldc.i4.1
-		IL_0027: newarr [System.Runtime]System.Object
-		IL_002c: dup
-		IL_002d: ldc.i4.0
-		IL_002e: ldnull
-		IL_002f: stelem.ref
-		IL_0030: stloc.s 5
-		IL_0032: ldarg.1
-		IL_0033: ldloc.s 5
-		IL_0035: ldstr "util"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003f: stloc.s 4
-		IL_0041: ldloc.s 4
-		IL_0043: stloc.2
-		IL_0044: ldloc.2
-		IL_0045: ldstr "promisify"
-		IL_004a: ldloc.1
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0050: stloc.s 4
-		IL_0052: ldloc.s 4
-		IL_0054: stloc.3
-		IL_0055: ldc.i4.1
-		IL_0056: newarr [System.Runtime]System.Object
-		IL_005b: dup
-		IL_005c: ldc.i4.0
-		IL_005d: ldnull
-		IL_005e: stelem.ref
-		IL_005f: stloc.s 5
-		IL_0061: ldloc.3
-		IL_0062: ldloc.s 5
-		IL_0064: ldc.i4.0
-		IL_0065: box [System.Runtime]System.Boolean
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_006f: stloc.s 4
-		IL_0071: ldnull
-		IL_0072: ldftn object Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L18C25::__js_call__(object, object)
-		IL_0078: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_007d: ldc.i4.1
-		IL_007e: newarr [System.Runtime]System.Object
-		IL_0083: dup
-		IL_0084: ldc.i4.0
-		IL_0085: ldloc.0
-		IL_0086: stelem.ref
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0091: stloc.s 6
-		IL_0093: ldloc.s 4
-		IL_0095: ldstr "then"
-		IL_009a: ldloc.s 6
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a1: stloc.s 6
-		IL_00a3: ldnull
-		IL_00a4: ldftn object Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L20C10::__js_call__(object, object)
-		IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00af: ldc.i4.1
-		IL_00b0: newarr [System.Runtime]System.Object
-		IL_00b5: dup
-		IL_00b6: ldc.i4.0
-		IL_00b7: ldloc.0
-		IL_00b8: stelem.ref
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00c3: stloc.s 4
-		IL_00c5: ldloc.s 6
-		IL_00c7: ldstr "catch"
-		IL_00cc: ldloc.s 4
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ldc.i4.1
-		IL_00d5: newarr [System.Runtime]System.Object
-		IL_00da: dup
-		IL_00db: ldc.i4.0
-		IL_00dc: ldnull
-		IL_00dd: stelem.ref
-		IL_00de: stloc.s 5
-		IL_00e0: ldloc.3
-		IL_00e1: ldloc.s 5
-		IL_00e3: ldc.i4.1
-		IL_00e4: box [System.Runtime]System.Boolean
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00ee: stloc.s 4
-		IL_00f0: ldnull
-		IL_00f1: ldftn object Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L25C24::__js_call__(object, object)
-		IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00fc: ldc.i4.1
-		IL_00fd: newarr [System.Runtime]System.Object
-		IL_0102: dup
-		IL_0103: ldc.i4.0
-		IL_0104: ldloc.0
-		IL_0105: stelem.ref
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0110: stloc.s 6
-		IL_0112: ldloc.s 4
-		IL_0114: ldstr "then"
-		IL_0119: ldloc.s 6
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0120: stloc.s 6
-		IL_0122: ldnull
-		IL_0123: ldftn object Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L27C10::__js_call__(object, object)
-		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_012e: ldc.i4.1
-		IL_012f: newarr [System.Runtime]System.Object
-		IL_0134: dup
-		IL_0135: ldc.i4.0
-		IL_0136: ldloc.0
-		IL_0137: stelem.ref
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0142: stloc.s 4
-		IL_0144: ldloc.s 6
-		IL_0146: ldstr "catch"
-		IL_014b: ldloc.s 4
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0152: pop
-		IL_0153: ret
+		IL_0026: ldarg.1
+		IL_0027: ldstr "util"
+		IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0031: stloc.s 4
+		IL_0033: ldloc.s 4
+		IL_0035: stloc.2
+		IL_0036: ldloc.2
+		IL_0037: ldstr "promisify"
+		IL_003c: ldloc.1
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0042: stloc.s 4
+		IL_0044: ldloc.s 4
+		IL_0046: stloc.3
+		IL_0047: ldc.i4.1
+		IL_0048: newarr [System.Runtime]System.Object
+		IL_004d: dup
+		IL_004e: ldc.i4.0
+		IL_004f: ldnull
+		IL_0050: stelem.ref
+		IL_0051: stloc.s 5
+		IL_0053: ldloc.3
+		IL_0054: ldloc.s 5
+		IL_0056: ldc.i4.0
+		IL_0057: box [System.Runtime]System.Boolean
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_0061: stloc.s 4
+		IL_0063: ldnull
+		IL_0064: ldftn object Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L18C25::__js_call__(object, object)
+		IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_006f: ldc.i4.1
+		IL_0070: newarr [System.Runtime]System.Object
+		IL_0075: dup
+		IL_0076: ldc.i4.0
+		IL_0077: ldloc.0
+		IL_0078: stelem.ref
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0083: stloc.s 6
+		IL_0085: ldloc.s 4
+		IL_0087: ldstr "then"
+		IL_008c: ldloc.s 6
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0093: stloc.s 6
+		IL_0095: ldnull
+		IL_0096: ldftn object Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L20C10::__js_call__(object, object)
+		IL_009c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00a1: ldc.i4.1
+		IL_00a2: newarr [System.Runtime]System.Object
+		IL_00a7: dup
+		IL_00a8: ldc.i4.0
+		IL_00a9: ldloc.0
+		IL_00aa: stelem.ref
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00b5: stloc.s 4
+		IL_00b7: ldloc.s 6
+		IL_00b9: ldstr "catch"
+		IL_00be: ldloc.s 4
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c5: pop
+		IL_00c6: ldc.i4.1
+		IL_00c7: newarr [System.Runtime]System.Object
+		IL_00cc: dup
+		IL_00cd: ldc.i4.0
+		IL_00ce: ldnull
+		IL_00cf: stelem.ref
+		IL_00d0: stloc.s 5
+		IL_00d2: ldloc.3
+		IL_00d3: ldloc.s 5
+		IL_00d5: ldc.i4.1
+		IL_00d6: box [System.Runtime]System.Boolean
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_00e0: stloc.s 4
+		IL_00e2: ldnull
+		IL_00e3: ldftn object Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L25C24::__js_call__(object, object)
+		IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00ee: ldc.i4.1
+		IL_00ef: newarr [System.Runtime]System.Object
+		IL_00f4: dup
+		IL_00f5: ldc.i4.0
+		IL_00f6: ldloc.0
+		IL_00f7: stelem.ref
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0102: stloc.s 6
+		IL_0104: ldloc.s 4
+		IL_0106: ldstr "then"
+		IL_010b: ldloc.s 6
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0112: stloc.s 6
+		IL_0114: ldnull
+		IL_0115: ldftn object Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L27C10::__js_call__(object, object)
+		IL_011b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0120: ldc.i4.1
+		IL_0121: newarr [System.Runtime]System.Object
+		IL_0126: dup
+		IL_0127: ldc.i4.0
+		IL_0128: ldloc.0
+		IL_0129: stelem.ref
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0134: stloc.s 4
+		IL_0136: ldloc.s 6
+		IL_0138: ldstr "catch"
+		IL_013d: ldloc.s 4
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0144: pop
+		IL_0145: ret
 	} // end of method Require_Util_Promisify_ErrorHandling::__js_module_init__
 
 } // end of class Modules.Require_Util_Promisify_ErrorHandling
@@ -556,7 +548,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22be
+		// Method begins at RVA 0x22b2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsArray.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsArray.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21aa
+			// Method begins at RVA 0x219c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 334 (0x14e)
+		// Code size: 320 (0x140)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_IsArray/Scope,
@@ -48,112 +48,103 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [System.Linq.Expressions]System.Dynamic.ExpandoObject,
 			[4] string,
-			[5] object[],
-			[6] object
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Util_Types_IsArray/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 5
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "util"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 5
 		IL_0013: ldloc.s 5
-		IL_0015: ldstr "util"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 6
-		IL_0021: ldloc.s 6
-		IL_0023: stloc.1
-		IL_0024: ldc.i4.3
-		IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_002a: dup
-		IL_002b: ldc.r8 1
-		IL_0034: box [System.Runtime]System.Double
-		IL_0039: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_003e: dup
-		IL_003f: ldc.r8 2
-		IL_0048: box [System.Runtime]System.Double
-		IL_004d: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0052: dup
-		IL_0053: ldc.r8 3
-		IL_005c: box [System.Runtime]System.Double
-		IL_0061: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
-		IL_0066: stloc.2
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_006c: dup
-		IL_006d: ldstr "0"
-		IL_0072: ldc.r8 1
-		IL_007b: box [System.Runtime]System.Double
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0085: pop
-		IL_0086: dup
-		IL_0087: ldstr "1"
-		IL_008c: ldc.r8 2
-		IL_0095: box [System.Runtime]System.Double
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_009f: pop
-		IL_00a0: dup
-		IL_00a1: ldstr "length"
-		IL_00a6: ldc.r8 2
-		IL_00af: box [System.Runtime]System.Double
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_00b9: pop
-		IL_00ba: stloc.3
-		IL_00bb: ldstr "hello"
-		IL_00c0: stloc.s 4
-		IL_00c2: ldloc.1
-		IL_00c3: ldstr "types"
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00cd: ldstr "isArray"
-		IL_00d2: ldloc.2
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d8: stloc.s 6
-		IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00df: ldc.i4.1
-		IL_00e0: newarr [System.Runtime]System.Object
-		IL_00e5: dup
-		IL_00e6: ldc.i4.0
-		IL_00e7: ldloc.s 6
-		IL_00e9: stelem.ref
-		IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00ef: pop
-		IL_00f0: ldloc.1
-		IL_00f1: ldstr "types"
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00fb: ldstr "isArray"
-		IL_0100: ldloc.3
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0106: stloc.s 6
-		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010d: ldc.i4.1
-		IL_010e: newarr [System.Runtime]System.Object
-		IL_0113: dup
-		IL_0114: ldc.i4.0
-		IL_0115: ldloc.s 6
-		IL_0117: stelem.ref
-		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_011d: pop
-		IL_011e: ldloc.1
-		IL_011f: ldstr "types"
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0129: ldstr "isArray"
-		IL_012e: ldloc.s 4
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0135: stloc.s 6
-		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013c: ldc.i4.1
-		IL_013d: newarr [System.Runtime]System.Object
-		IL_0142: dup
-		IL_0143: ldc.i4.0
-		IL_0144: ldloc.s 6
-		IL_0146: stelem.ref
-		IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_014c: pop
-		IL_014d: ret
+		IL_0015: stloc.1
+		IL_0016: ldc.i4.3
+		IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_001c: dup
+		IL_001d: ldc.r8 1
+		IL_0026: box [System.Runtime]System.Double
+		IL_002b: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0030: dup
+		IL_0031: ldc.r8 2
+		IL_003a: box [System.Runtime]System.Double
+		IL_003f: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0044: dup
+		IL_0045: ldc.r8 3
+		IL_004e: box [System.Runtime]System.Double
+		IL_0053: callvirt instance void class [System.Collections]System.Collections.Generic.List`1<object>::Add(!0)
+		IL_0058: stloc.2
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_005e: dup
+		IL_005f: ldstr "0"
+		IL_0064: ldc.r8 1
+		IL_006d: box [System.Runtime]System.Double
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0077: pop
+		IL_0078: dup
+		IL_0079: ldstr "1"
+		IL_007e: ldc.r8 2
+		IL_0087: box [System.Runtime]System.Double
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0091: pop
+		IL_0092: dup
+		IL_0093: ldstr "length"
+		IL_0098: ldc.r8 2
+		IL_00a1: box [System.Runtime]System.Double
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_00ab: pop
+		IL_00ac: stloc.3
+		IL_00ad: ldstr "hello"
+		IL_00b2: stloc.s 4
+		IL_00b4: ldloc.1
+		IL_00b5: ldstr "types"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00bf: ldstr "isArray"
+		IL_00c4: ldloc.2
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ca: stloc.s 5
+		IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d1: ldc.i4.1
+		IL_00d2: newarr [System.Runtime]System.Object
+		IL_00d7: dup
+		IL_00d8: ldc.i4.0
+		IL_00d9: ldloc.s 5
+		IL_00db: stelem.ref
+		IL_00dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00e1: pop
+		IL_00e2: ldloc.1
+		IL_00e3: ldstr "types"
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00ed: ldstr "isArray"
+		IL_00f2: ldloc.3
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f8: stloc.s 5
+		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ff: ldc.i4.1
+		IL_0100: newarr [System.Runtime]System.Object
+		IL_0105: dup
+		IL_0106: ldc.i4.0
+		IL_0107: ldloc.s 5
+		IL_0109: stelem.ref
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_010f: pop
+		IL_0110: ldloc.1
+		IL_0111: ldstr "types"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_011b: ldstr "isArray"
+		IL_0120: ldloc.s 4
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0127: stloc.s 5
+		IL_0129: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012e: ldc.i4.1
+		IL_012f: newarr [System.Runtime]System.Object
+		IL_0134: dup
+		IL_0135: ldc.i4.0
+		IL_0136: ldloc.s 5
+		IL_0138: stelem.ref
+		IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_013e: pop
+		IL_013f: ret
 	} // end of method Require_Util_Types_IsArray::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_IsArray
@@ -165,7 +156,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b3
+		// Method begins at RVA 0x21a5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsFunction.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ae
+				// Method begins at RVA 0x21a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x219f
+			// Method begins at RVA 0x2191
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b7
+				// Method begins at RVA 0x21a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -80,7 +80,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x21a2
+			// Method begins at RVA 0x2194
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -105,7 +105,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a5
+			// Method begins at RVA 0x2197
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -131,7 +131,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 323 (0x143)
+		// Code size: 309 (0x135)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_IsFunction/Scope,
@@ -141,8 +141,7 @@
 			[4] float64,
 			[5] class [System.Linq.Expressions]System.Dynamic.ExpandoObject,
 			[6] object,
-			[7] object[],
-			[8] object
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Util_Types_IsFunction/Scope::.ctor()
@@ -160,108 +159,100 @@
 		IL_0021: stloc.s 6
 		IL_0023: ldloc.s 6
 		IL_0025: stloc.1
-		IL_0026: ldc.i4.1
-		IL_0027: newarr [System.Runtime]System.Object
-		IL_002c: dup
-		IL_002d: ldc.i4.0
-		IL_002e: ldnull
-		IL_002f: stelem.ref
-		IL_0030: stloc.s 7
-		IL_0032: ldarg.1
-		IL_0033: ldloc.s 7
-		IL_0035: ldstr "util"
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_003f: stloc.s 6
-		IL_0041: ldloc.s 6
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Require_Util_Types_IsFunction/ArrowFunction_L7C17::__js_call__(object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: stloc.s 6
-		IL_0066: ldloc.s 6
-		IL_0068: stloc.3
-		IL_0069: ldc.r8 42
-		IL_0072: stloc.s 4
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0079: stloc.s 5
-		IL_007b: ldloc.2
-		IL_007c: ldstr "types"
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_0086: ldstr "isFunction"
-		IL_008b: ldloc.1
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0091: stloc.s 6
-		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0098: ldc.i4.1
-		IL_0099: newarr [System.Runtime]System.Object
-		IL_009e: dup
-		IL_009f: ldc.i4.0
-		IL_00a0: ldloc.s 6
-		IL_00a2: stelem.ref
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00a8: pop
-		IL_00a9: ldloc.2
-		IL_00aa: ldstr "types"
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00b4: ldstr "isFunction"
-		IL_00b9: ldloc.3
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00bf: stloc.s 6
-		IL_00c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c6: ldc.i4.1
-		IL_00c7: newarr [System.Runtime]System.Object
-		IL_00cc: dup
-		IL_00cd: ldc.i4.0
-		IL_00ce: ldloc.s 6
-		IL_00d0: stelem.ref
-		IL_00d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00d6: pop
-		IL_00d7: ldloc.2
-		IL_00d8: ldstr "types"
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00e2: stloc.s 6
-		IL_00e4: ldloc.s 4
-		IL_00e6: box [System.Runtime]System.Double
-		IL_00eb: stloc.s 8
-		IL_00ed: ldloc.s 6
-		IL_00ef: ldstr "isFunction"
-		IL_00f4: ldloc.s 8
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00fb: stloc.s 6
-		IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0102: ldc.i4.1
-		IL_0103: newarr [System.Runtime]System.Object
-		IL_0108: dup
-		IL_0109: ldc.i4.0
-		IL_010a: ldloc.s 6
-		IL_010c: stelem.ref
-		IL_010d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0112: pop
-		IL_0113: ldloc.2
-		IL_0114: ldstr "types"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_011e: ldstr "isFunction"
-		IL_0123: ldloc.s 5
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_012a: stloc.s 6
-		IL_012c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0131: ldc.i4.1
-		IL_0132: newarr [System.Runtime]System.Object
-		IL_0137: dup
-		IL_0138: ldc.i4.0
-		IL_0139: ldloc.s 6
-		IL_013b: stelem.ref
-		IL_013c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0141: pop
-		IL_0142: ret
+		IL_0026: ldarg.1
+		IL_0027: ldstr "util"
+		IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0031: stloc.s 6
+		IL_0033: ldloc.s 6
+		IL_0035: stloc.2
+		IL_0036: ldnull
+		IL_0037: ldftn object Modules.Require_Util_Types_IsFunction/ArrowFunction_L7C17::__js_call__(object)
+		IL_003d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0042: ldc.i4.1
+		IL_0043: newarr [System.Runtime]System.Object
+		IL_0048: dup
+		IL_0049: ldc.i4.0
+		IL_004a: ldloc.0
+		IL_004b: stelem.ref
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0056: stloc.s 6
+		IL_0058: ldloc.s 6
+		IL_005a: stloc.3
+		IL_005b: ldc.r8 42
+		IL_0064: stloc.s 4
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_006b: stloc.s 5
+		IL_006d: ldloc.2
+		IL_006e: ldstr "types"
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0078: ldstr "isFunction"
+		IL_007d: ldloc.1
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0083: stloc.s 6
+		IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008a: ldc.i4.1
+		IL_008b: newarr [System.Runtime]System.Object
+		IL_0090: dup
+		IL_0091: ldc.i4.0
+		IL_0092: ldloc.s 6
+		IL_0094: stelem.ref
+		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_009a: pop
+		IL_009b: ldloc.2
+		IL_009c: ldstr "types"
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00a6: ldstr "isFunction"
+		IL_00ab: ldloc.3
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b1: stloc.s 6
+		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b8: ldc.i4.1
+		IL_00b9: newarr [System.Runtime]System.Object
+		IL_00be: dup
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldloc.s 6
+		IL_00c2: stelem.ref
+		IL_00c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00c8: pop
+		IL_00c9: ldloc.2
+		IL_00ca: ldstr "types"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00d4: stloc.s 6
+		IL_00d6: ldloc.s 4
+		IL_00d8: box [System.Runtime]System.Double
+		IL_00dd: stloc.s 7
+		IL_00df: ldloc.s 6
+		IL_00e1: ldstr "isFunction"
+		IL_00e6: ldloc.s 7
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ed: stloc.s 6
+		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f4: ldc.i4.1
+		IL_00f5: newarr [System.Runtime]System.Object
+		IL_00fa: dup
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldloc.s 6
+		IL_00fe: stelem.ref
+		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0104: pop
+		IL_0105: ldloc.2
+		IL_0106: ldstr "types"
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0110: ldstr "isFunction"
+		IL_0115: ldloc.s 5
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_011c: stloc.s 6
+		IL_011e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0123: ldc.i4.1
+		IL_0124: newarr [System.Runtime]System.Object
+		IL_0129: dup
+		IL_012a: ldc.i4.0
+		IL_012b: ldloc.s 6
+		IL_012d: stelem.ref
+		IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0133: pop
+		IL_0134: ret
 	} // end of method Require_Util_Types_IsFunction::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_IsFunction
@@ -273,7 +264,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c0
+		// Method begins at RVA 0x21b2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsPromise.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsPromise.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c7
+				// Method begins at RVA 0x21bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				object resolve
 			) cil managed 
 		{
-			// Method begins at RVA 0x218c
+			// Method begins at RVA 0x2180
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d0
+				// Method begins at RVA 0x21c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +105,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x21bb
+			// Method begins at RVA 0x21af
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -123,7 +123,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21be
+			// Method begins at RVA 0x21b2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -149,7 +149,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 304 (0x130)
+		// Code size: 290 (0x122)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_IsPromise/Scope,
@@ -157,122 +157,113 @@
 			[2] object,
 			[3] class [System.Linq.Expressions]System.Dynamic.ExpandoObject,
 			[4] float64,
-			[5] object[],
-			[6] object,
-			[7] class [System.Linq.Expressions]System.Dynamic.ExpandoObject,
-			[8] object
+			[5] object,
+			[6] class [System.Linq.Expressions]System.Dynamic.ExpandoObject,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Util_Types_IsPromise/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldnull
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 5
-		IL_0012: ldarg.1
+		IL_0006: ldarg.1
+		IL_0007: ldstr "util"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 5
 		IL_0013: ldloc.s 5
-		IL_0015: ldstr "util"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_001f: stloc.s 6
-		IL_0021: ldloc.s 6
-		IL_0023: stloc.1
-		IL_0024: ldnull
-		IL_0025: ldftn object Modules.Require_Util_Types_IsPromise/ArrowFunction_L6C24::__js_call__(object, object)
-		IL_002b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0030: ldc.i4.1
-		IL_0031: newarr [System.Runtime]System.Object
-		IL_0036: dup
-		IL_0037: ldc.i4.0
-		IL_0038: ldloc.0
-		IL_0039: stelem.ref
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0044: stloc.s 6
-		IL_0046: ldloc.s 6
-		IL_0048: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
-		IL_004d: stloc.s 6
-		IL_004f: ldloc.s 6
-		IL_0051: stloc.2
-		IL_0052: ldnull
-		IL_0053: ldftn object Modules.Require_Util_Types_IsPromise/ArrowFunction_L7C20::__js_call__(object)
-		IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005e: ldc.i4.1
-		IL_005f: newarr [System.Runtime]System.Object
-		IL_0064: dup
-		IL_0065: ldc.i4.0
-		IL_0066: ldloc.0
-		IL_0067: stelem.ref
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0072: stloc.s 6
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0079: dup
-		IL_007a: ldstr "then"
-		IL_007f: ldloc.s 6
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
-		IL_0086: pop
-		IL_0087: stloc.s 7
-		IL_0089: ldloc.s 7
-		IL_008b: stloc.3
-		IL_008c: ldc.r8 42
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.1
-		IL_0098: ldstr "types"
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00a2: ldstr "isPromise"
-		IL_00a7: ldloc.2
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ad: stloc.s 6
-		IL_00af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b4: ldc.i4.1
-		IL_00b5: newarr [System.Runtime]System.Object
-		IL_00ba: dup
-		IL_00bb: ldc.i4.0
-		IL_00bc: ldloc.s 6
-		IL_00be: stelem.ref
-		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00c4: pop
-		IL_00c5: ldloc.1
-		IL_00c6: ldstr "types"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00d0: ldstr "isPromise"
-		IL_00d5: ldloc.3
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00db: stloc.s 6
-		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e2: ldc.i4.1
-		IL_00e3: newarr [System.Runtime]System.Object
-		IL_00e8: dup
-		IL_00e9: ldc.i4.0
-		IL_00ea: ldloc.s 6
-		IL_00ec: stelem.ref
-		IL_00ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00f2: pop
-		IL_00f3: ldloc.1
-		IL_00f4: ldstr "types"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
-		IL_00fe: stloc.s 6
-		IL_0100: ldloc.s 4
-		IL_0102: box [System.Runtime]System.Double
-		IL_0107: stloc.s 8
-		IL_0109: ldloc.s 6
-		IL_010b: ldstr "isPromise"
-		IL_0110: ldloc.s 8
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0117: stloc.s 6
-		IL_0119: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011e: ldc.i4.1
-		IL_011f: newarr [System.Runtime]System.Object
-		IL_0124: dup
-		IL_0125: ldc.i4.0
-		IL_0126: ldloc.s 6
-		IL_0128: stelem.ref
-		IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_012e: pop
-		IL_012f: ret
+		IL_0015: stloc.1
+		IL_0016: ldnull
+		IL_0017: ldftn object Modules.Require_Util_Types_IsPromise/ArrowFunction_L6C24::__js_call__(object, object)
+		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0022: ldc.i4.1
+		IL_0023: newarr [System.Runtime]System.Object
+		IL_0028: dup
+		IL_0029: ldc.i4.0
+		IL_002a: ldloc.0
+		IL_002b: stelem.ref
+		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0036: stloc.s 5
+		IL_0038: ldloc.s 5
+		IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+		IL_003f: stloc.s 5
+		IL_0041: ldloc.s 5
+		IL_0043: stloc.2
+		IL_0044: ldnull
+		IL_0045: ldftn object Modules.Require_Util_Types_IsPromise/ArrowFunction_L7C20::__js_call__(object)
+		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0050: ldc.i4.1
+		IL_0051: newarr [System.Runtime]System.Object
+		IL_0056: dup
+		IL_0057: ldc.i4.0
+		IL_0058: ldloc.0
+		IL_0059: stelem.ref
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0064: stloc.s 5
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_006b: dup
+		IL_006c: ldstr "then"
+		IL_0071: ldloc.s 5
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+		IL_0078: pop
+		IL_0079: stloc.s 6
+		IL_007b: ldloc.s 6
+		IL_007d: stloc.3
+		IL_007e: ldc.r8 42
+		IL_0087: stloc.s 4
+		IL_0089: ldloc.1
+		IL_008a: ldstr "types"
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_0094: ldstr "isPromise"
+		IL_0099: ldloc.2
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_009f: stloc.s 5
+		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a6: ldc.i4.1
+		IL_00a7: newarr [System.Runtime]System.Object
+		IL_00ac: dup
+		IL_00ad: ldc.i4.0
+		IL_00ae: ldloc.s 5
+		IL_00b0: stelem.ref
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00b6: pop
+		IL_00b7: ldloc.1
+		IL_00b8: ldstr "types"
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00c2: ldstr "isPromise"
+		IL_00c7: ldloc.3
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00cd: stloc.s 5
+		IL_00cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d4: ldc.i4.1
+		IL_00d5: newarr [System.Runtime]System.Object
+		IL_00da: dup
+		IL_00db: ldc.i4.0
+		IL_00dc: ldloc.s 5
+		IL_00de: stelem.ref
+		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00e4: pop
+		IL_00e5: ldloc.1
+		IL_00e6: ldstr "types"
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, object)
+		IL_00f0: stloc.s 5
+		IL_00f2: ldloc.s 4
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: stloc.s 7
+		IL_00fb: ldloc.s 5
+		IL_00fd: ldstr "isPromise"
+		IL_0102: ldloc.s 7
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0109: stloc.s 5
+		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0110: ldc.i4.1
+		IL_0111: newarr [System.Runtime]System.Object
+		IL_0116: dup
+		IL_0117: ldc.i4.0
+		IL_0118: ldloc.s 5
+		IL_011a: stelem.ref
+		IL_011b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0120: pop
+		IL_0121: ret
 	} // end of method Require_Util_Types_IsPromise::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_IsPromise
@@ -284,7 +275,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d9
+		// Method begins at RVA 0x21cd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- normalize RequireDelegate-typed dynamic function-value calls to direct LIRCallRequire in post-LIR normalization
- keep HIR-to-LIR lowering unchanged and apply specialization only during normalization
- include updated generator snapshots after the normalization change

## Validation
- dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj --filter "LIRIntrinsicNormalizationTests" --nologo