### PR TITLE
docs(triage): sync IssueTriage-2026-03-06

### DIFF
--- a/docs/tracking-issues/IssueTriage-2026-03-06.md
+++ b/docs/tracking-issues/IssueTriage-2026-03-06.md
@@ -2,90 +2,101 @@
 
 This file captures a point-in-time prioritized list of open issues/PRs and a single recommended “next item to fix”.
 
+Synced to:
+- Repo: `master` @ `78edaae0` (fix(esm): complete issue #772)
+- GitHub: open issues/PRs state as of 2026-03-06
+
 ## Recommended next item
-**Merge PR #704** (READY; checks green):
+**Merge PR #704** (OPEN; non-draft):
 - https://github.com/tomacox74/js2il/pull/704
 
 Rationale:
-- It’s already implemented + validated by CI, so landing it is high-leverage vs starting a new feature.
-- Improves ecosystem stability via a real-world canary smoke gate.
+- Lands the canary smoke gate (fixes #583) and improves ecosystem stability.
+- It’s a contained change set vs starting a new runtime/spec feature.
 
 ## Triage note (hygiene)
-**Issue #787 is still OPEN even though it was merged via PR #804**. It should be closed as done:
-- https://github.com/tomacox74/js2il/issues/787
+**Issue #772 is still OPEN but appears implemented on `master`** (commit `78edaae0` “fix(esm): complete issue #772 ...”). If verified, close the issue:
+- https://github.com/tomacox74/js2il/issues/772
+- https://github.com/tomacox74/js2il/commit/78edaae01b2b3da4560068b12314005a4c40387a
 
-## Top 10 open issues (excluding #787)
-(Heuristic ranking using priority labels + lane keywords in titles/labels; recommendation-only.)
+## Top 10 open issues (excluding #772, which appears completed in `master`)
+(Heuristic ranking using `priority:*` labels + module/spec/perf keywords in titles/labels; recommendation-only.)
 
-1. #772 (priority:high) ES Modules live bindings/module records
-   - https://github.com/tomacox74/js2il/issues/772
-2. #581 (priority:high) differential testing harness (Node vs JS2IL)
+1. #581 (priority:high) Quality: bounded differential testing (Node vs JS2IL) for semantic regressions
    - https://github.com/tomacox74/js2il/issues/581
-3. #775 (priority:high) modern RegExp flags + symbol methods parity
-   - https://github.com/tomacox74/js2il/issues/775
-4. #774 (priority:high) complete `%TypedArray%` constructors + prototype methods
-   - https://github.com/tomacox74/js2il/issues/774
-5. #773 (priority:high) ArrayBuffer + DataView primitives
-   - https://github.com/tomacox74/js2il/issues/773
-6. #584 (priority:high) compiler shape-coverage micro-tests
+2. #584 (priority:high) Quality: add compiler shape-coverage micro-tests (joins/back-edges/materialization)
    - https://github.com/tomacox74/js2il/issues/584
-7. #790 (priority:medium) node crypto minimum subset
-   - https://github.com/tomacox74/js2il/issues/790
-8. #789 (priority:medium) node url/querystring baseline
-   - https://github.com/tomacox74/js2il/issues/789
-9. #788 (priority:medium) child_process beyond sync
-   - https://github.com/tomacox74/js2il/issues/788
-10. #780 (priority:medium) Array iterator methods
-   - https://github.com/tomacox74/js2il/issues/780
+3. #773 (priority:high) ECMA-262: Implement ArrayBuffer + DataView primitives (foundation for TypedArray semantics)
+   - https://github.com/tomacox74/js2il/issues/773
+4. #774 (priority:high) ECMA-262: Complete %TypedArray% constructors + prototype methods
+   - https://github.com/tomacox74/js2il/issues/774
+5. #775 (priority:high) ECMA-262: RegExp modern flags and symbol methods parity (u/y/d/v, @@match, etc.)
+   - https://github.com/tomacox74/js2il/issues/775
+6. #583 (priority:medium) Quality: add real-world canary corpus smoke tests (bounded) for ecosystem stability
+   - https://github.com/tomacox74/js2il/issues/583
+7. #776 (priority:medium) ECMA-262: Ordinary object internal method invariants (DefineOwnProperty/GetOwnProperty, keys ordering)
+   - https://github.com/tomacox74/js2il/issues/776
+8. #777 (priority:medium) ECMA-262: Object integrity APIs semantics audit (freeze/seal/preventExtensions/is*)
+   - https://github.com/tomacox74/js2il/issues/777
+9. #778 (priority:medium) ECMA-262: Support Function constructor (new Function / CreateDynamicFunction)
+   - https://github.com/tomacox74/js2il/issues/778
+10. #779 (priority:medium) ECMA-262: Symbol ecosystem completeness audit (well-known symbols + symbol-key introspection semantics)
+    - https://github.com/tomacox74/js2il/issues/779
 
 ## Next 20 open issues
-11. #779 (priority:medium) Symbol ecosystem completeness audit
-    - https://github.com/tomacox74/js2il/issues/779
-12. #778 (priority:medium) Function constructor (`new Function`)
-    - https://github.com/tomacox74/js2il/issues/778
-13. #777 (priority:medium) Object integrity APIs semantics audit
-    - https://github.com/tomacox74/js2il/issues/777
-14. #776 (priority:medium) Ordinary object internal method invariants
-    - https://github.com/tomacox74/js2il/issues/776
-15. #583 (priority:medium) real-world canary corpus smoke tests (bounded)
-    - https://github.com/tomacox74/js2il/issues/583
-16. #792 (priority:low) http/https/net/tls baseline plan
-    - https://github.com/tomacox74/js2il/issues/792
-17. #791 (priority:low) ESM interop baseline plan
-    - https://github.com/tomacox74/js2il/issues/791
-18. #781 (priority:low) WeakRef + FinalizationRegistry host cleanup model
+11. #780 (priority:medium) ECMA-262: Expose Array iterator methods (entries/keys/values/[Symbol.iterator])
+    - https://github.com/tomacox74/js2il/issues/780
+12. #787 (priority:medium) node: expand util essentials (format, inspect parity, util.types breadth)
+    - https://github.com/tomacox74/js2il/issues/787
+13. #788 (priority:medium) node: expand child_process beyond sync (spawn/exec/execFile, stdio pipes)
+    - https://github.com/tomacox74/js2il/issues/788
+14. #789 (priority:medium) node: implement url/querystring baseline (URL, URLSearchParams, parse/stringify)
+    - https://github.com/tomacox74/js2il/issues/789
+15. #790 (priority:medium) node: implement crypto minimum practical subset (createHash, randomBytes, webcrypto bridge)
+    - https://github.com/tomacox74/js2il/issues/790
+16. #781 (priority:low) ECMA-262: Implement WeakRef + FinalizationRegistry host cleanup model
     - https://github.com/tomacox74/js2il/issues/781
-19. #738 perf(prime): close PrimeJavaScript gap
-    - https://github.com/tomacox74/js2il/issues/738
-20. #737 perf: callsite-based typed parameter specialization
-    - https://github.com/tomacox74/js2il/issues/737
-21. #419 Hosting: mutable CommonJS exports
+17. #791 (priority:low) node: add ESM interop baseline (import.meta.url + Node-style ESM resolution plan)
+    - https://github.com/tomacox74/js2il/issues/791
+18. #792 (priority:low) node: add http/https/net/tls baseline plan (client/server skeleton)
+    - https://github.com/tomacox74/js2il/issues/792
+19. #419 Hosting: support mutable CommonJS exports (Node-like)
     - https://github.com/tomacox74/js2il/issues/419
-22. #768 Perf: devirtualize calls to const/arrow bindings
-    - https://github.com/tomacox74/js2il/issues/768
-23. #746 perf: make dromaeo-object-regexp faster than Jint prepared
-    - https://github.com/tomacox74/js2il/issues/746
-24. #748 perf(dispatch): RegExp fast paths in Object.CallMember1/2
-    - https://github.com/tomacox74/js2il/issues/748
-25. #747 perf(regexp): cache Regex instances by source+flags
-    - https://github.com/tomacox74/js2il/issues/747
-26. #743 perf(prime): add Prime perf acceptance gate and reporting
-    - https://github.com/tomacox74/js2il/issues/743
-27. #742 perf(prime): trim timing/config coercion overhead
-    - https://github.com/tomacox74/js2il/issues/742
-28. #740 perf(prime): keep sieve loop math in typed locals
-    - https://github.com/tomacox74/js2il/issues/740
-29. #451 perf(il): expand typed temps/locals to reduce casts/boxing
+20. #439 Hosting: publish referenceable library/build NuGet package
+    - https://github.com/tomacox74/js2il/issues/439
+21. #451 perf(il): expand typed temps/locals to reduce casts/boxing
     - https://github.com/tomacox74/js2il/issues/451
-30. #728 Bound function semantics for constructor/new-target/metadata
+22. #727 Function length/name should be descriptor-backed own properties
+    - https://github.com/tomacox74/js2il/issues/727
+23. #728 Complete bound function semantics for constructor/new-target and metadata
     - https://github.com/tomacox74/js2il/issues/728
+24. #737 perf: callsite-based typed parameter specialization for non-exported functions
+    - https://github.com/tomacox74/js2il/issues/737
+25. #738 perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations
+    - https://github.com/tomacox74/js2il/issues/738
+26. #740 perf(prime): keep sieve loop math in typed locals with fallback
+    - https://github.com/tomacox74/js2il/issues/740
+27. #742 perf(prime): trim timing/config coercion overhead in main path
+    - https://github.com/tomacox74/js2il/issues/742
+28. #743 perf(prime): add Prime perf acceptance gate and reporting
+    - https://github.com/tomacox74/js2il/issues/743
+29. #746 perf: make dromaeo-object-regexp faster than Jint prepared
+    - https://github.com/tomacox74/js2il/issues/746
+30. #747 perf(regexp): cache Regex instances by source+flags
+    - https://github.com/tomacox74/js2il/issues/747
+
+## Remaining open issues
+31. #748 perf(dispatch): add RegExp fast paths in Object.CallMember1/2
+    - https://github.com/tomacox74/js2il/issues/748
+32. #768 Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)
+    - https://github.com/tomacox74/js2il/issues/768
 
 ## Open PRs (for context)
-- #704 (READY): https://github.com/tomacox74/js2il/pull/704
+- #704 (OPEN): https://github.com/tomacox74/js2il/pull/704
 - #702 (DRAFT): https://github.com/tomacox74/js2il/pull/702
 - #703 (DRAFT): https://github.com/tomacox74/js2il/pull/703
 
 ## Label/metadata gaps (as of this snapshot)
 - Open issues: 33
 - Missing `priority:*` label: 14
-- Missing lane categorization (heuristic): 17
+- Missing `lane:*` label: 33


### PR DESCRIPTION
Sync triage snapshot to current repo state (master @ 78edaae0) and current GitHub open issues/PRs.\n\nKey fixes:\n- Remove stale note about #787 being merged; instead flag #772 as implemented but still open.\n- Refresh ranked open-issue lists and label-gap counts.