### PR TITLE
fix(commonjs): strongly type module require locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+- commonjs/lowering: emit safe injected module-scope `require` fields as strongly typed `JavaScriptRuntime.CommonJS.RequireDelegate` and preserve typed reads so `require("...")` lowers to direct `RequireDelegate::Invoke` instead of late-bound `Closure.InvokeWithArgs*`; updated affected Node FS generator snapshots.
 
 ## v0.8.22 - 2026-02-24
 

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Buffer.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Buffer.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225a
+				// Method begins at RVA 0x220c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,15 +47,14 @@
 				object buffer
 			) cil managed 
 		{
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x216c
 			// Header size: 12
-			// Code size: 123 (0x7b)
+			// Code size: 109 (0x6d)
 			.maxstack 8
 			.locals init (
 				[0] bool,
 				[1] object,
-				[2] object[],
-				[3] object
+				[2] object
 			)
 
 			IL_0000: ldarg.2
@@ -76,35 +75,25 @@
 			IL_002f: box [System.Runtime]System.Double
 			IL_0034: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_0039: pop
-			IL_003a: ldc.i4.1
-			IL_003b: newarr [System.Runtime]System.Object
-			IL_0040: dup
-			IL_0041: ldc.i4.0
-			IL_0042: ldarg.0
-			IL_0043: ldc.i4.0
-			IL_0044: ldelem.ref
-			IL_0045: stelem.ref
-			IL_0046: stloc.2
-			IL_0047: ldarg.0
-			IL_0048: ldc.i4.0
-			IL_0049: ldelem.ref
-			IL_004a: castclass Modules.FSPromises_ReadFile_Buffer/Scope
-			IL_004f: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::require
-			IL_0054: ldloc.2
-			IL_0055: ldstr "fs"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-			IL_005f: stloc.3
-			IL_0060: ldloc.3
-			IL_0061: ldstr "rmSync"
-			IL_0066: ldarg.0
-			IL_0067: ldc.i4.0
-			IL_0068: ldelem.ref
-			IL_0069: castclass Modules.FSPromises_ReadFile_Buffer/Scope
-			IL_006e: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0078: pop
-			IL_0079: ldnull
-			IL_007a: ret
+			IL_003a: ldarg.0
+			IL_003b: ldc.i4.0
+			IL_003c: ldelem.ref
+			IL_003d: castclass Modules.FSPromises_ReadFile_Buffer/Scope
+			IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Buffer/Scope::require
+			IL_0047: ldstr "fs"
+			IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0051: stloc.2
+			IL_0052: ldloc.2
+			IL_0053: ldstr "rmSync"
+			IL_0058: ldarg.0
+			IL_0059: ldc.i4.0
+			IL_005a: ldelem.ref
+			IL_005b: castclass Modules.FSPromises_ReadFile_Buffer/Scope
+			IL_0060: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_006a: pop
+			IL_006b: ldnull
+			IL_006c: ret
 		} // end of method ArrowFunction_L8C28::__js_call__
 
 	} // end of class ArrowFunction_L8C28
@@ -127,7 +116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2263
+				// Method begins at RVA 0x2215
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -148,7 +137,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2233
+			// Method begins at RVA 0x21e5
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -175,14 +164,14 @@
 			46 69 6c 65 3d 7b 74 65 73 74 46 69 6c 65 7d 00 00
 		)
 		// Fields
-		.field public object require
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
 		.field public object testFile
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2251
+			// Method begins at RVA 0x2203
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -208,142 +197,109 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 333 (0x14d)
+		// Code size: 269 (0x10d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_ReadFile_Buffer/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object,
-			[5] object
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.FSPromises_ReadFile_Buffer/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldarg.1
-		IL_0008: stfld object Modules.FSPromises_ReadFile_Buffer/Scope::require
-		IL_000d: ldc.i4.1
-		IL_000e: newarr [System.Runtime]System.Object
-		IL_0013: dup
-		IL_0014: ldc.i4.0
-		IL_0015: ldnull
-		IL_0016: stelem.ref
-		IL_0017: stloc.3
-		IL_0018: ldloc.0
-		IL_0019: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::require
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Buffer/Scope::require
+		IL_000d: ldloc.0
+		IL_000e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Buffer/Scope::require
+		IL_0013: ldstr "fs/promises"
+		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_001d: stloc.3
 		IL_001e: ldloc.3
