### PR TITLE
fix(benchmarks): respect BenchmarkDotNet CLI exporters

### DIFF
--- a/tests/performance/Benchmarks/Program.cs
+++ b/tests/performance/Benchmarks/Program.cs
@@ -9,21 +9,30 @@ if (programArgs.Length > 0 && programArgs[0] == "--validate")
     // Run validation tests for runtime adapters
     ValidationTest.RunValidation();
 }
-else if (programArgs.Length > 0 && programArgs[0] == "--phased")
-{
-    // Run phased benchmarks (js2il compile/execute plus Jint prepare/prepared execution)
-    BenchmarkRunner.Run<Js2ILPhasedBenchmarks>();
-}
-else if (programArgs.Length > 0 && programArgs[0] == "--all")
-{
-    // Run all benchmarks
-    BenchmarkRunner.Run<JavaScriptRuntimeBenchmarks>();
-    BenchmarkRunner.Run<Js2ILPhasedBenchmarks>();
-}
 else
 {
-    // Run cross-runtime comparison by default
-    BenchmarkRunner.Run<JavaScriptRuntimeBenchmarks>();
+    BenchmarkSwitcher switcher;
+    var benchmarkArgs = programArgs;
+
+    if (programArgs.Length > 0 && programArgs[0] == "--phased")
+    {
+        // Run phased benchmarks (js2il compile/execute plus Jint prepare/prepared execution)
+        switcher = BenchmarkSwitcher.FromTypes([typeof(Js2ILPhasedBenchmarks)]);
+        benchmarkArgs = programArgs.Skip(1).ToArray();
+    }
+    else if (programArgs.Length > 0 && programArgs[0] == "--all")
+    {
+        // Run all benchmarks
+        switcher = BenchmarkSwitcher.FromTypes([typeof(JavaScriptRuntimeBenchmarks), typeof(Js2ILPhasedBenchmarks)]);
+        benchmarkArgs = programArgs.Skip(1).ToArray();
+    }
+    else
+    {
+        // Run cross-runtime comparison by default
+        switcher = BenchmarkSwitcher.FromTypes([typeof(JavaScriptRuntimeBenchmarks)]);
+    }
+
+    switcher.Run(benchmarkArgs);
 }
 
 Console.WriteLine("\nBenchmark execution complete!");


### PR DESCRIPTION
## Summary
- update benchmark entrypoint to run via `BenchmarkSwitcher`
- forward BenchmarkDotNet CLI args so options like `--exporters json` are respected
- keep `--validate` behavior unchanged

## Verification
- built `tests/performance/Benchmarks/Benchmarks.csproj` in Release
- ran phased benchmark with `--exporters json` and observed JSON artifact generation