### PR TITLE
perf(prime): devirtualize arity member calls with guarded dispatch

### DIFF
--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x218d
+				// Method begins at RVA 0x2189
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2115
+			// Method begins at RVA 0x2111
 			// Header size: 1
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -62,7 +62,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2172
+				// Method begins at RVA 0x216e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217b
+				// Method begins at RVA 0x2177
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2184
+				// Method begins at RVA 0x2180
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -125,7 +125,7 @@
 				object initial
 			) cil managed 
 		{
-			// Method begins at RVA 0x2126
+			// Method begins at RVA 0x2122
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -141,7 +141,7 @@
 		.method public hidebysig 
 			instance object makeGetter () cil managed 
 		{
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x2134
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -177,7 +177,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2169
+			// Method begins at RVA 0x2165
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -203,7 +203,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 185 (0xb9)
+		// Code size: 181 (0xb5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalThis_CreatedInMethod/Scope,
@@ -212,8 +212,8 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] class Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter,
-			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_LexicalThis_CreatedInMethod/Scope::.ctor()
@@ -225,52 +225,50 @@
 		IL_001b: ldloc.s 5
 		IL_001d: stloc.1
 		IL_001e: ldloc.1
-		IL_001f: ldstr "makeGetter"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0029: stloc.s 6
-		IL_002b: ldloc.s 6
-		IL_002d: stloc.2
-		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0033: dup
-		IL_0034: ldstr "x"
-		IL_0039: ldc.r8 99
-		IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0047: dup
-		IL_0048: ldstr "g"
-		IL_004d: ldloc.2
-		IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0053: stloc.s 7
-		IL_0055: ldloc.s 7
-		IL_0057: stloc.3
-		IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_005d: dup
-		IL_005e: ldstr "x"
-		IL_0063: ldc.r8 1
-		IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0071: dup
-		IL_0072: ldstr "g"
-		IL_0077: ldloc.2
-		IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_007d: stloc.s 7
-		IL_007f: ldloc.s 7
-		IL_0081: stloc.s 4
-		IL_0083: ldloc.3
-		IL_0084: ldstr "g"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_008e: stloc.s 6
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0095: ldloc.s 6
-		IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009c: pop
-		IL_009d: ldloc.s 4
-		IL_009f: ldstr "g"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00a9: stloc.s 6
-		IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b0: ldloc.s 6
-		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b7: pop
-		IL_00b8: ret
+		IL_001f: castclass Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter
+		IL_0024: callvirt instance object Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter::makeGetter()
+		IL_0029: stloc.2
+		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_002f: dup
+		IL_0030: ldstr "x"
+		IL_0035: ldc.r8 99
+		IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0043: dup
+		IL_0044: ldstr "g"
+		IL_0049: ldloc.2
+		IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_004f: stloc.s 6
+		IL_0051: ldloc.s 6
+		IL_0053: stloc.3
+		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0059: dup
+		IL_005a: ldstr "x"
+		IL_005f: ldc.r8 1
+		IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_006d: dup
+		IL_006e: ldstr "g"
+		IL_0073: ldloc.2
+		IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0079: stloc.s 6
+		IL_007b: ldloc.s 6
+		IL_007d: stloc.s 4
+		IL_007f: ldloc.3
+		IL_0080: ldstr "g"
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_008a: stloc.s 7
+		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0091: ldloc.s 7
+		IL_0093: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0098: pop
+		IL_0099: ldloc.s 4
+		IL_009b: ldstr "g"
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00a5: stloc.s 7
+		IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ac: ldloc.s 7
+		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b3: pop
+		IL_00b4: ret
 	} // end of method ArrowFunction_LexicalThis_CreatedInMethod::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_CreatedInMethod
@@ -282,7 +280,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2196
+		// Method begins at RVA 0x2192
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ObjectLiteralProperty.verified.txt
+++ b/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ObjectLiteralProperty.verified.txt
@@ -38,7 +38,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x20a5
+			// Method begins at RVA 0x20a3
 			// Header size: 1
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -238,7 +238,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 73 (0x49)
+		// Code size: 71 (0x47)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/Scope,
@@ -259,23 +259,21 @@
 		IL_0015: stloc.2
 		IL_0016: ldloc.2
 		IL_0017: stloc.1
-		IL_0018: ldloc.1
-		IL_0019: ldstr "make"
-		IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0023: stloc.3
-		IL_0024: ldloc.0
-		IL_0025: ldloc.3
-		IL_0026: stfld object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/Scope::someObject
-		IL_002b: ldloc.0
-		IL_002c: ldfld object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/Scope::someObject
-		IL_0031: ldstr "getValue"
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_003b: stloc.3
-		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0041: ldloc.3
-		IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0047: pop
-		IL_0048: ret
+		IL_0018: ldloc.0
+		IL_0019: ldloc.1
+		IL_001a: castclass Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C
+		IL_001f: callvirt instance object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C::make()
+		IL_0024: stfld object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/Scope::someObject
+		IL_0029: ldloc.0
+		IL_002a: ldfld object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/Scope::someObject
+		IL_002f: ldstr "getValue"
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0039: stloc.3
+		IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_003f: ldloc.3
+		IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0045: pop
+		IL_0046: ret
 	} // end of method ArrowFunction_LexicalThis_ObjectLiteralProperty::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty

--- a/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
+++ b/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228a
+				// Method begins at RVA 0x2286
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				object 'value'
 			) cil managed 
 		{
-			// Method begins at RVA 0x2103
+			// Method begins at RVA 0x20ff
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2281
+				// Method begins at RVA 0x227d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -104,7 +104,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2118
+			// Method begins at RVA 0x2114
 			// Header size: 12
 			// Code size: 249 (0xf9)
 			.maxstack 8
@@ -216,7 +216,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2266
+				// Method begins at RVA 0x2262
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -236,7 +236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226f
+				// Method begins at RVA 0x226b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -256,7 +256,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2278
+				// Method begins at RVA 0x2274
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -279,7 +279,7 @@
 				object initial
 			) cil managed 
 		{
-			// Method begins at RVA 0x221d
+			// Method begins at RVA 0x2219
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -295,7 +295,7 @@
 		.method public hidebysig 
 			instance object makeGetter () cil managed 
 		{
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x2228
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -331,7 +331,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x225d
+			// Method begins at RVA 0x2259
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -357,7 +357,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 167 (0xa7)
+		// Code size: 163 (0xa3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ArrowFunction_LexicalThis/Scope,
@@ -365,8 +365,8 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] class Modules.Async_ArrowFunction_LexicalThis/Counter,
-			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] object,
 			[7] object
 		)
 
@@ -379,49 +379,47 @@
 		IL_001b: ldloc.s 4
 		IL_001d: stloc.1
 		IL_001e: ldloc.1
-		IL_001f: ldstr "makeGetter"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0029: stloc.s 5
-		IL_002b: ldloc.s 5
-		IL_002d: stloc.2
-		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0033: dup
-		IL_0034: ldstr "x"
-		IL_0039: ldc.r8 99
-		IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0047: dup
-		IL_0048: ldstr "g"
-		IL_004d: ldloc.2
-		IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0053: stloc.s 6
-		IL_0055: ldloc.s 6
-		IL_0057: stloc.3
-		IL_0058: ldloc.3
-		IL_0059: ldstr "g"
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0063: stloc.s 5
-		IL_0065: ldnull
-		IL_0066: ldftn object Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L23C16::__js_call__(object, object)
-		IL_006c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0071: ldc.i4.1
-		IL_0072: newarr [System.Runtime]System.Object
-		IL_0077: dup
-		IL_0078: ldc.i4.0
-		IL_0079: ldloc.0
-		IL_007a: stelem.ref
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0085: stloc.s 7
-		IL_0087: ldloc.s 5
-		IL_0089: ldstr "then"
-		IL_008e: ldloc.s 7
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0095: pop
-		IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009b: ldstr "After calling async getter"
-		IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a5: pop
-		IL_00a6: ret
+		IL_001f: castclass Modules.Async_ArrowFunction_LexicalThis/Counter
+		IL_0024: callvirt instance object Modules.Async_ArrowFunction_LexicalThis/Counter::makeGetter()
+		IL_0029: stloc.2
+		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_002f: dup
+		IL_0030: ldstr "x"
+		IL_0035: ldc.r8 99
+		IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0043: dup
+		IL_0044: ldstr "g"
+		IL_0049: ldloc.2
+		IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_004f: stloc.s 5
+		IL_0051: ldloc.s 5
+		IL_0053: stloc.3
+		IL_0054: ldloc.3
+		IL_0055: ldstr "g"
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_005f: stloc.s 6
+		IL_0061: ldnull
+		IL_0062: ldftn object Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L23C16::__js_call__(object, object)
+		IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_006d: ldc.i4.1
+		IL_006e: newarr [System.Runtime]System.Object
+		IL_0073: dup
+		IL_0074: ldc.i4.0
+		IL_0075: ldloc.0
+		IL_0076: stelem.ref
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0081: stloc.s 7
+		IL_0083: ldloc.s 6
+		IL_0085: ldstr "then"
+		IL_008a: ldloc.s 7
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0091: pop
+		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0097: ldstr "After calling async getter"
+		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a1: pop
+		IL_00a2: ret
 	} // end of method Async_ArrowFunction_LexicalThis::__js_module_init__
 
 } // end of class Modules.Async_ArrowFunction_LexicalThis
@@ -433,7 +431,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2293
+		// Method begins at RVA 0x228f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
+++ b/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c8
+				// Method begins at RVA 0x22d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				object result
 			) cil managed 
 		{
-			// Method begins at RVA 0x20a7
+			// Method begins at RVA 0x20b2
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ad
+				// Method begins at RVA 0x22b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b6
+				// Method begins at RVA 0x22c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -134,7 +134,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22bf
+				// Method begins at RVA 0x22cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -152,7 +152,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20bb
+			// Method begins at RVA 0x20c6
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -168,7 +168,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x20c4
+			// Method begins at RVA 0x20d0
 			// Header size: 12
 			// Code size: 196 (0xc4)
 			.maxstack 8
@@ -260,7 +260,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2194
+			// Method begins at RVA 0x21a0
 			// Header size: 12
 			// Code size: 260 (0x104)
 			.maxstack 8
@@ -395,7 +395,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x22b0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -421,7 +421,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 75 (0x4b)
+		// Code size: 86 (0x56)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ClassMethod_CallsOtherAsync/Scope,
@@ -438,27 +438,34 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "processData"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0019: stloc.3
-		IL_001a: ldnull
-		IL_001b: ldftn object Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28::__js_call__(object, object)
-		IL_0021: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0026: ldc.i4.1
-		IL_0027: newarr [System.Runtime]System.Object
-		IL_002c: dup
-		IL_002d: ldc.i4.0
-		IL_002e: ldloc.0
-		IL_002f: stelem.ref
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_003a: stloc.s 4
-		IL_003c: ldloc.3
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.s 4
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0049: pop
-		IL_004a: ret
+		IL_000f: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
+		IL_0014: ldc.i4.1
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: dup
+		IL_001b: ldc.i4.0
+		IL_001c: ldloc.0
+		IL_001d: stelem.ref
+		IL_001e: ldnull
+		IL_001f: callvirt instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::processData(object[], object)
+		IL_0024: stloc.3
+		IL_0025: ldnull
+		IL_0026: ldftn object Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28::__js_call__(object, object)
+		IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0031: ldc.i4.1
+		IL_0032: newarr [System.Runtime]System.Object
+		IL_0037: dup
+		IL_0038: ldc.i4.0
+		IL_0039: ldloc.0
+		IL_003a: stelem.ref
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0045: stloc.s 4
+		IL_0047: ldloc.3
+		IL_0048: ldstr "then"
+		IL_004d: ldloc.s 4
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0054: pop
+		IL_0055: ret
 	} // end of method Async_ClassMethod_CallsOtherAsync::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_CallsOtherAsync
@@ -470,7 +477,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22d1
+		// Method begins at RVA 0x22dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
+++ b/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227e
+				// Method begins at RVA 0x2286
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				object result
 			) cil managed 
 		{
-			// Method begins at RVA 0x20d5
+			// Method begins at RVA 0x20e0
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226c
+				// Method begins at RVA 0x2274
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2275
+				// Method begins at RVA 0x227d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,7 +126,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20e9
+			// Method begins at RVA 0x20f4
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -143,7 +143,7 @@
 				object items
 			) cil managed 
 		{
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20fc
 			// Header size: 12
 			// Code size: 355 (0x163)
 			.maxstack 8
@@ -322,7 +322,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2263
+			// Method begins at RVA 0x226b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -348,7 +348,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 121 (0x79)
+		// Code size: 132 (0x84)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ClassMethod_MultipleAwaits/Scope,
@@ -365,37 +365,44 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "process"
-		IL_0014: ldc.i4.2
-		IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_000f: castclass Modules.Async_ClassMethod_MultipleAwaits/Processor
+		IL_0014: ldc.i4.1
+		IL_0015: newarr [System.Runtime]System.Object
 		IL_001a: dup
-		IL_001b: ldc.r8 10
-		IL_0024: box [System.Runtime]System.Double
-		IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_002e: dup
-		IL_002f: ldc.r8 32
-		IL_0038: box [System.Runtime]System.Double
-		IL_003d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0047: stloc.3
-		IL_0048: ldnull
-		IL_0049: ldftn object Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34::__js_call__(object, object)
-		IL_004f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0054: ldc.i4.1
-		IL_0055: newarr [System.Runtime]System.Object
-		IL_005a: dup
-		IL_005b: ldc.i4.0
-		IL_005c: ldloc.0
-		IL_005d: stelem.ref
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0068: stloc.s 4
-		IL_006a: ldloc.3
-		IL_006b: ldstr "then"
-		IL_0070: ldloc.s 4
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0077: pop
-		IL_0078: ret
+		IL_001b: ldc.i4.0
+		IL_001c: ldloc.0
+		IL_001d: stelem.ref
+		IL_001e: ldnull
+		IL_001f: ldc.i4.2
+		IL_0020: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0025: dup
+		IL_0026: ldc.r8 10
+		IL_002f: box [System.Runtime]System.Double
+		IL_0034: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0039: dup
+		IL_003a: ldc.r8 32
+		IL_0043: box [System.Runtime]System.Double
+		IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_004d: callvirt instance object Modules.Async_ClassMethod_MultipleAwaits/Processor::process(object[], object, object)
+		IL_0052: stloc.3
+		IL_0053: ldnull
+		IL_0054: ldftn object Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34::__js_call__(object, object)
+		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_005f: ldc.i4.1
+		IL_0060: newarr [System.Runtime]System.Object
+		IL_0065: dup
+		IL_0066: ldc.i4.0
+		IL_0067: ldloc.0
+		IL_0068: stelem.ref
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0073: stloc.s 4
+		IL_0075: ldloc.3
+		IL_0076: ldstr "then"
+		IL_007b: ldloc.s 4
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0082: pop
+		IL_0083: ret
 	} // end of method Async_ClassMethod_MultipleAwaits::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_MultipleAwaits
@@ -407,7 +414,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2287
+		// Method begins at RVA 0x228f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
+++ b/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d6
+				// Method begins at RVA 0x21e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				object result
 			) cil managed 
 		{
-			// Method begins at RVA 0x20c3
+			// Method begins at RVA 0x20ce
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c4
+				// Method begins at RVA 0x21d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cd
+				// Method begins at RVA 0x21d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +121,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d7
+			// Method begins at RVA 0x20e2
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -139,7 +139,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x20e0
+			// Method begins at RVA 0x20ec
 			// Header size: 12
 			// Code size: 207 (0xcf)
 			.maxstack 8
@@ -248,7 +248,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21bb
+			// Method begins at RVA 0x21c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -274,7 +274,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 103 (0x67)
+		// Code size: 114 (0x72)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ClassMethod_SimpleAwait/Scope,
@@ -291,31 +291,38 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "add"
-		IL_0014: ldc.r8 2
-		IL_001d: box [System.Runtime]System.Double
-		IL_0022: ldc.r8 3
-		IL_002b: box [System.Runtime]System.Double
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0035: stloc.3
-		IL_0036: ldnull
-		IL_0037: ldftn object Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21::__js_call__(object, object)
-		IL_003d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0042: ldc.i4.1
-		IL_0043: newarr [System.Runtime]System.Object
-		IL_0048: dup
-		IL_0049: ldc.i4.0
-		IL_004a: ldloc.0
-		IL_004b: stelem.ref
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.3
-		IL_0059: ldstr "then"
-		IL_005e: ldloc.s 4
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0065: pop
-		IL_0066: ret
+		IL_000f: castclass Modules.Async_ClassMethod_SimpleAwait/Calculator
+		IL_0014: ldc.i4.1
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: dup
+		IL_001b: ldc.i4.0
+		IL_001c: ldloc.0
+		IL_001d: stelem.ref
+		IL_001e: ldnull
+		IL_001f: ldc.r8 2
+		IL_0028: box [System.Runtime]System.Double
+		IL_002d: ldc.r8 3
+		IL_0036: box [System.Runtime]System.Double
+		IL_003b: callvirt instance object Modules.Async_ClassMethod_SimpleAwait/Calculator::'add'(object[], object, object, object)
+		IL_0040: stloc.3
+		IL_0041: ldnull
+		IL_0042: ldftn object Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21::__js_call__(object, object)
+		IL_0048: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_004d: ldc.i4.1
+		IL_004e: newarr [System.Runtime]System.Object
+		IL_0053: dup
+		IL_0054: ldc.i4.0
+		IL_0055: ldloc.0
+		IL_0056: stelem.ref
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0061: stloc.s 4
+		IL_0063: ldloc.3
+		IL_0064: ldstr "then"
+		IL_0069: ldloc.s 4
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0070: pop
+		IL_0071: ret
 	} // end of method Async_ClassMethod_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_SimpleAwait