-		IL_001f: ldstr "fs/promises"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0029: stloc.s 4
-		IL_002b: ldloc.s 4
-		IL_002d: stloc.1
-		IL_002e: ldc.i4.1
-		IL_002f: newarr [System.Runtime]System.Object
-		IL_0034: dup
-		IL_0035: ldc.i4.0
-		IL_0036: ldnull
-		IL_0037: stelem.ref
-		IL_0038: stloc.3
-		IL_0039: ldloc.0
-		IL_003a: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::require
-		IL_003f: ldloc.3
-		IL_0040: ldstr "path"
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_004a: stloc.s 4
-		IL_004c: ldloc.s 4
-		IL_004e: stloc.2
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldnull
-		IL_0058: stelem.ref
-		IL_0059: stloc.3
-		IL_005a: ldloc.0
-		IL_005b: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::require
-		IL_0060: ldloc.3
-		IL_0061: ldstr "os"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_006b: stloc.s 4
-		IL_006d: ldloc.s 4
-		IL_006f: ldstr "tmpdir"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0079: stloc.s 4
-		IL_007b: ldloc.2
-		IL_007c: ldstr "join"
-		IL_0081: ldloc.s 4
-		IL_0083: ldstr "test-readfile-buffer.txt"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_008d: stloc.s 4
-		IL_008f: ldloc.0
-		IL_0090: ldloc.s 4
-		IL_0092: stfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-		IL_0097: ldc.i4.1
-		IL_0098: newarr [System.Runtime]System.Object
-		IL_009d: dup
-		IL_009e: ldc.i4.0
-		IL_009f: ldnull
-		IL_00a0: stelem.ref
-		IL_00a1: stloc.3
-		IL_00a2: ldloc.0
-		IL_00a3: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::require
-		IL_00a8: ldloc.3
-		IL_00a9: ldstr "fs"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00b3: stloc.s 4
-		IL_00b5: ldloc.0
-		IL_00b6: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-		IL_00bb: stloc.s 5
-		IL_00bd: ldloc.s 4
-		IL_00bf: ldstr "writeFileSync"
-		IL_00c4: ldloc.s 5
-		IL_00c6: ldstr "Buffer test"
-		IL_00cb: ldstr "utf8"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00d5: pop
-		IL_00d6: ldloc.1
-		IL_00d7: ldstr "readFile"
-		IL_00dc: ldloc.0
-		IL_00dd: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e7: stloc.s 5
-		IL_00e9: ldnull
-		IL_00ea: ldftn object Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L8C28::__js_call__(object[], object, object)
-		IL_00f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_00f5: ldc.i4.1
-		IL_00f6: newarr [System.Runtime]System.Object
-		IL_00fb: dup
-		IL_00fc: ldc.i4.0
-		IL_00fd: ldloc.0
-		IL_00fe: stelem.ref
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0109: stloc.s 4
-		IL_010b: ldloc.s 5
-		IL_010d: ldstr "then"
-		IL_0112: ldloc.s 4
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0119: stloc.s 4
-		IL_011b: ldnull
-		IL_011c: ldftn object Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10::__js_call__(object, object)
-		IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0127: ldc.i4.1
-		IL_0128: newarr [System.Runtime]System.Object
-		IL_012d: dup
-		IL_012e: ldc.i4.0
-		IL_012f: ldloc.0
-		IL_0130: stelem.ref
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_013b: stloc.s 5
-		IL_013d: ldloc.s 4
-		IL_013f: ldstr "catch"
-		IL_0144: ldloc.s 5
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014b: pop
-		IL_014c: ret
+		IL_001f: stloc.1
+		IL_0020: ldloc.0
+		IL_0021: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Buffer/Scope::require
+		IL_0026: ldstr "path"
+		IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0030: stloc.3
+		IL_0031: ldloc.3
+		IL_0032: stloc.2
+		IL_0033: ldloc.0
+		IL_0034: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Buffer/Scope::require
+		IL_0039: ldstr "os"
+		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0043: stloc.3
+		IL_0044: ldloc.3
+		IL_0045: ldstr "tmpdir"
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_004f: stloc.3
+		IL_0050: ldloc.2
+		IL_0051: ldstr "join"
+		IL_0056: ldloc.3
+		IL_0057: ldstr "test-readfile-buffer.txt"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0061: stloc.3
+		IL_0062: ldloc.0
+		IL_0063: ldloc.3
+		IL_0064: stfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
+		IL_0069: ldloc.0
+		IL_006a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Buffer/Scope::require
+		IL_006f: ldstr "fs"
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0079: stloc.3
+		IL_007a: ldloc.0
+		IL_007b: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldstr "writeFileSync"
+		IL_0088: ldloc.s 4
+		IL_008a: ldstr "Buffer test"
+		IL_008f: ldstr "utf8"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0099: pop
+		IL_009a: ldloc.1
+		IL_009b: ldstr "readFile"
+		IL_00a0: ldloc.0
+		IL_00a1: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ab: stloc.s 4
+		IL_00ad: ldnull
+		IL_00ae: ldftn object Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L8C28::__js_call__(object[], object, object)
+		IL_00b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_00b9: ldc.i4.1
+		IL_00ba: newarr [System.Runtime]System.Object
+		IL_00bf: dup
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldloc.0
+		IL_00c2: stelem.ref
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00cd: stloc.3
+		IL_00ce: ldloc.s 4
+		IL_00d0: ldstr "then"
+		IL_00d5: ldloc.3
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00db: stloc.3
+		IL_00dc: ldnull
+		IL_00dd: ldftn object Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10::__js_call__(object, object)
+		IL_00e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00e8: ldc.i4.1
+		IL_00e9: newarr [System.Runtime]System.Object
+		IL_00ee: dup
+		IL_00ef: ldc.i4.0
+		IL_00f0: ldloc.0
+		IL_00f1: stelem.ref
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00fc: stloc.s 4
+		IL_00fe: ldloc.3
+		IL_00ff: ldstr "catch"
+		IL_0104: ldloc.s 4
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_010b: pop
+		IL_010c: ret
 	} // end of method FSPromises_ReadFile_Buffer::__js_module_init__
 
 } // end of class Modules.FSPromises_ReadFile_Buffer
@@ -355,7 +311,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226c
+		// Method begins at RVA 0x221e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Utf8.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Utf8.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2239
+				// Method begins at RVA 0x21eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,13 +47,12 @@
 				object content
 			) cil managed 
 		{
-			// Method begins at RVA 0x21b4
+			// Method begins at RVA 0x2174
 			// Header size: 12
-			// Code size: 82 (0x52)
+			// Code size: 68 (0x44)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -61,35 +60,25 @@
 			IL_000a: ldarg.2
 			IL_000b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_0010: pop
-			IL_0011: ldc.i4.1
-			IL_0012: newarr [System.Runtime]System.Object
-			IL_0017: dup
-			IL_0018: ldc.i4.0
-			IL_0019: ldarg.0
-			IL_001a: ldc.i4.0
-			IL_001b: ldelem.ref
-			IL_001c: stelem.ref
-			IL_001d: stloc.0
-			IL_001e: ldarg.0
-			IL_001f: ldc.i4.0
-			IL_0020: ldelem.ref
-			IL_0021: castclass Modules.FSPromises_ReadFile_Utf8/Scope
-			IL_0026: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::require
-			IL_002b: ldloc.0
-			IL_002c: ldstr "fs"
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-			IL_0036: stloc.1
-			IL_0037: ldloc.1
-			IL_0038: ldstr "rmSync"
-			IL_003d: ldarg.0
-			IL_003e: ldc.i4.0
-			IL_003f: ldelem.ref
-			IL_0040: castclass Modules.FSPromises_ReadFile_Utf8/Scope
-			IL_0045: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_004f: pop
-			IL_0050: ldnull
-			IL_0051: ret
+			IL_0011: ldarg.0
+			IL_0012: ldc.i4.0
+			IL_0013: ldelem.ref
+			IL_0014: castclass Modules.FSPromises_ReadFile_Utf8/Scope
+			IL_0019: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Utf8/Scope::require
+			IL_001e: ldstr "fs"
+			IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0028: stloc.0
+			IL_0029: ldloc.0
+			IL_002a: ldstr "rmSync"
+			IL_002f: ldarg.0
+			IL_0030: ldc.i4.0
+			IL_0031: ldelem.ref
+			IL_0032: castclass Modules.FSPromises_ReadFile_Utf8/Scope
+			IL_0037: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0041: pop
+			IL_0042: ldnull
+			IL_0043: ret
 		} // end of method ArrowFunction_L8C36::__js_call__
 
 	} // end of class ArrowFunction_L8C36
@@ -112,7 +101,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2242
+				// Method begins at RVA 0x21f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +122,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2212
+			// Method begins at RVA 0x21c4
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -160,14 +149,14 @@
 			46 69 6c 65 3d 7b 74 65 73 74 46 69 6c 65 7d 00 00
 		)
 		// Fields
-		.field public object require
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
 		.field public object testFile
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2230
+			// Method begins at RVA 0x21e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -193,145 +182,112 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 342 (0x156)
+		// Code size: 278 (0x116)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_ReadFile_Utf8/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object,
-			[5] object
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.FSPromises_ReadFile_Utf8/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldarg.1
-		IL_0008: stfld object Modules.FSPromises_ReadFile_Utf8/Scope::require
-		IL_000d: ldc.i4.1
-		IL_000e: newarr [System.Runtime]System.Object
-		IL_0013: dup
-		IL_0014: ldc.i4.0
-		IL_0015: ldnull
-		IL_0016: stelem.ref
-		IL_0017: stloc.3
-		IL_0018: ldloc.0
-		IL_0019: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::require
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Utf8/Scope::require
+		IL_000d: ldloc.0
+		IL_000e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Utf8/Scope::require
+		IL_0013: ldstr "fs/promises"
+		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_001d: stloc.3
 		IL_001e: ldloc.3
