### PR TITLE
test: add dromaeo-object-regexp generator test

### DIFF
--- a/Js2IL.Tests/Integration/GeneratorTests.cs
+++ b/Js2IL.Tests/Integration/GeneratorTests.cs
@@ -23,6 +23,9 @@ namespace Js2IL.Tests.Integration
         public Task Compile_Performance_Dromaeo_Object_Array_Modern() => GenerateTest(nameof(Compile_Performance_Dromaeo_Object_Array_Modern));
 
         [Fact]
+        public Task Compile_Performance_Dromaeo_Object_Regexp() => GenerateTest(nameof(Compile_Performance_Dromaeo_Object_Regexp));
+
+        [Fact]
         public Task Compile_Performance_PrimeJavaScript() => GenerateTest(nameof(Compile_Performance_PrimeJavaScript));
     }
 }

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -1,0 +1,7718 @@
+﻿// IL code: Compile_Performance_Dromaeo_Object_Regexp
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Compile_Performance_Dromaeo_Object_Regexp
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit startTest
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4f2b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object _name,
+				object _id
+			) cil managed 
+		{
+			// Method begins at RVA 0x304c
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldnull
+			IL_0001: ret
+		} // end of method startTest::__js_call__
+
+	} // end of class startTest
+
+	.class nested public auto ansi abstract sealed beforefieldinit endTest
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4f34
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x304f
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldnull
+			IL_0001: ret
+		} // end of method endTest::__js_call__
+
+	} // end of class endTest
+
+	.class nested public auto ansi abstract sealed beforefieldinit prep
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L5C50
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4f46
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L5C50::.ctor
+
+			} // end of class Block_L5C50
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4f3d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object fn
+			) cil managed 
+		{
+			// Method begins at RVA 0x3054
+			// Header size: 12
+			// Code size: 42 (0x2a)
+			.maxstack 8
+			.locals init (
+				[0] bool
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0006: ldstr "function"
+			IL_000b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: brfalse IL_0028
+
+			IL_0017: ldarg.1
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: ldnull
+			IL_0021: stelem.ref
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
+			IL_0027: pop
+
+			IL_0028: ldnull
+			IL_0029: ret
+		} // end of method prep::__js_call__
+
+	} // end of class prep
+
+	.class nested public auto ansi abstract sealed beforefieldinit test
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L6C57
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4f58
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L6C57::.ctor
+
+			} // end of class Block_L6C57
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4f4f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object _name,
+				object fn
+			) cil managed 
+		{
+			// Method begins at RVA 0x308c
+			// Header size: 12
+			// Code size: 42 (0x2a)
+			.maxstack 8
+			.locals init (
+				[0] bool
+			)
+
+			IL_0000: ldarg.2
+			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0006: ldstr "function"
+			IL_000b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: brfalse IL_0028
+
+			IL_0017: ldarg.2
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: ldnull
+			IL_0021: stelem.ref
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
+			IL_0027: pop
+
+			IL_0028: ldnull
+			IL_0029: ret
+		} // end of method test::__js_call__
+
+	} // end of class test
+
+	.class nested public auto ansi abstract sealed beforefieldinit randomChar
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4f61
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x30c4
+			// Header size: 12
+			// Code size: 58 (0x3a)
+			.maxstack 8
+			.locals init (
+				[0] class [System.Runtime]System.Func`3<object[], object, string>,
+				[1] float64,
+				[2] object,
+				[3] object
+			)
+
+			IL_0000: call class [System.Runtime]System.Func`3<object[], object, string> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_String()
+			IL_0005: stloc.0
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_000b: stloc.1
+			IL_000c: ldc.r8 25
+			IL_0015: ldloc.1
+			IL_0016: mul
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ldc.r8 97
+			IL_0022: add
+			IL_0023: stloc.1
+			IL_0024: ldloc.1
+			IL_0025: box [System.Runtime]System.Double
+			IL_002a: stloc.2
+			IL_002b: ldloc.0
+			IL_002c: ldstr "fromCharCode"
+			IL_0031: ldloc.2
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0037: stloc.3
+			IL_0038: ldloc.3
+			IL_0039: ret
+		} // end of method randomChar::__js_call__
+
+	} // end of class randomChar
+
+	.class nested public auto ansi abstract sealed beforefieldinit generateTestStrings
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L28C53
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L32C39
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4f7c
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L32C39::.ctor
+
+				} // end of class Block_L32C39
+
+				.class nested private auto ansi beforefieldinit Block_L37C48
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4f85
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L37C48::.ctor
+
+				} // end of class Block_L37C48
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4f73
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L28C53::.ctor
+
+			} // end of class Block_L28C53
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4f6a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget,
+				object count
+			) cil managed 
+		{
+			// Method begins at RVA 0x310c
+			// Header size: 12
+			// Code size: 549 (0x225)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] float64,
+				[3] float64,
+				[4] float64,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[6] object,
+				[7] object,
+				[8] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: box [System.Runtime]System.Double
+			IL_0006: stloc.0
+			IL_0007: ldnull
+			IL_0008: box [System.Runtime]System.Double
+			IL_000d: stloc.1
+			IL_000e: ldarg.0
+			IL_000f: ldc.i4.0
+			IL_0010: ldelem.ref
+			IL_0011: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0016: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_001b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0020: conv.r8
+			IL_0021: stloc.s 4
+			IL_0023: ldloc.s 4
+			IL_0025: ldarg.2
+			IL_0026: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_002b: clt
+			IL_002d: ldc.i4.0
+			IL_002e: ceq
+			IL_0030: brfalse IL_005f
+
+			IL_0035: ldarg.0
+			IL_0036: ldc.i4.0
+			IL_0037: ldelem.ref
+			IL_0038: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_003d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0042: stloc.s 5
+			IL_0044: ldloc.s 5
+			IL_0046: ldc.r8 0.0
+			IL_004f: box [System.Runtime]System.Double
+			IL_0054: ldarg.2
+			IL_0055: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice(object, object)
+			IL_005a: stloc.s 5
+			IL_005c: ldloc.s 5
+			IL_005e: ret
+
+			IL_005f: ldarg.0
+			IL_0060: ldc.i4.0
+			IL_0061: ldelem.ref
+			IL_0062: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0067: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_006c: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0071: conv.r8
+			IL_0072: stloc.2
+			// loop start (head: IL_0073)
+				IL_0073: ldloc.2
+				IL_0074: ldarg.2
+				IL_0075: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_007a: clt
+				IL_007c: brfalse IL_0217
+
+				IL_0081: ldnull
+				IL_0082: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+				IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_008d: ldnull
+				IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+				IL_0093: stloc.s 6
+				IL_0095: ldloc.s 6
+				IL_0097: ldarg.0
+				IL_0098: ldc.i4.0
+				IL_0099: ldelem.ref
+				IL_009a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_009f: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+				IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00a9: stloc.s 7
+				IL_00ab: ldnull
+				IL_00ac: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+				IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_00b7: ldnull
+				IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+				IL_00bd: stloc.s 6
+				IL_00bf: ldloc.s 7
+				IL_00c1: ldloc.s 6
+				IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00c8: stloc.s 7
+				IL_00ca: ldloc.s 7
+				IL_00cc: stloc.0
+				IL_00cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+				IL_00d2: stloc.s 4
+				IL_00d4: ldc.r8 4
+				IL_00dd: ldloc.s 4
+				IL_00df: mul
+				IL_00e0: stloc.s 4
+				IL_00e2: ldloc.s 4
+				IL_00e4: box [System.Runtime]System.Double
+				IL_00e9: stloc.s 8
+				IL_00eb: ldloc.s 8
+				IL_00ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+				IL_00f2: stloc.s 4
+				IL_00f4: ldloc.s 4
+				IL_00f6: box [System.Runtime]System.Double
+				IL_00fb: stloc.s 8
+				IL_00fd: ldloc.s 8
+				IL_00ff: stloc.1
+				IL_0100: ldc.r8 0.0
+				IL_0109: stloc.3
+				// loop start (head: IL_010a)
+					IL_010a: ldloc.1
+					IL_010b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0110: stloc.s 4
+					IL_0112: ldloc.3
+					IL_0113: ldloc.s 4
+					IL_0115: clt
+					IL_0117: brfalse IL_016d
+
+					IL_011c: ldnull
+					IL_011d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+					IL_0123: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0128: ldnull
+					IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+					IL_012e: stloc.s 6
+					IL_0130: ldloc.s 6
+					IL_0132: ldloc.0
+					IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0138: stloc.s 7
+					IL_013a: ldnull
+					IL_013b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+					IL_0141: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0146: ldnull
+					IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+					IL_014c: stloc.s 6
+					IL_014e: ldloc.s 7
+					IL_0150: ldloc.s 6
+					IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0157: stloc.s 7
+					IL_0159: ldloc.s 7
+					IL_015b: stloc.0
+					IL_015c: ldloc.3
+					IL_015d: ldc.r8 1
+					IL_0166: add
+					IL_0167: stloc.3
+					IL_0168: br IL_010a
+				// end loop
+
+				IL_016d: ldc.r8 0.0
+				IL_0176: stloc.3
+				// loop start (head: IL_0177)
+					IL_0177: ldloc.3
+					IL_0178: ldloc.0
+					IL_0179: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+					IL_017e: clt
+					IL_0180: brfalse IL_01e4
+
+					IL_0185: ldarg.0
+					IL_0186: ldc.i4.0
+					IL_0187: ldelem.ref
+					IL_0188: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+					IL_018d: ldloc.0
+					IL_018e: ldloc.3
+					IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+					IL_0194: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_0199: ldloc.3
+					IL_019a: box [System.Runtime]System.Double
+					IL_019f: stloc.s 8
+					IL_01a1: ldloc.0
+					IL_01a2: ldstr "substring"
+					IL_01a7: ldloc.s 8
+					IL_01a9: ldloc.3
+					IL_01aa: ldc.r8 100
+					IL_01b3: add
+					IL_01b4: box [System.Runtime]System.Double
+					IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_01be: stloc.s 6
+					IL_01c0: ldarg.0
+					IL_01c1: ldc.i4.0
+					IL_01c2: ldelem.ref
+					IL_01c3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+					IL_01c8: ldloc.s 6
+					IL_01ca: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_01cf: ldloc.3
+					IL_01d0: ldc.r8 100
+					IL_01d9: add
+					IL_01da: stloc.s 4
+					IL_01dc: ldloc.s 4
+					IL_01de: stloc.3
+					IL_01df: br IL_0177
+				// end loop
+
+				IL_01e4: ldarg.0
+				IL_01e5: ldc.i4.0
+				IL_01e6: ldelem.ref
+				IL_01e7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_01ec: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+				IL_01f1: stloc.s 5
+				IL_01f3: ldloc.2
+				IL_01f4: box [System.Runtime]System.Double
+				IL_01f9: stloc.s 8
+				IL_01fb: ldloc.s 5
+				IL_01fd: ldloc.s 8
+				IL_01ff: ldloc.0
+				IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SetItem(object, object, object)
+				IL_0205: pop
+				IL_0206: ldloc.2
+				IL_0207: ldc.r8 1
+				IL_0210: add
+				IL_0211: stloc.2
+				IL_0212: br IL_0073
+			// end loop
+
+			IL_0217: ldarg.0
+			IL_0218: ldc.i4.0
+			IL_0219: ldelem.ref
+			IL_021a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_021f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0224: ret
+		} // end of method generateTestStrings::__js_call__
+
+	} // end of class generateTestStrings
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L48C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4f8e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3340
+			// Header size: 12
+			// Code size: 91 (0x5b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "(?:)"
+			IL_0005: ldstr ""
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0018: ldloc.0
+			IL_0019: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_001e: ldnull
+			IL_001f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_002a: ldc.i4.1
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: ldc.i4.0
+			IL_0034: ldelem.ref
+			IL_0035: stelem.ref
+			IL_0036: ldnull
+			IL_0037: ldc.r8 30
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_004a: stloc.0
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0053: ldloc.0
+			IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0059: ldnull
+			IL_005a: ret
+		} // end of method FunctionExpression_L48C5::__js_call__
+
+	} // end of class FunctionExpression_L48C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L56C36
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4f97
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x33a8
+			// Header size: 12
+			// Code size: 103 (0x67)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 30
+				IL_0014: clt
+				IL_0016: brfalse IL_0065
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0028: ldloc.0
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_002e: ldstr "split"
+				IL_0033: ldarg.0
+				IL_0034: ldc.i4.0
+				IL_0035: ldelem.ref
+				IL_0036: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_003b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0045: stloc.1
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_004e: ldloc.1
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: ldc.r8 1
+				IL_005e: add
+				IL_005f: stloc.0
+				IL_0060: br IL_000a
+			// end loop
+
+			IL_0065: ldnull
+			IL_0066: ret
+		} // end of method FunctionExpression_L56C36::__js_call__
+
+	} // end of class FunctionExpression_L56C36
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L61C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fa0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x341c
+			// Header size: 12
+			// Code size: 91 (0x5b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "a"
+			IL_0005: ldstr ""
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0018: ldloc.0
+			IL_0019: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_001e: ldnull
+			IL_001f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_002a: ldc.i4.1
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: ldc.i4.0
+			IL_0034: ldelem.ref
+			IL_0035: stelem.ref
+			IL_0036: ldnull
+			IL_0037: ldc.r8 30
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_004a: stloc.0
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0053: ldloc.0
+			IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0059: ldnull
+			IL_005a: ret
+		} // end of method FunctionExpression_L61C5::__js_call__
+
+	} // end of class FunctionExpression_L61C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L66C35
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fa9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3484
+			// Header size: 12
+			// Code size: 103 (0x67)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 30
+				IL_0014: clt
+				IL_0016: brfalse IL_0065
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0028: ldloc.0
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_002e: ldstr "split"
+				IL_0033: ldarg.0
+				IL_0034: ldc.i4.0
+				IL_0035: ldelem.ref
+				IL_0036: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_003b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0045: stloc.1
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_004e: ldloc.1
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: ldc.r8 1
+				IL_005e: add
+				IL_005f: stloc.0
+				IL_0060: br IL_000a
+			// end loop
+
+			IL_0065: ldnull
+			IL_0066: ret
+		} // end of method FunctionExpression_L66C35::__js_call__
+
+	} // end of class FunctionExpression_L66C35
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L71C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fb2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x34f8
+			// Header size: 12
+			// Code size: 91 (0x5b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr ".*"
+			IL_0005: ldstr ""
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0018: ldloc.0
+			IL_0019: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_001e: ldnull
+			IL_001f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_002a: ldc.i4.1
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: ldc.i4.0
+			IL_0034: ldelem.ref
+			IL_0035: stelem.ref
+			IL_0036: ldnull
+			IL_0037: ldc.r8 100
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_004a: stloc.0
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0053: ldloc.0
+			IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0059: ldnull
+			IL_005a: ret
+		} // end of method FunctionExpression_L71C5::__js_call__
+
+	} // end of class FunctionExpression_L71C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L76C39
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fbb
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3560
+			// Header size: 12
+			// Code size: 103 (0x67)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0065
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0028: ldloc.0
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_002e: ldstr "split"
+				IL_0033: ldarg.0
+				IL_0034: ldc.i4.0
+				IL_0035: ldelem.ref
+				IL_0036: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_003b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0045: stloc.1
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_004e: ldloc.1
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: ldc.r8 1
+				IL_005e: add
+				IL_005f: stloc.0
+				IL_0060: br IL_000a
+			// end loop
+
+			IL_0065: ldnull
+			IL_0066: ret
+		} // end of method FunctionExpression_L76C39::__js_call__
+
+	} // end of class FunctionExpression_L76C39
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L83C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fc4
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x35d4
+			// Header size: 12
+			// Code size: 91 (0x5b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "aaaaaaaaaa"
+			IL_0005: ldstr "g"
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0018: ldloc.0
+			IL_0019: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_001e: ldnull
+			IL_001f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_002a: ldc.i4.1
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: ldc.i4.0
+			IL_0034: ldelem.ref
+			IL_0035: stelem.ref
+			IL_0036: ldnull
+			IL_0037: ldc.r8 100
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_004a: stloc.0
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0053: ldloc.0
+			IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0059: ldnull
+			IL_005a: ret
+		} // end of method FunctionExpression_L83C5::__js_call__
+
+	} // end of class FunctionExpression_L83C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L88C23
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fcd
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x363c
+			// Header size: 12
+			// Code size: 103 (0x67)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0065
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0028: ldloc.0
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_002e: ldstr "match"
+				IL_0033: ldarg.0
+				IL_0034: ldc.i4.0
+				IL_0035: ldelem.ref
+				IL_0036: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_003b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0045: stloc.1
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_004e: ldloc.1
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: ldc.r8 1
+				IL_005e: add
+				IL_005f: stloc.0
+				IL_0060: br IL_000a
+			// end loop
+
+			IL_0065: ldnull
+			IL_0066: ret
+		} // end of method FunctionExpression_L88C23::__js_call__
+
+	} // end of class FunctionExpression_L88C23
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L93C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fd6
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x36b0
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L93C5::__js_call__
+
+	} // end of class FunctionExpression_L93C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L97C22
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fdf
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x36fc
+			// Header size: 12
+			// Code size: 105 (0x69)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0067
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldloc.1
+				IL_002a: ldstr "test"
+				IL_002f: ldarg.0
+				IL_0030: ldc.i4.0
+				IL_0031: ldelem.ref
+				IL_0032: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0037: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_003c: ldloc.0
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0047: stloc.1
+				IL_0048: ldarg.0
+				IL_0049: ldc.i4.0
+				IL_004a: ldelem.ref
+				IL_004b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0050: ldloc.1
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
+			// end loop
+
+			IL_0067: ldnull
+			IL_0068: ret
+		} // end of method FunctionExpression_L97C22::__js_call__
+
+	} // end of class FunctionExpression_L97C22
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L102C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4fe8
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3774
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L102C5::__js_call__
+
+	} // end of class FunctionExpression_L102C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L106C31
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4ff1
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x37c0
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr ""
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L106C31::__js_call__
+
+	} // end of class FunctionExpression_L106C31
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L111C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4ffa
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x383c
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L111C5::__js_call__
+
+	} // end of class FunctionExpression_L111C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L115C33
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5003
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3888
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr "asdfasdfasdf"
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L115C33::__js_call__
+
+	} // end of class FunctionExpression_L115C33
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L120C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x500c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3904
+			// Header size: 12
+			// Code size: 91 (0x5b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "aaaaaaaaaa"
+			IL_0005: ldstr "g"
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0018: ldloc.0
+			IL_0019: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_001e: ldnull
+			IL_001f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_002a: ldc.i4.1
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: ldc.i4.0
+			IL_0034: ldelem.ref
+			IL_0035: stelem.ref
+			IL_0036: ldnull
+			IL_0037: ldc.r8 100
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_004a: stloc.0
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0053: ldloc.0
+			IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0059: ldnull
+			IL_005a: ret
+		} // end of method FunctionExpression_L120C5::__js_call__
+
+	} // end of class FunctionExpression_L120C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L125C30
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5015
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x396c
+			// Header size: 12
+			// Code size: 103 (0x67)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0065
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0028: ldloc.0
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_002e: ldstr "match"
+				IL_0033: ldarg.0
+				IL_0034: ldc.i4.0
+				IL_0035: ldelem.ref
+				IL_0036: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_003b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0045: stloc.1
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_004e: ldloc.1
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: ldc.r8 1
+				IL_005e: add
+				IL_005f: stloc.0
+				IL_0060: br IL_000a
+			// end loop
+
+			IL_0065: ldnull
+			IL_0066: ret
+		} // end of method FunctionExpression_L125C30::__js_call__
+
+	} // end of class FunctionExpression_L125C30
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L130C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x501e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x39e0
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L130C5::__js_call__
+
+	} // end of class FunctionExpression_L130C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L134C29
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5027
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3a2c
+			// Header size: 12
+			// Code size: 105 (0x69)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0067
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldloc.1
+				IL_002a: ldstr "test"
+				IL_002f: ldarg.0
+				IL_0030: ldc.i4.0
+				IL_0031: ldelem.ref
+				IL_0032: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0037: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_003c: ldloc.0
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0047: stloc.1
+				IL_0048: ldarg.0
+				IL_0049: ldc.i4.0
+				IL_004a: ldelem.ref
+				IL_004b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0050: ldloc.1
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
+			// end loop
+
+			IL_0067: ldnull
+			IL_0068: ret
+		} // end of method FunctionExpression_L134C29::__js_call__
+
+	} // end of class FunctionExpression_L134C29
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L139C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5030
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3aa4
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L139C5::__js_call__
+
+	} // end of class FunctionExpression_L139C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L143C38
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5039
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3af0
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr ""
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L143C38::__js_call__
+
+	} // end of class FunctionExpression_L143C38
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L148C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5042
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3b6c
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L148C5::__js_call__
+
+	} // end of class FunctionExpression_L148C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L152C40
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x504b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3bb8
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr "asdfasdfasdf"
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L152C40::__js_call__
+
+	} // end of class FunctionExpression_L152C40
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L157C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5054
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3c34
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L157C5::__js_call__
+
+	} // end of class FunctionExpression_L157C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L161C49
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L163C33
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5066
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					object all
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ed0
+				// Header size: 1
+				// Code size: 6 (0x6)
+				.maxstack 8
+
+				IL_0000: ldstr "asdfasdfasdf"
+				IL_0005: ret
+			} // end of method FunctionExpression_L163C33::__js_call__
+
+		} // end of class FunctionExpression_L163C33
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x505d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3c80
+			// Header size: 12
+			// Code size: 142 (0x8e)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/Scope,
+				[1] float64,
+				[2] object,
+				[3] object
+			)
+
+			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldc.r8 0.0
+			IL_000f: stloc.1
+			// loop start (head: IL_0010)
+				IL_0010: ldloc.1
+				IL_0011: ldc.r8 50
+				IL_001a: clt
+				IL_001c: brfalse IL_008c
+
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.0
+				IL_0023: ldelem.ref
+				IL_0024: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0029: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_002e: stloc.2
+				IL_002f: ldnull
+				IL_0030: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
+				IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_003b: ldc.i4.1
+				IL_003c: newarr [System.Runtime]System.Object
+				IL_0041: dup
+				IL_0042: ldc.i4.0
+				IL_0043: ldarg.0
+				IL_0044: ldc.i4.0
+				IL_0045: ldelem.ref
+				IL_0046: stelem.ref
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_005a: ldloc.1
+				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0060: ldstr "replace"
+				IL_0065: ldloc.2
+				IL_0066: ldloc.3
+				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_006c: stloc.3
+				IL_006d: ldarg.0
+				IL_006e: ldc.i4.0
+				IL_006f: ldelem.ref
+				IL_0070: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0075: ldloc.3
+				IL_0076: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007b: ldloc.1
+				IL_007c: ldc.r8 1
+				IL_0085: add
+				IL_0086: stloc.1
+				IL_0087: br IL_0010
+			// end loop
+
+			IL_008c: ldnull
+			IL_008d: ret
+		} // end of method FunctionExpression_L161C49::__js_call__
+
+	} // end of class FunctionExpression_L161C49
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L170C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x506f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3d1c
+			// Header size: 12
+			// Code size: 91 (0x5b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "a.*a"
+			IL_0005: ldstr ""
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0018: ldloc.0
+			IL_0019: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_001e: ldnull
+			IL_001f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_002a: ldc.i4.1
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: ldc.i4.0
+			IL_0034: ldelem.ref
+			IL_0035: stelem.ref
+			IL_0036: ldnull
+			IL_0037: ldc.r8 100
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_004a: stloc.0
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0053: ldloc.0
+			IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0059: ldnull
+			IL_005a: ret
+		} // end of method FunctionExpression_L170C5::__js_call__
+
+	} // end of class FunctionExpression_L170C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L175C32
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5078
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3d84
+			// Header size: 12
+			// Code size: 103 (0x67)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0065
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0028: ldloc.0
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_002e: ldstr "match"
+				IL_0033: ldarg.0
+				IL_0034: ldc.i4.0
+				IL_0035: ldelem.ref
+				IL_0036: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_003b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0045: stloc.1
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_004e: ldloc.1
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: ldc.r8 1
+				IL_005e: add
+				IL_005f: stloc.0
+				IL_0060: br IL_000a
+			// end loop
+
+			IL_0065: ldnull
+			IL_0066: ret
+		} // end of method FunctionExpression_L175C32::__js_call__
+
+	} // end of class FunctionExpression_L175C32
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L180C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5081
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3df8
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L180C5::__js_call__
+
+	} // end of class FunctionExpression_L180C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L184C31
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x508a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3e44
+			// Header size: 12
+			// Code size: 105 (0x69)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0067
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldloc.1
+				IL_002a: ldstr "test"
+				IL_002f: ldarg.0
+				IL_0030: ldc.i4.0
+				IL_0031: ldelem.ref
+				IL_0032: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0037: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_003c: ldloc.0
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0047: stloc.1
+				IL_0048: ldarg.0
+				IL_0049: ldc.i4.0
+				IL_004a: ldelem.ref
+				IL_004b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0050: ldloc.1
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
+			// end loop
+
+			IL_0067: ldnull
+			IL_0068: ret
+		} // end of method FunctionExpression_L184C31::__js_call__
+
+	} // end of class FunctionExpression_L184C31
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L189C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5093
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3ebc
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L189C5::__js_call__
+
+	} // end of class FunctionExpression_L189C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L193C40
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x509c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3f08
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr ""
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L193C40::__js_call__
+
+	} // end of class FunctionExpression_L193C40
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L198C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50a5
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3f84
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L198C5::__js_call__
+
+	} // end of class FunctionExpression_L198C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L202C42
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50ae
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x3fd0
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr "asdfasdfasdf"
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L202C42::__js_call__
+
+	} // end of class FunctionExpression_L202C42
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L207C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50b7
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x404c
+			// Header size: 12
+			// Code size: 91 (0x5b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "aaaaaaaaaa"
+			IL_0005: ldstr "g"
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0018: ldloc.0
+			IL_0019: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_001e: ldnull
+			IL_001f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_002a: ldc.i4.1
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: ldc.i4.0
+			IL_0034: ldelem.ref
+			IL_0035: stelem.ref
+			IL_0036: ldnull
+			IL_0037: ldc.r8 100
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_004a: stloc.0
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0053: ldloc.0
+			IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0059: ldnull
+			IL_005a: ret
+		} // end of method FunctionExpression_L207C5::__js_call__
+
+	} // end of class FunctionExpression_L207C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L212C39
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50c0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x40b4
+			// Header size: 12
+			// Code size: 103 (0x67)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0065
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0028: ldloc.0
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_002e: ldstr "match"
+				IL_0033: ldarg.0
+				IL_0034: ldc.i4.0
+				IL_0035: ldelem.ref
+				IL_0036: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_003b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0045: stloc.1
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_004e: ldloc.1
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: ldc.r8 1
+				IL_005e: add
+				IL_005f: stloc.0
+				IL_0060: br IL_000a
+			// end loop
+
+			IL_0065: ldnull
+			IL_0066: ret
+		} // end of method FunctionExpression_L212C39::__js_call__
+
+	} // end of class FunctionExpression_L212C39
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L217C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50c9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4128
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L217C5::__js_call__
+
+	} // end of class FunctionExpression_L217C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L221C38
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50d2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4174
+			// Header size: 12
+			// Code size: 105 (0x69)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0067
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldloc.1
+				IL_002a: ldstr "test"
+				IL_002f: ldarg.0
+				IL_0030: ldc.i4.0
+				IL_0031: ldelem.ref
+				IL_0032: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0037: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_003c: ldloc.0
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0047: stloc.1
+				IL_0048: ldarg.0
+				IL_0049: ldc.i4.0
+				IL_004a: ldelem.ref
+				IL_004b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0050: ldloc.1
+				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_000a
+			// end loop
+
+			IL_0067: ldnull
+			IL_0068: ret
+		} // end of method FunctionExpression_L221C38::__js_call__
+
+	} // end of class FunctionExpression_L221C38
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L226C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50db
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x41ec
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L226C5::__js_call__
+
+	} // end of class FunctionExpression_L226C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L230C47
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50e4
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4238
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr ""
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L230C47::__js_call__
+
+	} // end of class FunctionExpression_L230C47
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L235C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50ed
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x42b4
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L235C5::__js_call__
+
+	} // end of class FunctionExpression_L235C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L239C49
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50f6
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4300
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr "asdfasdfasdf"
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L239C49::__js_call__
+
+	} // end of class FunctionExpression_L239C49
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L244C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x50ff
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x437c
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L244C5::__js_call__
+
+	} // end of class FunctionExpression_L244C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L248C58
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L250C33
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5111
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					object all
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ed7
+				// Header size: 1
+				// Code size: 6 (0x6)
+				.maxstack 8
+
+				IL_0000: ldstr "asdfasdfasdf"
+				IL_0005: ret
+			} // end of method FunctionExpression_L250C33::__js_call__
+
+		} // end of class FunctionExpression_L250C33
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5108
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x43c8
+			// Header size: 12
+			// Code size: 142 (0x8e)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/Scope,
+				[1] float64,
+				[2] object,
+				[3] object
+			)
+
+			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldc.r8 0.0
+			IL_000f: stloc.1
+			// loop start (head: IL_0010)
+				IL_0010: ldloc.1
+				IL_0011: ldc.r8 50
+				IL_001a: clt
+				IL_001c: brfalse IL_008c
+
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.0
+				IL_0023: ldelem.ref
+				IL_0024: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0029: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_002e: stloc.2
+				IL_002f: ldnull
+				IL_0030: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
+				IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_003b: ldc.i4.1
+				IL_003c: newarr [System.Runtime]System.Object
+				IL_0041: dup
+				IL_0042: ldc.i4.0
+				IL_0043: ldarg.0
+				IL_0044: ldc.i4.0
+				IL_0045: ldelem.ref
+				IL_0046: stelem.ref
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_005a: ldloc.1
+				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0060: ldstr "replace"
+				IL_0065: ldloc.2
+				IL_0066: ldloc.3
+				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_006c: stloc.3
+				IL_006d: ldarg.0
+				IL_006e: ldc.i4.0
+				IL_006f: ldelem.ref
+				IL_0070: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0075: ldloc.3
+				IL_0076: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007b: ldloc.1
+				IL_007c: ldc.r8 1
+				IL_0085: add
+				IL_0086: stloc.1
+				IL_0087: br IL_0010
+			// end loop
+
+			IL_008c: ldnull
+			IL_008d: ret
+		} // end of method FunctionExpression_L248C58::__js_call__
+
+	} // end of class FunctionExpression_L248C58
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L257C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x511a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4464
+			// Header size: 12
+			// Code size: 91 (0x5b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "aa(b)aa"
+			IL_0005: ldstr "g"
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0018: ldloc.0
+			IL_0019: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_001e: ldnull
+			IL_001f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_002a: ldc.i4.1
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: ldc.i4.0
+			IL_0034: ldelem.ref
+			IL_0035: stelem.ref
+			IL_0036: ldnull
+			IL_0037: ldc.r8 100
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_004a: stloc.0
+			IL_004b: ldarg.0
+			IL_004c: ldc.i4.0
+			IL_004d: ldelem.ref
+			IL_004e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0053: ldloc.0
+			IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0059: ldnull
+			IL_005a: ret
+		} // end of method FunctionExpression_L257C5::__js_call__
+
+	} // end of class FunctionExpression_L257C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L262C31
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5123
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x44cc
+			// Header size: 12
+			// Code size: 103 (0x67)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0065
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0028: ldloc.0
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_002e: ldstr "match"
+				IL_0033: ldarg.0
+				IL_0034: ldc.i4.0
+				IL_0035: ldelem.ref
+				IL_0036: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_003b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0045: stloc.1
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_004e: ldloc.1
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: ldc.r8 1
+				IL_005e: add
+				IL_005f: stloc.0
+				IL_0060: br IL_000a
+			// end loop
+
+			IL_0065: ldnull
+			IL_0066: ret
+		} // end of method FunctionExpression_L262C31::__js_call__
+
+	} // end of class FunctionExpression_L262C31
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L267C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x512c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4540
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L267C5::__js_call__
+
+	} // end of class FunctionExpression_L267C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L271C33
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5135
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x458c
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr "asdfasdfasdf"
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L271C33::__js_call__
+
+	} // end of class FunctionExpression_L271C33
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L276C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x513e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4608
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L276C5::__js_call__
+
+	} // end of class FunctionExpression_L276C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L280C46
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5147
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4654
+			// Header size: 12
+			// Code size: 110 (0x6e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006c
+
+				IL_001b: ldarg.0
+				IL_001c: ldc.i4.0
+				IL_001d: ldelem.ref
+				IL_001e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0023: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0028: stloc.1
+				IL_0029: ldarg.0
+				IL_002a: ldc.i4.0
+				IL_002b: ldelem.ref
+				IL_002c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0031: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0036: ldloc.0
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003c: ldstr "replace"
+				IL_0041: ldloc.1
+				IL_0042: ldstr "asdf\\1asdfasdf"
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004c: stloc.1
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldloc.1
+				IL_0056: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005b: ldloc.0
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.0
+				IL_0067: br IL_000a
+			// end loop
+
+			IL_006c: ldnull
+			IL_006d: ret
+		} // end of method FunctionExpression_L280C46::__js_call__
+
+	} // end of class FunctionExpression_L280C46
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L285C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5150
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x46d0
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L285C5::__js_call__
+
+	} // end of class FunctionExpression_L285C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L289C55
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L291C33
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5162
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					object all,
+					object capture
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ee0
+				// Header size: 12
+				// Code size: 26 (0x1a)
+				.maxstack 8
+				.locals init (
+					[0] object
+				)
+
+				IL_0000: ldstr "asdf"
+				IL_0005: ldarg.2
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_000b: stloc.0
+				IL_000c: ldloc.0
+				IL_000d: ldstr "asdfasdf"
+				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0017: stloc.0
+				IL_0018: ldloc.0
+				IL_0019: ret
+			} // end of method FunctionExpression_L291C33::__js_call__
+
+		} // end of class FunctionExpression_L291C33
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5159
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x471c
+			// Header size: 12
+			// Code size: 142 (0x8e)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/Scope,
+				[1] float64,
+				[2] object,
+				[3] object
+			)
+
+			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldc.r8 0.0
+			IL_000f: stloc.1
+			// loop start (head: IL_0010)
+				IL_0010: ldloc.1
+				IL_0011: ldc.r8 50
+				IL_001a: clt
+				IL_001c: brfalse IL_008c
+
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.0
+				IL_0023: ldelem.ref
+				IL_0024: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0029: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_002e: stloc.2
+				IL_002f: ldnull
+				IL_0030: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
+				IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+				IL_003b: ldc.i4.1
+				IL_003c: newarr [System.Runtime]System.Object
+				IL_0041: dup
+				IL_0042: ldc.i4.0
+				IL_0043: ldarg.0
+				IL_0044: ldc.i4.0
+				IL_0045: ldelem.ref
+				IL_0046: stelem.ref
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_005a: ldloc.1
+				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0060: ldstr "replace"
+				IL_0065: ldloc.2
+				IL_0066: ldloc.3
+				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_006c: stloc.3
+				IL_006d: ldarg.0
+				IL_006e: ldc.i4.0
+				IL_006f: ldelem.ref
+				IL_0070: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0075: ldloc.3
+				IL_0076: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007b: ldloc.1
+				IL_007c: ldc.r8 1
+				IL_0085: add
+				IL_0086: stloc.1
+				IL_0087: br IL_0010
+			// end loop
+
+			IL_008c: ldnull
+			IL_008d: ret
+		} // end of method FunctionExpression_L289C55::__js_call__
+
+	} // end of class FunctionExpression_L289C55
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L296C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x516b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x47b8
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L296C5::__js_call__
+
+	} // end of class FunctionExpression_L296C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L300C64
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L302C33
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x517d
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					object all,
+					object capture
+				) cil managed 
+			{
+				// Method begins at RVA 0x4f08
+				// Header size: 12
+				// Code size: 14 (0xe)
+				.maxstack 8
+				.locals init (
+					[0] object
+				)
+
+				IL_0000: ldarg.2
+				IL_0001: ldstr "toUpperCase"
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_000b: stloc.0
+				IL_000c: ldloc.0
+				IL_000d: ret
+			} // end of method FunctionExpression_L302C33::__js_call__
+
+		} // end of class FunctionExpression_L302C33
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5174
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4804
+			// Header size: 12
+			// Code size: 142 (0x8e)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/Scope,
+				[1] float64,
+				[2] object,
+				[3] object
+			)
+
+			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldc.r8 0.0
+			IL_000f: stloc.1
+			// loop start (head: IL_0010)
+				IL_0010: ldloc.1
+				IL_0011: ldc.r8 50
+				IL_001a: clt
+				IL_001c: brfalse IL_008c
+
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.0
+				IL_0023: ldelem.ref
+				IL_0024: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0029: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_002e: stloc.2
+				IL_002f: ldnull
+				IL_0030: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
+				IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+				IL_003b: ldc.i4.1
+				IL_003c: newarr [System.Runtime]System.Object
+				IL_0041: dup
+				IL_0042: ldc.i4.0
+				IL_0043: ldarg.0
+				IL_0044: ldc.i4.0
+				IL_0045: ldelem.ref
+				IL_0046: stelem.ref
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0055: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_005a: ldloc.1
+				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0060: ldstr "replace"
+				IL_0065: ldloc.2
+				IL_0066: ldloc.3
+				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_006c: stloc.3
+				IL_006d: ldarg.0
+				IL_006e: ldc.i4.0
+				IL_006f: ldelem.ref
+				IL_0070: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0075: ldloc.3
+				IL_0076: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007b: ldloc.1
+				IL_007c: ldc.r8 1
+				IL_0085: add
+				IL_0086: stloc.1
+				IL_0087: br IL_0010
+			// end loop
+
+			IL_008c: ldnull
+			IL_008d: ret
+		} // end of method FunctionExpression_L300C64::__js_call__
+
+	} // end of class FunctionExpression_L300C64
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L309C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5186
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x48a0
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L309C5::__js_call__
+
+	} // end of class FunctionExpression_L309C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L313C25
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x518f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x48ec
+			// Header size: 12
+			// Code size: 107 (0x6b)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0069
+
+				IL_001b: ldstr "aaaaaaaaaa"
+				IL_0020: ldstr "g"
+				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002a: stloc.1
+				IL_002b: ldarg.0
+				IL_002c: ldc.i4.0
+				IL_002d: ldelem.ref
+				IL_002e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0033: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0038: ldloc.0
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003e: ldstr "match"
+				IL_0043: ldloc.1
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0049: stloc.1
+				IL_004a: ldarg.0
+				IL_004b: ldc.i4.0
+				IL_004c: ldelem.ref
+				IL_004d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0052: ldloc.1
+				IL_0053: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0058: ldloc.0
+				IL_0059: ldc.r8 1
+				IL_0062: add
+				IL_0063: stloc.0
+				IL_0064: br IL_000a
+			// end loop
+
+			IL_0069: ldnull
+			IL_006a: ret
+		} // end of method FunctionExpression_L313C25::__js_call__
+
+	} // end of class FunctionExpression_L313C25
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L318C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5198
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4964
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L318C5::__js_call__
+
+	} // end of class FunctionExpression_L318C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L322C24
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51a1
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x49b0
+			// Header size: 12
+			// Code size: 107 (0x6b)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0069
+
+				IL_001b: ldstr "aaaaaaaaaa"
+				IL_0020: ldstr "g"
+				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002a: stloc.1
+				IL_002b: ldloc.1
+				IL_002c: ldstr "test"
+				IL_0031: ldarg.0
+				IL_0032: ldc.i4.0
+				IL_0033: ldelem.ref
+				IL_0034: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0039: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_003e: ldloc.0
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0049: stloc.1
+				IL_004a: ldarg.0
+				IL_004b: ldc.i4.0
+				IL_004c: ldelem.ref
+				IL_004d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0052: ldloc.1
+				IL_0053: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0058: ldloc.0
+				IL_0059: ldc.r8 1
+				IL_0062: add
+				IL_0063: stloc.0
+				IL_0064: br IL_000a
+			// end loop
+
+			IL_0069: ldnull
+			IL_006a: ret
+		} // end of method FunctionExpression_L322C24::__js_call__
+
+	} // end of class FunctionExpression_L322C24
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L327C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51aa
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4a28
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L327C5::__js_call__
+
+	} // end of class FunctionExpression_L327C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L331C33
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51b3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4a74
+			// Header size: 12
+			// Code size: 112 (0x70)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006e
+
+				IL_001b: ldstr "aaaaaaaaaa"
+				IL_0020: ldstr "g"
+				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002a: stloc.1
+				IL_002b: ldarg.0
+				IL_002c: ldc.i4.0
+				IL_002d: ldelem.ref
+				IL_002e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0033: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0038: ldloc.0
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003e: ldstr "replace"
+				IL_0043: ldloc.1
+				IL_0044: ldstr ""
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004e: stloc.1
+				IL_004f: ldarg.0
+				IL_0050: ldc.i4.0
+				IL_0051: ldelem.ref
+				IL_0052: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0057: ldloc.1
+				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_000a
+			// end loop
+
+			IL_006e: ldnull
+			IL_006f: ret
+		} // end of method FunctionExpression_L331C33::__js_call__
+
+	} // end of class FunctionExpression_L331C33
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L336C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51bc
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4af0
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L336C5::__js_call__
+
+	} // end of class FunctionExpression_L336C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L340C35
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51c5
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4b3c
+			// Header size: 12
+			// Code size: 112 (0x70)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006e
+
+				IL_001b: ldstr "aaaaaaaaaa"
+				IL_0020: ldstr "g"
+				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002a: stloc.1
+				IL_002b: ldarg.0
+				IL_002c: ldc.i4.0
+				IL_002d: ldelem.ref
+				IL_002e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0033: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0038: ldloc.0
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003e: ldstr "replace"
+				IL_0043: ldloc.1
+				IL_0044: ldstr "asdfasdfasdf"
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004e: stloc.1
+				IL_004f: ldarg.0
+				IL_0050: ldc.i4.0
+				IL_0051: ldelem.ref
+				IL_0052: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0057: ldloc.1
+				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_000a
+			// end loop
+
+			IL_006e: ldnull
+			IL_006f: ret
+		} // end of method FunctionExpression_L340C35::__js_call__
+
+	} // end of class FunctionExpression_L340C35
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L345C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51ce
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4bb8
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L345C5::__js_call__
+
+	} // end of class FunctionExpression_L345C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L349C32
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51d7
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4c04
+			// Header size: 12
+			// Code size: 107 (0x6b)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0069
+
+				IL_001b: ldstr "aaaaaaaaaa"
+				IL_0020: ldstr "g"
+				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002a: stloc.1
+				IL_002b: ldarg.0
+				IL_002c: ldc.i4.0
+				IL_002d: ldelem.ref
+				IL_002e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0033: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0038: ldloc.0
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003e: ldstr "match"
+				IL_0043: ldloc.1
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0049: stloc.1
+				IL_004a: ldarg.0
+				IL_004b: ldc.i4.0
+				IL_004c: ldelem.ref
+				IL_004d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0052: ldloc.1
+				IL_0053: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0058: ldloc.0
+				IL_0059: ldc.r8 1
+				IL_0062: add
+				IL_0063: stloc.0
+				IL_0064: br IL_000a
+			// end loop
+
+			IL_0069: ldnull
+			IL_006a: ret
+		} // end of method FunctionExpression_L349C32::__js_call__
+
+	} // end of class FunctionExpression_L349C32
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L354C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51e0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4c7c
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 100
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L354C5::__js_call__
+
+	} // end of class FunctionExpression_L354C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L358C31
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51e9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4cc8
+			// Header size: 12
+			// Code size: 107 (0x6b)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 100
+				IL_0014: clt
+				IL_0016: brfalse IL_0069
+
+				IL_001b: ldstr "aaaaaaaaaa"
+				IL_0020: ldstr "g"
+				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002a: stloc.1
+				IL_002b: ldloc.1
+				IL_002c: ldstr "test"
+				IL_0031: ldarg.0
+				IL_0032: ldc.i4.0
+				IL_0033: ldelem.ref
+				IL_0034: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0039: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_003e: ldloc.0
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0049: stloc.1
+				IL_004a: ldarg.0
+				IL_004b: ldc.i4.0
+				IL_004c: ldelem.ref
+				IL_004d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0052: ldloc.1
+				IL_0053: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0058: ldloc.0
+				IL_0059: ldc.r8 1
+				IL_0062: add
+				IL_0063: stloc.0
+				IL_0064: br IL_000a
+			// end loop
+
+			IL_0069: ldnull
+			IL_006a: ret
+		} // end of method FunctionExpression_L358C31::__js_call__
+
+	} // end of class FunctionExpression_L358C31
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L363C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51f2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4d40
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L363C5::__js_call__
+
+	} // end of class FunctionExpression_L363C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L367C40
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51fb
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4d8c
+			// Header size: 12
+			// Code size: 112 (0x70)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006e
+
+				IL_001b: ldstr "aaaaaaaaaa"
+				IL_0020: ldstr "g"
+				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002a: stloc.1
+				IL_002b: ldarg.0
+				IL_002c: ldc.i4.0
+				IL_002d: ldelem.ref
+				IL_002e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0033: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0038: ldloc.0
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003e: ldstr "replace"
+				IL_0043: ldloc.1
+				IL_0044: ldstr ""
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004e: stloc.1
+				IL_004f: ldarg.0
+				IL_0050: ldc.i4.0
+				IL_0051: ldelem.ref
+				IL_0052: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0057: ldloc.1
+				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_000a
+			// end loop
+
+			IL_006e: ldnull
+			IL_006f: ret
+		} // end of method FunctionExpression_L367C40::__js_call__
+
+	} // end of class FunctionExpression_L367C40
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L372C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5204
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4e08
+			// Header size: 12
+			// Code size: 61 (0x3d)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: stelem.ref
+			IL_0018: ldnull
+			IL_0019: ldc.r8 50
+			IL_0022: box [System.Runtime]System.Double
+			IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::Invoke(object[], object, object)
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldc.i4.0
+			IL_002f: ldelem.ref
+			IL_0030: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0035: ldloc.0
+			IL_0036: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003b: ldnull
+			IL_003c: ret
+		} // end of method FunctionExpression_L372C5::__js_call__
+
+	} // end of class FunctionExpression_L372C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L376C42
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x520d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			// Method begins at RVA 0x4e54
+			// Header size: 12
+			// Code size: 112 (0x70)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: ldc.r8 50
+				IL_0014: clt
+				IL_0016: brfalse IL_006e
+
+				IL_001b: ldstr "aaaaaaaaaa"
+				IL_0020: ldstr "g"
+				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002a: stloc.1
+				IL_002b: ldarg.0
+				IL_002c: ldc.i4.0
+				IL_002d: ldelem.ref
+				IL_002e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0033: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0038: ldloc.0
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+				IL_003e: ldstr "replace"
+				IL_0043: ldloc.1
+				IL_0044: ldstr "asdfasdfasdf"
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_004e: stloc.1
+				IL_004f: ldarg.0
+				IL_0050: ldc.i4.0
+				IL_0051: ldelem.ref
+				IL_0052: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+				IL_0057: ldloc.1
+				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_000a
+			// end loop
+
+			IL_006e: ldnull
+			IL_006f: ret
+		} // end of method FunctionExpression_L376C42::__js_call__
+
+	} // end of class FunctionExpression_L376C42
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 77 53 63 6f 70 65 20 73 74 61 72 74 54 65
+			73 74 3d 7b 73 74 61 72 74 54 65 73 74 7d 2c 20
+			65 6e 64 54 65 73 74 3d 7b 65 6e 64 54 65 73 74
+			7d 2c 20 70 72 65 70 3d 7b 70 72 65 70 7d 2c 20
+			74 65 73 74 3d 7b 74 65 73 74 7d 2c 20 73 74 72
+			3d 7b 73 74 72 7d 2c 20 74 6d 70 3d 7b 74 6d 70
+			7d 2c 20 72 65 74 3d 7b 72 65 74 7d 2c 20 72 65
+			3d 7b 72 65 7d 2c 20 e2 80 a6 00 00
+		)
+		// Fields
+		.field public object startTest
+		.field public object endTest
+		.field public object prep
+		.field public object test
+		.field public object str
+		.field public object tmp
+		.field public object 'ret'
+		.field public object re
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array testStrings
+		.field public object randomChar
+		.field public object generateTestStrings
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x4f22
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 4080 (0xff0)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] float64,
+			[6] object,
+			[7] object,
+			[8] object
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, object, object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: newarr [System.Runtime]System.Object
+		IL_0018: dup
+		IL_0019: ldc.i4.0
+		IL_001a: ldloc.0
+		IL_001b: stelem.ref
+		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0021: stloc.s 6
+		IL_0023: ldloc.s 6
+		IL_0025: stloc.1
+		IL_0026: ldnull
+		IL_0027: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
+		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0032: ldc.i4.1
+		IL_0033: newarr [System.Runtime]System.Object
+		IL_0038: dup
+		IL_0039: ldc.i4.0
+		IL_003a: ldloc.0
+		IL_003b: stelem.ref
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0041: stloc.s 6
+		IL_0043: ldloc.s 6
+		IL_0045: stloc.2
+		IL_0046: ldnull
+		IL_0047: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0052: ldc.i4.1
+		IL_0053: newarr [System.Runtime]System.Object
+		IL_0058: dup
+		IL_0059: ldc.i4.0
+		IL_005a: ldloc.0
+		IL_005b: stelem.ref
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0061: stloc.s 6
+		IL_0063: ldloc.s 6
+		IL_0065: stloc.3
+		IL_0066: ldnull
+		IL_0067: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0072: ldc.i4.1
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldloc.0
+		IL_007b: stelem.ref
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0081: stloc.s 6
+		IL_0083: ldloc.s 6
+		IL_0085: stloc.s 4
+		IL_0087: ldnull
+		IL_0088: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+		IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0093: ldc.i4.1
+		IL_0094: newarr [System.Runtime]System.Object
+		IL_0099: dup
+		IL_009a: ldc.i4.0
+		IL_009b: ldloc.0
+		IL_009c: stelem.ref
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00a2: stloc.s 6
+		IL_00a4: ldloc.0
+		IL_00a5: ldloc.s 6
+		IL_00a7: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+		IL_00ac: ldnull
+		IL_00ad: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(object[], object, object)
+		IL_00b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+		IL_00b8: ldc.i4.1
+		IL_00b9: newarr [System.Runtime]System.Object
+		IL_00be: dup
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldloc.0
+		IL_00c1: stelem.ref
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_00c7: stloc.s 6
+		IL_00c9: ldloc.0
+		IL_00ca: ldloc.s 6
+		IL_00cc: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+		IL_00d1: ldnull
+		IL_00d2: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, object, object)
+		IL_00d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00dd: ldnull
+		IL_00de: ldstr "dromaeo-object-regexp"
+		IL_00e3: ldstr "812dde38"
+		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_00ed: pop
+		IL_00ee: ldloc.0
+		IL_00ef: ldc.i4.0
+		IL_00f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00f5: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_00fa: ldloc.0
+		IL_00fb: ldnull
+		IL_00fc: box [System.Runtime]System.Double
+		IL_0101: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+		IL_0106: ldloc.0
+		IL_0107: ldnull
+		IL_0108: box [System.Runtime]System.Double
+		IL_010d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+		IL_0112: ldloc.0
+		IL_0113: ldnull
+		IL_0114: box [System.Runtime]System.Double
+		IL_0119: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+		IL_011e: ldloc.0
+		IL_011f: ldc.i4.0
+		IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0125: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_012a: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+		IL_012f: ldc.r8 65536
+		IL_0138: stloc.s 5
+		IL_013a: ldc.r8 0.0
+		IL_0143: stloc.s 5
+		// loop start (head: IL_0145)
+			IL_0145: ldloc.s 5
+			IL_0147: ldc.r8 16384
+			IL_0150: clt
+			IL_0152: brfalse IL_0195
+
+			IL_0157: ldloc.0
+			IL_0158: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+			IL_015d: stloc.s 6
+			IL_015f: ldnull
+			IL_0160: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+			IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_016b: ldnull
+			IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+			IL_0171: stloc.s 7
+			IL_0173: ldloc.s 6
+			IL_0175: ldstr "push"
+			IL_017a: ldloc.s 7
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0181: pop
+			IL_0182: ldloc.s 5
+			IL_0184: ldc.r8 1
+			IL_018d: add
+			IL_018e: stloc.s 5
+			IL_0190: br IL_0145
+		// end loop
+
+		IL_0195: ldloc.0
+		IL_0196: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_019b: ldstr "join"
+		IL_01a0: ldstr ""
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01aa: stloc.s 7
+		IL_01ac: ldloc.0
+		IL_01ad: ldloc.s 7
+		IL_01af: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01b4: ldloc.0
+		IL_01b5: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01ba: ldloc.0
+		IL_01bb: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01c5: stloc.s 8
+		IL_01c7: ldloc.0
+		IL_01c8: ldloc.s 8
+		IL_01ca: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01cf: ldloc.0
+		IL_01d0: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01d5: ldloc.0
+		IL_01d6: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01e0: stloc.s 8
+		IL_01e2: ldloc.0
+		IL_01e3: ldloc.s 8
+		IL_01e5: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01ea: ldnull
+		IL_01eb: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(object[], object)
+		IL_01f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_01f6: ldc.i4.1
+		IL_01f7: newarr [System.Runtime]System.Object
+		IL_01fc: dup
+		IL_01fd: ldc.i4.0
+		IL_01fe: ldloc.0
+		IL_01ff: stelem.ref
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0205: stloc.s 7
+		IL_0207: ldnull
+		IL_0208: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_020e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0213: ldnull
+		IL_0214: ldloc.s 7
+		IL_0216: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_021b: pop
+		IL_021c: ldnull
+		IL_021d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(object[], object)
+		IL_0223: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0228: ldc.i4.1
+		IL_0229: newarr [System.Runtime]System.Object
+		IL_022e: dup
+		IL_022f: ldc.i4.0
+		IL_0230: ldloc.0
+		IL_0231: stelem.ref
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0237: stloc.s 7
+		IL_0239: ldnull
+		IL_023a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0240: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0245: ldnull
+		IL_0246: ldstr "Compiled Object Empty Split"
+		IL_024b: ldloc.s 7
+		IL_024d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0252: pop
+		IL_0253: ldnull
+		IL_0254: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(object[], object)
+		IL_025a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_025f: ldc.i4.1
+		IL_0260: newarr [System.Runtime]System.Object
+		IL_0265: dup
+		IL_0266: ldc.i4.0
+		IL_0267: ldloc.0
+		IL_0268: stelem.ref
+		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_026e: stloc.s 7
+		IL_0270: ldnull
+		IL_0271: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0277: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_027c: ldnull
+		IL_027d: ldloc.s 7
+		IL_027f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0284: pop
+		IL_0285: ldnull
+		IL_0286: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(object[], object)
+		IL_028c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0291: ldc.i4.1
+		IL_0292: newarr [System.Runtime]System.Object
+		IL_0297: dup
+		IL_0298: ldc.i4.0
+		IL_0299: ldloc.0
+		IL_029a: stelem.ref
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_02a0: stloc.s 7
+		IL_02a2: ldnull
+		IL_02a3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_02a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_02ae: ldnull
+		IL_02af: ldstr "Compiled Object Char Split"
+		IL_02b4: ldloc.s 7
+		IL_02b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_02bb: pop
+		IL_02bc: ldnull
+		IL_02bd: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(object[], object)
+		IL_02c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_02c8: ldc.i4.1
+		IL_02c9: newarr [System.Runtime]System.Object
+		IL_02ce: dup
+		IL_02cf: ldc.i4.0
+		IL_02d0: ldloc.0
+		IL_02d1: stelem.ref
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_02d7: stloc.s 7
+		IL_02d9: ldnull
+		IL_02da: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_02e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02e5: ldnull
+		IL_02e6: ldloc.s 7
+		IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_02ed: pop
+		IL_02ee: ldnull
+		IL_02ef: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(object[], object)
+		IL_02f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_02fa: ldc.i4.1
+		IL_02fb: newarr [System.Runtime]System.Object
+		IL_0300: dup
+		IL_0301: ldc.i4.0
+		IL_0302: ldloc.0
+		IL_0303: stelem.ref
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0309: stloc.s 7
+		IL_030b: ldnull
+		IL_030c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0312: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0317: ldnull
+		IL_0318: ldstr "Compiled Object Variable Split"
+		IL_031d: ldloc.s 7
+		IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0324: pop
+		IL_0325: ldnull
+		IL_0326: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(object[], object)
+		IL_032c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0331: ldc.i4.1
+		IL_0332: newarr [System.Runtime]System.Object
+		IL_0337: dup
+		IL_0338: ldc.i4.0
+		IL_0339: ldloc.0
+		IL_033a: stelem.ref
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0340: stloc.s 7
+		IL_0342: ldnull
+		IL_0343: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0349: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_034e: ldnull
+		IL_034f: ldloc.s 7
+		IL_0351: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0356: pop
+		IL_0357: ldnull
+		IL_0358: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(object[], object)
+		IL_035e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0363: ldc.i4.1
+		IL_0364: newarr [System.Runtime]System.Object
+		IL_0369: dup
+		IL_036a: ldc.i4.0
+		IL_036b: ldloc.0
+		IL_036c: stelem.ref
+		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0372: stloc.s 7
+		IL_0374: ldnull
+		IL_0375: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_037b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0380: ldnull
+		IL_0381: ldstr "Compiled Match"
+		IL_0386: ldloc.s 7
+		IL_0388: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_038d: pop
+		IL_038e: ldnull
+		IL_038f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(object[], object)
+		IL_0395: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_039a: ldc.i4.1
+		IL_039b: newarr [System.Runtime]System.Object
+		IL_03a0: dup
+		IL_03a1: ldc.i4.0
+		IL_03a2: ldloc.0
+		IL_03a3: stelem.ref
+		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_03a9: stloc.s 7
+		IL_03ab: ldnull
+		IL_03ac: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_03b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_03b7: ldnull
+		IL_03b8: ldloc.s 7
+		IL_03ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_03bf: pop
+		IL_03c0: ldnull
+		IL_03c1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(object[], object)
+		IL_03c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_03cc: ldc.i4.1
+		IL_03cd: newarr [System.Runtime]System.Object
+		IL_03d2: dup
+		IL_03d3: ldc.i4.0
+		IL_03d4: ldloc.0
+		IL_03d5: stelem.ref
+		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_03db: stloc.s 7
+		IL_03dd: ldnull
+		IL_03de: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_03e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_03e9: ldnull
+		IL_03ea: ldstr "Compiled Test"
+		IL_03ef: ldloc.s 7
+		IL_03f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_03f6: pop
+		IL_03f7: ldnull
+		IL_03f8: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(object[], object)
+		IL_03fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0403: ldc.i4.1
+		IL_0404: newarr [System.Runtime]System.Object
+		IL_0409: dup
+		IL_040a: ldc.i4.0
+		IL_040b: ldloc.0
+		IL_040c: stelem.ref
+		IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0412: stloc.s 7
+		IL_0414: ldnull
+		IL_0415: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_041b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0420: ldnull
+		IL_0421: ldloc.s 7
+		IL_0423: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0428: pop
+		IL_0429: ldnull
+		IL_042a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(object[], object)
+		IL_0430: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0435: ldc.i4.1
+		IL_0436: newarr [System.Runtime]System.Object
+		IL_043b: dup
+		IL_043c: ldc.i4.0
+		IL_043d: ldloc.0
+		IL_043e: stelem.ref
+		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0444: stloc.s 7
+		IL_0446: ldnull
+		IL_0447: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_044d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0452: ldnull
+		IL_0453: ldstr "Compiled Empty Replace"
+		IL_0458: ldloc.s 7
+		IL_045a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_045f: pop
+		IL_0460: ldnull
+		IL_0461: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(object[], object)
+		IL_0467: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_046c: ldc.i4.1
+		IL_046d: newarr [System.Runtime]System.Object
+		IL_0472: dup
+		IL_0473: ldc.i4.0
+		IL_0474: ldloc.0
+		IL_0475: stelem.ref
+		IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_047b: stloc.s 7
+		IL_047d: ldnull
+		IL_047e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0484: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0489: ldnull
+		IL_048a: ldloc.s 7
+		IL_048c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0491: pop
+		IL_0492: ldnull
+		IL_0493: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(object[], object)
+		IL_0499: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_049e: ldc.i4.1
+		IL_049f: newarr [System.Runtime]System.Object
+		IL_04a4: dup
+		IL_04a5: ldc.i4.0
+		IL_04a6: ldloc.0
+		IL_04a7: stelem.ref
+		IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_04ad: stloc.s 7
+		IL_04af: ldnull
+		IL_04b0: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_04b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_04bb: ldnull
+		IL_04bc: ldstr "Compiled 12 Char Replace"
+		IL_04c1: ldloc.s 7
+		IL_04c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_04c8: pop
+		IL_04c9: ldnull
+		IL_04ca: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(object[], object)
+		IL_04d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_04d5: ldc.i4.1
+		IL_04d6: newarr [System.Runtime]System.Object
+		IL_04db: dup
+		IL_04dc: ldc.i4.0
+		IL_04dd: ldloc.0
+		IL_04de: stelem.ref
+		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_04e4: stloc.s 7
+		IL_04e6: ldnull
+		IL_04e7: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_04ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_04f2: ldnull
+		IL_04f3: ldloc.s 7
+		IL_04f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_04fa: pop
+		IL_04fb: ldnull
+		IL_04fc: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(object[], object)
+		IL_0502: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0507: ldc.i4.1
+		IL_0508: newarr [System.Runtime]System.Object
+		IL_050d: dup
+		IL_050e: ldc.i4.0
+		IL_050f: ldloc.0
+		IL_0510: stelem.ref
+		IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0516: stloc.s 7
+		IL_0518: ldnull
+		IL_0519: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_051f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0524: ldnull
+		IL_0525: ldstr "Compiled Object Match"
+		IL_052a: ldloc.s 7
+		IL_052c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0531: pop
+		IL_0532: ldnull
+		IL_0533: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(object[], object)
+		IL_0539: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_053e: ldc.i4.1
+		IL_053f: newarr [System.Runtime]System.Object
+		IL_0544: dup
+		IL_0545: ldc.i4.0
+		IL_0546: ldloc.0
+		IL_0547: stelem.ref
+		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_054d: stloc.s 7
+		IL_054f: ldnull
+		IL_0550: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0556: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_055b: ldnull
+		IL_055c: ldloc.s 7
+		IL_055e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0563: pop
+		IL_0564: ldnull
+		IL_0565: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(object[], object)
+		IL_056b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0570: ldc.i4.1
+		IL_0571: newarr [System.Runtime]System.Object
+		IL_0576: dup
+		IL_0577: ldc.i4.0
+		IL_0578: ldloc.0
+		IL_0579: stelem.ref
+		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_057f: stloc.s 7
+		IL_0581: ldnull
+		IL_0582: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0588: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_058d: ldnull
+		IL_058e: ldstr "Compiled Object Test"
+		IL_0593: ldloc.s 7
+		IL_0595: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_059a: pop
+		IL_059b: ldnull
+		IL_059c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(object[], object)
+		IL_05a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_05a7: ldc.i4.1
+		IL_05a8: newarr [System.Runtime]System.Object
+		IL_05ad: dup
+		IL_05ae: ldc.i4.0
+		IL_05af: ldloc.0
+		IL_05b0: stelem.ref
+		IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_05b6: stloc.s 7
+		IL_05b8: ldnull
+		IL_05b9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_05bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_05c4: ldnull
+		IL_05c5: ldloc.s 7
+		IL_05c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_05cc: pop
+		IL_05cd: ldnull
+		IL_05ce: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(object[], object)
+		IL_05d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_05d9: ldc.i4.1
+		IL_05da: newarr [System.Runtime]System.Object
+		IL_05df: dup
+		IL_05e0: ldc.i4.0
+		IL_05e1: ldloc.0
+		IL_05e2: stelem.ref
+		IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_05e8: stloc.s 7
+		IL_05ea: ldnull
+		IL_05eb: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_05f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_05f6: ldnull
+		IL_05f7: ldstr "Compiled Object Empty Replace"
+		IL_05fc: ldloc.s 7
+		IL_05fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0603: pop
+		IL_0604: ldnull
+		IL_0605: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(object[], object)
+		IL_060b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0610: ldc.i4.1
+		IL_0611: newarr [System.Runtime]System.Object
+		IL_0616: dup
+		IL_0617: ldc.i4.0
+		IL_0618: ldloc.0
+		IL_0619: stelem.ref
+		IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_061f: stloc.s 7
+		IL_0621: ldnull
+		IL_0622: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0628: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_062d: ldnull
+		IL_062e: ldloc.s 7
+		IL_0630: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0635: pop
+		IL_0636: ldnull
+		IL_0637: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(object[], object)
+		IL_063d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0642: ldc.i4.1
+		IL_0643: newarr [System.Runtime]System.Object
+		IL_0648: dup
+		IL_0649: ldc.i4.0
+		IL_064a: ldloc.0
+		IL_064b: stelem.ref
+		IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0651: stloc.s 7
+		IL_0653: ldnull
+		IL_0654: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_065a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_065f: ldnull
+		IL_0660: ldstr "Compiled Object 12 Char Replace"
+		IL_0665: ldloc.s 7
+		IL_0667: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_066c: pop
+		IL_066d: ldnull
+		IL_066e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(object[], object)
+		IL_0674: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0679: ldc.i4.1
+		IL_067a: newarr [System.Runtime]System.Object
+		IL_067f: dup
+		IL_0680: ldc.i4.0
+		IL_0681: ldloc.0
+		IL_0682: stelem.ref
+		IL_0683: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0688: stloc.s 7
+		IL_068a: ldnull
+		IL_068b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0691: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0696: ldnull
+		IL_0697: ldloc.s 7
+		IL_0699: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_069e: pop
+		IL_069f: ldnull
+		IL_06a0: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(object[], object)
+		IL_06a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_06ab: ldc.i4.1
+		IL_06ac: newarr [System.Runtime]System.Object
+		IL_06b1: dup
+		IL_06b2: ldc.i4.0
+		IL_06b3: ldloc.0
+		IL_06b4: stelem.ref
+		IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_06ba: stloc.s 7
+		IL_06bc: ldnull
+		IL_06bd: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_06c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_06c8: ldnull
+		IL_06c9: ldstr "Compiled Object 12 Char Replace Function"
+		IL_06ce: ldloc.s 7
+		IL_06d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_06d5: pop
+		IL_06d6: ldnull
+		IL_06d7: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(object[], object)
+		IL_06dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_06e2: ldc.i4.1
+		IL_06e3: newarr [System.Runtime]System.Object
+		IL_06e8: dup
+		IL_06e9: ldc.i4.0
+		IL_06ea: ldloc.0
+		IL_06eb: stelem.ref
+		IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_06f1: stloc.s 7
+		IL_06f3: ldnull
+		IL_06f4: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_06fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_06ff: ldnull
+		IL_0700: ldloc.s 7
+		IL_0702: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0707: pop
+		IL_0708: ldnull
+		IL_0709: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(object[], object)
+		IL_070f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0714: ldc.i4.1
+		IL_0715: newarr [System.Runtime]System.Object
+		IL_071a: dup
+		IL_071b: ldc.i4.0
+		IL_071c: ldloc.0
+		IL_071d: stelem.ref
+		IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0723: stloc.s 7
+		IL_0725: ldnull
+		IL_0726: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_072c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0731: ldnull
+		IL_0732: ldstr "Compiled Variable Match"
+		IL_0737: ldloc.s 7
+		IL_0739: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_073e: pop
+		IL_073f: ldnull
+		IL_0740: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(object[], object)
+		IL_0746: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_074b: ldc.i4.1
+		IL_074c: newarr [System.Runtime]System.Object
+		IL_0751: dup
+		IL_0752: ldc.i4.0
+		IL_0753: ldloc.0
+		IL_0754: stelem.ref
+		IL_0755: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_075a: stloc.s 7
+		IL_075c: ldnull
+		IL_075d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0763: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0768: ldnull
+		IL_0769: ldloc.s 7
+		IL_076b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0770: pop
+		IL_0771: ldnull
+		IL_0772: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(object[], object)
+		IL_0778: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_077d: ldc.i4.1
+		IL_077e: newarr [System.Runtime]System.Object
+		IL_0783: dup
+		IL_0784: ldc.i4.0
+		IL_0785: ldloc.0
+		IL_0786: stelem.ref
+		IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_078c: stloc.s 7
+		IL_078e: ldnull
+		IL_078f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0795: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_079a: ldnull
+		IL_079b: ldstr "Compiled Variable Test"
+		IL_07a0: ldloc.s 7
+		IL_07a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_07a7: pop
+		IL_07a8: ldnull
+		IL_07a9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(object[], object)
+		IL_07af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_07b4: ldc.i4.1
+		IL_07b5: newarr [System.Runtime]System.Object
+		IL_07ba: dup
+		IL_07bb: ldc.i4.0
+		IL_07bc: ldloc.0
+		IL_07bd: stelem.ref
+		IL_07be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_07c3: stloc.s 7
+		IL_07c5: ldnull
+		IL_07c6: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_07cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_07d1: ldnull
+		IL_07d2: ldloc.s 7
+		IL_07d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_07d9: pop
+		IL_07da: ldnull
+		IL_07db: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(object[], object)
+		IL_07e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_07e6: ldc.i4.1
+		IL_07e7: newarr [System.Runtime]System.Object
+		IL_07ec: dup
+		IL_07ed: ldc.i4.0
+		IL_07ee: ldloc.0
+		IL_07ef: stelem.ref
+		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_07f5: stloc.s 7
+		IL_07f7: ldnull
+		IL_07f8: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_07fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0803: ldnull
+		IL_0804: ldstr "Compiled Variable Empty Replace"
+		IL_0809: ldloc.s 7
+		IL_080b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0810: pop
+		IL_0811: ldnull
+		IL_0812: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(object[], object)
+		IL_0818: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_081d: ldc.i4.1
+		IL_081e: newarr [System.Runtime]System.Object
+		IL_0823: dup
+		IL_0824: ldc.i4.0
+		IL_0825: ldloc.0
+		IL_0826: stelem.ref
+		IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_082c: stloc.s 7
+		IL_082e: ldnull
+		IL_082f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0835: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_083a: ldnull
+		IL_083b: ldloc.s 7
+		IL_083d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0842: pop
+		IL_0843: ldnull
+		IL_0844: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(object[], object)
+		IL_084a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_084f: ldc.i4.1
+		IL_0850: newarr [System.Runtime]System.Object
+		IL_0855: dup
+		IL_0856: ldc.i4.0
+		IL_0857: ldloc.0
+		IL_0858: stelem.ref
+		IL_0859: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_085e: stloc.s 7
+		IL_0860: ldnull
+		IL_0861: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0867: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_086c: ldnull
+		IL_086d: ldstr "Compiled Variable 12 Char Replace"
+		IL_0872: ldloc.s 7
+		IL_0874: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0879: pop
+		IL_087a: ldnull
+		IL_087b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(object[], object)
+		IL_0881: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0886: ldc.i4.1
+		IL_0887: newarr [System.Runtime]System.Object
+		IL_088c: dup
+		IL_088d: ldc.i4.0
+		IL_088e: ldloc.0
+		IL_088f: stelem.ref
+		IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0895: stloc.s 7
+		IL_0897: ldnull
+		IL_0898: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_089e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_08a3: ldnull
+		IL_08a4: ldloc.s 7
+		IL_08a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_08ab: pop
+		IL_08ac: ldnull
+		IL_08ad: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(object[], object)
+		IL_08b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_08b8: ldc.i4.1
+		IL_08b9: newarr [System.Runtime]System.Object
+		IL_08be: dup
+		IL_08bf: ldc.i4.0
+		IL_08c0: ldloc.0
+		IL_08c1: stelem.ref
+		IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_08c7: stloc.s 7
+		IL_08c9: ldnull
+		IL_08ca: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_08d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_08d5: ldnull
+		IL_08d6: ldstr "Compiled Variable Object Match"
+		IL_08db: ldloc.s 7
+		IL_08dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_08e2: pop
+		IL_08e3: ldnull
+		IL_08e4: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(object[], object)
+		IL_08ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_08ef: ldc.i4.1
+		IL_08f0: newarr [System.Runtime]System.Object
+		IL_08f5: dup
+		IL_08f6: ldc.i4.0
+		IL_08f7: ldloc.0
+		IL_08f8: stelem.ref
+		IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_08fe: stloc.s 7
+		IL_0900: ldnull
+		IL_0901: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0907: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_090c: ldnull
+		IL_090d: ldloc.s 7
+		IL_090f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0914: pop
+		IL_0915: ldnull
+		IL_0916: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(object[], object)
+		IL_091c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0921: ldc.i4.1
+		IL_0922: newarr [System.Runtime]System.Object
+		IL_0927: dup
+		IL_0928: ldc.i4.0
+		IL_0929: ldloc.0
+		IL_092a: stelem.ref
+		IL_092b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0930: stloc.s 7
+		IL_0932: ldnull
+		IL_0933: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0939: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_093e: ldnull
+		IL_093f: ldstr "Compiled Variable Object Test"
+		IL_0944: ldloc.s 7
+		IL_0946: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_094b: pop
+		IL_094c: ldnull
+		IL_094d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(object[], object)
+		IL_0953: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0958: ldc.i4.1
+		IL_0959: newarr [System.Runtime]System.Object
+		IL_095e: dup
+		IL_095f: ldc.i4.0
+		IL_0960: ldloc.0
+		IL_0961: stelem.ref
+		IL_0962: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0967: stloc.s 7
+		IL_0969: ldnull
+		IL_096a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0970: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0975: ldnull
+		IL_0976: ldloc.s 7
+		IL_0978: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_097d: pop
+		IL_097e: ldnull
+		IL_097f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(object[], object)
+		IL_0985: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_098a: ldc.i4.1
+		IL_098b: newarr [System.Runtime]System.Object
+		IL_0990: dup
+		IL_0991: ldc.i4.0
+		IL_0992: ldloc.0
+		IL_0993: stelem.ref
+		IL_0994: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0999: stloc.s 7
+		IL_099b: ldnull
+		IL_099c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_09a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_09a7: ldnull
+		IL_09a8: ldstr "Compiled Variable Object Empty Replace"
+		IL_09ad: ldloc.s 7
+		IL_09af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_09b4: pop
+		IL_09b5: ldnull
+		IL_09b6: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(object[], object)
+		IL_09bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_09c1: ldc.i4.1
+		IL_09c2: newarr [System.Runtime]System.Object
+		IL_09c7: dup
+		IL_09c8: ldc.i4.0
+		IL_09c9: ldloc.0
+		IL_09ca: stelem.ref
+		IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_09d0: stloc.s 7
+		IL_09d2: ldnull
+		IL_09d3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_09d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_09de: ldnull
+		IL_09df: ldloc.s 7
+		IL_09e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_09e6: pop
+		IL_09e7: ldnull
+		IL_09e8: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(object[], object)
+		IL_09ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_09f3: ldc.i4.1
+		IL_09f4: newarr [System.Runtime]System.Object
+		IL_09f9: dup
+		IL_09fa: ldc.i4.0
+		IL_09fb: ldloc.0
+		IL_09fc: stelem.ref
+		IL_09fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0a02: stloc.s 7
+		IL_0a04: ldnull
+		IL_0a05: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0a0b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0a10: ldnull
+		IL_0a11: ldstr "Compiled Variable Object 12 Char Replace"
+		IL_0a16: ldloc.s 7
+		IL_0a18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0a1d: pop
+		IL_0a1e: ldnull
+		IL_0a1f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(object[], object)
+		IL_0a25: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0a2a: ldc.i4.1
+		IL_0a2b: newarr [System.Runtime]System.Object
+		IL_0a30: dup
+		IL_0a31: ldc.i4.0
+		IL_0a32: ldloc.0
+		IL_0a33: stelem.ref
+		IL_0a34: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0a39: stloc.s 7
+		IL_0a3b: ldnull
+		IL_0a3c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0a42: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0a47: ldnull
+		IL_0a48: ldloc.s 7
+		IL_0a4a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0a4f: pop
+		IL_0a50: ldnull
+		IL_0a51: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(object[], object)
+		IL_0a57: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0a5c: ldc.i4.1
+		IL_0a5d: newarr [System.Runtime]System.Object
+		IL_0a62: dup
+		IL_0a63: ldc.i4.0
+		IL_0a64: ldloc.0
+		IL_0a65: stelem.ref
+		IL_0a66: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0a6b: stloc.s 7
+		IL_0a6d: ldnull
+		IL_0a6e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0a74: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0a79: ldnull
+		IL_0a7a: ldstr "Compiled Variable Object 12 Char Replace Function"
+		IL_0a7f: ldloc.s 7
+		IL_0a81: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0a86: pop
+		IL_0a87: ldnull
+		IL_0a88: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(object[], object)
+		IL_0a8e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0a93: ldc.i4.1
+		IL_0a94: newarr [System.Runtime]System.Object
+		IL_0a99: dup
+		IL_0a9a: ldc.i4.0
+		IL_0a9b: ldloc.0
+		IL_0a9c: stelem.ref
+		IL_0a9d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0aa2: stloc.s 7
+		IL_0aa4: ldnull
+		IL_0aa5: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0aab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0ab0: ldnull
+		IL_0ab1: ldloc.s 7
+		IL_0ab3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0ab8: pop
+		IL_0ab9: ldnull
+		IL_0aba: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(object[], object)
+		IL_0ac0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0ac5: ldc.i4.1
+		IL_0ac6: newarr [System.Runtime]System.Object
+		IL_0acb: dup
+		IL_0acc: ldc.i4.0
+		IL_0acd: ldloc.0
+		IL_0ace: stelem.ref
+		IL_0acf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0ad4: stloc.s 7
+		IL_0ad6: ldnull
+		IL_0ad7: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0add: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0ae2: ldnull
+		IL_0ae3: ldstr "Compiled Capture Match"
+		IL_0ae8: ldloc.s 7
+		IL_0aea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0aef: pop
+		IL_0af0: ldnull
+		IL_0af1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(object[], object)
+		IL_0af7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0afc: ldc.i4.1
+		IL_0afd: newarr [System.Runtime]System.Object
+		IL_0b02: dup
+		IL_0b03: ldc.i4.0
+		IL_0b04: ldloc.0
+		IL_0b05: stelem.ref
+		IL_0b06: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0b0b: stloc.s 7
+		IL_0b0d: ldnull
+		IL_0b0e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0b14: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0b19: ldnull
+		IL_0b1a: ldloc.s 7
+		IL_0b1c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0b21: pop
+		IL_0b22: ldnull
+		IL_0b23: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(object[], object)
+		IL_0b29: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0b2e: ldc.i4.1
+		IL_0b2f: newarr [System.Runtime]System.Object
+		IL_0b34: dup
+		IL_0b35: ldc.i4.0
+		IL_0b36: ldloc.0
+		IL_0b37: stelem.ref
+		IL_0b38: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0b3d: stloc.s 7
+		IL_0b3f: ldnull
+		IL_0b40: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0b46: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0b4b: ldnull
+		IL_0b4c: ldstr "Compiled Capture Replace"
+		IL_0b51: ldloc.s 7
+		IL_0b53: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0b58: pop
+		IL_0b59: ldnull
+		IL_0b5a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(object[], object)
+		IL_0b60: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0b65: ldc.i4.1
+		IL_0b66: newarr [System.Runtime]System.Object
+		IL_0b6b: dup
+		IL_0b6c: ldc.i4.0
+		IL_0b6d: ldloc.0
+		IL_0b6e: stelem.ref
+		IL_0b6f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0b74: stloc.s 7
+		IL_0b76: ldnull
+		IL_0b77: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0b7d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0b82: ldnull
+		IL_0b83: ldloc.s 7
+		IL_0b85: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0b8a: pop
+		IL_0b8b: ldnull
+		IL_0b8c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(object[], object)
+		IL_0b92: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0b97: ldc.i4.1
+		IL_0b98: newarr [System.Runtime]System.Object
+		IL_0b9d: dup
+		IL_0b9e: ldc.i4.0
+		IL_0b9f: ldloc.0
+		IL_0ba0: stelem.ref
+		IL_0ba1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0ba6: stloc.s 7
+		IL_0ba8: ldnull
+		IL_0ba9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0baf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0bb4: ldnull
+		IL_0bb5: ldstr "Compiled Capture Replace with Capture"
+		IL_0bba: ldloc.s 7
+		IL_0bbc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0bc1: pop
+		IL_0bc2: ldnull
+		IL_0bc3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(object[], object)
+		IL_0bc9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0bce: ldc.i4.1
+		IL_0bcf: newarr [System.Runtime]System.Object
+		IL_0bd4: dup
+		IL_0bd5: ldc.i4.0
+		IL_0bd6: ldloc.0
+		IL_0bd7: stelem.ref
+		IL_0bd8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0bdd: stloc.s 7
+		IL_0bdf: ldnull
+		IL_0be0: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0be6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0beb: ldnull
+		IL_0bec: ldloc.s 7
+		IL_0bee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0bf3: pop
+		IL_0bf4: ldnull
+		IL_0bf5: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(object[], object)
+		IL_0bfb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0c00: ldc.i4.1
+		IL_0c01: newarr [System.Runtime]System.Object
+		IL_0c06: dup
+		IL_0c07: ldc.i4.0
+		IL_0c08: ldloc.0
+		IL_0c09: stelem.ref
+		IL_0c0a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0c0f: stloc.s 7
+		IL_0c11: ldnull
+		IL_0c12: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0c18: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0c1d: ldnull
+		IL_0c1e: ldstr "Compiled Capture Replace with Capture Function"
+		IL_0c23: ldloc.s 7
+		IL_0c25: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0c2a: pop
+		IL_0c2b: ldnull
+		IL_0c2c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(object[], object)
+		IL_0c32: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0c37: ldc.i4.1
+		IL_0c38: newarr [System.Runtime]System.Object
+		IL_0c3d: dup
+		IL_0c3e: ldc.i4.0
+		IL_0c3f: ldloc.0
+		IL_0c40: stelem.ref
+		IL_0c41: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0c46: stloc.s 7
+		IL_0c48: ldnull
+		IL_0c49: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0c4f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0c54: ldnull
+		IL_0c55: ldloc.s 7
+		IL_0c57: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0c5c: pop
+		IL_0c5d: ldnull
+		IL_0c5e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(object[], object)
+		IL_0c64: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0c69: ldc.i4.1
+		IL_0c6a: newarr [System.Runtime]System.Object
+		IL_0c6f: dup
+		IL_0c70: ldc.i4.0
+		IL_0c71: ldloc.0
+		IL_0c72: stelem.ref
+		IL_0c73: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0c78: stloc.s 7
+		IL_0c7a: ldnull
+		IL_0c7b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0c81: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0c86: ldnull
+		IL_0c87: ldstr "Compiled Capture Replace with Upperase Capture Function"
+		IL_0c8c: ldloc.s 7
+		IL_0c8e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0c93: pop
+		IL_0c94: ldnull
+		IL_0c95: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(object[], object)
+		IL_0c9b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0ca0: ldc.i4.1
+		IL_0ca1: newarr [System.Runtime]System.Object
+		IL_0ca6: dup
+		IL_0ca7: ldc.i4.0
+		IL_0ca8: ldloc.0
+		IL_0ca9: stelem.ref
+		IL_0caa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0caf: stloc.s 7
+		IL_0cb1: ldnull
+		IL_0cb2: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0cb8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0cbd: ldnull
+		IL_0cbe: ldloc.s 7
+		IL_0cc0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0cc5: pop
+		IL_0cc6: ldnull
+		IL_0cc7: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(object[], object)
+		IL_0ccd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0cd2: ldc.i4.1
+		IL_0cd3: newarr [System.Runtime]System.Object
+		IL_0cd8: dup
+		IL_0cd9: ldc.i4.0
+		IL_0cda: ldloc.0
+		IL_0cdb: stelem.ref
+		IL_0cdc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0ce1: stloc.s 7
+		IL_0ce3: ldnull
+		IL_0ce4: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0cea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0cef: ldnull
+		IL_0cf0: ldstr "Uncompiled Match"
+		IL_0cf5: ldloc.s 7
+		IL_0cf7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0cfc: pop
+		IL_0cfd: ldnull
+		IL_0cfe: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(object[], object)
+		IL_0d04: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0d09: ldc.i4.1
+		IL_0d0a: newarr [System.Runtime]System.Object
+		IL_0d0f: dup
+		IL_0d10: ldc.i4.0
+		IL_0d11: ldloc.0
+		IL_0d12: stelem.ref
+		IL_0d13: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0d18: stloc.s 7
+		IL_0d1a: ldnull
+		IL_0d1b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0d21: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0d26: ldnull
+		IL_0d27: ldloc.s 7
+		IL_0d29: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0d2e: pop
+		IL_0d2f: ldnull
+		IL_0d30: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(object[], object)
+		IL_0d36: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0d3b: ldc.i4.1
+		IL_0d3c: newarr [System.Runtime]System.Object
+		IL_0d41: dup
+		IL_0d42: ldc.i4.0
+		IL_0d43: ldloc.0
+		IL_0d44: stelem.ref
+		IL_0d45: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0d4a: stloc.s 7
+		IL_0d4c: ldnull
+		IL_0d4d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0d53: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0d58: ldnull
+		IL_0d59: ldstr "Uncompiled Test"
+		IL_0d5e: ldloc.s 7
+		IL_0d60: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0d65: pop
+		IL_0d66: ldnull
+		IL_0d67: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(object[], object)
+		IL_0d6d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0d72: ldc.i4.1
+		IL_0d73: newarr [System.Runtime]System.Object
+		IL_0d78: dup
+		IL_0d79: ldc.i4.0
+		IL_0d7a: ldloc.0
+		IL_0d7b: stelem.ref
+		IL_0d7c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0d81: stloc.s 7
+		IL_0d83: ldnull
+		IL_0d84: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0d8a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0d8f: ldnull
+		IL_0d90: ldloc.s 7
+		IL_0d92: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0d97: pop
+		IL_0d98: ldnull
+		IL_0d99: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(object[], object)
+		IL_0d9f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0da4: ldc.i4.1
+		IL_0da5: newarr [System.Runtime]System.Object
+		IL_0daa: dup
+		IL_0dab: ldc.i4.0
+		IL_0dac: ldloc.0
+		IL_0dad: stelem.ref
+		IL_0dae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0db3: stloc.s 7
+		IL_0db5: ldnull
+		IL_0db6: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0dbc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0dc1: ldnull
+		IL_0dc2: ldstr "Uncompiled Empty Replace"
+		IL_0dc7: ldloc.s 7
+		IL_0dc9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0dce: pop
+		IL_0dcf: ldnull
+		IL_0dd0: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(object[], object)
+		IL_0dd6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0ddb: ldc.i4.1
+		IL_0ddc: newarr [System.Runtime]System.Object
+		IL_0de1: dup
+		IL_0de2: ldc.i4.0
+		IL_0de3: ldloc.0
+		IL_0de4: stelem.ref
+		IL_0de5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0dea: stloc.s 7
+		IL_0dec: ldnull
+		IL_0ded: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0df3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0df8: ldnull
+		IL_0df9: ldloc.s 7
+		IL_0dfb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0e00: pop
+		IL_0e01: ldnull
+		IL_0e02: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(object[], object)
+		IL_0e08: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0e0d: ldc.i4.1
+		IL_0e0e: newarr [System.Runtime]System.Object
+		IL_0e13: dup
+		IL_0e14: ldc.i4.0
+		IL_0e15: ldloc.0
+		IL_0e16: stelem.ref
+		IL_0e17: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0e1c: stloc.s 7
+		IL_0e1e: ldnull
+		IL_0e1f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0e25: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0e2a: ldnull
+		IL_0e2b: ldstr "Uncompiled 12 Char Replace"
+		IL_0e30: ldloc.s 7
+		IL_0e32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0e37: pop
+		IL_0e38: ldnull
+		IL_0e39: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(object[], object)
+		IL_0e3f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0e44: ldc.i4.1
+		IL_0e45: newarr [System.Runtime]System.Object
+		IL_0e4a: dup
+		IL_0e4b: ldc.i4.0
+		IL_0e4c: ldloc.0
+		IL_0e4d: stelem.ref
+		IL_0e4e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0e53: stloc.s 7
+		IL_0e55: ldnull
+		IL_0e56: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0e5c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0e61: ldnull
+		IL_0e62: ldloc.s 7
+		IL_0e64: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0e69: pop
+		IL_0e6a: ldnull
+		IL_0e6b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(object[], object)
+		IL_0e71: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0e76: ldc.i4.1
+		IL_0e77: newarr [System.Runtime]System.Object
+		IL_0e7c: dup
+		IL_0e7d: ldc.i4.0
+		IL_0e7e: ldloc.0
+		IL_0e7f: stelem.ref
+		IL_0e80: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0e85: stloc.s 7
+		IL_0e87: ldnull
+		IL_0e88: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0e8e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0e93: ldnull
+		IL_0e94: ldstr "Uncompiled Object Match"
+		IL_0e99: ldloc.s 7
+		IL_0e9b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0ea0: pop
+		IL_0ea1: ldnull
+		IL_0ea2: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(object[], object)
+		IL_0ea8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0ead: ldc.i4.1
+		IL_0eae: newarr [System.Runtime]System.Object
+		IL_0eb3: dup
+		IL_0eb4: ldc.i4.0
+		IL_0eb5: ldloc.0
+		IL_0eb6: stelem.ref
+		IL_0eb7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0ebc: stloc.s 7
+		IL_0ebe: ldnull
+		IL_0ebf: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0ec5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0eca: ldnull
+		IL_0ecb: ldloc.s 7
+		IL_0ecd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0ed2: pop
+		IL_0ed3: ldnull
+		IL_0ed4: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(object[], object)
+		IL_0eda: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0edf: ldc.i4.1
+		IL_0ee0: newarr [System.Runtime]System.Object
+		IL_0ee5: dup
+		IL_0ee6: ldc.i4.0
+		IL_0ee7: ldloc.0
+		IL_0ee8: stelem.ref
+		IL_0ee9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0eee: stloc.s 7
+		IL_0ef0: ldnull
+		IL_0ef1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0ef7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0efc: ldnull
+		IL_0efd: ldstr "Uncompiled Object Test"
+		IL_0f02: ldloc.s 7
+		IL_0f04: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0f09: pop
+		IL_0f0a: ldnull
+		IL_0f0b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(object[], object)
+		IL_0f11: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0f16: ldc.i4.1
+		IL_0f17: newarr [System.Runtime]System.Object
+		IL_0f1c: dup
+		IL_0f1d: ldc.i4.0
+		IL_0f1e: ldloc.0
+		IL_0f1f: stelem.ref
+		IL_0f20: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0f25: stloc.s 7
+		IL_0f27: ldnull
+		IL_0f28: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0f2e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0f33: ldnull
+		IL_0f34: ldloc.s 7
+		IL_0f36: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0f3b: pop
+		IL_0f3c: ldnull
+		IL_0f3d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(object[], object)
+		IL_0f43: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0f48: ldc.i4.1
+		IL_0f49: newarr [System.Runtime]System.Object
+		IL_0f4e: dup
+		IL_0f4f: ldc.i4.0
+		IL_0f50: ldloc.0
+		IL_0f51: stelem.ref
+		IL_0f52: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0f57: stloc.s 7
+		IL_0f59: ldnull
+		IL_0f5a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0f60: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0f65: ldnull
+		IL_0f66: ldstr "Uncompiled Object Empty Replace"
+		IL_0f6b: ldloc.s 7
+		IL_0f6d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0f72: pop
+		IL_0f73: ldnull
+		IL_0f74: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(object[], object)
+		IL_0f7a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0f7f: ldc.i4.1
+		IL_0f80: newarr [System.Runtime]System.Object
+		IL_0f85: dup
+		IL_0f86: ldc.i4.0
+		IL_0f87: ldloc.0
+		IL_0f88: stelem.ref
+		IL_0f89: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0f8e: stloc.s 7
+		IL_0f90: ldnull
+		IL_0f91: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0f97: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0f9c: ldnull
+		IL_0f9d: ldloc.s 7
+		IL_0f9f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+		IL_0fa4: pop
+		IL_0fa5: ldnull
+		IL_0fa6: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(object[], object)
+		IL_0fac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_0fb1: ldc.i4.1
+		IL_0fb2: newarr [System.Runtime]System.Object
+		IL_0fb7: dup
+		IL_0fb8: ldc.i4.0
+		IL_0fb9: ldloc.0
+		IL_0fba: stelem.ref
+		IL_0fbb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+		IL_0fc0: stloc.s 7
+		IL_0fc2: ldnull
+		IL_0fc3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
+		IL_0fc9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0fce: ldnull
+		IL_0fcf: ldstr "Uncompiled Object 12 Char Replace"
+		IL_0fd4: ldloc.s 7
+		IL_0fd6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0fdb: pop
+		IL_0fdc: ldnull
+		IL_0fdd: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
+		IL_0fe3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0fe8: ldnull
+		IL_0fe9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+		IL_0fee: pop
+		IL_0fef: ret
+	} // end of method Compile_Performance_Dromaeo_Object_Regexp::__js_module_init__
+
+} // end of class Modules.Compile_Performance_Dromaeo_Object_Regexp
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x5216
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Compile_Performance_Dromaeo_Object_Regexp::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Js2IL.Tests.csproj
+++ b/Js2IL.Tests/Js2IL.Tests.csproj
@@ -38,6 +38,9 @@
     <EmbeddedResource Include="..\tests\performance\Benchmarks\Scenarios\dromaeo-object-array-modern.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Performance_Dromaeo_Object_Array_Modern.js</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\tests\performance\Benchmarks\Scenarios\dromaeo-object-regexp.js">
+      <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Performance_Dromaeo_Object_Regexp.js</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\tests\performance\PrimeJavaScript.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Performance_PrimeJavaScript.js</LogicalName>
     </EmbeddedResource>


### PR DESCRIPTION
## Summary
- add integration generator test for Compile_Performance_Dromaeo_Object_Regexp
- embed dromaeo-object-regexp.js for the new test logical name
- add verified snapshot for the new generator test

## Validation
- dotnet test Js2IL.Tests\Js2IL.Tests.csproj --filter FullyQualifiedName~Compile_Performance_Dromaeo_Object_Regexp --nologo