@@ -327,7 +334,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21df
+		// Method begins at RVA 0x21eb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
+++ b/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d2
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				object 'value'
 			) cil managed 
 		{
-			// Method begins at RVA 0x20a7
+			// Method begins at RVA 0x20b2
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b7
+				// Method begins at RVA 0x21c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c0
+				// Method begins at RVA 0x21cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -123,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c9
+				// Method begins at RVA 0x21d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +144,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20bb
+			// Method begins at RVA 0x20c6
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -163,7 +163,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x20d4
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 206 (0xce)
 			.maxstack 8
@@ -260,7 +260,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ae
+			// Method begins at RVA 0x21ba
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -286,7 +286,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 75 (0x4b)
+		// Code size: 86 (0x56)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ClassMethod_WithThis/Scope,
@@ -303,27 +303,34 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "getCount"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0019: stloc.3
-		IL_001a: ldnull
-		IL_001b: ldftn object Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25::__js_call__(object, object)
-		IL_0021: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0026: ldc.i4.1
-		IL_0027: newarr [System.Runtime]System.Object
-		IL_002c: dup
-		IL_002d: ldc.i4.0
-		IL_002e: ldloc.0
-		IL_002f: stelem.ref
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_003a: stloc.s 4
-		IL_003c: ldloc.3
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.s 4
-		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0049: pop
-		IL_004a: ret
+		IL_000f: castclass Modules.Async_ClassMethod_WithThis/Counter
+		IL_0014: ldc.i4.1
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: dup
+		IL_001b: ldc.i4.0
+		IL_001c: ldloc.0
+		IL_001d: stelem.ref
+		IL_001e: ldnull
+		IL_001f: callvirt instance object Modules.Async_ClassMethod_WithThis/Counter::getCount(object[], object)
+		IL_0024: stloc.3
+		IL_0025: ldnull
+		IL_0026: ldftn object Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25::__js_call__(object, object)
+		IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0031: ldc.i4.1
+		IL_0032: newarr [System.Runtime]System.Object
+		IL_0037: dup
+		IL_0038: ldc.i4.0
+		IL_0039: ldloc.0
+		IL_003a: stelem.ref
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0045: stloc.s 4
+		IL_0047: ldloc.3
+		IL_0048: ldstr "then"
+		IL_004d: ldloc.s 4
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0054: pop
+		IL_0055: ret
 	} // end of method Async_ClassMethod_WithThis::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_WithThis
@@ -335,7 +342,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21db
+		// Method begins at RVA 0x21e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
+++ b/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a8
+				// Method begins at RVA 0x22b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				object result
 			) cil managed 
 		{
-			// Method begins at RVA 0x20a3
+			// Method begins at RVA 0x20a9
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2284
+				// Method begins at RVA 0x228c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228d
+				// Method begins at RVA 0x2295
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +121,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20b7
+			// Method begins at RVA 0x20bd
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -138,7 +138,7 @@
 				object x
 			) cil managed 
 		{
-			// Method begins at RVA 0x20c8
+			// Method begins at RVA 0x20d0
 			// Header size: 12
 			// Code size: 209 (0xd1)
 			.maxstack 8
@@ -247,7 +247,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2296
+				// Method begins at RVA 0x229e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -277,7 +277,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229f
+				// Method begins at RVA 0x22a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -295,7 +295,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20bf
+			// Method begins at RVA 0x20c5
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -311,7 +311,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x21a8
+			// Method begins at RVA 0x21b0
 			// Header size: 12
 			// Code size: 199 (0xc7)
 			.maxstack 8
@@ -409,7 +409,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227b
+			// Method begins at RVA 0x2283
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -435,7 +435,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 71 (0x47)
+		// Code size: 77 (0x4d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_Inheritance_SuperAsyncMethod/Scope,
@@ -449,27 +449,33 @@
 		IL_0006: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/Derived::.ctor()
 		IL_000b: stloc.1
 		IL_000c: ldloc.1
-		IL_000d: ldstr "run"
-		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0017: stloc.2
-		IL_0018: ldnull
-		IL_0019: ldftn object Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26::__js_call__(object, object)
-		IL_001f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0024: ldc.i4.1
-		IL_0025: newarr [System.Runtime]System.Object
-		IL_002a: dup
-		IL_002b: ldc.i4.0
-		IL_002c: ldloc.0
-		IL_002d: stelem.ref
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0038: stloc.3
-		IL_0039: ldloc.2
-		IL_003a: ldstr "then"
-		IL_003f: ldloc.3
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0045: pop
-		IL_0046: ret
+		IL_000d: ldc.i4.1
+		IL_000e: newarr [System.Runtime]System.Object
+		IL_0013: dup
+		IL_0014: ldc.i4.0
+		IL_0015: ldloc.0
+		IL_0016: stelem.ref
+		IL_0017: ldnull
+		IL_0018: callvirt instance object Modules.Async_Inheritance_SuperAsyncMethod/Derived::run(object[], object)
+		IL_001d: stloc.2
+		IL_001e: ldnull
+		IL_001f: ldftn object Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26::__js_call__(object, object)
+		IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.0
+		IL_0033: stelem.ref
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_003e: stloc.3
+		IL_003f: ldloc.2
+		IL_0040: ldstr "then"
+		IL_0045: ldloc.3
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_004b: pop
+		IL_004c: ret
 	} // end of method Async_Inheritance_SuperAsyncMethod::__js_module_init__
 
 } // end of class Modules.Async_Inheritance_SuperAsyncMethod
@@ -481,7 +487,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b1
+		// Method begins at RVA 0x22b9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddDynamicThenToNumber_StringPreserved.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddDynamicThenToNumber_StringPreserved.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20e3
+				// Method begins at RVA 0x20eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20ec
+				// Method begins at RVA 0x20f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ae
+			// Method begins at RVA 0x20b8
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -71,7 +71,7 @@
 				object 'value'
 			) cil managed 
 		{
-			// Method begins at RVA 0x20b8
+			// Method begins at RVA 0x20c0
 			// Header size: 12
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -101,7 +101,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20da
+			// Method begins at RVA 0x20e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -127,7 +127,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 82 (0x52)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Scope,
@@ -143,25 +143,27 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "addAndCoerce"
+		IL_000f: castclass Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator
 		IL_0014: ldstr "2"
-		IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_001e: stloc.3
-		IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0024: ldloc.3
-		IL_0025: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_002a: pop
-		IL_002b: ldloc.1
-		IL_002c: ldstr "addAndCoerce"
-		IL_0031: ldc.r8 2
-		IL_003a: box [System.Runtime]System.Double
-		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0044: stloc.3
-		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004a: ldloc.3
-		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0050: pop
-		IL_0051: ret
+		IL_0019: callvirt instance float64 Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator::addAndCoerce(object)
+		IL_001e: box [System.Runtime]System.Double
+		IL_0023: stloc.3
+		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0029: ldloc.3
+		IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_002f: pop
+		IL_0030: ldloc.1
+		IL_0031: castclass Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator
+		IL_0036: ldc.r8 2
+		IL_003f: box [System.Runtime]System.Double
+		IL_0044: callvirt instance float64 Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator::addAndCoerce(object)
+		IL_0049: box [System.Runtime]System.Double
+		IL_004e: stloc.3
+		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0054: ldloc.3
+		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005a: pop
+		IL_005b: ret
 	} // end of method BinaryOperator_AddDynamicThenToNumber_StringPreserved::__js_module_init__
 
 } // end of class Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved
@@ -173,7 +175,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f5
+		// Method begins at RVA 0x20fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualMethodReturn.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualMethodReturn.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212a
+				// Method begins at RVA 0x212b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2133
+				// Method begins at RVA 0x2134
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x210e
+			// Method begins at RVA 0x210f
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -69,7 +69,7 @@
 		.method public hidebysig 
 			instance float64 getValue () cil managed 
 		{
-			// Method begins at RVA 0x2116
+			// Method begins at RVA 0x2117
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -87,7 +87,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2121
+			// Method begins at RVA 0x2122
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -113,7 +113,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 178 (0xb2)
+		// Code size: 179 (0xb3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_EqualMethodReturn/Scope,
@@ -122,9 +122,8 @@
 			[3] float64,
 			[4] class Modules.BinaryOperator_EqualMethodReturn/TestClass,
 			[5] object,
-			[6] object,
-			[7] bool,
-			[8] object
+			[6] bool,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_EqualMethodReturn/Scope::.ctor()
@@ -134,59 +133,58 @@
 		IL_000d: ldloc.s 4
 		IL_000f: stloc.1
 		IL_0010: ldloc.1
-		IL_0011: ldstr "getValue"
-		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_001b: stloc.s 5
-		IL_001d: ldloc.s 5
-		IL_001f: stloc.2
-		IL_0020: ldc.r8 4
-		IL_0029: stloc.3
-		IL_002a: ldloc.3
-		IL_002b: box [System.Runtime]System.Double
-		IL_0030: stloc.s 6
-		IL_0032: ldloc.2
-		IL_0033: ldloc.s 6
-		IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-		IL_003a: stloc.s 7
-		IL_003c: ldloc.s 7
-		IL_003e: box [System.Runtime]System.Boolean
-		IL_0043: stloc.s 8
-		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004a: ldstr "methodResult == literalValue:"
-		IL_004f: ldloc.s 8
-		IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0056: pop
-		IL_0057: ldloc.3
-		IL_0058: box [System.Runtime]System.Double
-		IL_005d: stloc.s 6
-		IL_005f: ldloc.s 6
-		IL_0061: ldloc.2
-		IL_0062: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-		IL_0067: stloc.s 7
-		IL_0069: ldloc.s 7
-		IL_006b: box [System.Runtime]System.Boolean
-		IL_0070: stloc.s 8
-		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0077: ldstr "literalValue == methodResult:"
-		IL_007c: ldloc.s 8
-		IL_007e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0083: pop
-		IL_0084: ldloc.3
-		IL_0085: box [System.Runtime]System.Double
-		IL_008a: stloc.s 6
-		IL_008c: ldloc.2
-		IL_008d: ldloc.s 6
-		IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0094: stloc.s 7
-		IL_0096: ldloc.s 7
-		IL_0098: box [System.Runtime]System.Boolean
-		IL_009d: stloc.s 8
-		IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a4: ldstr "methodResult === literalValue:"
-		IL_00a9: ldloc.s 8
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b0: pop
-		IL_00b1: ret
+		IL_0011: castclass Modules.BinaryOperator_EqualMethodReturn/TestClass
+		IL_0016: callvirt instance float64 Modules.BinaryOperator_EqualMethodReturn/TestClass::getValue()
+		IL_001b: box [System.Runtime]System.Double
+		IL_0020: stloc.2
+		IL_0021: ldc.r8 4
+		IL_002a: stloc.3
+		IL_002b: ldloc.3
+		IL_002c: box [System.Runtime]System.Double
+		IL_0031: stloc.s 5
+		IL_0033: ldloc.2
+		IL_0034: ldloc.s 5
+		IL_0036: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+		IL_003b: stloc.s 6
+		IL_003d: ldloc.s 6
+		IL_003f: box [System.Runtime]System.Boolean
+		IL_0044: stloc.s 7
+		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004b: ldstr "methodResult == literalValue:"
+		IL_0050: ldloc.s 7
+		IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0057: pop
+		IL_0058: ldloc.3
+		IL_0059: box [System.Runtime]System.Double
+		IL_005e: stloc.s 5
+		IL_0060: ldloc.s 5
+		IL_0062: ldloc.2
+		IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+		IL_0068: stloc.s 6
+		IL_006a: ldloc.s 6
+		IL_006c: box [System.Runtime]System.Boolean
+		IL_0071: stloc.s 7
+		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0078: ldstr "literalValue == methodResult:"
+		IL_007d: ldloc.s 7
+		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0084: pop
+		IL_0085: ldloc.3
+		IL_0086: box [System.Runtime]System.Double
+		IL_008b: stloc.s 5
+		IL_008d: ldloc.2
+		IL_008e: ldloc.s 5
+		IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0095: stloc.s 6
+		IL_0097: ldloc.s 6
+		IL_0099: box [System.Runtime]System.Boolean
+		IL_009e: stloc.s 7
+		IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a5: ldstr "methodResult === literalValue:"
+		IL_00aa: ldloc.s 7
+		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b1: pop
+		IL_00b2: ret
 	} // end of method BinaryOperator_EqualMethodReturn::__js_module_init__
 
 } // end of class Modules.BinaryOperator_EqualMethodReturn
@@ -198,7 +196,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213c
+		// Method begins at RVA 0x213d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualObjectPropertyVsMethodReturn.verified.txt
+++ b/Js2IL.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualObjectPropertyVsMethodReturn.verified.txt
@@ -193,7 +193,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 163 (0xa3)
+		// Code size: 164 (0xa4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Scope,
@@ -202,9 +202,8 @@
 			[3] object,
 			[4] object,
 			[5] class Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter,
-			[6] object,
-			[7] bool,
-			[8] object
+			[6] bool,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Scope::.ctor()
@@ -230,35 +229,34 @@
 		IL_0045: ldloc.s 5
 		IL_0047: stloc.2
 		IL_0048: ldloc.2
-		IL_0049: ldstr "count"
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0053: stloc.s 6
-		IL_0055: ldloc.s 6
-		IL_0057: stloc.3
-		IL_0058: ldloc.1
-		IL_0059: ldc.r8 10
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-		IL_0067: stloc.s 4
-		IL_0069: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006e: ldloc.3
-		IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0074: pop
-		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007a: ldloc.s 4
-		IL_007c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0081: pop
-		IL_0082: ldloc.3
-		IL_0083: ldloc.s 4
-		IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-		IL_008a: stloc.s 7
-		IL_008c: ldloc.s 7
-		IL_008e: box [System.Runtime]System.Boolean
-		IL_0093: stloc.s 8
-		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009a: ldloc.s 8
-		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a1: pop
-		IL_00a2: ret
+		IL_0049: castclass Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter
+		IL_004e: callvirt instance float64 Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter::count()
+		IL_0053: box [System.Runtime]System.Double
+		IL_0058: stloc.3
+		IL_0059: ldloc.1
+		IL_005a: ldc.r8 10
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_0068: stloc.s 4
+		IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006f: ldloc.3
+		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0075: pop
+		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007b: ldloc.s 4
+		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0082: pop
+		IL_0083: ldloc.3
+		IL_0084: ldloc.s 4
+		IL_0086: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+		IL_008b: stloc.s 6
+		IL_008d: ldloc.s 6
+		IL_008f: box [System.Runtime]System.Boolean
+		IL_0094: stloc.s 7
+		IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009b: ldloc.s 7
+		IL_009d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a2: pop
+		IL_00a3: ret
 	} // end of method BinaryOperator_EqualObjectPropertyVsMethodReturn::__js_module_init__
 
 } // end of class Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_BitShiftInCtor_Int32Array.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_BitShiftInCtor_Int32Array.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21bb
+				// Method begins at RVA 0x21bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c4
+				// Method begins at RVA 0x21c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cd
+				// Method begins at RVA 0x21d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d6
+				// Method begins at RVA 0x21da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 				object n
 			) cil managed 
 		{
-			// Method begins at RVA 0x20bc
+			// Method begins at RVA 0x20c0
 			// Header size: 12
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -140,7 +140,7 @@
 				object i
 			) cil managed 
 		{
-			// Method begins at RVA 0x2104
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -193,7 +193,7 @@
 				object i
 			) cil managed 
 		{
-			// Method begins at RVA 0x2158
+			// Method begins at RVA 0x215c
 			// Header size: 12
 			// Code size: 78 (0x4e)
 			.maxstack 8
@@ -257,7 +257,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b2
+			// Method begins at RVA 0x21b6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -283,7 +283,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 93 (0x5d)
+		// Code size: 98 (0x62)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_BitShiftInCtor_Int32Array/Scope,
@@ -301,22 +301,23 @@
 		IL_001a: ldloc.2
 		IL_001b: stloc.1
 		IL_001c: ldloc.1
-		IL_001d: ldstr "set"
+		IL_001d: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
 		IL_0022: ldc.r8 1
 		IL_002b: box [System.Runtime]System.Double
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0030: callvirt instance object Modules.Classes_BitShiftInCtor_Int32Array/BitBag::set(object)
 		IL_0035: pop
 		IL_0036: ldloc.1
-		IL_0037: ldstr "test"
+		IL_0037: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
 		IL_003c: ldc.r8 1
 		IL_0045: box [System.Runtime]System.Double
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_004f: stloc.3
-		IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0055: ldloc.3
-		IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005b: pop
-		IL_005c: ret
+		IL_004a: callvirt instance float64 Modules.Classes_BitShiftInCtor_Int32Array/BitBag::test(object)
+		IL_004f: box [System.Runtime]System.Double
+		IL_0054: stloc.3
+		IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_005a: ldloc.3
+		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0060: pop
+		IL_0061: ret
 	} // end of method Classes_BitShiftInCtor_Int32Array::__js_module_init__
 
 } // end of class Modules.Classes_BitShiftInCtor_Int32Array
@@ -328,7 +329,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21df
+		// Method begins at RVA 0x21e3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
@@ -162,8 +162,8 @@
 		IL_0011: ldloc.2
 		IL_0012: stloc.1
 		IL_0013: ldloc.1
-		IL_0014: ldstr "sayName"
-		IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0014: castclass Modules.Classes_ClassConstructor_Param_Field_Log/Greeter
+		IL_0019: callvirt instance object Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::sayName()
 		IL_001e: pop
 		IL_001f: ret
 	} // end of method Classes_ClassConstructor_Param_Field_Log::__js_module_init__

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_ParameterDestructuring.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_ParameterDestructuring.verified.txt
@@ -670,8 +670,8 @@
 		IL_00cd: ldloc.s 9
 		IL_00cf: stloc.3
 		IL_00d0: ldloc.3