-		IL_001f: ldstr "fs/promises"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0029: stloc.s 4
-		IL_002b: ldloc.s 4
-		IL_002d: stloc.1
-		IL_002e: ldc.i4.1
-		IL_002f: newarr [System.Runtime]System.Object
-		IL_0034: dup
-		IL_0035: ldc.i4.0
-		IL_0036: ldnull
-		IL_0037: stelem.ref
-		IL_0038: stloc.3
-		IL_0039: ldloc.0
-		IL_003a: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::require
-		IL_003f: ldloc.3
-		IL_0040: ldstr "path"
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_004a: stloc.s 4
-		IL_004c: ldloc.s 4
-		IL_004e: stloc.2
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldnull
-		IL_0058: stelem.ref
-		IL_0059: stloc.3
-		IL_005a: ldloc.0
-		IL_005b: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::require
-		IL_0060: ldloc.3
-		IL_0061: ldstr "os"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_006b: stloc.s 4
-		IL_006d: ldloc.s 4
-		IL_006f: ldstr "tmpdir"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0079: stloc.s 4
-		IL_007b: ldloc.2
-		IL_007c: ldstr "join"
-		IL_0081: ldloc.s 4
-		IL_0083: ldstr "test-readfile.txt"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_008d: stloc.s 4
-		IL_008f: ldloc.0
-		IL_0090: ldloc.s 4
-		IL_0092: stfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-		IL_0097: ldc.i4.1
-		IL_0098: newarr [System.Runtime]System.Object
-		IL_009d: dup
-		IL_009e: ldc.i4.0
-		IL_009f: ldnull
-		IL_00a0: stelem.ref
-		IL_00a1: stloc.3
-		IL_00a2: ldloc.0
-		IL_00a3: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::require
-		IL_00a8: ldloc.3
-		IL_00a9: ldstr "fs"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00b3: stloc.s 4
-		IL_00b5: ldloc.0
-		IL_00b6: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-		IL_00bb: stloc.s 5
-		IL_00bd: ldloc.s 4
-		IL_00bf: ldstr "writeFileSync"
-		IL_00c4: ldloc.s 5
-		IL_00c6: ldstr "Hello, fs/promises!"
-		IL_00cb: ldstr "utf8"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00d5: pop
-		IL_00d6: ldloc.0
-		IL_00d7: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-		IL_00dc: stloc.s 5
-		IL_00de: ldloc.1
-		IL_00df: ldstr "readFile"
-		IL_00e4: ldloc.s 5
-		IL_00e6: ldstr "utf8"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00f0: stloc.s 5
-		IL_00f2: ldnull
-		IL_00f3: ldftn object Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L8C36::__js_call__(object[], object, object)
-		IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_00fe: ldc.i4.1
-		IL_00ff: newarr [System.Runtime]System.Object
-		IL_0104: dup
-		IL_0105: ldc.i4.0
-		IL_0106: ldloc.0
-		IL_0107: stelem.ref
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0112: stloc.s 4
-		IL_0114: ldloc.s 5
-		IL_0116: ldstr "then"
-		IL_011b: ldloc.s 4
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0122: stloc.s 4
-		IL_0124: ldnull
-		IL_0125: ldftn object Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10::__js_call__(object, object)
-		IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0130: ldc.i4.1
-		IL_0131: newarr [System.Runtime]System.Object
-		IL_0136: dup
-		IL_0137: ldc.i4.0
-		IL_0138: ldloc.0
-		IL_0139: stelem.ref
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0144: stloc.s 5
-		IL_0146: ldloc.s 4
-		IL_0148: ldstr "catch"
-		IL_014d: ldloc.s 5
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0154: pop
-		IL_0155: ret
+		IL_001f: stloc.1
+		IL_0020: ldloc.0
+		IL_0021: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Utf8/Scope::require
+		IL_0026: ldstr "path"
+		IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0030: stloc.3
+		IL_0031: ldloc.3
+		IL_0032: stloc.2
+		IL_0033: ldloc.0
+		IL_0034: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Utf8/Scope::require
+		IL_0039: ldstr "os"
+		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0043: stloc.3
+		IL_0044: ldloc.3
+		IL_0045: ldstr "tmpdir"
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_004f: stloc.3
+		IL_0050: ldloc.2
+		IL_0051: ldstr "join"
+		IL_0056: ldloc.3
+		IL_0057: ldstr "test-readfile.txt"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0061: stloc.3
+		IL_0062: ldloc.0
+		IL_0063: ldloc.3
+		IL_0064: stfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
+		IL_0069: ldloc.0
+		IL_006a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Utf8/Scope::require
+		IL_006f: ldstr "fs"
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0079: stloc.3
+		IL_007a: ldloc.0
+		IL_007b: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldstr "writeFileSync"
+		IL_0088: ldloc.s 4
+		IL_008a: ldstr "Hello, fs/promises!"
+		IL_008f: ldstr "utf8"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0099: pop
+		IL_009a: ldloc.0
+		IL_009b: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
+		IL_00a0: stloc.s 4
+		IL_00a2: ldloc.1
+		IL_00a3: ldstr "readFile"
+		IL_00a8: ldloc.s 4
+		IL_00aa: ldstr "utf8"
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00b4: stloc.s 4
+		IL_00b6: ldnull
+		IL_00b7: ldftn object Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L8C36::__js_call__(object[], object, object)
+		IL_00bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_00c2: ldc.i4.1
+		IL_00c3: newarr [System.Runtime]System.Object
+		IL_00c8: dup
+		IL_00c9: ldc.i4.0
+		IL_00ca: ldloc.0
+		IL_00cb: stelem.ref
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00d6: stloc.3
+		IL_00d7: ldloc.s 4
+		IL_00d9: ldstr "then"
+		IL_00de: ldloc.3
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e4: stloc.3
+		IL_00e5: ldnull
+		IL_00e6: ldftn object Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10::__js_call__(object, object)
+		IL_00ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f1: ldc.i4.1
+		IL_00f2: newarr [System.Runtime]System.Object
+		IL_00f7: dup
+		IL_00f8: ldc.i4.0
+		IL_00f9: ldloc.0
+		IL_00fa: stelem.ref
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0105: stloc.s 4
+		IL_0107: ldloc.3
+		IL_0108: ldstr "catch"
+		IL_010d: ldloc.s 4
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0114: pop
+		IL_0115: ret
 	} // end of method FSPromises_ReadFile_Utf8::__js_module_init__
 
 } // end of class Modules.FSPromises_ReadFile_Utf8
