### PR TITLE
docs(ecma262): sync 22.1 String Objects status matrix

### DIFF
--- a/docs/ECMA262/22/Section22_1.json
+++ b/docs/ECMA262/22/Section22_1.json
@@ -96,19 +96,19 @@
     {
       "clause": "22.1.3.7",
       "title": "String.prototype.endsWith ( searchString [ , endPosition ] )",
-      "status": "Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.endswith"
     },
     {
       "clause": "22.1.3.8",
       "title": "String.prototype.includes ( searchString [ , position ] )",
-      "status": "Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.includes"
     },
     {
       "clause": "22.1.3.9",
       "title": "String.prototype.indexOf ( searchString [ , position ] )",
-      "status": "Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.indexof"
     },
     {
@@ -216,13 +216,13 @@
     {
       "clause": "22.1.3.23",
       "title": "String.prototype.split ( separator , limit )",
-      "status": "Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.split"
     },
     {
       "clause": "22.1.3.24",
       "title": "String.prototype.startsWith ( searchString [ , position ] )",
-      "status": "Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.startswith"
     },
     {
@@ -362,36 +362,44 @@
       {
         "clause": "22.1.3.24",
         "feature": "String.prototype.startsWith",
-        "status": "Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.startswith",
         "testScripts": [
-          "Js2IL.Tests/String/JavaScript/String_StartsWith_Basic.js"
+          "Js2IL.Tests/String/JavaScript/String_StartsWith_Basic.js",
+          "Js2IL.Tests/String/JavaScript/String_StartsWith_NestedParam.js"
         ],
-        "notes": "Reflection-based string dispatch routes CLR string receivers to JavaScriptRuntime.String.StartsWith with optional position argument. Returns a boolean value (boxed)."
+        "notes": "Routed via JavaScriptRuntime.Object string member-call fast paths to JavaScriptRuntime.String.StartsWith. Known differences vs spec: does not reject RegExp searchString, and when called with zero arguments the fast path uses an empty string instead of ToString(undefined)."
       },
       {
         "clause": "22.1.3.8",
         "feature": "String.prototype.includes",
-        "status": "Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.includes",
-        "notes": "Reflection-based dispatch recognizes definite string receivers and routes to JavaScriptRuntime.String.Includes; supports optional position argument. Returns a boolean value. (No dedicated JS fixture currently referenced in this doc.)"
+        "testScripts": [
+          "Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js",
+          "Js2IL.Tests/Node/FS/JavaScript/FSPromises_Realpath.js"
+        ],
+        "notes": "Routed via JavaScriptRuntime.Object string member-call fast paths to JavaScriptRuntime.String.Includes. Known differences vs spec: does not reject RegExp searchString, and when called with zero arguments the fast path uses an empty string instead of ToString(undefined)."
       },
       {
         "clause": "22.1.3.7",
         "feature": "String.prototype.endsWith",
-        "status": "Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.endswith",
-        "notes": "Implemented in JavaScriptRuntime.String and wired via IL generator for definite string receivers. Supports optional end position. Returns a boolean value. (No dedicated JS fixture currently referenced in this doc.)"
+        "testScripts": [
+          "Js2IL.Tests/Node/Path/JavaScript/Require_Path_Parse_And_Format.js"
+        ],
+        "notes": "Routed via JavaScriptRuntime.Object string member-call fast paths to JavaScriptRuntime.String.EndsWith with optional endPosition argument. Known differences vs spec: does not reject RegExp searchString, and when called with zero arguments the fast path uses an empty string instead of ToString(undefined)."
       },
       {
         "clause": "22.1.3.23",
         "feature": "String.prototype.split",
-        "status": "Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.split",
         "testScripts": [
           "Js2IL.Tests/String/JavaScript/String_Split_Basic.js"
         ],
-        "notes": "Supports string and regular-expression separators and optional limit. Implemented via JavaScriptRuntime.String.Split and returned as JavaScriptRuntime.Array. Separator omitted or undefined returns [input]. Empty string separator splits into individual UTF-16 code units."
+        "notes": "Implemented via JavaScriptRuntime.String.Split and returned as JavaScriptRuntime.Array. Separator omitted or undefined returns [input]. Empty string separator splits into individual UTF-16 code units. RegExp separator behavior is incomplete: JavaScriptRuntime.RegExp is currently coerced to string rather than treated as a regex separator, and @@split hooks are not implemented."
       },
       {
         "clause": "22.1.3.19",
@@ -467,9 +475,13 @@
       {
         "clause": "22.1.3.9",
         "feature": "String.prototype.indexOf",
-        "status": "Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.indexof",
-        "notes": "Implemented in JavaScriptRuntime.String.IndexOf and routed via Object.CallMember for definite string receivers. Supports optional position argument."
+        "testScripts": [
+          "Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js",
+          "Js2IL.Tests/Function/JavaScript/Function_Prototype_ToString_Basic.js"
+        ],
+        "notes": "Implemented in JavaScriptRuntime.String.IndexOf and routed via JavaScriptRuntime.Object string member-call fast paths. Known differences vs spec: when called with zero arguments the fast path searches for an empty string instead of ToString(undefined)."
       },
       {
         "clause": "22.1.3.22",
@@ -490,21 +502,30 @@
         "feature": "String.prototype.trim",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.trim",
-        "notes": "Implemented in JavaScriptRuntime.String.Trim using CLR whitespace trimming. Full ECMAScript whitespace set matching is not exhaustively validated."
+        "testScripts": [
+          "Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js"
+        ],
+        "notes": "Implemented in JavaScriptRuntime.String.Trim via TrimEcma (explicit ECMAScript whitespace set). Not exhaustively validated against all edge-case observable behaviors (e.g., exotic receivers / property attributes)."
       },
       {
         "clause": "22.1.3.33",
         "feature": "String.prototype.trimEnd",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.trimend",
-        "notes": "Implemented in JavaScriptRuntime.String.TrimEnd (and TrimRight alias) using CLR whitespace trimming."
+        "testScripts": [
+          "Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js"
+        ],
+        "notes": "Implemented in JavaScriptRuntime.String.TrimEnd (and TrimRight alias) via TrimEndEcma (explicit ECMAScript whitespace set)."
       },
       {
         "clause": "22.1.3.34",
         "feature": "String.prototype.trimStart",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.trimstart",
-        "notes": "Implemented in JavaScriptRuntime.String.TrimStart (and TrimLeft alias) using CLR whitespace trimming."
+        "testScripts": [
+          "Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js"
+        ],
+        "notes": "Implemented in JavaScriptRuntime.String.TrimStart (and TrimLeft alias) via TrimStartEcma (explicit ECMAScript whitespace set)."
       },
       {
         "clause": "22.1.3.21",

--- a/docs/ECMA262/22/Section22_1.md
+++ b/docs/ECMA262/22/Section22_1.md
@@ -26,9 +26,9 @@
 | 22.1.3.4 | String.prototype.codePointAt ( pos ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.codepointat) |
 | 22.1.3.5 | String.prototype.concat ( ... args ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.concat) |
 | 22.1.3.6 | String.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.constructor) |
-| 22.1.3.7 | String.prototype.endsWith ( searchString [ , endPosition ] ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.endswith) |
-| 22.1.3.8 | String.prototype.includes ( searchString [ , position ] ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.includes) |
-| 22.1.3.9 | String.prototype.indexOf ( searchString [ , position ] ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.indexof) |
+| 22.1.3.7 | String.prototype.endsWith ( searchString [ , endPosition ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.endswith) |
+| 22.1.3.8 | String.prototype.includes ( searchString [ , position ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.includes) |
+| 22.1.3.9 | String.prototype.indexOf ( searchString [ , position ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.indexof) |
 | 22.1.3.10 | String.prototype.isWellFormed ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.iswellformed) |
 | 22.1.3.11 | String.prototype.lastIndexOf ( searchString [ , position ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.lastindexof) |
 | 22.1.3.12 | String.prototype.localeCompare ( that [ , reserved1 [ , reserved2 ] ] ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.localecompare) |
@@ -46,8 +46,8 @@
 | 22.1.3.20 | String.prototype.replaceAll ( searchValue , replaceValue ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.replaceall) |
 | 22.1.3.21 | String.prototype.search ( regexp ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.search) |
 | 22.1.3.22 | String.prototype.slice ( start , end ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.slice) |
-| 22.1.3.23 | String.prototype.split ( separator , limit ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.split) |
-| 22.1.3.24 | String.prototype.startsWith ( searchString [ , position ] ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.startswith) |
+| 22.1.3.23 | String.prototype.split ( separator , limit ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.split) |
+| 22.1.3.24 | String.prototype.startsWith ( searchString [ , position ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.startswith) |
 | 22.1.3.25 | String.prototype.substring ( start , end ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.substring) |
 | 22.1.3.26 | String.prototype.toLocaleLowerCase ( [ reserved1 [ , reserved2 ] ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.tolocalelowercase) |
 | 22.1.3.27 | String.prototype.toLocaleUpperCase ( [ reserved1 [ , reserved2 ] ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.tolocaleuppercase) |
@@ -89,19 +89,19 @@ Feature-level support tracking with test script references.
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| String.prototype.endsWith | Supported |  | Implemented in JavaScriptRuntime.String and wired via IL generator for definite string receivers. Supports optional end position. Returns a boolean value. (No dedicated JS fixture currently referenced in this doc.) |
+| String.prototype.endsWith | Supported with Limitations | [`Require_Path_Parse_And_Format.js`](../../../Js2IL.Tests/Node/Path/JavaScript/Require_Path_Parse_And_Format.js) | Routed via JavaScriptRuntime.Object string member-call fast paths to JavaScriptRuntime.String.EndsWith with optional endPosition argument. Known differences vs spec: does not reject RegExp searchString, and when called with zero arguments the fast path uses an empty string instead of ToString(undefined). |
 
 ### 22.1.3.8 ([tc39.es](https://tc39.es/ecma262/#sec-string.prototype.includes))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| String.prototype.includes | Supported |  | Reflection-based dispatch recognizes definite string receivers and routes to JavaScriptRuntime.String.Includes; supports optional position argument. Returns a boolean value. (No dedicated JS fixture currently referenced in this doc.) |
+| String.prototype.includes | Supported with Limitations | [`String_MemberCall_FastPath_CommonMethods.js`](../../../Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js)<br>[`FSPromises_Realpath.js`](../../../Js2IL.Tests/Node/FS/JavaScript/FSPromises_Realpath.js) | Routed via JavaScriptRuntime.Object string member-call fast paths to JavaScriptRuntime.String.Includes. Known differences vs spec: does not reject RegExp searchString, and when called with zero arguments the fast path uses an empty string instead of ToString(undefined). |
 
 ### 22.1.3.9 ([tc39.es](https://tc39.es/ecma262/#sec-string.prototype.indexof))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| String.prototype.indexOf | Supported |  | Implemented in JavaScriptRuntime.String.IndexOf and routed via Object.CallMember for definite string receivers. Supports optional position argument. |
+| String.prototype.indexOf | Supported with Limitations | [`String_MemberCall_FastPath_CommonMethods.js`](../../../Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js)<br>[`Function_Prototype_ToString_Basic.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Prototype_ToString_Basic.js) | Implemented in JavaScriptRuntime.String.IndexOf and routed via JavaScriptRuntime.Object string member-call fast paths. Known differences vs spec: when called with zero arguments the fast path searches for an empty string instead of ToString(undefined). |
 
 ### 22.1.3.12 ([tc39.es](https://tc39.es/ecma262/#sec-string.prototype.localecompare))
 
@@ -143,13 +143,13 @@ Feature-level support tracking with test script references.
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| String.prototype.split | Supported | [`String_Split_Basic.js`](../../../Js2IL.Tests/String/JavaScript/String_Split_Basic.js) | Supports string and regular-expression separators and optional limit. Implemented via JavaScriptRuntime.String.Split and returned as JavaScriptRuntime.Array. Separator omitted or undefined returns [input]. Empty string separator splits into individual UTF-16 code units. |
+| String.prototype.split | Supported with Limitations | [`String_Split_Basic.js`](../../../Js2IL.Tests/String/JavaScript/String_Split_Basic.js) | Implemented via JavaScriptRuntime.String.Split and returned as JavaScriptRuntime.Array. Separator omitted or undefined returns [input]. Empty string separator splits into individual UTF-16 code units. RegExp separator behavior is incomplete: JavaScriptRuntime.RegExp is currently coerced to string rather than treated as a regex separator, and @@split hooks are not implemented. |
 
 ### 22.1.3.24 ([tc39.es](https://tc39.es/ecma262/#sec-string.prototype.startswith))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| String.prototype.startsWith | Supported | [`String_StartsWith_Basic.js`](../../../Js2IL.Tests/String/JavaScript/String_StartsWith_Basic.js) | Reflection-based string dispatch routes CLR string receivers to JavaScriptRuntime.String.StartsWith with optional position argument. Returns a boolean value (boxed). |
+| String.prototype.startsWith | Supported with Limitations | [`String_StartsWith_Basic.js`](../../../Js2IL.Tests/String/JavaScript/String_StartsWith_Basic.js)<br>[`String_StartsWith_NestedParam.js`](../../../Js2IL.Tests/String/JavaScript/String_StartsWith_NestedParam.js) | Routed via JavaScriptRuntime.Object string member-call fast paths to JavaScriptRuntime.String.StartsWith. Known differences vs spec: does not reject RegExp searchString, and when called with zero arguments the fast path uses an empty string instead of ToString(undefined). |
 
 ### 22.1.3.25 ([tc39.es](https://tc39.es/ecma262/#sec-string.prototype.substring))
 
@@ -173,17 +173,17 @@ Feature-level support tracking with test script references.
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| String.prototype.trim | Supported with Limitations |  | Implemented in JavaScriptRuntime.String.Trim using CLR whitespace trimming. Full ECMAScript whitespace set matching is not exhaustively validated. |
+| String.prototype.trim | Supported with Limitations | [`String_MemberCall_FastPath_CommonMethods.js`](../../../Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js) | Implemented in JavaScriptRuntime.String.Trim via TrimEcma (explicit ECMAScript whitespace set). Not exhaustively validated against all edge-case observable behaviors (e.g., exotic receivers / property attributes). |
 
 ### 22.1.3.33 ([tc39.es](https://tc39.es/ecma262/#sec-string.prototype.trimend))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| String.prototype.trimEnd | Supported with Limitations |  | Implemented in JavaScriptRuntime.String.TrimEnd (and TrimRight alias) using CLR whitespace trimming. |
+| String.prototype.trimEnd | Supported with Limitations | [`String_MemberCall_FastPath_CommonMethods.js`](../../../Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js) | Implemented in JavaScriptRuntime.String.TrimEnd (and TrimRight alias) via TrimEndEcma (explicit ECMAScript whitespace set). |
 
 ### 22.1.3.34 ([tc39.es](https://tc39.es/ecma262/#sec-string.prototype.trimstart))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| String.prototype.trimStart | Supported with Limitations |  | Implemented in JavaScriptRuntime.String.TrimStart (and TrimLeft alias) using CLR whitespace trimming. |
+| String.prototype.trimStart | Supported with Limitations | [`String_MemberCall_FastPath_CommonMethods.js`](../../../Js2IL.Tests/String/JavaScript/String_MemberCall_FastPath_CommonMethods.js) | Implemented in JavaScriptRuntime.String.TrimStart (and TrimLeft alias) via TrimStartEcma (explicit ECMAScript whitespace set). |
 


### PR DESCRIPTION
## Summary
- update ECMA-262 §22.1 clause/subclause statuses in `docs/ECMA262/22/Section22_1.json`
- align status values with currently implemented String runtime/compiler support
- regenerate `docs/ECMA262/22/Section22_1.md`