-		IL_00d1: ldstr "greet"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00d1: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Person
+		IL_00d6: callvirt instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Person::greet()
 		IL_00db: pop
 		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_00e1: dup
@@ -691,8 +691,8 @@
 		IL_011c: ldloc.s 9
 		IL_011e: stloc.s 4
 		IL_0120: ldloc.s 4
-		IL_0122: ldstr "greet"
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0122: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Person
+		IL_0127: callvirt instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Person::greet()
 		IL_012c: pop
 		IL_012d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0132: dup

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_AddMethod.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_AddMethod.verified.txt
@@ -182,16 +182,16 @@
 		IL_003a: ldloc.3
 		IL_003b: stloc.2
 		IL_003c: ldloc.1
-		IL_003d: ldstr "add"
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_003d: castclass Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder
+		IL_0042: callvirt instance object Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder::'add'()
 		IL_0047: stloc.s 4
 		IL_0049: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_004e: ldloc.s 4
 		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0055: pop
 		IL_0056: ldloc.2
-		IL_0057: ldstr "add"
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: castclass Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder
+		IL_005c: callvirt instance object Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder::'add'()
 		IL_0061: stloc.s 4
 		IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0068: ldloc.s 4

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_SubtractMethod.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_SubtractMethod.verified.txt
@@ -193,16 +193,16 @@
 		IL_003a: ldloc.3
 		IL_003b: stloc.2
 		IL_003c: ldloc.1
-		IL_003d: ldstr "sub"
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_003d: castclass Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber
+		IL_0042: callvirt instance object Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber::'sub'()
 		IL_0047: stloc.s 4
 		IL_0049: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_004e: ldloc.s 4
 		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0055: pop
 		IL_0056: ldloc.2
-		IL_0057: ldstr "sub"
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: castclass Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber
+		IL_005c: callvirt instance object Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber::'sub'()
 		IL_0061: stloc.s 4
 		IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0068: ldloc.s 4

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
@@ -173,12 +173,12 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "increment"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_000f: castclass Modules.Classes_ClassFieldTypeInference_Primitives/Counter
+		IL_0014: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
 		IL_0019: pop
 		IL_001a: ldloc.1
-		IL_001b: ldstr "increment"
-		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_001b: castclass Modules.Classes_ClassFieldTypeInference_Primitives/Counter
+		IL_0020: callvirt instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
 		IL_0025: pop
 		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002b: ldloc.1

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -183,8 +183,8 @@
 			IL_0027: ldloc.2
 			IL_0028: stloc.1
 			IL_0029: ldloc.1
-			IL_002a: ldstr "logValues"
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_002a: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
+			IL_002f: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
 			IL_0034: pop
 			IL_0035: ldnull
 			IL_0036: ret

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -174,8 +174,8 @@
 			IL_0027: ldloc.2
 			IL_0028: stloc.1
 			IL_0029: ldloc.1
-			IL_002a: ldstr "logValue"
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_002a: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
+			IL_002f: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
 			IL_0034: pop
 			IL_0035: ldnull
 			IL_0036: ret

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -183,8 +183,8 @@
 			IL_0027: ldloc.2
 			IL_0028: stloc.1
 			IL_0029: ldloc.1
-			IL_002a: ldstr "logValues"
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_002a: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
+			IL_002f: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
 			IL_0034: pop
 			IL_0035: ldnull
 			IL_0036: ret

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -174,8 +174,8 @@
 			IL_0027: ldloc.2
 			IL_0028: stloc.1
 			IL_0029: ldloc.1
-			IL_002a: ldstr "logValue"
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_002a: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
+			IL_002f: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
 			IL_0034: pop
 			IL_0035: ldnull
 			IL_0036: ret

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
@@ -167,8 +167,8 @@
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
 		IL_0023: ldloc.1
-		IL_0024: ldstr "logGlobal"
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0024: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
+		IL_0029: callvirt instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
 		IL_002e: pop
 		IL_002f: ret
 	} // end of method Classes_ClassMethod_AccessGlobalVariable_Log::__js_module_init__

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
@@ -243,8 +243,8 @@
 		IL_0011: ldloc.2
 		IL_0012: stloc.1
 		IL_0013: ldloc.1
-		IL_0014: ldstr "logHello"
-		IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0014: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+		IL_0019: callvirt instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::logHello()
 		IL_001e: pop
 		IL_001f: ret
 	} // end of method Classes_ClassMethod_CallsAnotherMethod::__js_module_init__

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
@@ -332,14 +332,14 @@
 		IL_0026: ldloc.3
 		IL_0027: stloc.1
 		IL_0028: ldloc.1
-		IL_0029: ldstr "addRange"
+		IL_0029: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
 		IL_002e: ldc.r8 5
 		IL_0037: box [System.Runtime]System.Double
-		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_003c: callvirt instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::addRange(object)
 		IL_0041: pop
 		IL_0042: ldloc.1
-		IL_0043: ldstr "log"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0043: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+		IL_0048: callvirt instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::log()
 		IL_004d: pop
 		IL_004e: ret
 	} // end of method Classes_ClassMethod_ForLoop_CallsAnotherMethod::__js_module_init__

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
@@ -220,50 +220,48 @@
 		{
 			// Method begins at RVA 0x20d8
 			// Header size: 12
-			// Code size: 102 (0x66)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] float64,
-				[4] object
+				[2] float64,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 1
 			IL_0009: stloc.0
 			IL_000a: ldarg.0
 			IL_000b: ldfld class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::counter
-			IL_0010: ldstr "getNext"
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_001a: stloc.2
-			IL_001b: ldloc.2
-			IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0021: stloc.3
-			IL_0022: ldloc.3
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: box [System.Runtime]System.Double
-			IL_002a: stloc.s 4
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0031: ldstr "factor after getNext:"
-			IL_0036: ldloc.s 4
-			IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_003d: pop
-			IL_003e: ldloc.0
-			IL_003f: ldc.r8 2
-			IL_0048: mul
-			IL_0049: stloc.1
-			IL_004a: ldloc.1
-			IL_004b: box [System.Runtime]System.Double
-			IL_0050: stloc.s 4
+			IL_0010: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
+			IL_0015: callvirt instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter::getNext()
+			IL_001a: box [System.Runtime]System.Double
+			IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0024: stloc.2
+			IL_0025: ldloc.2
+			IL_0026: stloc.0
+			IL_0027: ldloc.0
+			IL_0028: box [System.Runtime]System.Double
+			IL_002d: stloc.3
+			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0033: ldstr "factor after getNext:"
+			IL_0038: ldloc.3
+			IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_003e: pop
+			IL_003f: ldloc.0
+			IL_0040: ldc.r8 2
+			IL_0049: mul
+			IL_004a: stloc.1
+			IL_004b: ldloc.1
+			IL_004c: box [System.Runtime]System.Double
+			IL_0051: stloc.3
 			IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0057: ldstr "result:"
-			IL_005c: ldloc.s 4
-			IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0063: pop
-			IL_0064: ldloc.1
-			IL_0065: ret
+			IL_005c: ldloc.3
+			IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0062: pop
+			IL_0063: ldloc.1
+			IL_0064: ret
 		} // end of method Calculator::compute
 
 	} // end of class Calculator
@@ -308,14 +306,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 58 (0x3a)
+		// Code size: 59 (0x3b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope,
 			[1] object,
 			[2] object,
-			[3] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator,
-			[4] object
+			[3] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope::.ctor()
@@ -331,17 +328,16 @@
 		IL_0016: ldloc.3
 		IL_0017: stloc.1
 		IL_0018: ldloc.1
-		IL_0019: ldstr "compute"
-		IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0023: stloc.s 4
-		IL_0025: ldloc.s 4
-		IL_0027: stloc.2
-		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002d: ldstr "final output:"
-		IL_0032: ldloc.2
-		IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0038: pop
-		IL_0039: ret
+		IL_0019: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+		IL_001e: callvirt instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
+		IL_0023: box [System.Runtime]System.Double
+		IL_0028: stloc.2
+		IL_0029: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_002e: ldstr "final output:"
+		IL_0033: ldloc.2
+		IL_0034: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0039: pop
+		IL_003a: ret
 	} // end of method Classes_ClassMethod_LocalVar_ReassignedFromMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterDestructuring.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterDestructuring.verified.txt
@@ -658,7 +658,7 @@
 		IL_000d: ldloc.s 4
 		IL_000f: stloc.1
 		IL_0010: ldloc.1
-		IL_0011: ldstr "add"
+		IL_0011: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
 		IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_001b: dup
 		IL_001c: ldstr "a"
@@ -668,14 +668,14 @@
 		IL_0030: ldstr "b"
 		IL_0035: ldc.r8 3
 		IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0043: callvirt instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::'add'(object)
 		IL_0048: stloc.s 5
 		IL_004a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_004f: ldloc.s 5
 		IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0056: pop
 		IL_0057: ldloc.1
-		IL_0058: ldstr "multiply"
+		IL_0058: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
 		IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0062: dup
 		IL_0063: ldstr "x"
@@ -685,7 +685,7 @@
 		IL_0077: ldstr "y"
 		IL_007c: ldc.r8 7
 		IL_0085: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008a: callvirt instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::multiply(object)
 		IL_008f: stloc.s 5
 		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0096: ldloc.s 5
@@ -696,7 +696,7 @@
 		IL_00a5: ldloc.s 6
 		IL_00a7: stloc.2
 		IL_00a8: ldloc.2
-		IL_00a9: ldstr "formatPerson"
+		IL_00a9: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
 		IL_00ae: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_00b3: dup
 		IL_00b4: ldstr "name"
@@ -710,14 +710,14 @@
 		IL_00d8: ldstr "city"
 		IL_00dd: ldstr "Seattle"
 		IL_00e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e7: callvirt instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatPerson(object)
 		IL_00ec: stloc.s 5
 		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00f3: ldloc.s 5
 		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_00fa: pop
 		IL_00fb: ldloc.2
-		IL_00fc: ldstr "formatDate"
+		IL_00fc: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
 		IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0106: dup
 		IL_0107: ldstr "year"
@@ -731,7 +731,7 @@
 		IL_012f: ldstr "day"
 		IL_0134: ldc.r8 30
 		IL_013d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0142: callvirt instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatDate(object)
 		IL_0147: stloc.s 5
 		IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_014e: ldloc.s 5
@@ -742,20 +742,20 @@
 		IL_015d: ldloc.s 7
 		IL_015f: stloc.3
 		IL_0160: ldloc.3
-		IL_0161: ldstr "setConnection"
+		IL_0161: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Config
 		IL_0166: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_016b: dup
 		IL_016c: ldstr "host"
 		IL_0171: ldstr "example.com"
 		IL_0176: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_017b: callvirt instance object Modules.Classes_ClassMethod_ParameterDestructuring/Config::setConnection(object)
 		IL_0180: stloc.s 5
 		IL_0182: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0187: ldloc.s 5
 		IL_0189: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_018e: pop
 		IL_018f: ldloc.3
-		IL_0190: ldstr "setConnection"
+		IL_0190: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Config
 		IL_0195: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_019a: dup
 		IL_019b: ldstr "host"
@@ -769,16 +769,16 @@
 		IL_01bf: ldstr "secure"
 		IL_01c4: ldc.i4.1
 		IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01ca: callvirt instance object Modules.Classes_ClassMethod_ParameterDestructuring/Config::setConnection(object)
 		IL_01cf: stloc.s 5
 		IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_01d6: ldloc.s 5
 		IL_01d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_01dd: pop
 		IL_01de: ldloc.3
-		IL_01df: ldstr "setConnection"
+		IL_01df: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Config
 		IL_01e4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01e9: callvirt instance object Modules.Classes_ClassMethod_ParameterDestructuring/Config::setConnection(object)
 		IL_01ee: stloc.s 5
 		IL_01f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_01f5: ldloc.s 5

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ReturnsThis_IsSelf_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ReturnsThis_IsSelf_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20b3
+				// Method begins at RVA 0x20ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20bc
+				// Method begins at RVA 0x20b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x209f
+			// Method begins at RVA 0x2099
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -69,7 +69,7 @@
 		.method public hidebysig 
 			instance class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self isSelf () cil managed 
 		{
-			// Method begins at RVA 0x20a7
+			// Method begins at RVA 0x20a1
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -87,7 +87,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20aa
+			// Method begins at RVA 0x20a4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -113,15 +113,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 67 (0x43)
+		// Code size: 61 (0x3d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Scope,
 			[1] object,
 			[2] class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self,
-			[3] object,
-			[4] bool,
-			[5] object
+			[3] bool,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Scope::.ctor()
@@ -131,26 +130,24 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "isSelf"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0019: stloc.3
-		IL_001a: ldloc.3
-		IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_0020: ldc.i4.0
-		IL_0021: ceq
-		IL_0023: stloc.s 4
-		IL_0025: ldloc.s 4
-		IL_0027: ldc.i4.0
-		IL_0028: ceq
-		IL_002a: stloc.s 4
-		IL_002c: ldloc.s 4
-		IL_002e: box [System.Runtime]System.Boolean
-		IL_0033: stloc.s 5
-		IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003a: ldloc.s 5
-		IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0041: pop
-		IL_0042: ret
+		IL_000f: castclass Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self
+		IL_0014: callvirt instance class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self::isSelf()
+		IL_0019: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_001e: ldc.i4.0
+		IL_001f: ceq
+		IL_0021: stloc.3
+		IL_0022: ldloc.3
+		IL_0023: ldc.i4.0
+		IL_0024: ceq
+		IL_0026: stloc.3
+		IL_0027: ldloc.3
+		IL_0028: box [System.Runtime]System.Boolean
+		IL_002d: stloc.s 4
+		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0034: ldloc.s 4
+		IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_003b: pop
+		IL_003c: ret
 	} // end of method Classes_ClassMethod_ReturnsThis_IsSelf_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log
@@ -162,7 +159,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c5
+		// Method begins at RVA 0x20bf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
@@ -172,10 +172,10 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "run"
+		IL_000f: castclass Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter
 		IL_0014: ldc.r8 0.0
 		IL_001d: box [System.Runtime]System.Double
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0022: callvirt instance object Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter::run(object)
 		IL_0027: pop
 		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002d: ldstr "Classes_ClassMethod_While_Increment_Param_Postfix"

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Prefix.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Prefix.verified.txt
@@ -172,10 +172,10 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "run"
+		IL_000f: castclass Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter
 		IL_0014: ldc.r8 0.0
 		IL_001d: box [System.Runtime]System.Double
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0022: callvirt instance object Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter::run(object)
 		IL_0027: pop
 		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002d: ldstr "Classes_ClassMethod_While_Increment_Param_Prefix"

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Postfix.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Postfix.verified.txt
@@ -171,10 +171,10 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "run"
+		IL_000f: castclass Modules.Classes_ClassMethod_While_Increment_Postfix/Counter
 		IL_0014: ldc.r8 3
 		IL_001d: box [System.Runtime]System.Double
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0022: callvirt instance object Modules.Classes_ClassMethod_While_Increment_Postfix/Counter::run(object)
 		IL_0027: pop
 		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002d: ldstr "Classes_ClassMethod_While_Increment_Postfix"

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Prefix.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Prefix.verified.txt
@@ -171,10 +171,10 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "run"
+		IL_000f: castclass Modules.Classes_ClassMethod_While_Increment_Prefix/Counter
 		IL_0014: ldc.r8 3
 		IL_001d: box [System.Runtime]System.Double
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0022: callvirt instance object Modules.Classes_ClassMethod_While_Increment_Prefix/Counter::run(object)
 		IL_0027: pop
 		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002d: ldstr "Classes_ClassMethod_While_Increment_Prefix"

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
@@ -139,8 +139,8 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "logSecret"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_000f: castclass Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+		IL_0014: callvirt instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
 		IL_0019: pop
 		IL_001a: ret
 	} // end of method Classes_ClassPrivateField_HelperMethod_Log::__js_module_init__

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateProperty_HelperMethod_Log.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateProperty_HelperMethod_Log.verified.txt
@@ -139,8 +139,8 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "logSecret"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_000f: castclass Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter
+		IL_0014: callvirt instance object Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter::logSecret()
 		IL_0019: pop
 		IL_001a: ret
 	} // end of method Classes_ClassPrivateProperty_HelperMethod_Log::__js_module_init__

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_HelloWorld.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_HelloWorld.verified.txt
@@ -132,8 +132,8 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "helloWorld"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_000f: castclass Modules.Classes_ClassWithMethod_HelloWorld/Greeter
+		IL_0014: callvirt instance object Modules.Classes_ClassWithMethod_HelloWorld/Greeter::helloWorld()
 		IL_0019: pop
 		IL_001a: ret
 	} // end of method Classes_ClassWithMethod_HelloWorld::__js_module_init__

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Constructor.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Constructor.verified.txt
@@ -499,8 +499,8 @@
 		IL_000f: ldloc.s 9
 		IL_0011: stloc.1
 		IL_0012: ldloc.1
-		IL_0013: ldstr "display"
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0013: castclass Modules.Classes_DefaultParameterValue_Constructor/Person
+		IL_0018: callvirt instance object Modules.Classes_DefaultParameterValue_Constructor/Person::display()
 		IL_001d: pop
 		IL_001e: ldstr "Alice"
 		IL_0023: ldnull
@@ -509,8 +509,8 @@
 		IL_002b: ldloc.s 9
 		IL_002d: stloc.2
 		IL_002e: ldloc.2