@@ -343,7 +299,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x224b
+		// Method begins at RVA 0x21fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2268
+				// Method begins at RVA 0x221a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,13 +47,12 @@
 				object fullPath
 			) cil managed 
 		{
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x216c
 			// Header size: 12
-			// Code size: 137 (0x89)
+			// Code size: 123 (0x7b)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object[]
+				[0] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -75,35 +74,25 @@
 			IL_0041: ldloc.0
 			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_0047: pop
-			IL_0048: ldc.i4.1
-			IL_0049: newarr [System.Runtime]System.Object
-			IL_004e: dup
-			IL_004f: ldc.i4.0
-			IL_0050: ldarg.0
-			IL_0051: ldc.i4.0
-			IL_0052: ldelem.ref
-			IL_0053: stelem.ref
-			IL_0054: stloc.1
-			IL_0055: ldarg.0
-			IL_0056: ldc.i4.0
-			IL_0057: ldelem.ref
-			IL_0058: castclass Modules.FSPromises_Realpath/Scope
-			IL_005d: ldfld object Modules.FSPromises_Realpath/Scope::require
-			IL_0062: ldloc.1
-			IL_0063: ldstr "fs"
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-			IL_006d: stloc.0
-			IL_006e: ldloc.0
-			IL_006f: ldstr "rmSync"
-			IL_0074: ldarg.0
-			IL_0075: ldc.i4.0
-			IL_0076: ldelem.ref
-			IL_0077: castclass Modules.FSPromises_Realpath/Scope
-			IL_007c: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldnull
-			IL_0088: ret
+			IL_0048: ldarg.0
+			IL_0049: ldc.i4.0
+			IL_004a: ldelem.ref
+			IL_004b: castclass Modules.FSPromises_Realpath/Scope
+			IL_0050: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
+			IL_0055: ldstr "fs"
+			IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_005f: stloc.0
+			IL_0060: ldloc.0
+			IL_0061: ldstr "rmSync"
+			IL_0066: ldarg.0
+			IL_0067: ldc.i4.0
+			IL_0068: ldelem.ref
+			IL_0069: castclass Modules.FSPromises_Realpath/Scope
+			IL_006e: ldfld object Modules.FSPromises_Realpath/Scope::testFile
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldnull
+			IL_007a: ret
 		} // end of method ArrowFunction_L8C28::__js_call__
 
 	} // end of class ArrowFunction_L8C28
@@ -126,7 +115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2271
+				// Method begins at RVA 0x2223
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +136,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x2241
+			// Method begins at RVA 0x21f3
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -174,14 +163,14 @@
 			46 69 6c 65 3d 7b 74 65 73 74 46 69 6c 65 7d 00 00
 		)
 		// Fields
-		.field public object require
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
 		.field public object testFile
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x225f
+			// Method begins at RVA 0x2211
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -207,142 +196,109 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 333 (0x14d)
+		// Code size: 269 (0x10d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Realpath/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object,
-			[5] object
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.FSPromises_Realpath/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldarg.1
-		IL_0008: stfld object Modules.FSPromises_Realpath/Scope::require
-		IL_000d: ldc.i4.1
-		IL_000e: newarr [System.Runtime]System.Object
-		IL_0013: dup
-		IL_0014: ldc.i4.0
-		IL_0015: ldnull
-		IL_0016: stelem.ref
-		IL_0017: stloc.3
-		IL_0018: ldloc.0
-		IL_0019: ldfld object Modules.FSPromises_Realpath/Scope::require
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
+		IL_000d: ldloc.0
+		IL_000e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
+		IL_0013: ldstr "fs/promises"
+		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_001d: stloc.3
 		IL_001e: ldloc.3
-		IL_001f: ldstr "fs/promises"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0029: stloc.s 4
-		IL_002b: ldloc.s 4
-		IL_002d: stloc.1
-		IL_002e: ldc.i4.1
-		IL_002f: newarr [System.Runtime]System.Object
-		IL_0034: dup
-		IL_0035: ldc.i4.0
-		IL_0036: ldnull
-		IL_0037: stelem.ref
-		IL_0038: stloc.3
-		IL_0039: ldloc.0
-		IL_003a: ldfld object Modules.FSPromises_Realpath/Scope::require
-		IL_003f: ldloc.3
-		IL_0040: ldstr "path"
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_004a: stloc.s 4
-		IL_004c: ldloc.s 4
-		IL_004e: stloc.2
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldnull
-		IL_0058: stelem.ref
-		IL_0059: stloc.3
-		IL_005a: ldloc.0
-		IL_005b: ldfld object Modules.FSPromises_Realpath/Scope::require
-		IL_0060: ldloc.3
-		IL_0061: ldstr "os"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_006b: stloc.s 4
-		IL_006d: ldloc.s 4
-		IL_006f: ldstr "tmpdir"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0079: stloc.s 4
-		IL_007b: ldloc.2
-		IL_007c: ldstr "join"
-		IL_0081: ldloc.s 4
-		IL_0083: ldstr "test-realpath.txt"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_008d: stloc.s 4
-		IL_008f: ldloc.0
-		IL_0090: ldloc.s 4
-		IL_0092: stfld object Modules.FSPromises_Realpath/Scope::testFile
-		IL_0097: ldc.i4.1
-		IL_0098: newarr [System.Runtime]System.Object
-		IL_009d: dup
-		IL_009e: ldc.i4.0
-		IL_009f: ldnull
-		IL_00a0: stelem.ref
-		IL_00a1: stloc.3
-		IL_00a2: ldloc.0
-		IL_00a3: ldfld object Modules.FSPromises_Realpath/Scope::require
-		IL_00a8: ldloc.3
-		IL_00a9: ldstr "fs"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00b3: stloc.s 4
-		IL_00b5: ldloc.0
-		IL_00b6: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-		IL_00bb: stloc.s 5
-		IL_00bd: ldloc.s 4
-		IL_00bf: ldstr "writeFileSync"
-		IL_00c4: ldloc.s 5
-		IL_00c6: ldstr "test"
-		IL_00cb: ldstr "utf8"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00d5: pop
-		IL_00d6: ldloc.1
-		IL_00d7: ldstr "realpath"
-		IL_00dc: ldloc.0
-		IL_00dd: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e7: stloc.s 5
-		IL_00e9: ldnull
-		IL_00ea: ldftn object Modules.FSPromises_Realpath/ArrowFunction_L8C28::__js_call__(object[], object, object)
-		IL_00f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_00f5: ldc.i4.1
-		IL_00f6: newarr [System.Runtime]System.Object
-		IL_00fb: dup
-		IL_00fc: ldc.i4.0
-		IL_00fd: ldloc.0
-		IL_00fe: stelem.ref
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0109: stloc.s 4
-		IL_010b: ldloc.s 5
-		IL_010d: ldstr "then"
-		IL_0112: ldloc.s 4
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0119: stloc.s 4
-		IL_011b: ldnull
-		IL_011c: ldftn object Modules.FSPromises_Realpath/ArrowFunction_L12C10::__js_call__(object, object)
-		IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0127: ldc.i4.1
-		IL_0128: newarr [System.Runtime]System.Object
-		IL_012d: dup
-		IL_012e: ldc.i4.0
-		IL_012f: ldloc.0
-		IL_0130: stelem.ref
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_013b: stloc.s 5
-		IL_013d: ldloc.s 4
-		IL_013f: ldstr "catch"
-		IL_0144: ldloc.s 5
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014b: pop
-		IL_014c: ret
+		IL_001f: stloc.1
+		IL_0020: ldloc.0
+		IL_0021: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
+		IL_0026: ldstr "path"
+		IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0030: stloc.3
+		IL_0031: ldloc.3
+		IL_0032: stloc.2
+		IL_0033: ldloc.0
+		IL_0034: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
+		IL_0039: ldstr "os"
+		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0043: stloc.3
+		IL_0044: ldloc.3
+		IL_0045: ldstr "tmpdir"
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_004f: stloc.3
+		IL_0050: ldloc.2
+		IL_0051: ldstr "join"
+		IL_0056: ldloc.3
+		IL_0057: ldstr "test-realpath.txt"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0061: stloc.3
+		IL_0062: ldloc.0
+		IL_0063: ldloc.3
+		IL_0064: stfld object Modules.FSPromises_Realpath/Scope::testFile
+		IL_0069: ldloc.0
+		IL_006a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
+		IL_006f: ldstr "fs"
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0079: stloc.3
+		IL_007a: ldloc.0
+		IL_007b: ldfld object Modules.FSPromises_Realpath/Scope::testFile
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldstr "writeFileSync"
+		IL_0088: ldloc.s 4
+		IL_008a: ldstr "test"
+		IL_008f: ldstr "utf8"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0099: pop
+		IL_009a: ldloc.1
+		IL_009b: ldstr "realpath"
+		IL_00a0: ldloc.0
+		IL_00a1: ldfld object Modules.FSPromises_Realpath/Scope::testFile
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ab: stloc.s 4
+		IL_00ad: ldnull
+		IL_00ae: ldftn object Modules.FSPromises_Realpath/ArrowFunction_L8C28::__js_call__(object[], object, object)
+		IL_00b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_00b9: ldc.i4.1
+		IL_00ba: newarr [System.Runtime]System.Object
+		IL_00bf: dup
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldloc.0
+		IL_00c2: stelem.ref
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00cd: stloc.3
+		IL_00ce: ldloc.s 4
+		IL_00d0: ldstr "then"
+		IL_00d5: ldloc.3
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00db: stloc.3
+		IL_00dc: ldnull
+		IL_00dd: ldftn object Modules.FSPromises_Realpath/ArrowFunction_L12C10::__js_call__(object, object)
+		IL_00e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00e8: ldc.i4.1
+		IL_00e9: newarr [System.Runtime]System.Object
+		IL_00ee: dup
+		IL_00ef: ldc.i4.0
+		IL_00f0: ldloc.0
+		IL_00f1: stelem.ref
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00fc: stloc.s 4
+		IL_00fe: ldloc.3
+		IL_00ff: ldstr "catch"
+		IL_0104: ldloc.s 4
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_010b: pop
+		IL_010c: ret
 	} // end of method FSPromises_Realpath::__js_module_init__
 
 } // end of class Modules.FSPromises_Realpath
