### PR TITLE
fix(benchmarks): align phased ScriptName keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+- benchmarks/perf: fix `Js2ILPhasedBenchmarks` scenario keying to use plain script names (matching BenchmarkDotNet `ScriptName`) so phased runs no longer hit dictionary `KeyNotFoundException` and produce `NA`-only results.
 
 ## v0.8.21 - 2026-02-24
 

--- a/tests/performance/Benchmarks/Js2ILPhasedBenchmarks.cs
+++ b/tests/performance/Benchmarks/Js2ILPhasedBenchmarks.cs
@@ -47,7 +47,7 @@ public class Js2ILPhasedBenchmarks
             var scriptPath = scriptFiles[i];
             var scriptFile = Path.GetFileName(scriptPath);
             var scriptName = Path.GetFileNameWithoutExtension(scriptFile);
-            var scenarioKey = $"{i + 1:D2}-{scriptName}";
+            var scenarioKey = scriptName;
             var scriptContent = File.ReadAllText(scriptPath);
             _scripts[scenarioKey] = scriptContent;
             _scenarioKeyToScriptName[scenarioKey] = scriptName;


### PR DESCRIPTION
## Summary
- align `Js2ILPhasedBenchmarks` scenario keys with BenchmarkDotNet `ScriptName` values
- prevent phased benchmark `KeyNotFoundException` and `NA`-only results
- add changelog note under `Unreleased`

## Verification
- local target verification harness for `dromaeo-object-array-modern` completed (`TARGET-VERIFICATION:OK`)
- local ingestion parser smoke-check completed (`Prepared 52 rows from 'benchmarkdotnet'`)