-		IL_002f: ldstr "display"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_002f: castclass Modules.Classes_DefaultParameterValue_Constructor/Person
+		IL_0034: callvirt instance object Modules.Classes_DefaultParameterValue_Constructor/Person::display()
 		IL_0039: pop
 		IL_003a: ldstr "Bob"
 		IL_003f: ldc.r8 25
@@ -520,8 +520,8 @@
 		IL_0054: ldloc.s 9
 		IL_0056: stloc.3
 		IL_0057: ldloc.3
-		IL_0058: ldstr "display"
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0058: castclass Modules.Classes_DefaultParameterValue_Constructor/Person
+		IL_005d: callvirt instance object Modules.Classes_DefaultParameterValue_Constructor/Person::display()
 		IL_0062: pop
 		IL_0063: ldc.r8 10
 		IL_006c: box [System.Runtime]System.Double
@@ -532,8 +532,8 @@
 		IL_007a: ldloc.s 10
 		IL_007c: stloc.s 4
 		IL_007e: ldloc.s 4
-		IL_0080: ldstr "volume"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0080: castclass Modules.Classes_DefaultParameterValue_Constructor/Box
+		IL_0085: callvirt instance object Modules.Classes_DefaultParameterValue_Constructor/Box::volume()
 		IL_008a: pop
 		IL_008b: ldc.r8 5
 		IL_0094: box [System.Runtime]System.Double
@@ -545,8 +545,8 @@
 		IL_00af: ldloc.s 10
 		IL_00b1: stloc.s 5
 		IL_00b3: ldloc.s 5
-		IL_00b5: ldstr "volume"
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00b5: castclass Modules.Classes_DefaultParameterValue_Constructor/Box
+		IL_00ba: callvirt instance object Modules.Classes_DefaultParameterValue_Constructor/Box::volume()
 		IL_00bf: pop
 		IL_00c0: ldc.r8 5
 		IL_00c9: box [System.Runtime]System.Double
@@ -559,8 +559,8 @@
 		IL_00f1: ldloc.s 10
 		IL_00f3: stloc.s 6
 		IL_00f5: ldloc.s 6
-		IL_00f7: ldstr "volume"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00f7: castclass Modules.Classes_DefaultParameterValue_Constructor/Box
+		IL_00fc: callvirt instance object Modules.Classes_DefaultParameterValue_Constructor/Box::volume()
 		IL_0101: pop
 		IL_0102: ldc.r8 5
 		IL_010b: box [System.Runtime]System.Double
@@ -570,8 +570,8 @@
 		IL_0118: ldloc.s 11
 		IL_011a: stloc.s 7
 		IL_011c: ldloc.s 7
-		IL_011e: ldstr "area"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_011e: castclass Modules.Classes_DefaultParameterValue_Constructor/Rectangle
+		IL_0123: callvirt instance object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::area()
 		IL_0128: pop
 		IL_0129: ldc.r8 5
 		IL_0132: box [System.Runtime]System.Double
@@ -582,8 +582,8 @@
 		IL_014c: ldloc.s 11
 		IL_014e: stloc.s 8
 		IL_0150: ldloc.s 8
-		IL_0152: ldstr "area"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0152: castclass Modules.Classes_DefaultParameterValue_Constructor/Rectangle
+		IL_0157: callvirt instance object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::area()
 		IL_015c: pop
 		IL_015d: ret
 	} // end of method Classes_DefaultParameterValue_Constructor::__js_module_init__

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Method.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Method.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230d
+				// Method begins at RVA 0x2319
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2316
+				// Method begins at RVA 0x2322
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231f
+				// Method begins at RVA 0x232b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2328
+				// Method begins at RVA 0x2334
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2331
+				// Method begins at RVA 0x233d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +116,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c6
+			// Method begins at RVA 0x21d1
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -132,7 +132,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x21d0
+			// Method begins at RVA 0x21dc
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -166,7 +166,7 @@
 				object z
 			) cil managed 
 		{
-			// Method begins at RVA 0x228c
+			// Method begins at RVA 0x2298
 			// Header size: 12
 			// Code size: 108 (0x6c)
 			.maxstack 8
@@ -220,7 +220,7 @@
 				object name
 			) cil managed 
 		{
-			// Method begins at RVA 0x2258
+			// Method begins at RVA 0x2264
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -253,7 +253,7 @@
 				object c
 			) cil managed 
 		{
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x2214
 			// Header size: 12
 			// Code size: 66 (0x42)
 			.maxstack 8
@@ -297,7 +297,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2304
+			// Method begins at RVA 0x2310
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -323,7 +323,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 362 (0x16a)
+		// Code size: 373 (0x175)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_DefaultParameterValue_Method/Scope,
@@ -338,81 +338,92 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "greet"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0019: pop
-		IL_001a: ldloc.1
-		IL_001b: ldstr "greet"
-		IL_0020: ldstr "Alice"
-		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_002a: pop
-		IL_002b: ldloc.1
-		IL_002c: ldstr "add"
-		IL_0031: ldc.r8 5
-		IL_003a: box [System.Runtime]System.Double
-		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0044: pop
-		IL_0045: ldloc.1
-		IL_0046: ldstr "add"
-		IL_004b: ldc.r8 5
-		IL_0054: box [System.Runtime]System.Double
-		IL_0059: ldc.r8 15
-		IL_0062: box [System.Runtime]System.Double
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_006c: pop
-		IL_006d: ldloc.1
-		IL_006e: ldstr "multiply"
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0078: pop
-		IL_0079: ldloc.1
-		IL_007a: ldstr "multiply"
-		IL_007f: ldc.r8 2
-		IL_0088: box [System.Runtime]System.Double
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0092: pop
-		IL_0093: ldloc.1
-		IL_0094: ldstr "multiply"
-		IL_0099: ldc.r8 2
-		IL_00a2: box [System.Runtime]System.Double
-		IL_00a7: ldc.r8 4
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00ba: pop
-		IL_00bb: ldloc.1
-		IL_00bc: ldstr "multiply"
-		IL_00c1: ldc.r8 2
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: ldc.r8 4
-		IL_00d8: box [System.Runtime]System.Double
-		IL_00dd: ldc.r8 3
-		IL_00e6: box [System.Runtime]System.Double
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00f0: pop
-		IL_00f1: ldloc.1
-		IL_00f2: ldstr "calculate"
-		IL_00f7: ldc.r8 5
-		IL_0100: box [System.Runtime]System.Double
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010a: pop
-		IL_010b: ldloc.1
-		IL_010c: ldstr "calculate"
-		IL_0111: ldc.r8 5
-		IL_011a: box [System.Runtime]System.Double
-		IL_011f: ldc.r8 8
-		IL_0128: box [System.Runtime]System.Double
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0132: pop
-		IL_0133: ldloc.1
-		IL_0134: ldstr "calculate"
-		IL_0139: ldc.r8 5
-		IL_0142: box [System.Runtime]System.Double
-		IL_0147: ldc.r8 8
-		IL_0150: box [System.Runtime]System.Double
-		IL_0155: ldc.r8 20
-		IL_015e: box [System.Runtime]System.Double
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0168: pop
-		IL_0169: ret
+		IL_000f: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_0014: ldnull
+		IL_0015: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::greet(object)
+		IL_001a: pop
+		IL_001b: ldloc.1
+		IL_001c: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_0021: ldstr "Alice"
+		IL_0026: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::greet(object)
+		IL_002b: pop
+		IL_002c: ldloc.1
+		IL_002d: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_0032: ldc.r8 5
+		IL_003b: box [System.Runtime]System.Double
+		IL_0040: ldnull
+		IL_0041: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::'add'(object, object)
+		IL_0046: pop
+		IL_0047: ldloc.1
+		IL_0048: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_004d: ldc.r8 5
+		IL_0056: box [System.Runtime]System.Double
+		IL_005b: ldc.r8 15
+		IL_0064: box [System.Runtime]System.Double
+		IL_0069: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::'add'(object, object)
+		IL_006e: pop
+		IL_006f: ldloc.1
+		IL_0070: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_0075: ldnull
+		IL_0076: ldnull
+		IL_0077: ldnull
+		IL_0078: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::multiply(object, object, object)
+		IL_007d: pop
+		IL_007e: ldloc.1
+		IL_007f: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_0084: ldc.r8 2
+		IL_008d: box [System.Runtime]System.Double
+		IL_0092: ldnull
+		IL_0093: ldnull
+		IL_0094: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::multiply(object, object, object)
+		IL_0099: pop
+		IL_009a: ldloc.1
+		IL_009b: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_00a0: ldc.r8 2
+		IL_00a9: box [System.Runtime]System.Double
+		IL_00ae: ldc.r8 4
+		IL_00b7: box [System.Runtime]System.Double
+		IL_00bc: ldnull
+		IL_00bd: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::multiply(object, object, object)
+		IL_00c2: pop
+		IL_00c3: ldloc.1
+		IL_00c4: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_00c9: ldc.r8 2
+		IL_00d2: box [System.Runtime]System.Double
+		IL_00d7: ldc.r8 4
+		IL_00e0: box [System.Runtime]System.Double
+		IL_00e5: ldc.r8 3
+		IL_00ee: box [System.Runtime]System.Double
+		IL_00f3: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::multiply(object, object, object)
+		IL_00f8: pop
+		IL_00f9: ldloc.1
+		IL_00fa: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_00ff: ldc.r8 5
+		IL_0108: box [System.Runtime]System.Double
+		IL_010d: ldnull
+		IL_010e: ldnull
+		IL_010f: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::calculate(object, object, object)
+		IL_0114: pop
+		IL_0115: ldloc.1
+		IL_0116: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_011b: ldc.r8 5
+		IL_0124: box [System.Runtime]System.Double
+		IL_0129: ldc.r8 8
+		IL_0132: box [System.Runtime]System.Double
+		IL_0137: ldnull
+		IL_0138: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::calculate(object, object, object)
+		IL_013d: pop
+		IL_013e: ldloc.1
+		IL_013f: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+		IL_0144: ldc.r8 5
+		IL_014d: box [System.Runtime]System.Double
+		IL_0152: ldc.r8 8
+		IL_015b: box [System.Runtime]System.Double
+		IL_0160: ldc.r8 20
+		IL_0169: box [System.Runtime]System.Double
+		IL_016e: callvirt instance object Modules.Classes_DefaultParameterValue_Method/Calculator::calculate(object, object, object)
+		IL_0173: pop
+		IL_0174: ret
 	} // end of method Classes_DefaultParameterValue_Method::__js_module_init__
 
 } // end of class Modules.Classes_DefaultParameterValue_Method
@@ -424,7 +435,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x233a
+		// Method begins at RVA 0x2346
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ForLoopMin.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ForLoopMin.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20d3
+				// Method begins at RVA 0x20d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x20e5
+					// Method begins at RVA 0x20e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20dc
+				// Method begins at RVA 0x20e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2083
+			// Method begins at RVA 0x2088
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig 
 			instance float64 run () cil managed 
 		{
-			// Method begins at RVA 0x208c
+			// Method begins at RVA 0x2090
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -133,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ca
+			// Method begins at RVA 0x20ce
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,7 +159,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 39 (0x27)
+		// Code size: 44 (0x2c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ForLoopMin/Scope,
@@ -175,14 +175,15 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "run"
-		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0019: stloc.3
-		IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_001f: ldloc.3
-		IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0025: pop
-		IL_0026: ret
+		IL_000f: castclass Modules.Classes_ForLoopMin/C
+		IL_0014: callvirt instance float64 Modules.Classes_ForLoopMin/C::run()
+		IL_0019: box [System.Runtime]System.Double
+		IL_001e: stloc.3
+		IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0024: ldloc.3
+		IL_0025: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_002a: pop
+		IL_002b: ret
 	} // end of method Classes_ForLoopMin::__js_module_init__
 
 } // end of class Modules.Classes_ForLoopMin
@@ -194,7 +195,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20ee
+		// Method begins at RVA 0x20f2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2117
+					// Method begins at RVA 0x2113
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2120
+					// Method begins at RVA 0x211c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20b6
+				// Method begins at RVA 0x20b1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig 
 				instance object n () cil managed 
 			{
-				// Method begins at RVA 0x20c0
+				// Method begins at RVA 0x20bc
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x210e
+				// Method begins at RVA 0x210a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -127,7 +127,7 @@
 		{
 			// Method begins at RVA 0x207c
 			// Header size: 12
-			// Code size: 38 (0x26)
+			// Code size: 33 (0x21)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/Scope,
@@ -140,15 +140,14 @@
 			IL_0006: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::.ctor()
 			IL_000b: stloc.1
 			IL_000c: ldloc.1
-			IL_000d: ldstr "n"
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0017: stloc.2
-			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_001d: ldloc.2
-			IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0023: pop
-			IL_0024: ldnull
-			IL_0025: ret
+			IL_000d: callvirt instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
+			IL_0012: stloc.2
+			IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0018: ldloc.2
+			IL_0019: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_001e: pop
+			IL_001f: ldnull
+			IL_0020: ret
 		} // end of method makeAndRun::__js_call__
 
 	} // end of class makeAndRun