@@ -354,7 +310,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x227a
+		// Method begins at RVA 0x222c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_FileSize.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_FileSize.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2243
+				// Method begins at RVA 0x21fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,13 +47,12 @@
 				object stats
 			) cil managed 
 		{
-			// Method begins at RVA 0x21b4
+			// Method begins at RVA 0x217c
 			// Header size: 12
-			// Code size: 92 (0x5c)
+			// Code size: 78 (0x4e)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -63,35 +62,25 @@
 			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
 			IL_0015: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_001a: pop
-			IL_001b: ldc.i4.1
-			IL_001c: newarr [System.Runtime]System.Object
-			IL_0021: dup
-			IL_0022: ldc.i4.0
-			IL_0023: ldarg.0
-			IL_0024: ldc.i4.0
-			IL_0025: ldelem.ref
-			IL_0026: stelem.ref
-			IL_0027: stloc.0
-			IL_0028: ldarg.0
-			IL_0029: ldc.i4.0
-			IL_002a: ldelem.ref
-			IL_002b: castclass Modules.FSPromises_Stat_FileSize/Scope
-			IL_0030: ldfld object Modules.FSPromises_Stat_FileSize/Scope::require
-			IL_0035: ldloc.0
-			IL_0036: ldstr "fs"
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-			IL_0040: stloc.1
-			IL_0041: ldloc.1
-			IL_0042: ldstr "rmSync"
-			IL_0047: ldarg.0
-			IL_0048: ldc.i4.0
-			IL_0049: ldelem.ref
-			IL_004a: castclass Modules.FSPromises_Stat_FileSize/Scope
-			IL_004f: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0059: pop
-			IL_005a: ldnull
-			IL_005b: ret
+			IL_001b: ldarg.0
+			IL_001c: ldc.i4.0
+			IL_001d: ldelem.ref
+			IL_001e: castclass Modules.FSPromises_Stat_FileSize/Scope
+			IL_0023: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Stat_FileSize/Scope::require
+			IL_0028: ldstr "fs"
+			IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0032: stloc.0
+			IL_0033: ldloc.0
+			IL_0034: ldstr "rmSync"
+			IL_0039: ldarg.0
+			IL_003a: ldc.i4.0
+			IL_003b: ldelem.ref
+			IL_003c: castclass Modules.FSPromises_Stat_FileSize/Scope
+			IL_0041: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004b: pop
+			IL_004c: ldnull
+			IL_004d: ret
 		} // end of method ArrowFunction_L9C24::__js_call__
 
 	} // end of class ArrowFunction_L9C24
@@ -114,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224c
+				// Method begins at RVA 0x2206
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -135,7 +124,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x221c
+			// Method begins at RVA 0x21d6
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -162,14 +151,14 @@
 			46 69 6c 65 3d 7b 74 65 73 74 46 69 6c 65 7d 00 00
 		)
 		// Fields
-		.field public object require
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
 		.field public object testFile
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x223a
+			// Method begins at RVA 0x21f4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -195,145 +184,112 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 343 (0x157)
+		// Code size: 287 (0x11f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Stat_FileSize/Scope,
 			[1] object,
 			[2] object,
 			[3] string,
-			[4] object[],
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.FSPromises_Stat_FileSize/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldarg.1
-		IL_0008: stfld object Modules.FSPromises_Stat_FileSize/Scope::require
-		IL_000d: ldc.i4.1
-		IL_000e: newarr [System.Runtime]System.Object
-		IL_0013: dup
-		IL_0014: ldc.i4.0
-		IL_0015: ldnull
-		IL_0016: stelem.ref
-		IL_0017: stloc.s 4
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.FSPromises_Stat_FileSize/Scope::require
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Stat_FileSize/Scope::require
+		IL_000d: ldloc.0
+		IL_000e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Stat_FileSize/Scope::require
+		IL_0013: ldstr "fs/promises"
+		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_001d: stloc.s 4
 		IL_001f: ldloc.s 4
