### PR TITLE
docs(changelog): document PR731 array performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## Unreleased
 
 - benchmarks/workflows: enforce BenchmarkDotNet JSON output by annotating benchmark suites with `JsonExporterAttribute.FullCompressed`, so release/workflow ingestion reliably uses JSON artifacts (preserving full script-name fidelity instead of markdown-abbreviated labels).
+- perf(array)/codegen: internalize `JavaScriptRuntime.Array` storage (composition over `List<object?>` inheritance), add/retain array fast paths (including `ToArray()` compatibility for spread/apply call paths), and lower proven array operations (including `arr.length = value`) to early-bound calls to reduce late-bound runtime dispatch in hot paths.
 
 ## v0.8.23 - 2026-02-25
 


### PR DESCRIPTION
## Summary
- add Unreleased changelog entry for the array runtime/codegen performance work merged in PR #731
- document internalized Array storage, spread/apply compatibility, and early-bound array length assignment lowering