@@ -164,7 +163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20fc
+				// Method begins at RVA 0x20f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -184,7 +183,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2105
+				// Method begins at RVA 0x2101
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -202,7 +201,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ae
+			// Method begins at RVA 0x20a9
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -215,7 +214,7 @@
 		.method public hidebysig 
 			instance float64 m () cil managed 
 		{
-			// Method begins at RVA 0x20e8
+			// Method begins at RVA 0x20e4
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -241,7 +240,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f3
+			// Method begins at RVA 0x20ef
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -298,7 +297,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2129
+		// Method begins at RVA 0x2125
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2170
+					// Method begins at RVA 0x216c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2179
+					// Method begins at RVA 0x2175
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -65,7 +65,7 @@
 					object[] scopes
 				) cil managed 
 			{
-				// Method begins at RVA 0x20e8
+				// Method begins at RVA 0x20e4
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -86,7 +86,7 @@
 			.method public hidebysig 
 				instance float64 m () cil managed 
 			{
-				// Method begins at RVA 0x2140
+				// Method begins at RVA 0x213c
 				// Header size: 1
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -115,7 +115,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2182
+					// Method begins at RVA 0x217e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -135,7 +135,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218b
+					// Method begins at RVA 0x2187
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 					object[] scopes
 				) cil managed 
 			{
-				// Method begins at RVA 0x2104
+				// Method begins at RVA 0x2100
 				// Header size: 12
 				// Code size: 17 (0x11)
 				.maxstack 8
@@ -180,7 +180,7 @@
 			.method public hidebysig 
 				instance object n () cil managed 
 			{
-				// Method begins at RVA 0x2124
+				// Method begins at RVA 0x2120
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -215,7 +215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2167
+				// Method begins at RVA 0x2163
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -238,7 +238,7 @@
 		{
 			// Method begins at RVA 0x208c
 			// Header size: 12
-			// Code size: 79 (0x4f)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope,
@@ -268,15 +268,14 @@
 			IL_002f: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
 			IL_0034: stloc.1
 			IL_0035: ldloc.1
-			IL_0036: ldstr "n"
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0040: stloc.2
-			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0046: ldloc.2
-			IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_004c: pop
-			IL_004d: ldnull
-			IL_004e: ret
+			IL_0036: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+			IL_003b: stloc.2
+			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0041: ldloc.2
+			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0047: pop
+			IL_0048: ldnull
+			IL_0049: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -295,7 +294,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x215e
+			// Method begins at RVA 0x215a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -363,7 +362,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2194
+		// Method begins at RVA 0x2190
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
+++ b/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b7
+				// Method begins at RVA 0x21a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c0
+				// Method begins at RVA 0x21b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c9
+				// Method begins at RVA 0x21b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d2
+				// Method begins at RVA 0x21c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21db
+				// Method begins at RVA 0x21cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e4
+				// Method begins at RVA 0x21d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -141,7 +141,7 @@
 				object 'value'
 			) cil managed 
 		{
-			// Method begins at RVA 0x2166
+			// Method begins at RVA 0x2156
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -157,7 +157,7 @@
 		.method public hidebysig 
 			instance object doNothing () cil managed 
 		{
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x2168
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -183,7 +183,7 @@
 		.method public hidebysig 
 			instance object returnsUndefined () cil managed 
 		{
-			// Method begins at RVA 0x21a3
+			// Method begins at RVA 0x2193
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -195,7 +195,7 @@
 		.method public hidebysig 
 			instance object returnsValue () cil managed 
 		{
-			// Method begins at RVA 0x21a6
+			// Method begins at RVA 0x2196
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -208,7 +208,7 @@
 		.method public hidebysig 
 			instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator returnsThis () cil managed 
 		{
-			// Method begins at RVA 0x21a0
+			// Method begins at RVA 0x2190
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -226,7 +226,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ae
+			// Method begins at RVA 0x219e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -252,7 +252,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 266 (0x10a)
+		// Code size: 250 (0xfa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Method_DefaultReturnUndefined/Scope,
@@ -265,9 +265,8 @@
 			[7] object,
 			[8] object,
 			[9] class Modules.Classes_Method_DefaultReturnUndefined/Calculator,
-			[10] object,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[12] bool
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[11] bool
 		)
 
 		IL_0000: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Scope::.ctor()
@@ -279,94 +278,86 @@
 		IL_001b: ldloc.s 9
 		IL_001d: stloc.1
 		IL_001e: ldloc.1
-		IL_001f: ldstr "doNothing"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0029: stloc.s 10
-		IL_002b: ldloc.s 10
-		IL_002d: stloc.2
-		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0033: stloc.s 11
-		IL_0035: ldloc.2
-		IL_0036: ldnull
-		IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_003c: stloc.s 12
-		IL_003e: ldloc.s 12
-		IL_0040: brfalse IL_0050
+		IL_001f: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+		IL_0024: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
+		IL_0029: stloc.2
+		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_002f: stloc.s 10
+		IL_0031: ldloc.2
+		IL_0032: ldnull
+		IL_0033: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0038: stloc.s 11
+		IL_003a: ldloc.s 11
+		IL_003c: brfalse IL_004c
 
-		IL_0045: ldstr "undefined"
-		IL_004a: stloc.3
-		IL_004b: br IL_0056
+		IL_0041: ldstr "undefined"
+		IL_0046: stloc.3
+		IL_0047: br IL_0052
 
-		IL_0050: ldstr "not undefined"
-		IL_0055: stloc.3
+		IL_004c: ldstr "not undefined"
+		IL_0051: stloc.3
 
-		IL_0056: ldloc.s 11
-		IL_0058: ldloc.3
-		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005e: pop
-		IL_005f: ldloc.1
-		IL_0060: ldstr "returnsUndefined"
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_006a: stloc.s 10
-		IL_006c: ldloc.s 10
-		IL_006e: stloc.s 4
-		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0075: stloc.s 11
-		IL_0077: ldloc.s 4
-		IL_0079: ldnull
-		IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_007f: stloc.s 12
-		IL_0081: ldloc.s 12
-		IL_0083: brfalse IL_0094
+		IL_0052: ldloc.s 10
+		IL_0054: ldloc.3
+		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005a: pop
+		IL_005b: ldloc.1
+		IL_005c: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+		IL_0061: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
+		IL_0066: stloc.s 4
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: stloc.s 10
+		IL_006f: ldloc.s 4
+		IL_0071: ldnull
+		IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0077: stloc.s 11
+		IL_0079: ldloc.s 11
+		IL_007b: brfalse IL_008c
 
-		IL_0088: ldstr "undefined"
-		IL_008d: stloc.s 5
-		IL_008f: br IL_009b
+		IL_0080: ldstr "undefined"
+		IL_0085: stloc.s 5
+		IL_0087: br IL_0093
 
-		IL_0094: ldstr "not undefined"
-		IL_0099: stloc.s 5
+		IL_008c: ldstr "not undefined"
+		IL_0091: stloc.s 5
 
-		IL_009b: ldloc.s 11
-		IL_009d: ldloc.s 5
-		IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a4: pop
-		IL_00a5: ldloc.1
-		IL_00a6: ldstr "returnsValue"
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00b0: stloc.s 10
-		IL_00b2: ldloc.s 10
-		IL_00b4: stloc.s 6
-		IL_00b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bb: ldloc.s 6
-		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c2: pop
-		IL_00c3: ldloc.1
-		IL_00c4: ldstr "returnsThis"
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00ce: stloc.s 10
-		IL_00d0: ldloc.s 10
-		IL_00d2: stloc.s 7
-		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d9: stloc.s 11
-		IL_00db: ldloc.s 7
-		IL_00dd: ldloc.1
-		IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00e3: stloc.s 12
-		IL_00e5: ldloc.s 12
-		IL_00e7: brfalse IL_00f8
+		IL_0093: ldloc.s 10
+		IL_0095: ldloc.s 5
+		IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009c: pop
+		IL_009d: ldloc.1
+		IL_009e: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+		IL_00a3: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
+		IL_00a8: stloc.s 6
+		IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00af: ldloc.s 6
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: ldloc.1
+		IL_00b8: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+		IL_00bd: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
+		IL_00c2: stloc.s 7
+		IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c9: stloc.s 10
+		IL_00cb: ldloc.s 7
+		IL_00cd: ldloc.1
+		IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00d3: stloc.s 11
+		IL_00d5: ldloc.s 11
+		IL_00d7: brfalse IL_00e8
 
-		IL_00ec: ldstr "same instance"
-		IL_00f1: stloc.s 8
-		IL_00f3: br IL_00ff
+		IL_00dc: ldstr "same instance"
+		IL_00e1: stloc.s 8
+		IL_00e3: br IL_00ef
 
-		IL_00f8: ldstr "different"
-		IL_00fd: stloc.s 8
+		IL_00e8: ldstr "different"
+		IL_00ed: stloc.s 8
 
-		IL_00ff: ldloc.s 11
-		IL_0101: ldloc.s 8
-		IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0108: pop
-		IL_0109: ret
+		IL_00ef: ldloc.s 10
+		IL_00f1: ldloc.s 8
+		IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f8: pop
+		IL_00f9: ret
 	} // end of method Classes_Method_DefaultReturnUndefined::__js_module_init__
 
 } // end of class Modules.Classes_Method_DefaultReturnUndefined
@@ -378,7 +369,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ed
+		// Method begins at RVA 0x21dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2161
+			// Method begins at RVA 0x21c9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 150 (0x96)
+		// Code size: 254 (0xfe)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_Class/Scope,
@@ -65,32 +65,62 @@
 		IL_0021: ldloc.3
 		IL_0022: stloc.2
 		IL_0023: ldloc.2
-		IL_0024: ldstr "add"
-		IL_0029: ldc.r8 2
-		IL_0032: box [System.Runtime]System.Double
-		IL_0037: ldc.r8 3
-		IL_0040: box [System.Runtime]System.Double
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_004a: stloc.3
-		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0050: ldstr "add:"
-		IL_0055: ldloc.3
-		IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_005b: pop
-		IL_005c: ldloc.2
-		IL_005d: ldstr "multiply"
-		IL_0062: ldc.r8 4
-		IL_006b: box [System.Runtime]System.Double
-		IL_0070: ldc.r8 5
-		IL_0079: box [System.Runtime]System.Double
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0083: stloc.3
-		IL_0084: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0089: ldstr "multiply:"
-		IL_008e: ldloc.3
-		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0094: pop
-		IL_0095: ret
+		IL_0024: isinst Modules.CommonJS_Export_Class_Lib/Calculator
+		IL_0029: dup
+		IL_002a: brfalse IL_0056
+
+		IL_002f: ldc.r8 2
+		IL_0038: box [System.Runtime]System.Double
+		IL_003d: ldc.r8 3
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: callvirt instance object Modules.CommonJS_Export_Class_Lib/Calculator::'add'(object, object)
+		IL_0050: stloc.3
+		IL_0051: br IL_007f
+
+		IL_0056: pop
+		IL_0057: ldloc.2
+		IL_0058: ldstr "add"
+		IL_005d: ldc.r8 2
+		IL_0066: box [System.Runtime]System.Double
+		IL_006b: ldc.r8 3
+		IL_0074: box [System.Runtime]System.Double
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_007e: stloc.3
+
+		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0084: ldstr "add:"
+		IL_0089: ldloc.3
+		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008f: pop
+		IL_0090: ldloc.2
+		IL_0091: isinst Modules.CommonJS_Export_Class_Lib/Calculator
+		IL_0096: dup
+		IL_0097: brfalse IL_00c3
+
+		IL_009c: ldc.r8 4
+		IL_00a5: box [System.Runtime]System.Double
+		IL_00aa: ldc.r8 5
+		IL_00b3: box [System.Runtime]System.Double
+		IL_00b8: callvirt instance object Modules.CommonJS_Export_Class_Lib/Calculator::multiply(object, object)
+		IL_00bd: stloc.3
+		IL_00be: br IL_00ec
+
+		IL_00c3: pop
+		IL_00c4: ldloc.2
+		IL_00c5: ldstr "multiply"
+		IL_00ca: ldc.r8 4
+		IL_00d3: box [System.Runtime]System.Double
+		IL_00d8: ldc.r8 5
+		IL_00e1: box [System.Runtime]System.Double
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00eb: stloc.3
+
+		IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f1: ldstr "multiply:"
+		IL_00f6: ldloc.3
+		IL_00f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00fc: pop
+		IL_00fd: ret
 	} // end of method CommonJS_Export_Class::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_Class
@@ -110,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2173
+				// Method begins at RVA 0x21db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -130,7 +160,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217c
+				// Method begins at RVA 0x21e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -150,7 +180,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2185
+				// Method begins at RVA 0x21ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -168,7 +198,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211f
+			// Method begins at RVA 0x2187
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -184,7 +214,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x2128
+			// Method begins at RVA 0x2190
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -206,7 +236,7 @@
 				object b
 			) cil managed 
 		{
-			// Method begins at RVA 0x2140
+			// Method begins at RVA 0x21a8
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -234,7 +264,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216a
+			// Method begins at RVA 0x21d2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -258,7 +288,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20f4
+		// Method begins at RVA 0x215c
 		// Header size: 12
 		// Code size: 31 (0x1f)
 		.maxstack 8
@@ -289,7 +319,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218e
+		// Method begins at RVA 0x21f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 223 (0xdf)
+		// Code size: 273 (0x111)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ClassWithConstructor/Scope,
@@ -75,54 +75,76 @@
 		IL_003d: ldloc.s 4
 		IL_003f: stloc.2
 		IL_0040: ldloc.2
-		IL_0041: ldstr "greet"
-		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_004b: stloc.s 4
-		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0052: ldstr "default greeting:"
-		IL_0057: ldloc.s 4
-		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_005e: pop
-		IL_005f: ldloc.1
-		IL_0060: ldc.i4.2
-		IL_0061: newarr [System.Runtime]System.Object
-		IL_0066: dup
-		IL_0067: ldc.i4.0
-		IL_0068: ldstr "Alice"
-		IL_006d: stelem.ref
-		IL_006e: dup
-		IL_006f: ldc.i4.1
-		IL_0070: ldc.r8 30
-		IL_0079: box [System.Runtime]System.Double
-		IL_007e: stelem.ref
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0084: stloc.s 4
-		IL_0086: ldloc.s 4
-		IL_0088: stloc.3
-		IL_0089: ldloc.3
-		IL_008a: ldstr "greet"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0094: stloc.s 4
-		IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009b: ldstr "alice greeting:"
-		IL_00a0: ldloc.s 4
-		IL_00a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00a7: pop
-		IL_00a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ad: ldstr "alice name:"
-		IL_00b2: ldloc.3
-		IL_00b3: ldstr "name"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00c2: pop
-		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c8: ldstr "alice age:"
-		IL_00cd: ldloc.3
-		IL_00ce: ldstr "age"
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00dd: pop
-		IL_00de: ret
+		IL_0041: isinst Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
+		IL_0046: dup
+		IL_0047: brfalse IL_0058
+
+		IL_004c: callvirt instance object Modules.CommonJS_Export_ClassWithConstructor_Lib/Person::greet()
+		IL_0051: stloc.s 4
+		IL_0053: br IL_0066
+
+		IL_0058: pop
+		IL_0059: ldloc.2
+		IL_005a: ldstr "greet"
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0064: stloc.s 4
+
+		IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006b: ldstr "default greeting:"
+		IL_0070: ldloc.s 4
+		IL_0072: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0077: pop
+		IL_0078: ldloc.1
+		IL_0079: ldc.i4.2
+		IL_007a: newarr [System.Runtime]System.Object
+		IL_007f: dup
+		IL_0080: ldc.i4.0
+		IL_0081: ldstr "Alice"
+		IL_0086: stelem.ref
+		IL_0087: dup
+		IL_0088: ldc.i4.1
+		IL_0089: ldc.r8 30
+		IL_0092: box [System.Runtime]System.Double
+		IL_0097: stelem.ref
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_009d: stloc.s 4
+		IL_009f: ldloc.s 4
+		IL_00a1: stloc.3
+		IL_00a2: ldloc.3
+		IL_00a3: isinst Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
+		IL_00a8: dup
+		IL_00a9: brfalse IL_00ba
+
+		IL_00ae: callvirt instance object Modules.CommonJS_Export_ClassWithConstructor_Lib/Person::greet()
+		IL_00b3: stloc.s 4
+		IL_00b5: br IL_00c8
+
+		IL_00ba: pop
+		IL_00bb: ldloc.3
+		IL_00bc: ldstr "greet"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00c6: stloc.s 4
+
+		IL_00c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00cd: ldstr "alice greeting:"
+		IL_00d2: ldloc.s 4
+		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00d9: pop
+		IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00df: ldstr "alice name:"
+		IL_00e4: ldloc.3
+		IL_00e5: ldstr "name"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00f4: pop
+		IL_00f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fa: ldstr "alice age:"
+		IL_00ff: ldloc.3
+		IL_0100: ldstr "age"
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_010f: pop
+		IL_0110: ret
 	} // end of method CommonJS_Export_ClassWithConstructor::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ClassWithConstructor
@@ -142,7 +164,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d6
+				// Method begins at RVA 0x220a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +184,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21df
+				// Method begins at RVA 0x2213
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e8
+				// Method begins at RVA 0x221c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -207,7 +229,7 @@
 				object age
 			) cil managed 
 		{
-			// Method begins at RVA 0x2167
+			// Method begins at RVA 0x219b
 			// Header size: 1
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -226,7 +248,7 @@
 		.method public hidebysig 
 			instance object greet () cil managed 
 		{
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x21b4
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -265,7 +287,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21cd
+			// Method begins at RVA 0x2201
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -289,7 +311,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x213c
+		// Method begins at RVA 0x2170
 		// Header size: 12
 		// Code size: 31 (0x1f)
 		.maxstack 8
@@ -320,7 +342,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f1
+		// Method begins at RVA 0x2225
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/CompoundAssignment/Snapshots/GeneratorTests.CompoundAssignment_LocalVarIndex.verified.txt
+++ b/Js2IL.Tests/CompoundAssignment/Snapshots/GeneratorTests.CompoundAssignment_LocalVarIndex.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2126
+				// Method begins at RVA 0x211e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212f
+				// Method begins at RVA 0x2127
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2138
+				// Method begins at RVA 0x2130
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2078
+			// Method begins at RVA 0x2070
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -100,7 +100,7 @@
 		.method public hidebysig 
 			instance object test () cil managed 
 		{
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x209c
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -158,7 +158,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211d
+			// Method begins at RVA 0x2115
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -184,7 +184,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 25 (0x19)
+		// Code size: 20 (0x14)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CompoundAssignment_LocalVarIndex/Scope,
@@ -196,10 +196,9 @@
 		IL_0006: newobj instance void Modules.CompoundAssignment_LocalVarIndex/TestClass::.ctor()
 		IL_000b: stloc.1
 		IL_000c: ldloc.1
-		IL_000d: ldstr "test"
-		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0017: pop
-		IL_0018: ret
+		IL_000d: callvirt instance object Modules.CompoundAssignment_LocalVarIndex/TestClass::test()
+		IL_0012: pop
+		IL_0013: ret
 	} // end of method CompoundAssignment_LocalVarIndex::__js_module_init__
 
 } // end of class Modules.CompoundAssignment_LocalVarIndex
@@ -211,7 +210,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2141
+		// Method begins at RVA 0x2139
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_SimpleYield.verified.txt
+++ b/Js2IL.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_SimpleYield.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c8
+				// Method begins at RVA 0x22d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d1
+				// Method begins at RVA 0x22d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2172
+			// Method begins at RVA 0x2179
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -72,7 +72,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x217c
+			// Method begins at RVA 0x2184
 			// Header size: 12
 			// Code size: 311 (0x137)
 			.maxstack 8
@@ -208,7 +208,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22bf
+			// Method begins at RVA 0x22c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -234,7 +234,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 278 (0x116)
+		// Code size: 285 (0x11d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_ClassMethod_SimpleYield/Scope,
@@ -252,113 +252,118 @@
 		IL_000d: ldloc.s 4
 		IL_000f: stloc.1
 		IL_0010: ldloc.1
-		IL_0011: ldstr "values"
-		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_001b: stloc.s 5
-		IL_001d: ldloc.s 5
-		IL_001f: stloc.2
+		IL_0011: castclass Modules.Generator_ClassMethod_SimpleYield/Gen
+		IL_0016: ldc.i4.1
+		IL_0017: newarr [System.Runtime]System.Object
+		IL_001c: dup
+		IL_001d: ldc.i4.0
+		IL_001e: ldloc.0
+		IL_001f: stelem.ref
 		IL_0020: ldnull
-		IL_0021: stloc.3
-		IL_0022: ldloc.2
-		IL_0023: ldstr "next"
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_002d: stloc.s 5
-		IL_002f: ldloc.s 5
-		IL_0031: stloc.3
-		IL_0032: ldloc.3
-		IL_0033: ldstr "value"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_003d: stloc.s 5
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0044: ldc.i4.4
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldstr "v1:"
-		IL_0051: stelem.ref
-		IL_0052: dup
-		IL_0053: ldc.i4.1
-		IL_0054: ldloc.s 5
-		IL_0056: stelem.ref
-		IL_0057: dup
-		IL_0058: ldc.i4.2
-		IL_0059: ldstr "done:"
-		IL_005e: stelem.ref
-		IL_005f: dup
-		IL_0060: ldc.i4.3
-		IL_0061: ldloc.3
-		IL_0062: ldstr "done"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_006c: stelem.ref
-		IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0072: pop
-		IL_0073: ldloc.2
-		IL_0074: ldstr "next"
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_007e: stloc.s 5
-		IL_0080: ldloc.s 5
-		IL_0082: stloc.3
-		IL_0083: ldloc.3
-		IL_0084: ldstr "value"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_008e: stloc.s 5
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0095: ldc.i4.4
-		IL_0096: newarr [System.Runtime]System.Object
-		IL_009b: dup
-		IL_009c: ldc.i4.0
-		IL_009d: ldstr "v2:"
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.1
-		IL_00a5: ldloc.s 5
-		IL_00a7: stelem.ref
-		IL_00a8: dup
-		IL_00a9: ldc.i4.2
-		IL_00aa: ldstr "done:"
-		IL_00af: stelem.ref
-		IL_00b0: dup
-		IL_00b1: ldc.i4.3
-		IL_00b2: ldloc.3
-		IL_00b3: ldstr "done"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_00bd: stelem.ref
-		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00c3: pop
-		IL_00c4: ldloc.2
-		IL_00c5: ldstr "next"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00cf: stloc.s 5
-		IL_00d1: ldloc.s 5
-		IL_00d3: stloc.3
-		IL_00d4: ldloc.3
-		IL_00d5: ldstr "value"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_00df: stloc.s 5
-		IL_00e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e6: ldc.i4.4
-		IL_00e7: newarr [System.Runtime]System.Object
-		IL_00ec: dup
-		IL_00ed: ldc.i4.0
-		IL_00ee: ldstr "v3:"
-		IL_00f3: stelem.ref
-		IL_00f4: dup
-		IL_00f5: ldc.i4.1
-		IL_00f6: ldloc.s 5
-		IL_00f8: stelem.ref
-		IL_00f9: dup
-		IL_00fa: ldc.i4.2
-		IL_00fb: ldstr "done:"
-		IL_0100: stelem.ref
-		IL_0101: dup
-		IL_0102: ldc.i4.3
-		IL_0103: ldloc.3
-		IL_0104: ldstr "done"
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_010e: stelem.ref
-		IL_010f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0114: pop
-		IL_0115: ret
+		IL_0021: callvirt instance object Modules.Generator_ClassMethod_SimpleYield/Gen::values(object[], object)
+		IL_0026: stloc.2
+		IL_0027: ldnull
+		IL_0028: stloc.3
+		IL_0029: ldloc.2
+		IL_002a: ldstr "next"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0034: stloc.s 5
+		IL_0036: ldloc.s 5
+		IL_0038: stloc.3
+		IL_0039: ldloc.3
+		IL_003a: ldstr "value"
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0044: stloc.s 5
+		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004b: ldc.i4.4
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldstr "v1:"
+		IL_0058: stelem.ref
+		IL_0059: dup
+		IL_005a: ldc.i4.1
+		IL_005b: ldloc.s 5
+		IL_005d: stelem.ref
+		IL_005e: dup
+		IL_005f: ldc.i4.2
+		IL_0060: ldstr "done:"
+		IL_0065: stelem.ref
+		IL_0066: dup
+		IL_0067: ldc.i4.3
+		IL_0068: ldloc.3
+		IL_0069: ldstr "done"
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0073: stelem.ref
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0079: pop
+		IL_007a: ldloc.2
+		IL_007b: ldstr "next"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0085: stloc.s 5
+		IL_0087: ldloc.s 5
+		IL_0089: stloc.3
+		IL_008a: ldloc.3
+		IL_008b: ldstr "value"
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0095: stloc.s 5
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldc.i4.4
+		IL_009d: newarr [System.Runtime]System.Object
+		IL_00a2: dup
+		IL_00a3: ldc.i4.0
+		IL_00a4: ldstr "v2:"
+		IL_00a9: stelem.ref
+		IL_00aa: dup
+		IL_00ab: ldc.i4.1
+		IL_00ac: ldloc.s 5
+		IL_00ae: stelem.ref
+		IL_00af: dup
+		IL_00b0: ldc.i4.2
+		IL_00b1: ldstr "done:"
+		IL_00b6: stelem.ref
+		IL_00b7: dup
+		IL_00b8: ldc.i4.3
+		IL_00b9: ldloc.3
+		IL_00ba: ldstr "done"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_00c4: stelem.ref
+		IL_00c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00ca: pop
+		IL_00cb: ldloc.2
+		IL_00cc: ldstr "next"
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00d6: stloc.s 5
+		IL_00d8: ldloc.s 5
+		IL_00da: stloc.3
+		IL_00db: ldloc.3
+		IL_00dc: ldstr "value"
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_00e6: stloc.s 5
+		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ed: ldc.i4.4
+		IL_00ee: newarr [System.Runtime]System.Object
+		IL_00f3: dup
+		IL_00f4: ldc.i4.0
+		IL_00f5: ldstr "v3:"
+		IL_00fa: stelem.ref
+		IL_00fb: dup
+		IL_00fc: ldc.i4.1
+		IL_00fd: ldloc.s 5
+		IL_00ff: stelem.ref
+		IL_0100: dup
+		IL_0101: ldc.i4.2
+		IL_0102: ldstr "done:"
+		IL_0107: stelem.ref
+		IL_0108: dup
+		IL_0109: ldc.i4.3
+		IL_010a: ldloc.3
+		IL_010b: ldstr "done"
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0115: stelem.ref
+		IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_011b: pop
+		IL_011c: ret
 	} // end of method Generator_ClassMethod_SimpleYield::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_SimpleYield
@@ -370,7 +375,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22da
+		// Method begins at RVA 0x22e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_WithThis.verified.txt
+++ b/Js2IL.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_WithThis.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2224
+				// Method begins at RVA 0x222c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222d
+				// Method begins at RVA 0x2235
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2236
+				// Method begins at RVA 0x223e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2121
+			// Method begins at RVA 0x2128
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -98,7 +98,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x2140
 			// Header size: 12
 			// Code size: 215 (0xd7)
 			.maxstack 8
@@ -201,7 +201,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221b
+			// Method begins at RVA 0x2223
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -227,7 +227,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 197 (0xc5)
+		// Code size: 204 (0xcc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_ClassMethod_WithThis/Scope,
@@ -245,80 +245,85 @@
 		IL_000d: ldloc.s 4
 		IL_000f: stloc.1
 		IL_0010: ldloc.1
-		IL_0011: ldstr "getCountLater"
-		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_001b: stloc.s 5
-		IL_001d: ldloc.s 5
-		IL_001f: stloc.2
+		IL_0011: castclass Modules.Generator_ClassMethod_WithThis/Counter
+		IL_0016: ldc.i4.1
+		IL_0017: newarr [System.Runtime]System.Object
+		IL_001c: dup
+		IL_001d: ldc.i4.0
+		IL_001e: ldloc.0
+		IL_001f: stelem.ref
 		IL_0020: ldnull
-		IL_0021: stloc.3
-		IL_0022: ldloc.2
-		IL_0023: ldstr "next"
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_002d: stloc.s 5
-		IL_002f: ldloc.s 5
-		IL_0031: stloc.3
-		IL_0032: ldloc.3
-		IL_0033: ldstr "value"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_003d: stloc.s 5
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0044: ldc.i4.4
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldstr "t1:"
-		IL_0051: stelem.ref
-		IL_0052: dup
-		IL_0053: ldc.i4.1
-		IL_0054: ldloc.s 5
-		IL_0056: stelem.ref
-		IL_0057: dup
-		IL_0058: ldc.i4.2
-		IL_0059: ldstr "done:"
-		IL_005e: stelem.ref
-		IL_005f: dup
-		IL_0060: ldc.i4.3
-		IL_0061: ldloc.3
-		IL_0062: ldstr "done"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_006c: stelem.ref
-		IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0072: pop
-		IL_0073: ldloc.2
-		IL_0074: ldstr "next"
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_007e: stloc.s 5
-		IL_0080: ldloc.s 5
-		IL_0082: stloc.3
-		IL_0083: ldloc.3
-		IL_0084: ldstr "value"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_008e: stloc.s 5
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0095: ldc.i4.4
-		IL_0096: newarr [System.Runtime]System.Object
-		IL_009b: dup
-		IL_009c: ldc.i4.0
-		IL_009d: ldstr "t2:"
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.1
-		IL_00a5: ldloc.s 5
-		IL_00a7: stelem.ref
-		IL_00a8: dup
-		IL_00a9: ldc.i4.2
-		IL_00aa: ldstr "done:"
-		IL_00af: stelem.ref
-		IL_00b0: dup
-		IL_00b1: ldc.i4.3
-		IL_00b2: ldloc.3
-		IL_00b3: ldstr "done"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_00bd: stelem.ref
-		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00c3: pop
-		IL_00c4: ret
+		IL_0021: callvirt instance object Modules.Generator_ClassMethod_WithThis/Counter::getCountLater(object[], object)
+		IL_0026: stloc.2
+		IL_0027: ldnull
+		IL_0028: stloc.3
+		IL_0029: ldloc.2
+		IL_002a: ldstr "next"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0034: stloc.s 5
+		IL_0036: ldloc.s 5
+		IL_0038: stloc.3
+		IL_0039: ldloc.3
+		IL_003a: ldstr "value"
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0044: stloc.s 5
+		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004b: ldc.i4.4
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldstr "t1:"
+		IL_0058: stelem.ref
+		IL_0059: dup
+		IL_005a: ldc.i4.1
+		IL_005b: ldloc.s 5
+		IL_005d: stelem.ref
+		IL_005e: dup
+		IL_005f: ldc.i4.2
+		IL_0060: ldstr "done:"
+		IL_0065: stelem.ref
+		IL_0066: dup
+		IL_0067: ldc.i4.3
+		IL_0068: ldloc.3
+		IL_0069: ldstr "done"
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0073: stelem.ref
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0079: pop
+		IL_007a: ldloc.2
+		IL_007b: ldstr "next"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0085: stloc.s 5
+		IL_0087: ldloc.s 5
+		IL_0089: stloc.3
+		IL_008a: ldloc.3
+		IL_008b: ldstr "value"
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0095: stloc.s 5
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldc.i4.4
+		IL_009d: newarr [System.Runtime]System.Object
+		IL_00a2: dup
+		IL_00a3: ldc.i4.0
+		IL_00a4: ldstr "t2:"
+		IL_00a9: stelem.ref
+		IL_00aa: dup
+		IL_00ab: ldc.i4.1
+		IL_00ac: ldloc.s 5
+		IL_00ae: stelem.ref
+		IL_00af: dup
+		IL_00b0: ldc.i4.2
+		IL_00b1: ldstr "done:"
+		IL_00b6: stelem.ref
+		IL_00b7: dup
+		IL_00b8: ldc.i4.3
+		IL_00b9: ldloc.3
+		IL_00ba: ldstr "done"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_00c4: stelem.ref
+		IL_00c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00ca: pop
+		IL_00cb: ret
 	} // end of method Generator_ClassMethod_WithThis::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_WithThis
@@ -330,7 +335,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x223f
+		// Method begins at RVA 0x2247
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
+++ b/Js2IL.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d0
+				// Method begins at RVA 0x22d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d9
+				// Method begins at RVA 0x22e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x2187
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -72,7 +72,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x2188
+			// Method begins at RVA 0x2190
 			// Header size: 12
 			// Code size: 307 (0x133)
 			.maxstack 8
@@ -214,7 +214,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22c7
+			// Method begins at RVA 0x22cf
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -240,7 +240,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 292 (0x124)
+		// Code size: 299 (0x12b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_ClassMethod_YieldAssign/Scope,
@@ -258,115 +258,120 @@
 		IL_000d: ldloc.s 4
 		IL_000f: stloc.1
 		IL_0010: ldloc.1
-		IL_0011: ldstr "values"
-		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_001b: stloc.s 5
-		IL_001d: ldloc.s 5
-		IL_001f: stloc.2
+		IL_0011: castclass Modules.Generator_ClassMethod_YieldAssign/Gen
+		IL_0016: ldc.i4.1
+		IL_0017: newarr [System.Runtime]System.Object
+		IL_001c: dup
+		IL_001d: ldc.i4.0
+		IL_001e: ldloc.0
+		IL_001f: stelem.ref
 		IL_0020: ldnull
-		IL_0021: stloc.3
-		IL_0022: ldloc.2
-		IL_0023: ldstr "next"
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_002d: stloc.s 5
-		IL_002f: ldloc.s 5
-		IL_0031: stloc.3
-		IL_0032: ldloc.3
-		IL_0033: ldstr "value"
-		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_003d: stloc.s 5
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0044: ldc.i4.4
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldstr "y1:"
-		IL_0051: stelem.ref
-		IL_0052: dup
-		IL_0053: ldc.i4.1
-		IL_0054: ldloc.s 5
-		IL_0056: stelem.ref
-		IL_0057: dup
-		IL_0058: ldc.i4.2
-		IL_0059: ldstr "done:"
-		IL_005e: stelem.ref
-		IL_005f: dup
-		IL_0060: ldc.i4.3
-		IL_0061: ldloc.3
-		IL_0062: ldstr "done"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_006c: stelem.ref
-		IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0072: pop
-		IL_0073: ldloc.2
-		IL_0074: ldstr "next"
-		IL_0079: ldc.r8 42
-		IL_0082: box [System.Runtime]System.Double
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_008c: stloc.s 5
-		IL_008e: ldloc.s 5
-		IL_0090: stloc.3
-		IL_0091: ldloc.3
-		IL_0092: ldstr "value"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_009c: stloc.s 5
-		IL_009e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a3: ldc.i4.4
-		IL_00a4: newarr [System.Runtime]System.Object
-		IL_00a9: dup
-		IL_00aa: ldc.i4.0
-		IL_00ab: ldstr "y2:"
-		IL_00b0: stelem.ref
-		IL_00b1: dup
-		IL_00b2: ldc.i4.1
-		IL_00b3: ldloc.s 5
-		IL_00b5: stelem.ref
-		IL_00b6: dup
-		IL_00b7: ldc.i4.2
-		IL_00b8: ldstr "done:"
-		IL_00bd: stelem.ref
-		IL_00be: dup
-		IL_00bf: ldc.i4.3
-		IL_00c0: ldloc.3
-		IL_00c1: ldstr "done"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_00cb: stelem.ref
-		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00d1: pop
-		IL_00d2: ldloc.2
-		IL_00d3: ldstr "next"
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00dd: stloc.s 5
-		IL_00df: ldloc.s 5
-		IL_00e1: stloc.3
-		IL_00e2: ldloc.3
-		IL_00e3: ldstr "value"
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_00ed: stloc.s 5
-		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f4: ldc.i4.4
-		IL_00f5: newarr [System.Runtime]System.Object
-		IL_00fa: dup
-		IL_00fb: ldc.i4.0
-		IL_00fc: ldstr "y3:"
-		IL_0101: stelem.ref
-		IL_0102: dup
-		IL_0103: ldc.i4.1
-		IL_0104: ldloc.s 5
-		IL_0106: stelem.ref
-		IL_0107: dup
-		IL_0108: ldc.i4.2
-		IL_0109: ldstr "done:"
-		IL_010e: stelem.ref
-		IL_010f: dup
-		IL_0110: ldc.i4.3
-		IL_0111: ldloc.3
-		IL_0112: ldstr "done"
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_011c: stelem.ref
-		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0122: pop
-		IL_0123: ret
+		IL_0021: callvirt instance object Modules.Generator_ClassMethod_YieldAssign/Gen::values(object[], object)
+		IL_0026: stloc.2
+		IL_0027: ldnull
+		IL_0028: stloc.3
+		IL_0029: ldloc.2
+		IL_002a: ldstr "next"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0034: stloc.s 5
+		IL_0036: ldloc.s 5
+		IL_0038: stloc.3
+		IL_0039: ldloc.3
+		IL_003a: ldstr "value"
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0044: stloc.s 5
+		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004b: ldc.i4.4
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldstr "y1:"
+		IL_0058: stelem.ref
+		IL_0059: dup
+		IL_005a: ldc.i4.1
+		IL_005b: ldloc.s 5
+		IL_005d: stelem.ref
+		IL_005e: dup
+		IL_005f: ldc.i4.2
+		IL_0060: ldstr "done:"
+		IL_0065: stelem.ref
+		IL_0066: dup
+		IL_0067: ldc.i4.3
+		IL_0068: ldloc.3
+		IL_0069: ldstr "done"
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0073: stelem.ref
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0079: pop
+		IL_007a: ldloc.2
+		IL_007b: ldstr "next"
+		IL_0080: ldc.r8 42
+		IL_0089: box [System.Runtime]System.Double
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0093: stloc.s 5
+		IL_0095: ldloc.s 5
+		IL_0097: stloc.3
+		IL_0098: ldloc.3
+		IL_0099: ldstr "value"
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_00a3: stloc.s 5
+		IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00aa: ldc.i4.4
+		IL_00ab: newarr [System.Runtime]System.Object
+		IL_00b0: dup
+		IL_00b1: ldc.i4.0
+		IL_00b2: ldstr "y2:"
+		IL_00b7: stelem.ref
+		IL_00b8: dup
+		IL_00b9: ldc.i4.1
+		IL_00ba: ldloc.s 5
+		IL_00bc: stelem.ref
+		IL_00bd: dup
+		IL_00be: ldc.i4.2
+		IL_00bf: ldstr "done:"
+		IL_00c4: stelem.ref
+		IL_00c5: dup
+		IL_00c6: ldc.i4.3
+		IL_00c7: ldloc.3
+		IL_00c8: ldstr "done"
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_00d2: stelem.ref
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00d8: pop
+		IL_00d9: ldloc.2
+		IL_00da: ldstr "next"
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00e4: stloc.s 5
+		IL_00e6: ldloc.s 5
+		IL_00e8: stloc.3
+		IL_00e9: ldloc.3
+		IL_00ea: ldstr "value"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_00f4: stloc.s 5
+		IL_00f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fb: ldc.i4.4
+		IL_00fc: newarr [System.Runtime]System.Object
+		IL_0101: dup
+		IL_0102: ldc.i4.0
+		IL_0103: ldstr "y3:"
+		IL_0108: stelem.ref
+		IL_0109: dup
+		IL_010a: ldc.i4.1
+		IL_010b: ldloc.s 5
+		IL_010d: stelem.ref
+		IL_010e: dup
+		IL_010f: ldc.i4.2
+		IL_0110: ldstr "done:"
+		IL_0115: stelem.ref
+		IL_0116: dup
+		IL_0117: ldc.i4.3
+		IL_0118: ldloc.3
+		IL_0119: ldstr "done"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0123: stelem.ref
+		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0129: pop
+		IL_012a: ret
 	} // end of method Generator_ClassMethod_YieldAssign::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_YieldAssign