-		IL_0021: ldstr "fs/promises"
-		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_002b: stloc.s 5
-		IL_002d: ldloc.s 5
-		IL_002f: stloc.1
-		IL_0030: ldc.i4.1
-		IL_0031: newarr [System.Runtime]System.Object
-		IL_0036: dup
-		IL_0037: ldc.i4.0
-		IL_0038: ldnull
-		IL_0039: stelem.ref
-		IL_003a: stloc.s 4
-		IL_003c: ldloc.0
-		IL_003d: ldfld object Modules.FSPromises_Stat_FileSize/Scope::require
-		IL_0042: ldloc.s 4
-		IL_0044: ldstr "path"
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_004e: stloc.s 5
-		IL_0050: ldloc.s 5
-		IL_0052: stloc.2
-		IL_0053: ldc.i4.1
-		IL_0054: newarr [System.Runtime]System.Object
-		IL_0059: dup
-		IL_005a: ldc.i4.0
-		IL_005b: ldnull
-		IL_005c: stelem.ref
-		IL_005d: stloc.s 4
-		IL_005f: ldloc.0
-		IL_0060: ldfld object Modules.FSPromises_Stat_FileSize/Scope::require
-		IL_0065: ldloc.s 4
-		IL_0067: ldstr "os"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0071: stloc.s 5
-		IL_0073: ldloc.s 5
-		IL_0075: ldstr "tmpdir"
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_007f: stloc.s 5
-		IL_0081: ldloc.2
-		IL_0082: ldstr "join"
-		IL_0087: ldloc.s 5
-		IL_0089: ldstr "test-stat.txt"
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0093: stloc.s 5
-		IL_0095: ldloc.0
-		IL_0096: ldloc.s 5
-		IL_0098: stfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-		IL_009d: ldstr "Test content for stat"
-		IL_00a2: stloc.3
-		IL_00a3: ldc.i4.1
-		IL_00a4: newarr [System.Runtime]System.Object
-		IL_00a9: dup
-		IL_00aa: ldc.i4.0
-		IL_00ab: ldnull
-		IL_00ac: stelem.ref
-		IL_00ad: stloc.s 4
-		IL_00af: ldloc.0
-		IL_00b0: ldfld object Modules.FSPromises_Stat_FileSize/Scope::require
-		IL_00b5: ldloc.s 4
-		IL_00b7: ldstr "fs"
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_00c1: stloc.s 5
-		IL_00c3: ldloc.0
-		IL_00c4: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-		IL_00c9: stloc.s 6
-		IL_00cb: ldloc.s 5
-		IL_00cd: ldstr "writeFileSync"
-		IL_00d2: ldloc.s 6
-		IL_00d4: ldloc.3
-		IL_00d5: ldstr "utf8"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00df: pop
-		IL_00e0: ldloc.1
-		IL_00e1: ldstr "stat"
-		IL_00e6: ldloc.0
-		IL_00e7: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f1: stloc.s 6
-		IL_00f3: ldnull
-		IL_00f4: ldftn object Modules.FSPromises_Stat_FileSize/ArrowFunction_L9C24::__js_call__(object[], object, object)
-		IL_00fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-		IL_00ff: ldc.i4.1
-		IL_0100: newarr [System.Runtime]System.Object
-		IL_0105: dup
-		IL_0106: ldc.i4.0
-		IL_0107: ldloc.0
-		IL_0108: stelem.ref
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0113: stloc.s 5
-		IL_0115: ldloc.s 6
-		IL_0117: ldstr "then"
-		IL_011c: ldloc.s 5
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0123: stloc.s 5
-		IL_0125: ldnull
-		IL_0126: ldftn object Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10::__js_call__(object, object)
-		IL_012c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0131: ldc.i4.1
-		IL_0132: newarr [System.Runtime]System.Object
-		IL_0137: dup
-		IL_0138: ldc.i4.0
-		IL_0139: ldloc.0
-		IL_013a: stelem.ref
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0145: stloc.s 6
-		IL_0147: ldloc.s 5
-		IL_0149: ldstr "catch"
-		IL_014e: ldloc.s 6
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0155: pop
-		IL_0156: ret
+		IL_0021: stloc.1
+		IL_0022: ldloc.0
+		IL_0023: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Stat_FileSize/Scope::require
+		IL_0028: ldstr "path"
+		IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0032: stloc.s 4
+		IL_0034: ldloc.s 4
+		IL_0036: stloc.2
+		IL_0037: ldloc.0
+		IL_0038: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Stat_FileSize/Scope::require
+		IL_003d: ldstr "os"
+		IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0047: stloc.s 4
+		IL_0049: ldloc.s 4
+		IL_004b: ldstr "tmpdir"
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0055: stloc.s 4
+		IL_0057: ldloc.2
+		IL_0058: ldstr "join"
+		IL_005d: ldloc.s 4
+		IL_005f: ldstr "test-stat.txt"
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0069: stloc.s 4
+		IL_006b: ldloc.0
+		IL_006c: ldloc.s 4
+		IL_006e: stfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
+		IL_0073: ldstr "Test content for stat"
+		IL_0078: stloc.3
+		IL_0079: ldloc.0
+		IL_007a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Stat_FileSize/Scope::require
+		IL_007f: ldstr "fs"
+		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0089: stloc.s 4
+		IL_008b: ldloc.0
+		IL_008c: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
+		IL_0091: stloc.s 5
+		IL_0093: ldloc.s 4
+		IL_0095: ldstr "writeFileSync"
+		IL_009a: ldloc.s 5
+		IL_009c: ldloc.3
+		IL_009d: ldstr "utf8"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00a7: pop
+		IL_00a8: ldloc.1
+		IL_00a9: ldstr "stat"
+		IL_00ae: ldloc.0
+		IL_00af: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b9: stloc.s 5
+		IL_00bb: ldnull
+		IL_00bc: ldftn object Modules.FSPromises_Stat_FileSize/ArrowFunction_L9C24::__js_call__(object[], object, object)
+		IL_00c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_00c7: ldc.i4.1
+		IL_00c8: newarr [System.Runtime]System.Object
+		IL_00cd: dup
+		IL_00ce: ldc.i4.0
+		IL_00cf: ldloc.0
+		IL_00d0: stelem.ref
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00db: stloc.s 4
+		IL_00dd: ldloc.s 5
+		IL_00df: ldstr "then"
+		IL_00e4: ldloc.s 4
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00eb: stloc.s 4
+		IL_00ed: ldnull
+		IL_00ee: ldftn object Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10::__js_call__(object, object)
+		IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f9: ldc.i4.1
+		IL_00fa: newarr [System.Runtime]System.Object
+		IL_00ff: dup
+		IL_0100: ldc.i4.0
+		IL_0101: ldloc.0
+		IL_0102: stelem.ref
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_010d: stloc.s 5
+		IL_010f: ldloc.s 4
+		IL_0111: ldstr "catch"
+		IL_0116: ldloc.s 5
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_011d: pop
+		IL_011e: ret
 	} // end of method FSPromises_Stat_FileSize::__js_module_init__
 
 } // end of class Modules.FSPromises_Stat_FileSize
