### PR TITLE
fix(benchmarks): always emit JSON benchmark reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+- benchmarks/workflows: enforce BenchmarkDotNet JSON output by annotating benchmark suites with `JsonExporterAttribute.FullCompressed`, so release/workflow ingestion reliably uses JSON artifacts (preserving full script-name fidelity instead of markdown-abbreviated labels).
 
 ## v0.8.23 - 2026-02-25
 

--- a/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
+++ b/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Order;
 using Benchmarks.Runtimes;
 
@@ -14,6 +15,7 @@ namespace Benchmarks;
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByParams)]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[JsonExporterAttribute.FullCompressed]
 public class JavaScriptRuntimeBenchmarks
 {
     private readonly Dictionary<string, string> _scripts = new();

--- a/tests/performance/Benchmarks/Js2ILPhasedBenchmarks.cs
+++ b/tests/performance/Benchmarks/Js2ILPhasedBenchmarks.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Order;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -21,6 +22,7 @@ namespace Benchmarks;
 [RankColumn]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[JsonExporterAttribute.FullCompressed]
 public class Js2ILPhasedBenchmarks
 {
     private readonly Dictionary<string, string> _scripts = new();


### PR DESCRIPTION
## Summary
- add `JsonExporterAttribute.FullCompressed` to both benchmark suites so JSON output is always emitted even when CLI exporter args are not forwarded
- keep the existing workflow `--exporters json` argument as an extra safeguard
- add an Unreleased changelog note documenting the benchmark JSON export reliability fix

## Validation
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj -c Release`
- `dotnet run -c Release --project tests/performance/Benchmarks/Benchmarks.csproj -- --filter "*minimal*"` and verified `BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json` is generated