@@ -378,7 +383,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e2
+		// Method begins at RVA 0x22ea
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
+++ b/Js2IL.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222f
+				// Method begins at RVA 0x2227
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2238
+				// Method begins at RVA 0x2230
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2075
+			// Method begins at RVA 0x2070
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -72,7 +72,7 @@
 				object newTarget
 			) cil managed 
 		{
-			// Method begins at RVA 0x20f0
+			// Method begins at RVA 0x20e8
 			// Header size: 12
 			// Code size: 298 (0x12a)
 			.maxstack 8
@@ -211,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2241
+				// Method begins at RVA 0x2239
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -231,7 +231,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224a
+				// Method begins at RVA 0x2242
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -249,7 +249,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x207d
+			// Method begins at RVA 0x2078
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -262,7 +262,7 @@
 		.method public hidebysig 
 			instance object run () cil managed 
 		{
-			// Method begins at RVA 0x2088
+			// Method begins at RVA 0x2080
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -316,7 +316,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2226
+			// Method begins at RVA 0x221e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -342,7 +342,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 25 (0x19)
+		// Code size: 20 (0x14)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_Inheritance_SuperIteratorMethod/Scope,
@@ -354,10 +354,9 @@
 		IL_0006: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived::.ctor()
 		IL_000b: stloc.1
 		IL_000c: ldloc.1
-		IL_000d: ldstr "run"
-		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0017: pop
-		IL_0018: ret
+		IL_000d: callvirt instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
+		IL_0012: pop
+		IL_0013: ret
 	} // end of method Generator_Inheritance_SuperIteratorMethod::__js_module_init__
 
 } // end of class Modules.Generator_Inheritance_SuperIteratorMethod