@@ -345,7 +301,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2255
+		// Method begins at RVA 0x220f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_WriteFile_Utf8.verified.txt
+++ b/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_WriteFile_Utf8.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2245
+				// Method begins at RVA 0x21f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -39,83 +39,62 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x2144
 			// Header size: 12
-			// Code size: 154 (0x9a)
+			// Code size: 126 (0x7e)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object[],
-				[2] object,
-				[3] object
+				[1] object,
+				[2] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: ldc.i4.0
-			IL_000a: ldelem.ref
-			IL_000b: stelem.ref
-			IL_000c: stloc.1
-			IL_000d: ldarg.0
-			IL_000e: ldc.i4.0
-			IL_000f: ldelem.ref
-			IL_0010: castclass Modules.FSPromises_WriteFile_Utf8/Scope
-			IL_0015: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::require
-			IL_001a: ldloc.1
-			IL_001b: ldstr "fs"
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: castclass Modules.FSPromises_WriteFile_Utf8/Scope
+			IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
+			IL_000d: ldstr "fs"
+			IL_0012: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0017: stloc.1
+			IL_0018: ldarg.0
+			IL_0019: ldc.i4.0
+			IL_001a: ldelem.ref
+			IL_001b: castclass Modules.FSPromises_WriteFile_Utf8/Scope
+			IL_0020: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
 			IL_0025: stloc.2
-			IL_0026: ldarg.0
-			IL_0027: ldc.i4.0
-			IL_0028: ldelem.ref
-			IL_0029: castclass Modules.FSPromises_WriteFile_Utf8/Scope
-			IL_002e: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-			IL_0033: stloc.3
-			IL_0034: ldloc.2
-			IL_0035: ldstr "readFileSync"
-			IL_003a: ldloc.3
-			IL_003b: ldstr "utf8"
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0045: stloc.3
-			IL_0046: ldloc.3
-			IL_0047: stloc.0
-			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_004d: ldstr "Written content:"
-			IL_0052: ldloc.0
-			IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0058: pop
-			IL_0059: ldc.i4.1
-			IL_005a: newarr [System.Runtime]System.Object
-			IL_005f: dup
-			IL_0060: ldc.i4.0
-			IL_0061: ldarg.0
-			IL_0062: ldc.i4.0
-			IL_0063: ldelem.ref
-			IL_0064: stelem.ref
-			IL_0065: stloc.1
-			IL_0066: ldarg.0
-			IL_0067: ldc.i4.0
-			IL_0068: ldelem.ref
-			IL_0069: castclass Modules.FSPromises_WriteFile_Utf8/Scope
-			IL_006e: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::require
-			IL_0073: ldloc.1
-			IL_0074: ldstr "fs"
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-			IL_007e: stloc.3
-			IL_007f: ldloc.3
-			IL_0080: ldstr "rmSync"
-			IL_0085: ldarg.0
-			IL_0086: ldc.i4.0
-			IL_0087: ldelem.ref
-			IL_0088: castclass Modules.FSPromises_WriteFile_Utf8/Scope
-			IL_008d: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0097: pop
-			IL_0098: ldnull
-			IL_0099: ret
+			IL_0026: ldloc.1
+			IL_0027: ldstr "readFileSync"
+			IL_002c: ldloc.2
+			IL_002d: ldstr "utf8"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0037: stloc.2
+			IL_0038: ldloc.2
+			IL_0039: stloc.0
+			IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_003f: ldstr "Written content:"
+			IL_0044: ldloc.0
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_004a: pop
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.FSPromises_WriteFile_Utf8/Scope
+			IL_0053: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
+			IL_0058: ldstr "fs"
+			IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0062: stloc.2
+			IL_0063: ldloc.2
+			IL_0064: ldstr "rmSync"
+			IL_0069: ldarg.0
+			IL_006a: ldc.i4.0
+			IL_006b: ldelem.ref
+			IL_006c: castclass Modules.FSPromises_WriteFile_Utf8/Scope
+			IL_0071: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_007b: pop
+			IL_007c: ldnull
+			IL_007d: ret
 		} // end of method ArrowFunction_L7C63::__js_call__
 
 	} // end of class ArrowFunction_L7C63
@@ -138,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224e
+				// Method begins at RVA 0x21fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -159,7 +138,7 @@
 				object err
 			) cil managed 
 		{
-			// Method begins at RVA 0x221e
+			// Method begins at RVA 0x21ce
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -186,14 +165,14 @@
 			46 69 6c 65 3d 7b 74 65 73 74 46 69 6c 65 7d 00 00
 		)
 		// Fields
-		.field public object require
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
 		.field public object testFile
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x223c
+			// Method begins at RVA 0x21ec
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -219,91 +198,83 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 284 (0x11c)
+		// Code size: 232 (0xe8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_WriteFile_Utf8/Scope,
 			[1] object,
 			[2] object,
-			[3] object[],
-			[4] object,
-			[5] object
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.FSPromises_WriteFile_Utf8/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldarg.1
-		IL_0008: stfld object Modules.FSPromises_WriteFile_Utf8/Scope::require
-		IL_000d: ldc.i4.1
-		IL_000e: newarr [System.Runtime]System.Object
-		IL_0013: dup
-		IL_0014: ldc.i4.0
-		IL_0015: ldnull
-		IL_0016: stelem.ref
-		IL_0017: stloc.3
-		IL_0018: ldloc.0
-		IL_0019: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::require
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
+		IL_000d: ldloc.0
+		IL_000e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
+		IL_0013: ldstr "fs/promises"
+		IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_001d: stloc.3
 		IL_001e: ldloc.3