@@ -369,7 +368,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2253
+		// Method begins at RVA 0x224b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ea5
+					// Method begins at RVA 0x2e9e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e9c
+				// Method begins at RVA 0x2e95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,8 +140,8 @@
 				IL_0073: ldloc.s 7
 				IL_0075: stloc.3
 				IL_0076: ldloc.3
-				IL_0077: ldstr "runSieve"
-				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0077: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_007c: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
 				IL_0081: pop
 				IL_0082: ldloc.0
 				IL_0083: ldc.r8 1
@@ -204,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eae
+				// Method begins at RVA 0x2ea7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -228,7 +228,7 @@
 		{
 			// Method begins at RVA 0x22f8
 			// Header size: 12
-			// Code size: 427 (0x1ab)
+			// Code size: 414 (0x19e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -241,8 +241,8 @@
 				[7] object,
 				[8] float64,
 				[9] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
-				[10] object,
-				[11] bool,
+				[10] bool,
+				[11] object,
 				[12] float64,
 				[13] float64,
 				[14] string,
@@ -289,127 +289,122 @@
 			IL_005e: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], object)
 			IL_0063: stloc.s 9
 			IL_0065: ldloc.s 9
-			IL_0067: ldstr "runSieve"
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0071: stloc.s 10
-			IL_0073: ldloc.s 10
-			IL_0075: ldstr "validatePrimeCount"
-			IL_007a: ldloc.2
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0080: stloc.s 10
-			IL_0082: ldloc.s 10
-			IL_0084: stloc.s 4
-			IL_0086: ldloc.s 4
-			IL_0088: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_008d: ldc.i4.0
-			IL_008e: ceq
-			IL_0090: stloc.s 11
-			IL_0092: ldloc.s 11
-			IL_0094: brfalse IL_00a0
+			IL_0067: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
+			IL_006c: ldloc.2
+			IL_006d: callvirt instance bool Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::validatePrimeCount(object)
+			IL_0072: box [System.Runtime]System.Boolean
+			IL_0077: stloc.s 4
+			IL_0079: ldloc.s 4
+			IL_007b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0080: ldc.i4.0
+			IL_0081: ceq
+			IL_0083: stloc.s 10
+			IL_0085: ldloc.s 10
+			IL_0087: brfalse IL_0093
 
-			IL_0099: ldc.i4.0
-			IL_009a: box [System.Runtime]System.Boolean
-			IL_009f: ret
+			IL_008c: ldc.i4.0
+			IL_008d: box [System.Runtime]System.Boolean
+			IL_0092: ret
 
-			IL_00a0: ldarg.0
-			IL_00a1: ldc.i4.0
-			IL_00a2: ldelem.ref
-			IL_00a3: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-			IL_00a8: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_00ad: ldstr "now"
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00b7: stloc.s 10
-			IL_00b9: ldloc.s 10
-			IL_00bb: stloc.s 5
-			IL_00bd: ldarg.0
-			IL_00be: ldc.i4.0
-			IL_00bf: ldelem.ref
-			IL_00c0: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-			IL_00c5: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-			IL_00ca: ldc.i4.1
-			IL_00cb: newarr [System.Runtime]System.Object
-			IL_00d0: dup
-			IL_00d1: ldc.i4.0
-			IL_00d2: ldarg.0
-			IL_00d3: ldc.i4.0
-			IL_00d4: ldelem.ref
-			IL_00d5: stelem.ref
-			IL_00d6: ldloc.0
-			IL_00d7: ldloc.1
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs2(object, object[], object, object)
-			IL_00dd: stloc.s 10
-			IL_00df: ldloc.s 10
-			IL_00e1: stloc.s 6
-			IL_00e3: ldarg.0
-			IL_00e4: ldc.i4.0
-			IL_00e5: ldelem.ref
-			IL_00e6: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-			IL_00eb: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_00f0: ldstr "now"
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00fa: stloc.s 10
-			IL_00fc: ldloc.s 10
-			IL_00fe: stloc.s 7
-			IL_0100: ldloc.s 7
-			IL_0102: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0107: stloc.s 12
-			IL_0109: ldloc.s 5
-			IL_010b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0110: stloc.s 13
-			IL_0112: ldloc.s 12
-			IL_0114: ldloc.s 13
-			IL_0116: sub
-			IL_0117: stloc.s 13
-			IL_0119: ldloc.s 13
-			IL_011b: ldarg.0
-			IL_011c: ldc.i4.0
-			IL_011d: ldelem.ref
-			IL_011e: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-			IL_0123: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_0128: div
-			IL_0129: stloc.s 13
-			IL_012b: ldloc.s 13
-			IL_012d: stloc.s 8
-			IL_012f: ldloc.3
-			IL_0130: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0135: stloc.s 14
-			IL_0137: ldstr "\nrogiervandam-"
-			IL_013c: ldloc.s 14
-			IL_013e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0143: stloc.s 14
-			IL_0145: ldloc.s 14
-			IL_0147: ldstr ";"
-			IL_014c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0151: stloc.s 14
-			IL_0153: ldloc.s 6
-			IL_0155: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_015a: stloc.s 15
-			IL_015c: ldloc.s 14
-			IL_015e: ldloc.s 15
-			IL_0160: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0165: stloc.s 15
-			IL_0167: ldloc.s 15
-			IL_0169: ldstr ";"
-			IL_016e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0173: stloc.s 15
-			IL_0175: ldloc.s 8
-			IL_0177: box [System.Runtime]System.Double
-			IL_017c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0181: stloc.s 14
-			IL_0183: ldloc.s 15
-			IL_0185: ldloc.s 14
-			IL_0187: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018c: stloc.s 14
-			IL_018e: ldloc.s 14
-			IL_0190: ldstr ";1;algorithm=base,faithful=yes,bits=1"
-			IL_0195: call string [System.Runtime]System.String::Concat(string, string)
-			IL_019a: stloc.s 14
-			IL_019c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01a1: ldloc.s 14
-			IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01a8: pop
-			IL_01a9: ldnull
-			IL_01aa: ret
+			IL_0093: ldarg.0
+			IL_0094: ldc.i4.0
+			IL_0095: ldelem.ref
+			IL_0096: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+			IL_009b: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+			IL_00a0: ldstr "now"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00aa: stloc.s 11
+			IL_00ac: ldloc.s 11
+			IL_00ae: stloc.s 5
+			IL_00b0: ldarg.0
+			IL_00b1: ldc.i4.0
+			IL_00b2: ldelem.ref
+			IL_00b3: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+			IL_00b8: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+			IL_00bd: ldc.i4.1
+			IL_00be: newarr [System.Runtime]System.Object
+			IL_00c3: dup
+			IL_00c4: ldc.i4.0
+			IL_00c5: ldarg.0
+			IL_00c6: ldc.i4.0
+			IL_00c7: ldelem.ref
+			IL_00c8: stelem.ref
+			IL_00c9: ldloc.0
+			IL_00ca: ldloc.1
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs2(object, object[], object, object)
+			IL_00d0: stloc.s 11
+			IL_00d2: ldloc.s 11
+			IL_00d4: stloc.s 6
+			IL_00d6: ldarg.0
+			IL_00d7: ldc.i4.0
+			IL_00d8: ldelem.ref
+			IL_00d9: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+			IL_00de: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+			IL_00e3: ldstr "now"
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00ed: stloc.s 11
+			IL_00ef: ldloc.s 11
+			IL_00f1: stloc.s 7
+			IL_00f3: ldloc.s 7
+			IL_00f5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00fa: stloc.s 12
+			IL_00fc: ldloc.s 5
+			IL_00fe: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0103: stloc.s 13
+			IL_0105: ldloc.s 12
+			IL_0107: ldloc.s 13
+			IL_0109: sub
+			IL_010a: stloc.s 13
+			IL_010c: ldloc.s 13
+			IL_010e: ldarg.0
+			IL_010f: ldc.i4.0
+			IL_0110: ldelem.ref
+			IL_0111: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+			IL_0116: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
+			IL_011b: div
+			IL_011c: stloc.s 13
+			IL_011e: ldloc.s 13
+			IL_0120: stloc.s 8
+			IL_0122: ldloc.3
+			IL_0123: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0128: stloc.s 14
+			IL_012a: ldstr "\nrogiervandam-"
+			IL_012f: ldloc.s 14
+			IL_0131: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0136: stloc.s 14
+			IL_0138: ldloc.s 14
+			IL_013a: ldstr ";"
+			IL_013f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0144: stloc.s 14
+			IL_0146: ldloc.s 6
+			IL_0148: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_014d: stloc.s 15
+			IL_014f: ldloc.s 14
+			IL_0151: ldloc.s 15
+			IL_0153: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0158: stloc.s 15
+			IL_015a: ldloc.s 15
+			IL_015c: ldstr ";"
+			IL_0161: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0166: stloc.s 15
+			IL_0168: ldloc.s 8
+			IL_016a: box [System.Runtime]System.Double
+			IL_016f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0174: stloc.s 14
+			IL_0176: ldloc.s 15
+			IL_0178: ldloc.s 14
+			IL_017a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_017f: stloc.s 14
+			IL_0181: ldloc.s 14
+			IL_0183: ldstr ";1;algorithm=base,faithful=yes,bits=1"
+			IL_0188: call string [System.Runtime]System.String::Concat(string, string)
+			IL_018d: stloc.s 14
+			IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0194: ldloc.s 14
+			IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_019b: pop
+			IL_019c: ldnull
+			IL_019d: ret
 		} // end of method ArrowFunction_L229C14::__js_call__
 
 	} // end of class ArrowFunction_L229C14
@@ -425,7 +420,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d97
+				// Method begins at RVA 0x2d90
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -445,7 +440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2da0
+				// Method begins at RVA 0x2d99
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -465,7 +460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2da9
+				// Method begins at RVA 0x2da2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -493,7 +488,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2dc4
+						// Method begins at RVA 0x2dbd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -517,7 +512,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2dd6
+							// Method begins at RVA 0x2dcf
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -535,7 +530,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2dcd
+						// Method begins at RVA 0x2dc6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -553,7 +548,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2dbb
+					// Method begins at RVA 0x2db4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -581,7 +576,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2df1
+							// Method begins at RVA 0x2dea
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -599,7 +594,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2de8
+						// Method begins at RVA 0x2de1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -617,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ddf
+					// Method begins at RVA 0x2dd8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -641,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e03
+						// Method begins at RVA 0x2dfc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -659,7 +654,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2dfa
+					// Method begins at RVA 0x2df3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -677,7 +672,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2db2
+				// Method begins at RVA 0x2dab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -697,7 +692,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e0c
+				// Method begins at RVA 0x2e05
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -721,7 +716,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e1e
+					// Method begins at RVA 0x2e17
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -739,7 +734,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e15
+				// Method begins at RVA 0x2e0e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -764,7 +759,7 @@
 				object size
 			) cil managed 
 		{
-			// Method begins at RVA 0x2524
+			// Method begins at RVA 0x2518
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -810,7 +805,7 @@
 				object index
 			) cil managed 
 		{
-			// Method begins at RVA 0x2838
+			// Method begins at RVA 0x282c
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -878,7 +873,7 @@
 				object range_stop
 			) cil managed 
 		{
-			// Method begins at RVA 0x25b8
+			// Method begins at RVA 0x25ac
 			// Header size: 12
 			// Code size: 625 (0x271)
 			.maxstack 8
@@ -1182,7 +1177,7 @@
 				object index
 			) cil managed 
 		{
-			// Method begins at RVA 0x28a0
+			// Method begins at RVA 0x2894
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1243,7 +1238,7 @@
 				object index
 			) cil managed 
 		{
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2568
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -1290,7 +1285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e27
+				// Method begins at RVA 0x2e20
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1310,7 +1305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e30
+				// Method begins at RVA 0x2e29
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1334,7 +1329,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e42
+					// Method begins at RVA 0x2e3b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1352,7 +1347,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e39
+				// Method begins at RVA 0x2e32
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1372,7 +1367,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e4b
+				// Method begins at RVA 0x2e44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,7 +1395,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e66
+						// Method begins at RVA 0x2e5f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1418,7 +1413,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e5d
+					// Method begins at RVA 0x2e56
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1436,7 +1431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e54
+				// Method begins at RVA 0x2e4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1456,7 +1451,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e6f
+				// Method begins at RVA 0x2e68
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1480,7 +1475,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e81
+					// Method begins at RVA 0x2e7a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1498,7 +1493,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e78
+				// Method begins at RVA 0x2e71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1522,7 +1517,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e93
+					// Method begins at RVA 0x2e8c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1540,7 +1535,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e8a
+				// Method begins at RVA 0x2e83
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1567,7 +1562,7 @@
 				object sieveSize
 			) cil managed 
 		{
-			// Method begins at RVA 0x24b0
+			// Method begins at RVA 0x24a4
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -1628,9 +1623,9 @@
 		.method public hidebysig 
 			instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve runSieve () cil managed 
 		{
-			// Method begins at RVA 0x28fc
+			// Method begins at RVA 0x28f0
 			// Header size: 12
-			// Code size: 207 (0xcf)
+			// Code size: 208 (0xd0)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1639,8 +1634,7 @@
 				[3] float64,
 				[4] float64,
 				[5] object,
-				[6] object,
-				[7] object
+				[6] object
 			)
 
 			IL_0000: ldarg.0
@@ -1662,7 +1656,7 @@
 				IL_0031: ldloc.1
 				IL_0032: ldloc.0
 				IL_0033: clt
-				IL_0035: brfalse IL_00cd
+				IL_0035: brfalse IL_00ce
 
 				IL_003a: ldloc.1
 				IL_003b: ldc.r8 2
@@ -1692,48 +1686,46 @@
 				IL_0078: stloc.s 6
 				IL_007a: ldarg.0
 				IL_007b: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-				IL_0080: ldstr "setBitsTrue"
+				IL_0080: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
 				IL_0085: ldloc.s 5
 				IL_0087: ldloc.s 6
 				IL_0089: ldarg.0
 				IL_008a: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
 				IL_008f: box [System.Runtime]System.Double
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0094: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(object, object, object)
 				IL_0099: pop
 				IL_009a: ldarg.0
 				IL_009b: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-				IL_00a0: ldstr "searchBitFalse"
+				IL_00a0: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
 				IL_00a5: ldloc.1
 				IL_00a6: ldc.r8 1
 				IL_00af: add
 				IL_00b0: box [System.Runtime]System.Double
-				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00ba: stloc.s 7
-				IL_00bc: ldloc.s 7
-				IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00c3: stloc.s 4
-				IL_00c5: ldloc.s 4
-				IL_00c7: stloc.1
-				IL_00c8: br IL_0031
+				IL_00b5: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(object)
+				IL_00ba: box [System.Runtime]System.Double
+				IL_00bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00c4: stloc.s 4
+				IL_00c6: ldloc.s 4
+				IL_00c8: stloc.1
+				IL_00c9: br IL_0031
 			// end loop
 
-			IL_00cd: ldarg.0
-			IL_00ce: ret
+			IL_00ce: ldarg.0
+			IL_00cf: ret
 		} // end of method PrimeSieve::runSieve
 
 		.method public hidebysig 
 			instance float64 countPrimes () cil managed 
 		{
-			// Method begins at RVA 0x2c38
+			// Method begins at RVA 0x2c2c
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 109 (0x6d)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
 				[2] object,
-				[3] object,
-				[4] bool
+				[3] bool
 			)
 
 			IL_0000: ldc.r8 1
@@ -1745,39 +1737,38 @@
 				IL_0015: ldarg.0
 				IL_0016: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
 				IL_001b: clt