-		IL_001f: ldstr "fs/promises"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0029: stloc.s 4
-		IL_002b: ldloc.s 4
-		IL_002d: stloc.1
-		IL_002e: ldc.i4.1
-		IL_002f: newarr [System.Runtime]System.Object
-		IL_0034: dup
-		IL_0035: ldc.i4.0
-		IL_0036: ldnull
-		IL_0037: stelem.ref
-		IL_0038: stloc.3
-		IL_0039: ldloc.0
-		IL_003a: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::require
-		IL_003f: ldloc.3
-		IL_0040: ldstr "path"
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_004a: stloc.s 4
-		IL_004c: ldloc.s 4
-		IL_004e: stloc.2
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldnull
-		IL_0058: stelem.ref
-		IL_0059: stloc.3
-		IL_005a: ldloc.0
-		IL_005b: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::require
-		IL_0060: ldloc.3
-		IL_0061: ldstr "os"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_006b: stloc.s 4
-		IL_006d: ldloc.s 4
-		IL_006f: ldstr "tmpdir"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0079: stloc.s 4
-		IL_007b: ldloc.2
-		IL_007c: ldstr "join"
-		IL_0081: ldloc.s 4
-		IL_0083: ldstr "test-writefile.txt"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_008d: stloc.s 4
-		IL_008f: ldloc.0
-		IL_0090: ldloc.s 4
-		IL_0092: stfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-		IL_0097: ldloc.0
-		IL_0098: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-		IL_009d: stloc.s 4
-		IL_009f: ldloc.1
-		IL_00a0: ldstr "writeFile"
-		IL_00a5: ldloc.s 4
-		IL_00a7: ldstr "Written by fs/promises"
-		IL_00ac: ldstr "utf8"
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_001f: stloc.1
+		IL_0020: ldloc.0
+		IL_0021: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
+		IL_0026: ldstr "path"
+		IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0030: stloc.3
+		IL_0031: ldloc.3
+		IL_0032: stloc.2
+		IL_0033: ldloc.0
+		IL_0034: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
+		IL_0039: ldstr "os"
+		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0043: stloc.3
+		IL_0044: ldloc.3
+		IL_0045: ldstr "tmpdir"
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_004f: stloc.3
+		IL_0050: ldloc.2
+		IL_0051: ldstr "join"
+		IL_0056: ldloc.3
+		IL_0057: ldstr "test-writefile.txt"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0061: stloc.3
+		IL_0062: ldloc.0
+		IL_0063: ldloc.3
+		IL_0064: stfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
+		IL_0069: ldloc.0
+		IL_006a: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
+		IL_006f: stloc.3
+		IL_0070: ldloc.1
+		IL_0071: ldstr "writeFile"
+		IL_0076: ldloc.3
+		IL_0077: ldstr "Written by fs/promises"
+		IL_007c: ldstr "utf8"
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0086: stloc.3
+		IL_0087: ldnull
+		IL_0088: ldftn object Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L7C63::__js_call__(object[], object)
+		IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0093: ldc.i4.1
+		IL_0094: newarr [System.Runtime]System.Object
+		IL_0099: dup
+		IL_009a: ldc.i4.0
+		IL_009b: ldloc.0
+		IL_009c: stelem.ref
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00a7: stloc.s 4
+		IL_00a9: ldloc.3
+		IL_00aa: ldstr "then"
+		IL_00af: ldloc.s 4
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00b6: stloc.s 4
 		IL_00b8: ldnull
-		IL_00b9: ldftn object Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L7C63::__js_call__(object[], object)
-		IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_00b9: ldftn object Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10::__js_call__(object, object)
+		IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_00c4: ldc.i4.1
 		IL_00c5: newarr [System.Runtime]System.Object
 		IL_00ca: dup
@@ -312,30 +283,13 @@
 		IL_00cd: stelem.ref
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
 		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00d8: stloc.s 5
-		IL_00da: ldloc.s 4
-		IL_00dc: ldstr "then"
-		IL_00e1: ldloc.s 5
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e8: stloc.s 5
-		IL_00ea: ldnull
-		IL_00eb: ldftn object Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10::__js_call__(object, object)
-		IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00f6: ldc.i4.1
-		IL_00f7: newarr [System.Runtime]System.Object
-		IL_00fc: dup
-		IL_00fd: ldc.i4.0
-		IL_00fe: ldloc.0
-		IL_00ff: stelem.ref
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_010a: stloc.s 4
-		IL_010c: ldloc.s 5
-		IL_010e: ldstr "catch"
-		IL_0113: ldloc.s 4
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011a: pop
-		IL_011b: ret
+		IL_00d8: stloc.3
+		IL_00d9: ldloc.s 4
+		IL_00db: ldstr "catch"
+		IL_00e0: ldloc.3
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e6: pop
+		IL_00e7: ret
 	} // end of method FSPromises_WriteFile_Utf8::__js_module_init__
 
 } // end of class Modules.FSPromises_WriteFile_Utf8
@@ -347,7 +301,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2257
+		// Method begins at RVA 0x2207
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
+++ b/Js2IL/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
@@ -352,6 +352,11 @@ public sealed partial class HIRToLIRLowerer
 
                 static ValueStorage GetPreferredBindingReadStorage(BindingInfo b)
                 {
+                    if (IsSafeInjectedCommonJsRequireParameter(b))
+                    {
+                        return new ValueStorage(ValueStorageKind.Reference, typeof(global::JavaScriptRuntime.CommonJS.RequireDelegate));
+                    }
+
                     // Propagate unboxed primitives for stable inferred types. This matches the current
                     // typed-scope-field support in TypeGenerator/VariableRegistry.
                     if (b.IsStableType)

--- a/Js2IL/Services/VariableBindings/VariableRegistry.cs
+++ b/Js2IL/Services/VariableBindings/VariableRegistry.cs
@@ -60,7 +60,7 @@ namespace Js2IL.Services.VariableBindings
         /// </summary>
         public void AddVariable(string scopeName, string variableName, VariableType type,
                                FieldDefinitionHandle fieldHandle, TypeDefinitionHandle scopeTypeHandle,
-                               BindingKind bindingKind, Type? clrType, bool isStableType)
+                               BindingKind bindingKind, Type? clrType, bool isStableType, Type? declaredFieldClrType = null)
         {
             if (!_scopeVariables.ContainsKey(scopeName))
                 _scopeVariables[scopeName] = new List<VariableInfo>();
@@ -81,20 +81,19 @@ namespace Js2IL.Services.VariableBindings
             _scopeMetadata.RegisterField(scopeName, variableName, fieldHandle);
             if (!fieldHandle.IsNil)
             {
-                // Emit typed fields for stable inferred primitive/reference fast paths; everything else remains object.
                 // Keep this in sync with TypeGenerator's field signature emission.
-                var declaredFieldType = typeof(object);
-                if (isStableType && clrType != null)
+                var resolvedDeclaredFieldType = declaredFieldClrType ?? typeof(object);
+                if (resolvedDeclaredFieldType == typeof(object) && isStableType && clrType != null)
                 {
                     if (clrType == typeof(double)
                         || clrType == typeof(bool)
                         || clrType == typeof(string)
                         || clrType == typeof(JavaScriptRuntime.Array))
                     {
-                        declaredFieldType = clrType;
+                        resolvedDeclaredFieldType = clrType;
                     }
                 }
-                _scopeMetadata.RegisterFieldClrType(scopeName, variableName, declaredFieldType);
+                _scopeMetadata.RegisterFieldClrType(scopeName, variableName, resolvedDeclaredFieldType);
             }
             if (!scopeTypeHandle.IsNil)
             {


### PR DESCRIPTION
## Summary
- strongly type safe injected module-scope `require` fields as `JavaScriptRuntime.CommonJS.RequireDelegate`
- preserve typed binding reads so `require(...)` lowers to direct `RequireDelegate::Invoke` instead of `Closure.InvokeWithArgs*`
- update affected Node FS generator snapshots and add changelog note under Unreleased

## Verification
- dotnet test Js2IL.Tests/Js2IL.Tests.csproj -c Release --nologo --filter "FSPromises_ReadFile_Utf8"
- dotnet test Js2IL.Tests/Js2IL.Tests.csproj -c Release --nologo --filter "Js2IL.Tests.Node.FS."
- dotnet test Js2IL.Tests/Js2IL.Tests.csproj -c Release --nologo --filter "CommonJS_Require_Reassigned"
- dotnet test Js2IL.Tests/Js2IL.Tests.csproj -c Release --nologo --filter "Js2IL.Tests.Node."