-				IL_001d: brfalse IL_006a
+				IL_001d: brfalse IL_006b
 
 				IL_0022: ldloc.1
 				IL_0023: box [System.Runtime]System.Double
 				IL_0028: stloc.2
 				IL_0029: ldarg.0
 				IL_002a: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-				IL_002f: ldstr "testBitTrue"
+				IL_002f: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
 				IL_0034: ldloc.2
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0041: ldc.i4.0
-				IL_0042: ceq
-				IL_0044: stloc.s 4
-				IL_0046: ldloc.s 4
-				IL_0048: brfalse IL_0059
+				IL_0035: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(object)
+				IL_003a: box [System.Runtime]System.Double
+				IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0044: ldc.i4.0
+				IL_0045: ceq
+				IL_0047: stloc.3
+				IL_0048: ldloc.3
+				IL_0049: brfalse IL_005a
 
-				IL_004d: ldloc.0
-				IL_004e: ldc.r8 1
-				IL_0057: add
-				IL_0058: stloc.0
+				IL_004e: ldloc.0
+				IL_004f: ldc.r8 1
+				IL_0058: add
+				IL_0059: stloc.0
 
-				IL_0059: ldloc.1
-				IL_005a: ldc.r8 1
-				IL_0063: add
-				IL_0064: stloc.1
-				IL_0065: br IL_0014
+				IL_005a: ldloc.1
+				IL_005b: ldc.r8 1
+				IL_0064: add
+				IL_0065: stloc.1
+				IL_0066: br IL_0014
 			// end loop
 
-			IL_006a: ldloc.0
-			IL_006b: ret
+			IL_006b: ldloc.0
+			IL_006c: ret
 		} // end of method PrimeSieve::countPrimes
 
 		.method public hidebysig 
@@ -1785,18 +1776,17 @@
 				object max
 			) cil managed 
 		{
-			// Method begins at RVA 0x2cb0
+			// Method begins at RVA 0x2ca8
 			// Header size: 12
-			// Code size: 210 (0xd2)
+			// Code size: 211 (0xd3)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] float64,
 				[3] object,
-				[4] object,
-				[5] bool,
-				[6] float64
+				[4] bool,
+				[5] float64
 			)
 
 			IL_0000: ldarg.1
@@ -1822,7 +1812,7 @@
 				IL_0046: ldarg.0
 				IL_0047: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
 				IL_004c: clt
-				IL_004e: brfalse IL_00d0
+				IL_004e: brfalse IL_00d1
 
 				IL_0053: ldloc.2
 				IL_0054: ldarg.1
@@ -1832,48 +1822,47 @@
 				IL_005d: ceq
 				IL_005f: brfalse IL_0069
 
-				IL_0064: br IL_00d0
+				IL_0064: br IL_00d1
 
 				IL_0069: ldloc.1
 				IL_006a: box [System.Runtime]System.Double
 				IL_006f: stloc.3
 				IL_0070: ldarg.0
 				IL_0071: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-				IL_0076: ldstr "testBitTrue"
+				IL_0076: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
 				IL_007b: ldloc.3
-				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0081: stloc.s 4
-				IL_0083: ldloc.s 4
-				IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_008a: ldc.i4.0
-				IL_008b: ceq
-				IL_008d: stloc.s 5
-				IL_008f: ldloc.s 5
-				IL_0091: brfalse IL_00bf
+				IL_007c: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(object)
+				IL_0081: box [System.Runtime]System.Double
+				IL_0086: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_008b: ldc.i4.0
+				IL_008c: ceq
+				IL_008e: stloc.s 4
+				IL_0090: ldloc.s 4
+				IL_0092: brfalse IL_00c0
 
-				IL_0096: ldloc.1
-				IL_0097: ldc.r8 2
-				IL_00a0: mul
-				IL_00a1: stloc.s 6
-				IL_00a3: ldloc.0
-				IL_00a4: ldloc.s 6
-				IL_00a6: ldc.r8 1
-				IL_00af: add
-				IL_00b0: box [System.Runtime]System.Double
-				IL_00b5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00ba: stloc.s 6
-				IL_00bc: ldloc.s 6
-				IL_00be: stloc.2
+				IL_0097: ldloc.1
+				IL_0098: ldc.r8 2
+				IL_00a1: mul
+				IL_00a2: stloc.s 5
+				IL_00a4: ldloc.0
+				IL_00a5: ldloc.s 5
+				IL_00a7: ldc.r8 1
+				IL_00b0: add
+				IL_00b1: box [System.Runtime]System.Double
+				IL_00b6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00bb: stloc.s 5
+				IL_00bd: ldloc.s 5
+				IL_00bf: stloc.2
 
-				IL_00bf: ldloc.1
-				IL_00c0: ldc.r8 1
-				IL_00c9: add
-				IL_00ca: stloc.1
-				IL_00cb: br IL_0045
+				IL_00c0: ldloc.1
+				IL_00c1: ldc.r8 1
+				IL_00ca: add
+				IL_00cb: stloc.1
+				IL_00cc: br IL_0045
 			// end loop
 
-			IL_00d0: ldloc.0
-			IL_00d1: ret
+			IL_00d1: ldloc.0
+			IL_00d2: ret
 		} // end of method PrimeSieve::getPrimes
 
 		.method public hidebysig 
@@ -1881,7 +1870,7 @@
 				object verbose
 			) cil managed 
 		{
-			// Method begins at RVA 0x29d8
+			// Method begins at RVA 0x29cc
 			// Header size: 12
 			// Code size: 594 (0x252)
 			.maxstack 8
@@ -2114,7 +2103,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2d8e
+			// Method begins at RVA 0x2d87
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2293,7 +2282,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2eb7
+		// Method begins at RVA 0x2eb0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
+++ b/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
@@ -168,12 +168,12 @@
 		IL_000c: ldloc.2
 		IL_000d: stloc.1
 		IL_000e: ldloc.1
-		IL_000f: ldstr "setBeanCount"
+		IL_000f: castclass Modules.BeanCounter_Class_Index_Assign/BeanCounter
 		IL_0014: ldc.r8 1
 		IL_001d: box [System.Runtime]System.Double
 		IL_0022: ldc.r8 42
 		IL_002b: box [System.Runtime]System.Double
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0030: callvirt instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
 		IL_0035: pop
 		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_003b: ldloc.1

--- a/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -1047,13 +1047,13 @@
 		IL_014e: box [System.Runtime]System.Double
 		IL_0153: stloc.s 10
 		IL_0155: ldloc.1
-		IL_0156: ldstr "setBitsTrue"
+		IL_0156: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
 		IL_015b: ldloc.s 9
 		IL_015d: ldloc.s 10
 		IL_015f: ldloc.0
 		IL_0160: ldfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
 		IL_0165: box [System.Runtime]System.Double
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_016a: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
 		IL_016f: pop
 		IL_0170: ldloc.0
 		IL_0171: ldfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
@@ -1064,13 +1064,13 @@
 		IL_0183: box [System.Runtime]System.Double
 		IL_0188: stloc.s 9
 		IL_018a: ldloc.2
-		IL_018b: ldstr "setBitsTrue_Naive"
+		IL_018b: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
 		IL_0190: ldloc.s 10
 		IL_0192: ldloc.s 9
 		IL_0194: ldloc.0
 		IL_0195: ldfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
 		IL_019a: box [System.Runtime]System.Double
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_019f: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
 		IL_01a4: pop
 		IL_01a5: ldc.r8 0.0
 		IL_01ae: stloc.3

--- a/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2768
+				// Method begins at RVA 0x276c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2771
+				// Method begins at RVA 0x2775
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x277a
+				// Method begins at RVA 0x277e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x278c
+					// Method begins at RVA 0x2790
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x279e
+						// Method begins at RVA 0x27a2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27a7
+						// Method begins at RVA 0x27ab
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2795
+					// Method begins at RVA 0x2799
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2783
+				// Method begins at RVA 0x2787
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27b0
+				// Method begins at RVA 0x27b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -207,7 +207,7 @@
 				object size
 			) cil managed 
 		{
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x231c
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -253,7 +253,7 @@
 				object index
 			) cil managed 
 		{
-			// Method begins at RVA 0x2368
+			// Method begins at RVA 0x236c
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -321,7 +321,7 @@
 				object range_stop
 			) cil managed 
 		{
-			// Method begins at RVA 0x23d0
+			// Method begins at RVA 0x23d4
 			// Header size: 12
 			// Code size: 806 (0x326)
 			.maxstack 8
@@ -695,7 +695,7 @@
 				object index
 			) cil managed 
 		{
-			// Method begins at RVA 0x2704
+			// Method begins at RVA 0x2708
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -767,7 +767,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x275f
+			// Method begins at RVA 0x2763
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -793,7 +793,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 700 (0x2bc)
+		// Code size: 704 (0x2c0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope,
@@ -808,8 +808,7 @@
 			[9] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[12] object,
-			[13] bool
+			[12] bool
 		)
 
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::.ctor()
@@ -854,146 +853,142 @@
 		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 		IL_009a: pop
 		IL_009b: ldloc.1
-		IL_009c: ldstr "setBitsTrue"
+		IL_009c: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
 		IL_00a1: ldc.r8 4
 		IL_00aa: box [System.Runtime]System.Double
 		IL_00af: ldc.r8 3
 		IL_00b8: box [System.Runtime]System.Double
 		IL_00bd: ldc.r8 64
 		IL_00c6: box [System.Runtime]System.Double
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00cb: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
 		IL_00d0: pop
 		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00d6: stloc.s 11
 		IL_00d8: ldloc.1
-		IL_00d9: ldstr "testBitTrue"
+		IL_00d9: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
 		IL_00de: ldc.r8 4
 		IL_00e7: box [System.Runtime]System.Double
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f1: stloc.s 12
-		IL_00f3: ldloc.s 12
-		IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_00fa: stloc.s 13
-		IL_00fc: ldloc.s 13
-		IL_00fe: brfalse IL_0118
+		IL_00ec: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_00f1: box [System.Runtime]System.Double
+		IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_00fb: stloc.s 12
+		IL_00fd: ldloc.s 12
+		IL_00ff: brfalse IL_0119
 
-		IL_0103: ldc.r8 1
-		IL_010c: box [System.Runtime]System.Double
-		IL_0111: stloc.s 4
-		IL_0113: br IL_0128
+		IL_0104: ldc.r8 1
+		IL_010d: box [System.Runtime]System.Double
+		IL_0112: stloc.s 4
+		IL_0114: br IL_0129
 
-		IL_0118: ldc.r8 0.0
-		IL_0121: box [System.Runtime]System.Double
-		IL_0126: stloc.s 4
+		IL_0119: ldc.r8 0.0
+		IL_0122: box [System.Runtime]System.Double
+		IL_0127: stloc.s 4
 
-		IL_0128: ldloc.s 11
-		IL_012a: ldstr "bit4"
-		IL_012f: ldloc.s 4
-		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0136: pop
-		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013c: stloc.s 11
-		IL_013e: ldloc.1
-		IL_013f: ldstr "testBitTrue"
-		IL_0144: ldc.r8 7
-		IL_014d: box [System.Runtime]System.Double
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0157: stloc.s 12
-		IL_0159: ldloc.s 12
-		IL_015b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_0160: stloc.s 13
-		IL_0162: ldloc.s 13
-		IL_0164: brfalse IL_017e
+		IL_0129: ldloc.s 11
+		IL_012b: ldstr "bit4"
+		IL_0130: ldloc.s 4
+		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0137: pop
+		IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013d: stloc.s 11
+		IL_013f: ldloc.1
+		IL_0140: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_0145: ldc.r8 7
+		IL_014e: box [System.Runtime]System.Double
+		IL_0153: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0158: box [System.Runtime]System.Double
+		IL_015d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0162: stloc.s 12
+		IL_0164: ldloc.s 12
+		IL_0166: brfalse IL_0180
 
-		IL_0169: ldc.r8 1
-		IL_0172: box [System.Runtime]System.Double
-		IL_0177: stloc.s 5
-		IL_0179: br IL_018e
+		IL_016b: ldc.r8 1
+		IL_0174: box [System.Runtime]System.Double
+		IL_0179: stloc.s 5
+		IL_017b: br IL_0190
 
-		IL_017e: ldc.r8 0.0
-		IL_0187: box [System.Runtime]System.Double
-		IL_018c: stloc.s 5
+		IL_0180: ldc.r8 0.0
+		IL_0189: box [System.Runtime]System.Double
+		IL_018e: stloc.s 5
 
-		IL_018e: ldloc.s 11
-		IL_0190: ldstr "bit7"
-		IL_0195: ldloc.s 5
-		IL_0197: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_019c: pop
-		IL_019d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a2: stloc.s 11
-		IL_01a4: ldloc.1
-		IL_01a5: ldstr "testBitTrue"
-		IL_01aa: ldc.r8 31
-		IL_01b3: box [System.Runtime]System.Double
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01bd: stloc.s 12
-		IL_01bf: ldloc.s 12
-		IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_01c6: stloc.s 13
-		IL_01c8: ldloc.s 13
-		IL_01ca: brfalse IL_01e4
+		IL_0190: ldloc.s 11
+		IL_0192: ldstr "bit7"
+		IL_0197: ldloc.s 5
+		IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_019e: pop
+		IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a4: stloc.s 11
+		IL_01a6: ldloc.1
+		IL_01a7: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_01ac: ldc.r8 31
+		IL_01b5: box [System.Runtime]System.Double
+		IL_01ba: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_01bf: box [System.Runtime]System.Double
+		IL_01c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_01c9: stloc.s 12
+		IL_01cb: ldloc.s 12
+		IL_01cd: brfalse IL_01e7
 
-		IL_01cf: ldc.r8 1
-		IL_01d8: box [System.Runtime]System.Double
-		IL_01dd: stloc.s 6
-		IL_01df: br IL_01f4
+		IL_01d2: ldc.r8 1
+		IL_01db: box [System.Runtime]System.Double
+		IL_01e0: stloc.s 6
+		IL_01e2: br IL_01f7
 
-		IL_01e4: ldc.r8 0.0
-		IL_01ed: box [System.Runtime]System.Double
-		IL_01f2: stloc.s 6
+		IL_01e7: ldc.r8 0.0
+		IL_01f0: box [System.Runtime]System.Double
+		IL_01f5: stloc.s 6
 
-		IL_01f4: ldloc.s 11
-		IL_01f6: ldstr "bit31"
-		IL_01fb: ldloc.s 6
-		IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0202: pop
-		IL_0203: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0208: stloc.s 11
-		IL_020a: ldloc.1
-		IL_020b: ldstr "testBitTrue"
-		IL_0210: ldc.r8 5
-		IL_0219: box [System.Runtime]System.Double
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0223: stloc.s 12
-		IL_0225: ldloc.s 12
-		IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_022c: stloc.s 13
-		IL_022e: ldloc.s 13
-		IL_0230: brfalse IL_024a
+		IL_01f7: ldloc.s 11
+		IL_01f9: ldstr "bit31"
+		IL_01fe: ldloc.s 6
+		IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0205: pop
+		IL_0206: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_020b: stloc.s 11
+		IL_020d: ldloc.1
+		IL_020e: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_0213: ldc.r8 5
+		IL_021c: box [System.Runtime]System.Double
+		IL_0221: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0226: box [System.Runtime]System.Double
+		IL_022b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0230: stloc.s 12
+		IL_0232: ldloc.s 12
+		IL_0234: brfalse IL_024e
 
-		IL_0235: ldc.r8 1
-		IL_023e: box [System.Runtime]System.Double
-		IL_0243: stloc.s 7
-		IL_0245: br IL_025a
+		IL_0239: ldc.r8 1
+		IL_0242: box [System.Runtime]System.Double
+		IL_0247: stloc.s 7
+		IL_0249: br IL_025e
 
-		IL_024a: ldc.r8 0.0
-		IL_0253: box [System.Runtime]System.Double
-		IL_0258: stloc.s 7
+		IL_024e: ldc.r8 0.0
+		IL_0257: box [System.Runtime]System.Double
+		IL_025c: stloc.s 7
 
-		IL_025a: ldloc.s 11
-		IL_025c: ldstr "bit5"
-		IL_0261: ldloc.s 7
-		IL_0263: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0268: pop
-		IL_0269: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026e: ldstr "word0"
-		IL_0273: ldloc.1
-		IL_0274: ldstr "wordArray"
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_027e: ldc.r8 0.0
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-		IL_028c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0291: pop
-		IL_0292: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0297: ldstr "word1"
-		IL_029c: ldloc.1
-		IL_029d: ldstr "wordArray"
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
-		IL_02a7: ldc.r8 1
-		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
-		IL_02b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02ba: pop
-		IL_02bb: ret
+		IL_025e: ldloc.s 11
+		IL_0260: ldstr "bit5"
+		IL_0265: ldloc.s 7
+		IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_026c: pop
+		IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0272: ldstr "word0"
+		IL_0277: ldloc.1
+		IL_0278: ldstr "wordArray"
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_0282: ldc.r8 0.0
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_0290: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0295: pop
+		IL_0296: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_029b: ldstr "word1"
+		IL_02a0: ldloc.1
+		IL_02a1: ldstr "wordArray"
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, string)
+		IL_02ab: ldc.r8 1
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetItem(object, float64)
+		IL_02b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02be: pop
+		IL_02bf: ret
 	} // end of method Prime_SetBitsTrue_SmallStep_WordValueOrAssign::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign
@@ -1005,7 +1000,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27b9
+		// Method begins at RVA 0x27bd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- extend member-call normalization to cover arity-specific `LIRCallMember0/1/2/3`
- keep conservative guarded fallback behavior for dynamic member dispatch
- include regenerated generator snapshots currently in the working tree

## Validation
- Ran targeted Prime generator tests after snapshot updates (5 passed)

Closes #739