### PR TITLE
docs(ecma262): audit section 24 and add generated timestamps

### DIFF
--- a/docs/ECMA262/1/Section1.md
+++ b/docs/ECMA262/1/Section1.md
@@ -4,6 +4,8 @@ Defines the overall scope of the ECMAScript specification and how the document i
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 1 | Scope | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-scope) |

--- a/docs/ECMA262/10/Section10.md
+++ b/docs/ECMA262/10/Section10.md
@@ -4,6 +4,8 @@ Defines ordinary and exotic object behaviors, including internal methods/slots a
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/10/Section10_1.md
+++ b/docs/ECMA262/10/Section10_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 10.1 | Ordinary Object Internal Methods and Internal Slots | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots) |

--- a/docs/ECMA262/10/Section10_2.md
+++ b/docs/ECMA262/10/Section10_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 10.2 | ECMAScript Function Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-function-objects) |

--- a/docs/ECMA262/10/Section10_3.md
+++ b/docs/ECMA262/10/Section10_3.md
@@ -1,10 +1,21 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 10.3: Built-in Function Objects
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 10.3 | Built-in Function Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 10.3.1 | [[Call]] ( thisArgument , argumentsList ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist) |
+| 10.3.2 | [[Construct]] ( argumentsList , newTarget ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects-construct-argumentslist-newtarget) |
+| 10.3.3 | BuiltinCallOrConstruct ( F , thisArgument , argumentsList , newTarget ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-builtincallorconstruct) |
+| 10.3.4 | CreateBuiltinFunction ( behaviour , length , name , additionalInternalSlotsList [ , realm [ , prototype [ , prefix [ , async ] ] ] ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-createbuiltinfunction) |
 

--- a/docs/ECMA262/10/Section10_4.md
+++ b/docs/ECMA262/10/Section10_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 This section covers spec-defined *exotic objects* and their internal methods/slots (Bound Function, Array, String, Arguments, TypedArray, etc.). JS2IL currently does not attempt to model these internal-method details as specified. For the intrinsic function-scope `arguments` binding, JS2IL implements a minimal behavior tracked under Section 10.2 (non-arrow functions materialize `arguments` lazily as a JS Array snapshot; arrow functions capture `arguments` lexically). The full spec **Arguments Exotic Object** behavior (including mapped-arguments aliasing) remains not implemented.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/10/Section10_5.md
+++ b/docs/ECMA262/10/Section10_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 10.5 | Proxy Object Internal Methods and Internal Slots | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots) |

--- a/docs/ECMA262/11/Section11.md
+++ b/docs/ECMA262/11/Section11.md
@@ -4,6 +4,8 @@ Describes ECMAScript source text and how code is interpreted as scripts/modules.
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/11/Section11_1.md
+++ b/docs/ECMA262/11/Section11_1.md
@@ -1,10 +1,23 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 11.1: Source Text
 
 [Back to Section11](Section11.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 11.1 | Source Text | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-source-text) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 11.1.1 | Static Semantics: UTF16EncodeCodePoint ( cp ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-utf16encodecodepoint) |
+| 11.1.2 | Static Semantics: CodePointsToString ( text ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-codepointstostring) |
+| 11.1.3 | Static Semantics: UTF16SurrogatePairToCodePoint ( lead , trail ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-utf16decodesurrogatepair) |
+| 11.1.4 | Static Semantics: CodePointAt ( string , position ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-codepointat) |
+| 11.1.5 | Static Semantics: StringToCodePoints ( string ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-stringtocodepoints) |
+| 11.1.6 | Static Semantics: ParseText ( sourceText , goalSymbol ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-parsetext) |
 

--- a/docs/ECMA262/11/Section11_2.md
+++ b/docs/ECMA262/11/Section11_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section11](Section11.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 11.2 | Types of Source Code | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-types-of-source-code) |

--- a/docs/ECMA262/12/Section12.md
+++ b/docs/ECMA262/12/Section12.md
@@ -4,6 +4,8 @@ Defines the lexical grammar: tokens, literals, comments, whitespace, and related
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/12/Section12_1.md
+++ b/docs/ECMA262/12/Section12_1.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 12.1: Unicode Format-Control Characters
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.1 | Unicode Format-Control Characters | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-unicode-format-control-characters) |
-

--- a/docs/ECMA262/12/Section12_10.md
+++ b/docs/ECMA262/12/Section12_10.md
@@ -1,10 +1,23 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 12.10: Automatic Semicolon Insertion
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.10 | Automatic Semicolon Insertion | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-automatic-semicolon-insertion) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 12.10.1 | Rules of Automatic Semicolon Insertion | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-rules-of-automatic-semicolon-insertion) |
+| 12.10.2 | Examples of Automatic Semicolon Insertion | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-examples-of-automatic-semicolon-insertion) |
+| 12.10.3 | Interesting Cases of Automatic Semicolon Insertion | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-interesting-cases-of-automatic-semicolon-insertion) |
+| 12.10.3.1 | Interesting Cases of Automatic Semicolon Insertion in Statement Lists | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asi-interesting-cases-in-statement-lists) |
+| 12.10.3.2 | Cases of Automatic Semicolon Insertion and “[no LineTerminator here]” | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-asi-cases-with-no-lineterminator-here) |
+| 12.10.3.2.1 | List of Grammar Productions with Optional Operands and “[no LineTerminator here]” | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-no-lineterminator-here-automatic-semicolon-insertion-list) |
 

--- a/docs/ECMA262/12/Section12_2.md
+++ b/docs/ECMA262/12/Section12_2.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 12.2: White Space
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.2 | White Space | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-white-space) |
-

--- a/docs/ECMA262/12/Section12_3.md
+++ b/docs/ECMA262/12/Section12_3.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 12.3: Line Terminators
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.3 | Line Terminators | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-line-terminators) |
-

--- a/docs/ECMA262/12/Section12_4.md
+++ b/docs/ECMA262/12/Section12_4.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 12.4: Comments
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.4 | Comments | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-comments) |
-

--- a/docs/ECMA262/12/Section12_5.md
+++ b/docs/ECMA262/12/Section12_5.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 12.5: Hashbang Comments
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.5 | Hashbang Comments | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hashbang) |
-

--- a/docs/ECMA262/12/Section12_6.md
+++ b/docs/ECMA262/12/Section12_6.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 12.6: Tokens
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.6 | Tokens | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-tokens) |
-

--- a/docs/ECMA262/12/Section12_7.md
+++ b/docs/ECMA262/12/Section12_7.md
@@ -1,10 +1,22 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 12.7: Names and Keywords
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.7 | Names and Keywords | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-names-and-keywords) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 12.7.1 | Identifier Names | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-identifier-names) |
+| 12.7.1.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-identifier-names-static-semantics-early-errors) |
+| 12.7.1.2 | Static Semantics: IdentifierCodePoints | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-identifiercodepoints) |
+| 12.7.1.3 | Static Semantics: IdentifierCodePoint | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-identifiercodepoint) |
+| 12.7.2 | Keywords and Reserved Words | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-keywords-and-reserved-words) |
 

--- a/docs/ECMA262/12/Section12_8.md
+++ b/docs/ECMA262/12/Section12_8.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 12.8: Punctuators
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.8 | Punctuators | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-punctuators) |
-

--- a/docs/ECMA262/12/Section12_9.md
+++ b/docs/ECMA262/12/Section12_9.md
@@ -1,10 +1,33 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 12.9: Literals
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 12.9 | Literals | Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar-literals) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 12.9.1 | Null Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-null-literals) |
+| 12.9.2 | Boolean Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-boolean-literals) |
+| 12.9.3 | Numeric Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-literals-numeric-literals) |
+| 12.9.3.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-numeric-literals-early-errors) |
+| 12.9.3.2 | Static Semantics: MV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-mv) |
+| 12.9.3.3 | Static Semantics: NumericValue | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-numericvalue) |
+| 12.9.4 | String Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-literals-string-literals) |
+| 12.9.4.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-literals-early-errors) |
+| 12.9.4.2 | Static Semantics: SV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-sv) |
+| 12.9.4.3 | Static Semantics: MV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-literals-static-semantics-mv) |
+| 12.9.5 | Regular Expression Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-literals-regular-expression-literals) |
+| 12.9.5.1 | Static Semantics: BodyText | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-bodytext) |
+| 12.9.5.2 | Static Semantics: FlagText | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-flagtext) |
+| 12.9.6 | Template Literal Lexical Components | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-template-literal-lexical-components) |
+| 12.9.6.1 | Static Semantics: TV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-tv) |
+| 12.9.6.2 | Static Semantics: TRV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-trv) |
 

--- a/docs/ECMA262/13/Section13.md
+++ b/docs/ECMA262/13/Section13.md
@@ -4,6 +4,8 @@ Specifies the semantics of expressions, operators, and expression evaluation.
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/13/Section13_1.md
+++ b/docs/ECMA262/13/Section13_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.1 | Identifiers | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-identifiers) |

--- a/docs/ECMA262/13/Section13_10.md
+++ b/docs/ECMA262/13/Section13_10.md
@@ -1,10 +1,19 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.10: Relational Operators
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.10 | Relational Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-relational-operators) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.10.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation) |
+| 13.10.2 | InstanceofOperator ( V , target ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-instanceofoperator) |
 

--- a/docs/ECMA262/13/Section13_11.md
+++ b/docs/ECMA262/13/Section13_11.md
@@ -1,10 +1,18 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.11: Equality Operators
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.11 | Equality Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-equality-operators) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.11.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-equality-operators-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_12.md
+++ b/docs/ECMA262/13/Section13_12.md
@@ -1,10 +1,18 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.12: Binary Bitwise Operators
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.12 | Binary Bitwise Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-binary-bitwise-operators) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.12.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-binary-bitwise-operators-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_13.md
+++ b/docs/ECMA262/13/Section13_13.md
@@ -4,6 +4,8 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.13 | Binary Logical Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-binary-logical-operators) |

--- a/docs/ECMA262/13/Section13_14.md
+++ b/docs/ECMA262/13/Section13_14.md
@@ -1,10 +1,18 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.14: Conditional Operator ( ? : )
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.14 | Conditional Operator ( ? : ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-conditional-operator) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.14.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-conditional-operator-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_15.md
+++ b/docs/ECMA262/13/Section13_15.md
@@ -4,6 +4,8 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.15 | Assignment Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-assignment-operators) |

--- a/docs/ECMA262/13/Section13_16.md
+++ b/docs/ECMA262/13/Section13_16.md
@@ -1,10 +1,18 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.16: Comma Operator ( , )
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.16 | Comma Operator ( , ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-comma-operator) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.16.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-comma-operator-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_2.md
+++ b/docs/ECMA262/13/Section13_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.2 | Primary Expression | Supported | [tc39.es](https://tc39.es/ecma262/#sec-primary-expression) |

--- a/docs/ECMA262/13/Section13_3.md
+++ b/docs/ECMA262/13/Section13_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL supports the common Left-Hand-Side Expression forms used throughout the test suite (property access, function calls, `new`, `super`, and core meta-property behavior for `new.target` / `import.meta` in CommonJS-hosted scripts).
 
 Notes on scope: the statuses here describe JS2IL's *compiler/runtime behavior*, not a full mechanistic implementation of every spec abstract operation.

--- a/docs/ECMA262/13/Section13_4.md
+++ b/docs/ECMA262/13/Section13_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.4 | Update Expressions | Supported | [tc39.es](https://tc39.es/ecma262/#sec-update-expressions) |

--- a/docs/ECMA262/13/Section13_5.md
+++ b/docs/ECMA262/13/Section13_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.5 | Unary Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-unary-operators) |

--- a/docs/ECMA262/13/Section13_6.md
+++ b/docs/ECMA262/13/Section13_6.md
@@ -1,10 +1,18 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.6: Exponentiation Operator
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.6 | Exponentiation Operator | Supported | [tc39.es](https://tc39.es/ecma262/#sec-exp-operator) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.6.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-exp-operator-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_7.md
+++ b/docs/ECMA262/13/Section13_7.md
@@ -1,10 +1,18 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.7: Multiplicative Operators
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.7 | Multiplicative Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-multiplicative-operators) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.7.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-multiplicative-operators-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_8.md
+++ b/docs/ECMA262/13/Section13_8.md
@@ -1,10 +1,21 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.8: Additive Operators
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.8 | Additive Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-additive-operators) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.8.1 | The Addition Operator ( + ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-addition-operator-plus) |
+| 13.8.1.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-addition-operator-plus-runtime-semantics-evaluation) |
+| 13.8.2 | The Subtraction Operator ( - ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-subtraction-operator-minus) |
+| 13.8.2.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-subtraction-operator-minus-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_9.md
+++ b/docs/ECMA262/13/Section13_9.md
@@ -1,10 +1,23 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 13.9: Bitwise Shift Operators
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 13.9 | Bitwise Shift Operators | Supported | [tc39.es](https://tc39.es/ecma262/#sec-bitwise-shift-operators) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 13.9.1 | The Left Shift Operator ( << ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-left-shift-operator) |
+| 13.9.1.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-left-shift-operator-runtime-semantics-evaluation) |
+| 13.9.2 | The Signed Right Shift Operator ( >> ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-signed-right-shift-operator) |
+| 13.9.2.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-signed-right-shift-operator-runtime-semantics-evaluation) |
+| 13.9.3 | The Unsigned Right Shift Operator ( >>> ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-unsigned-right-shift-operator) |
+| 13.9.3.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-unsigned-right-shift-operator-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/14/Section14.md
+++ b/docs/ECMA262/14/Section14.md
@@ -4,13 +4,15 @@ Specifies statements and declarations, including control flow, blocks, and bindi
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 14 | ECMAScript Language: Statements and Declarations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) |
+| 14 | ECMAScript Language: Statements and Declarations | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) |
 
 ## Subsections
 

--- a/docs/ECMA262/14/Section14_1.md
+++ b/docs/ECMA262/14/Section14_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL supports most common statement forms (control flow, loops, switch, try/catch/finally, throw/return) but rejects some statement types in the validator and has known semantic gaps (notably iterator-protocol fidelity for general `for..of`).
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/14/Section14_10.md
+++ b/docs/ECMA262/14/Section14_10.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.10 | The return Statement | Supported | [tc39.es](https://tc39.es/ecma262/#sec-return-statement) |

--- a/docs/ECMA262/14/Section14_11.md
+++ b/docs/ECMA262/14/Section14_11.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.11 | The with Statement | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-with-statement) |

--- a/docs/ECMA262/14/Section14_12.md
+++ b/docs/ECMA262/14/Section14_12.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.12 | The switch Statement | Supported | [tc39.es](https://tc39.es/ecma262/#sec-switch-statement) |

--- a/docs/ECMA262/14/Section14_13.md
+++ b/docs/ECMA262/14/Section14_13.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.13 | Labelled Statements | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-labelled-statements) |

--- a/docs/ECMA262/14/Section14_14.md
+++ b/docs/ECMA262/14/Section14_14.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.14 | The throw Statement | Supported | [tc39.es](https://tc39.es/ecma262/#sec-throw-statement) |

--- a/docs/ECMA262/14/Section14_15.md
+++ b/docs/ECMA262/14/Section14_15.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 try/catch/finally is supported for common cases, including throwing and catching arbitrary JS values. Some edge-case fidelity (notably top-level unhandled throw behavior and certain early errors) is not exhaustively validated.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/14/Section14_16.md
+++ b/docs/ECMA262/14/Section14_16.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.16 | The debugger Statement | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-debugger-statement) |

--- a/docs/ECMA262/14/Section14_2.md
+++ b/docs/ECMA262/14/Section14_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 Block statements are supported, including lexical scoping for `let`/`const` declarations. Some early-error edge cases and full spec fidelity around declaration instantiation are not exhaustively validated.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/14/Section14_3.md
+++ b/docs/ECMA262/14/Section14_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL supports common declaration forms (`let`, `const`, `var`) and destructuring binding patterns. Some spec-required early errors are not exhaustively covered, and TDZ behavior currently has a skipped test (so not fully implemented/validated yet).
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/14/Section14_4.md
+++ b/docs/ECMA262/14/Section14_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.4 | Empty Statement | Supported | [tc39.es](https://tc39.es/ecma262/#sec-empty-statement) |

--- a/docs/ECMA262/14/Section14_5.md
+++ b/docs/ECMA262/14/Section14_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.5 | Expression Statement | Supported | [tc39.es](https://tc39.es/ecma262/#sec-expression-statement) |

--- a/docs/ECMA262/14/Section14_6.md
+++ b/docs/ECMA262/14/Section14_6.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.6 | The if Statement | Supported | [tc39.es](https://tc39.es/ecma262/#sec-if-statement) |

--- a/docs/ECMA262/14/Section14_7.md
+++ b/docs/ECMA262/14/Section14_7.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 do/while/for loops are supported including break/continue (with labels). for..of uses the iterator protocol; for..in uses a dedicated For-In Iterator (mutation-aware key enumeration) but does not yet provide full spec fidelity for all exotic objects. for await..of is supported in async functions.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/14/Section14_8.md
+++ b/docs/ECMA262/14/Section14_8.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.8 | The continue Statement | Supported | [tc39.es](https://tc39.es/ecma262/#sec-continue-statement) |

--- a/docs/ECMA262/14/Section14_9.md
+++ b/docs/ECMA262/14/Section14_9.md
@@ -4,6 +4,8 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 14.9 | The break Statement | Supported | [tc39.es](https://tc39.es/ecma262/#sec-break-statement) |

--- a/docs/ECMA262/15/Section15.md
+++ b/docs/ECMA262/15/Section15.md
@@ -4,13 +4,15 @@ Covers functions and classes, including callable/constructable semantics and cla
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 15 | ECMAScript Language: Functions and Classes | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) |
+| 15 | ECMAScript Language: Functions and Classes | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) |
 
 ## Subsections
 

--- a/docs/ECMA262/15/Section15_1.md
+++ b/docs/ECMA262/15/Section15_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 15.1 | Parameter Lists | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-parameter-lists) |

--- a/docs/ECMA262/15/Section15_10.md
+++ b/docs/ECMA262/15/Section15_10.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 ECMA-262 defines static tail-position analysis (IsInTailPosition / HasCallInTailPosition) and a runtime hook (PrepareForTailCall) used for Proper Tail Calls (PTC). JS2IL currently emits calls normally and does not implement PTC/tail-call optimization.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/15/Section15_2.md
+++ b/docs/ECMA262/15/Section15_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 15.2 | Function Definitions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-function-definitions) |

--- a/docs/ECMA262/15/Section15_3.md
+++ b/docs/ECMA262/15/Section15_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 15.3 | Arrow Function Definitions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arrow-function-definitions) |

--- a/docs/ECMA262/15/Section15_4.md
+++ b/docs/ECMA262/15/Section15_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 15.4 | Method Definitions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-method-definitions) |

--- a/docs/ECMA262/15/Section15_5.md
+++ b/docs/ECMA262/15/Section15_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 15.5 | Generator Function Definitions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-generator-function-definitions) |

--- a/docs/ECMA262/15/Section15_6.md
+++ b/docs/ECMA262/15/Section15_6.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 15.6 | Async Generator Function Definitions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-generator-function-definitions) |

--- a/docs/ECMA262/15/Section15_7.md
+++ b/docs/ECMA262/15/Section15_7.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL supports class declarations/expressions, methods (including async and generator methods), constructors (including derived constructors with super calls), and public/private instance/static fields with initializers. Limitations: class static blocks are not supported; class getters/setters are rejected; computed method/field names and private methods are rejected.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/15/Section15_8.md
+++ b/docs/ECMA262/15/Section15_8.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 15.8 | Async Function Definitions | Supported | [tc39.es](https://tc39.es/ecma262/#sec-async-function-definitions) |

--- a/docs/ECMA262/15/Section15_9.md
+++ b/docs/ECMA262/15/Section15_9.md
@@ -4,6 +4,8 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 15.9 | Async Arrow Function Definitions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-arrow-function-definitions) |

--- a/docs/ECMA262/16/Section16.md
+++ b/docs/ECMA262/16/Section16.md
@@ -4,6 +4,8 @@ Defines scripts and modules, including module records, loading/linking, and eval
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/16/Section16_1.md
+++ b/docs/ECMA262/16/Section16_1.md
@@ -1,10 +1,24 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 16.1: Scripts
 
 [Back to Section16](Section16.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 16.1 | Scripts | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-scripts) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 16.1.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-scripts-static-semantics-early-errors) |
+| 16.1.2 | Static Semantics: ScriptIsStrict | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-scriptisstrict) |
+| 16.1.3 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-script-semantics-runtime-semantics-evaluation) |
+| 16.1.4 | Script Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-script-records) |
+| 16.1.5 | ParseScript ( sourceText , realm , hostDefined ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-parse-script) |
+| 16.1.6 | ScriptEvaluation ( scriptRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation) |
+| 16.1.7 | GlobalDeclarationInstantiation ( script , env ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-globaldeclarationinstantiation) |
 

--- a/docs/ECMA262/16/Section16_2.md
+++ b/docs/ECMA262/16/Section16_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section16](Section16.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL supports a practical subset of static module syntax by lowering top-level `import` / `export` declarations to the existing CommonJS runtime model. This enables mixed CJS/ESM-style graphs for common patterns, but does not implement full ECMA-262 module-record/linking/evaluation semantics.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/17/Section17.md
+++ b/docs/ECMA262/17/Section17.md
@@ -4,6 +4,8 @@ Describes error handling and related language extensions, including structured e
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/17/Section17_1.md
+++ b/docs/ECMA262/17/Section17_1.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 17.1: Forbidden Extensions
 
 [Back to Section17](Section17.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 17.1 | Forbidden Extensions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-forbidden-extensions) |
-

--- a/docs/ECMA262/18/Section18.md
+++ b/docs/ECMA262/18/Section18.md
@@ -4,6 +4,8 @@ Introduces the standard built-in objects and shared conventions used by the buil
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _Note: In the current ECMA-262 spec, Section 18 is a single clause and does not have numbered subsections._
 
 ## Section Entry

--- a/docs/ECMA262/19/Section19.md
+++ b/docs/ECMA262/19/Section19.md
@@ -4,6 +4,8 @@ Defines the global object and global bindings exposed to ECMAScript code.
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/19/Section19_1.md
+++ b/docs/ECMA262/19/Section19_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 19.1 | Value Properties of the Global Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-value-properties-of-the-global-object) |

--- a/docs/ECMA262/19/Section19_2.md
+++ b/docs/ECMA262/19/Section19_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 19.2 | Function Properties of the Global Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-function-properties-of-the-global-object) |

--- a/docs/ECMA262/19/Section19_3.md
+++ b/docs/ECMA262/19/Section19_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 19.3 | Constructor Properties of the Global Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object) |
@@ -63,7 +65,7 @@ Feature-level support tracking with test script references.
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Global Boolean constructor is exposed as a callable function value (e.g., array.filter(Boolean)) | Supported with Limitations | [`Compile_Scripts_DecompileGeneratorTest.js`](../../../Js2IL.Tests/Integration/JavaScript/Compile_Scripts_DecompileGeneratorTest.js) | js2il supports calling Boolean(x) via primitive conversion lowering, and also supports using Boolean as a first-class function value by exposing it as JavaScriptRuntime.GlobalThis.Boolean (delegate). This is sufficient for common patterns like array.filter(Boolean), but does not implement full Boolean constructor/prototype semantics. |
+| Global Boolean constructor is exposed as a callable function value (e.g., array.filter(Boolean)) | Supported with Limitations | `Js2IL.Tests/Integration/JavaScript/Compile_Scripts_DecompileGeneratorTest.js` | js2il supports calling Boolean(x) via primitive conversion lowering, and also supports using Boolean as a first-class function value by exposing it as JavaScriptRuntime.GlobalThis.Boolean (delegate). This is sufficient for common patterns like array.filter(Boolean), but does not implement full Boolean constructor/prototype semantics. |
 
 ### 19.3.16 ([tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-function))
 

--- a/docs/ECMA262/19/Section19_4.md
+++ b/docs/ECMA262/19/Section19_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 19.4 | Other Properties of the Global Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-other-properties-of-the-global-object) |

--- a/docs/ECMA262/2/Section2.md
+++ b/docs/ECMA262/2/Section2.md
@@ -4,6 +4,8 @@ Describes conformance requirements for ECMAScript implementations and the meanin
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/2/Section2_1.md
+++ b/docs/ECMA262/2/Section2_1.md
@@ -1,10 +1,11 @@
-<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 2.1: Example Normative Optional Clause Heading
 
 [Back to Section2](Section2.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 2.1 | Example Normative Optional Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-normative-optional) |
-

--- a/docs/ECMA262/2/Section2_2.md
+++ b/docs/ECMA262/2/Section2_2.md
@@ -1,10 +1,11 @@
-<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 2.2: Example Legacy Clause Heading
 
 [Back to Section2](Section2.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 2.2 | Example Legacy Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy) |
-

--- a/docs/ECMA262/2/Section2_3.md
+++ b/docs/ECMA262/2/Section2_3.md
@@ -1,10 +1,11 @@
-<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 2.3: Example Legacy Normative Optional Clause Heading
 
 [Back to Section2](Section2.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 2.3 | Example Legacy Normative Optional Clause Heading | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance-legacy-normative-optional) |
-

--- a/docs/ECMA262/20/Section20.md
+++ b/docs/ECMA262/20/Section20.md
@@ -4,6 +4,8 @@ Covers fundamental built-ins (such as Object and Function) and shared foundation
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/20/Section20_1.md
+++ b/docs/ECMA262/20/Section20_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 20.1 | Object Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-object-objects) |

--- a/docs/ECMA262/20/Section20_2.md
+++ b/docs/ECMA262/20/Section20_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 20.2 | Function Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) |

--- a/docs/ECMA262/20/Section20_3.md
+++ b/docs/ECMA262/20/Section20_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 20.3 | Boolean Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-boolean-objects) |

--- a/docs/ECMA262/20/Section20_4.md
+++ b/docs/ECMA262/20/Section20_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL supports Symbol callable creation, global registry APIs (Symbol.for/keyFor), well-known symbols, and core Symbol.prototype behaviors (description/toString/valueOf). Some advanced descriptor-level semantics remain tracked as limitations.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/20/Section20_5.md
+++ b/docs/ECMA262/20/Section20_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 20.5 | Error Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error-objects) |

--- a/docs/ECMA262/21/Section21.md
+++ b/docs/ECMA262/21/Section21.md
@@ -4,6 +4,8 @@ Covers numeric and date/time built-ins and the associated numeric abstractions.
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/21/Section21_1.md
+++ b/docs/ECMA262/21/Section21_1.md
@@ -1,10 +1,45 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 21.1: Number Objects
 
 [Back to Section21](Section21.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 21.1 | Number Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-number-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 21.1.1 | The Number Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number-constructor) |
+| 21.1.1.1 | Number ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number-constructor-number-value) |
+| 21.1.2 | Properties of the Number Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-number-constructor) |
+| 21.1.2.1 | Number.EPSILON | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.epsilon) |
+| 21.1.2.2 | Number.isFinite ( number ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.isfinite) |
+| 21.1.2.3 | Number.isInteger ( number ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.isinteger) |
+| 21.1.2.4 | Number.isNaN ( number ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.isnan) |
+| 21.1.2.5 | Number.isSafeInteger ( number ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.issafeinteger) |
+| 21.1.2.6 | Number.MAX_SAFE_INTEGER | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.max_safe_integer) |
+| 21.1.2.7 | Number.MAX_VALUE | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.max_value) |
+| 21.1.2.8 | Number.MIN_SAFE_INTEGER | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.min_safe_integer) |
+| 21.1.2.9 | Number.MIN_VALUE | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.min_value) |
+| 21.1.2.10 | Number.NaN | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.nan) |
+| 21.1.2.11 | Number.NEGATIVE_INFINITY | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.negative_infinity) |
+| 21.1.2.12 | Number.parseFloat ( string ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.parsefloat) |
+| 21.1.2.13 | Number.parseInt ( string , radix ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.parseint) |
+| 21.1.2.14 | Number.POSITIVE_INFINITY | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.positive_infinity) |
+| 21.1.2.15 | Number.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype) |
+| 21.1.3 | Properties of the Number Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-number-prototype-object) |
+| 21.1.3.1 | Number.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype.constructor) |
+| 21.1.3.2 | Number.prototype.toExponential ( fractionDigits ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype.toexponential) |
+| 21.1.3.3 | Number.prototype.toFixed ( fractionDigits ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype.tofixed) |
+| 21.1.3.4 | Number.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype.tolocalestring) |
+| 21.1.3.5 | Number.prototype.toPrecision ( precision ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype.toprecision) |
+| 21.1.3.6 | Number.prototype.toString ( [ radix ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype.tostring) |
+| 21.1.3.7 | Number.prototype.valueOf ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype.valueof) |
+| 21.1.3.7.1 | ThisNumberValue ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-thisnumbervalue) |
+| 21.1.4 | Properties of Number Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-number-instances) |
 

--- a/docs/ECMA262/21/Section21_2.md
+++ b/docs/ECMA262/21/Section21_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section21](Section21.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL provides a minimal BigInt callable implementation backed by System.Numerics.BigInteger, sufficient for basic BigInt(value) usage and typeof semantics. The broader BigInt constructor/prototype surface and full spec conversion rules are not yet implemented.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/21/Section21_3.md
+++ b/docs/ECMA262/21/Section21_3.md
@@ -1,10 +1,65 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 21.3: The Math Object
 
 [Back to Section21](Section21.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 21.3 | The Math Object | Supported | [tc39.es](https://tc39.es/ecma262/#sec-math-object) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 21.3.1 | Value Properties of the Math Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-value-properties-of-the-math-object) |
+| 21.3.1.1 | Math.E | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.e) |
+| 21.3.1.2 | Math.LN10 | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.ln10) |
+| 21.3.1.3 | Math.LN2 | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.ln2) |
+| 21.3.1.4 | Math.LOG10E | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.log10e) |
+| 21.3.1.5 | Math.LOG2E | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.log2e) |
+| 21.3.1.6 | Math.PI | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.pi) |
+| 21.3.1.7 | Math.SQRT1_2 | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.sqrt1_2) |
+| 21.3.1.8 | Math.SQRT2 | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.sqrt2) |
+| 21.3.1.9 | Math [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%) |
+| 21.3.2 | Function Properties of the Math Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-properties-of-the-math-object) |
+| 21.3.2.1 | Math.abs ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.abs) |
+| 21.3.2.2 | Math.acos ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.acos) |
+| 21.3.2.3 | Math.acosh ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.acosh) |
+| 21.3.2.4 | Math.asin ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.asin) |
+| 21.3.2.5 | Math.asinh ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.asinh) |
+| 21.3.2.6 | Math.atan ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.atan) |
+| 21.3.2.7 | Math.atanh ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.atanh) |
+| 21.3.2.8 | Math.atan2 ( y , x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.atan2) |
+| 21.3.2.9 | Math.cbrt ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.cbrt) |
+| 21.3.2.10 | Math.ceil ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.ceil) |
+| 21.3.2.11 | Math.clz32 ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.clz32) |
+| 21.3.2.12 | Math.cos ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.cos) |
+| 21.3.2.13 | Math.cosh ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.cosh) |
+| 21.3.2.14 | Math.exp ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.exp) |
+| 21.3.2.15 | Math.expm1 ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.expm1) |
+| 21.3.2.16 | Math.floor ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.floor) |
+| 21.3.2.17 | Math.fround ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.fround) |
+| 21.3.2.18 | Math.f16round ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.f16round) |
+| 21.3.2.19 | Math.hypot ( ... args ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.hypot) |
+| 21.3.2.20 | Math.imul ( x , y ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.imul) |
+| 21.3.2.21 | Math.log ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.log) |
+| 21.3.2.22 | Math.log1p ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.log1p) |
+| 21.3.2.23 | Math.log10 ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.log10) |
+| 21.3.2.24 | Math.log2 ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.log2) |
+| 21.3.2.25 | Math.max ( ... args ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.max) |
+| 21.3.2.26 | Math.min ( ... args ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.min) |
+| 21.3.2.27 | Math.pow ( base , exponent ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.pow) |
+| 21.3.2.28 | Math.random ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.random) |
+| 21.3.2.29 | Math.round ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.round) |
+| 21.3.2.30 | Math.sign ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.sign) |
+| 21.3.2.31 | Math.sin ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.sin) |
+| 21.3.2.32 | Math.sinh ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.sinh) |
+| 21.3.2.33 | Math.sqrt ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.sqrt) |
+| 21.3.2.34 | Math.sumPrecise ( items ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.sumprecise) |
+| 21.3.2.35 | Math.tan ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.tan) |
+| 21.3.2.36 | Math.tanh ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.tanh) |
+| 21.3.2.37 | Math.trunc ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.trunc) |
 

--- a/docs/ECMA262/21/Section21_4.md
+++ b/docs/ECMA262/21/Section21_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section21](Section21.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 21.4 | Date Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-date-objects) |

--- a/docs/ECMA262/22/Section22.md
+++ b/docs/ECMA262/22/Section22.md
@@ -4,6 +4,8 @@ Covers text-processing built-ins, including strings and regular expressions.
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry
@@ -16,5 +18,5 @@ _This section is split into subsection documents for readability._
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 22.1 | String Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-string-objects) | [Section22_1.md](Section22_1.md) |
+| 22.1 | String Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string-objects) | [Section22_1.md](Section22_1.md) |
 | 22.2 | RegExp (Regular Expression) Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-regexp-regular-expression-objects) | [Section22_2.md](Section22_2.md) |

--- a/docs/ECMA262/22/Section22_1.md
+++ b/docs/ECMA262/22/Section22_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section22](Section22.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 22.1 | String Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string-objects) |

--- a/docs/ECMA262/22/Section22_2.md
+++ b/docs/ECMA262/22/Section22_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section22](Section22.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 22.2 | RegExp (Regular Expression) Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-regexp-regular-expression-objects) |

--- a/docs/ECMA262/23/Section23.md
+++ b/docs/ECMA262/23/Section23.md
@@ -5,13 +5,15 @@ The current ECMA-262 draft organizes this section into three top-level subsectio
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 23 | Indexed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) |
+| 23 | Indexed Collections | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) |
 
 ## Subsections
 

--- a/docs/ECMA262/23/Section23_1.md
+++ b/docs/ECMA262/23/Section23_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section23](Section23.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 23.1 | Array Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-array-objects) |

--- a/docs/ECMA262/23/Section23_2.md
+++ b/docs/ECMA262/23/Section23_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section23](Section23.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 23.2 | TypedArray Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-objects) |

--- a/docs/ECMA262/23/Section23_3.md
+++ b/docs/ECMA262/23/Section23_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section23](Section23.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 23.3 | Uint8Array Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-uint8array) |

--- a/docs/ECMA262/24/Section24.md
+++ b/docs/ECMA262/24/Section24.md
@@ -4,20 +4,22 @@ Covers keyed collections, including Map/Set and their weak variants.
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 24 | Keyed Collections | Supported | [tc39.es](https://tc39.es/ecma262/#sec-keyed-collections) |
+| 24 | Keyed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-keyed-collections) |
 
 ## Subsections
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 24.1 | Map Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map-objects) | [Section24_1.md](Section24_1.md) |
-| 24.2 | Set Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-set-objects) | [Section24_2.md](Section24_2.md) |
-| 24.3 | WeakMap Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weakmap-objects) | [Section24_3.md](Section24_3.md) |
-| 24.4 | WeakSet Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weakset-objects) | [Section24_4.md](Section24_4.md) |
-| 24.5 | Abstract Operations for Keyed Collections | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-keyed-collections) | [Section24_5.md](Section24_5.md) |
+| 24.1 | Map Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map-objects) | [Section24_1.md](Section24_1.md) |
+| 24.2 | Set Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-set-objects) | [Section24_2.md](Section24_2.md) |
+| 24.3 | WeakMap Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakmap-objects) | [Section24_3.md](Section24_3.md) |
+| 24.4 | WeakSet Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakset-objects) | [Section24_4.md](Section24_4.md) |
+| 24.5 | Abstract Operations for Keyed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-keyed-collections) | [Section24_5.md](Section24_5.md) |

--- a/docs/ECMA262/24/Section24_1.json
+++ b/docs/ECMA262/24/Section24_1.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "24.1",
   "title": "Map Objects",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-map-objects",
   "parent": {
     "clause": "24"
@@ -12,176 +12,246 @@
     {
       "clause": "24.1.1",
       "title": "The Map Constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-map-constructor"
     },
     {
       "clause": "24.1.1.1",
       "title": "Map ( [ iterable ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-map-iterable"
     },
     {
       "clause": "24.1.1.2",
       "title": "AddEntriesFromIterable ( target , iterable , adder )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-add-entries-from-iterable"
     },
     {
       "clause": "24.1.2",
       "title": "Properties of the Map Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-map-constructor"
     },
     {
       "clause": "24.1.2.1",
       "title": "Map.groupBy ( items , callback )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.groupby"
     },
     {
       "clause": "24.1.2.2",
       "title": "Map.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype"
     },
     {
       "clause": "24.1.2.3",
       "title": "get Map [ %Symbol.species% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-map-%symbol.species%"
     },
     {
       "clause": "24.1.3",
       "title": "Properties of the Map Prototype Object",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-map-prototype-object"
     },
     {
       "clause": "24.1.3.1",
       "title": "Map.prototype.clear ( )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.clear"
     },
     {
       "clause": "24.1.3.2",
       "title": "Map.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.constructor"
     },
     {
       "clause": "24.1.3.3",
       "title": "Map.prototype.delete ( key )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.delete"
     },
     {
       "clause": "24.1.3.4",
       "title": "Map.prototype.entries ( )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.entries"
     },
     {
       "clause": "24.1.3.5",
       "title": "Map.prototype.forEach ( callback [ , thisArg ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.foreach"
     },
     {
       "clause": "24.1.3.6",
       "title": "Map.prototype.get ( key )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.get"
     },
     {
       "clause": "24.1.3.7",
       "title": "Map.prototype.getOrInsert ( key , value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.getorinsert"
     },
     {
       "clause": "24.1.3.8",
       "title": "Map.prototype.getOrInsertComputed ( key , callback )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed"
     },
     {
       "clause": "24.1.3.9",
       "title": "Map.prototype.has ( key )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.has"
     },
     {
       "clause": "24.1.3.10",
       "title": "Map.prototype.keys ( )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.keys"
     },
     {
       "clause": "24.1.3.11",
       "title": "Map.prototype.set ( key , value )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.set"
     },
     {
       "clause": "24.1.3.12",
       "title": "get Map.prototype.size",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-map.prototype.size"
     },
     {
       "clause": "24.1.3.13",
       "title": "Map.prototype.values ( )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.values"
     },
     {
       "clause": "24.1.3.14",
       "title": "Map.prototype [ %Symbol.iterator% ] ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype-%symbol.iterator%"
     },
     {
       "clause": "24.1.3.15",
       "title": "Map.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "24.1.4",
       "title": "Properties of Map Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-map-instances"
     },
     {
       "clause": "24.1.5",
       "title": "Map Iterator Objects",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-map-iterator-objects"
     },
     {
       "clause": "24.1.5.1",
       "title": "CreateMapIterator ( map , kind )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-createmapiterator"
     },
     {
       "clause": "24.1.5.2",
       "title": "The %MapIteratorPrototype% Object",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-%mapiteratorprototype%-object"
     },
     {
       "clause": "24.1.5.2.1",
       "title": "%MapIteratorPrototype%.next ( )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next"
     },
     {
       "clause": "24.1.5.2.2",
       "title": "%MapIteratorPrototype% [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%mapiteratorprototype%-%symbol.tostringtag%"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "24.1.1.1",
+        "feature": "new Map()",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-map-iterable",
+        "testScripts": [
+          "Js2IL.Tests/Map/JavaScript/Map_Constructor_Empty.js"
+        ],
+        "notes": "Zero-argument construction lowers to JavaScriptRuntime.Map() and produces an insertion-ordered keyed collection."
+      },
+      {
+        "clause": "24.1.1.1",
+        "feature": "new Map(iterable)",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-map-iterable",
+        "notes": "Intrinsic construction only resolves 0/1/2-argument CLR constructors, and JavaScriptRuntime.Map currently exposes only a parameterless constructor; iterable initialization and AddEntriesFromIterable are therefore unavailable."
+      },
+      {
+        "clause": "24.1.2.2",
+        "feature": "Map constructor value and Map.prototype surface",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-map.prototype",
+        "notes": "Map is recognized by the compiler in new expressions, but JS2IL does not currently expose a first-class global Map constructor value on globalThis, so properties like Map.prototype cannot be read."
+      },
+      {
+        "clause": "24.1.3",
+        "feature": "Core Map mutators/accessors (set, get, has, delete, clear, size)",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-map-prototype-object",
+        "testScripts": [
+          "Js2IL.Tests/Map/JavaScript/Map_Set_Get_Basic.js",
+          "Js2IL.Tests/Map/JavaScript/Map_Has_Basic.js",
+          "Js2IL.Tests/Map/JavaScript/Map_Delete_Basic.js",
+          "Js2IL.Tests/Map/JavaScript/Map_Clear_Basic.js",
+          "Js2IL.Tests/Map/JavaScript/Map_Size_Property.js",
+          "Js2IL.Tests/Map/JavaScript/Map_Set_Returns_This.js",
+          "Js2IL.Tests/Map/JavaScript/Map_Update_Existing_Key.js",
+          "Js2IL.Tests/Map/JavaScript/Map_Multiple_Keys.js",
+          "Js2IL.Tests/Map/JavaScript/Map_Null_Key.js"
+        ],
+        "notes": "These operations are implemented by JavaScriptRuntime.Map with insertion-order storage and SameValueZero-style key comparison for common numeric cases."
+      },
+      {
+        "clause": "24.1.3.4",
+        "feature": "Map.prototype.keys / values / entries",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.entries",
+        "testScripts": [
+          "Js2IL.Tests/Map/JavaScript/Map_Keys_Values_Entries.js"
+        ],
+        "notes": "The methods are exposed and work with consumers like Array.from, but they return CLR IEnumerable-backed sequences rather than spec-visible JS iterator objects with .next() and @@iterator. The current test directly covers keys() and values(); entries() is implemented on the same model."
+      },
+      {
+        "clause": "24.1.3.5",
+        "feature": "Map.prototype.forEach / getOrInsert / getOrInsertComputed",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.foreach",
+        "notes": "Callback iteration and the newer getOrInsert APIs are not implemented on JavaScriptRuntime.Map."
+      },
+      {
+        "clause": "24.1.5.1",
+        "feature": "Map iteration in for-of and other runtime iterator consumers",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-createmapiterator",
+        "notes": "JavaScriptRuntime.Object.GetIterator falls back to System.Collections.IEnumerable, so Map instances and the enumerable results of keys/values/entries can be consumed by runtime iterator-based operations even though Map.prototype[@@iterator] and JS-visible iterator prototype objects are incomplete."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/24/Section24_1.md
+++ b/docs/ECMA262/24/Section24_1.md
@@ -4,41 +4,84 @@
 
 [Back to Section24](Section24.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 24.1 | Map Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map-objects) |
+| 24.1 | Map Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 24.1.1 | The Map Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map-constructor) |
-| 24.1.1.1 | Map ( [ iterable ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map-iterable) |
-| 24.1.1.2 | AddEntriesFromIterable ( target , iterable , adder ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-add-entries-from-iterable) |
-| 24.1.2 | Properties of the Map Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-map-constructor) |
-| 24.1.2.1 | Map.groupBy ( items , callback ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.groupby) |
-| 24.1.2.2 | Map.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype) |
-| 24.1.2.3 | get Map [ %Symbol.species% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-map-%symbol.species%) |
-| 24.1.3 | Properties of the Map Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-map-prototype-object) |
-| 24.1.3.1 | Map.prototype.clear ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.clear) |
-| 24.1.3.2 | Map.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.constructor) |
-| 24.1.3.3 | Map.prototype.delete ( key ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.delete) |
-| 24.1.3.4 | Map.prototype.entries ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.entries) |
-| 24.1.3.5 | Map.prototype.forEach ( callback [ , thisArg ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.foreach) |
-| 24.1.3.6 | Map.prototype.get ( key ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.get) |
-| 24.1.3.7 | Map.prototype.getOrInsert ( key , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsert) |
-| 24.1.3.8 | Map.prototype.getOrInsertComputed ( key , callback ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed) |
-| 24.1.3.9 | Map.prototype.has ( key ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.has) |
-| 24.1.3.10 | Map.prototype.keys ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.keys) |
-| 24.1.3.11 | Map.prototype.set ( key , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.set) |
-| 24.1.3.12 | get Map.prototype.size | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-map.prototype.size) |
-| 24.1.3.13 | Map.prototype.values ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.values) |
-| 24.1.3.14 | Map.prototype [ %Symbol.iterator% ] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype-%symbol.iterator%) |
-| 24.1.3.15 | Map.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype-%symbol.tostringtag%) |
-| 24.1.4 | Properties of Map Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-map-instances) |
-| 24.1.5 | Map Iterator Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-map-iterator-objects) |
-| 24.1.5.1 | CreateMapIterator ( map , kind ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-createmapiterator) |
-| 24.1.5.2 | The %MapIteratorPrototype% Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%mapiteratorprototype%-object) |
-| 24.1.5.2.1 | %MapIteratorPrototype%.next ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next) |
-| 24.1.5.2.2 | %MapIteratorPrototype% [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-%mapiteratorprototype%-%symbol.tostringtag%) |
+| 24.1.1 | The Map Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map-constructor) |
+| 24.1.1.1 | Map ( [ iterable ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map-iterable) |
+| 24.1.1.2 | AddEntriesFromIterable ( target , iterable , adder ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-add-entries-from-iterable) |
+| 24.1.2 | Properties of the Map Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-map-constructor) |
+| 24.1.2.1 | Map.groupBy ( items , callback ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.groupby) |
+| 24.1.2.2 | Map.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype) |
+| 24.1.2.3 | get Map [ %Symbol.species% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-map-%symbol.species%) |
+| 24.1.3 | Properties of the Map Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-map-prototype-object) |
+| 24.1.3.1 | Map.prototype.clear ( ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.clear) |
+| 24.1.3.2 | Map.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.constructor) |
+| 24.1.3.3 | Map.prototype.delete ( key ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.delete) |
+| 24.1.3.4 | Map.prototype.entries ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.entries) |
+| 24.1.3.5 | Map.prototype.forEach ( callback [ , thisArg ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.foreach) |
+| 24.1.3.6 | Map.prototype.get ( key ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.get) |
+| 24.1.3.7 | Map.prototype.getOrInsert ( key , value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsert) |
+| 24.1.3.8 | Map.prototype.getOrInsertComputed ( key , callback ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed) |
+| 24.1.3.9 | Map.prototype.has ( key ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.has) |
+| 24.1.3.10 | Map.prototype.keys ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.keys) |
+| 24.1.3.11 | Map.prototype.set ( key , value ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.set) |
+| 24.1.3.12 | get Map.prototype.size | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-map.prototype.size) |
+| 24.1.3.13 | Map.prototype.values ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.values) |
+| 24.1.3.14 | Map.prototype [ %Symbol.iterator% ] ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype-%symbol.iterator%) |
+| 24.1.3.15 | Map.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype-%symbol.tostringtag%) |
+| 24.1.4 | Properties of Map Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-map-instances) |
+| 24.1.5 | Map Iterator Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map-iterator-objects) |
+| 24.1.5.1 | CreateMapIterator ( map , kind ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createmapiterator) |
+| 24.1.5.2 | The %MapIteratorPrototype% Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-%mapiteratorprototype%-object) |
+| 24.1.5.2.1 | %MapIteratorPrototype%.next ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next) |
+| 24.1.5.2.2 | %MapIteratorPrototype% [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%mapiteratorprototype%-%symbol.tostringtag%) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 24.1.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-map-iterable))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| new Map() | Supported | [`Map_Constructor_Empty.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Constructor_Empty.js) | Zero-argument construction lowers to JavaScriptRuntime.Map() and produces an insertion-ordered keyed collection. |
+| new Map(iterable) | Not Yet Supported |  | Intrinsic construction only resolves 0/1/2-argument CLR constructors, and JavaScriptRuntime.Map currently exposes only a parameterless constructor; iterable initialization and AddEntriesFromIterable are therefore unavailable. |
+
+### 24.1.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-map.prototype))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Map constructor value and Map.prototype surface | Not Yet Supported |  | Map is recognized by the compiler in new expressions, but JS2IL does not currently expose a first-class global Map constructor value on globalThis, so properties like Map.prototype cannot be read. |
+
+### 24.1.3 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-map-prototype-object))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Core Map mutators/accessors (set, get, has, delete, clear, size) | Supported | [`Map_Set_Get_Basic.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Set_Get_Basic.js)<br>[`Map_Has_Basic.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Has_Basic.js)<br>[`Map_Delete_Basic.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Delete_Basic.js)<br>[`Map_Clear_Basic.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Clear_Basic.js)<br>[`Map_Size_Property.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Size_Property.js)<br>[`Map_Set_Returns_This.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Set_Returns_This.js)<br>[`Map_Update_Existing_Key.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Update_Existing_Key.js)<br>[`Map_Multiple_Keys.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Multiple_Keys.js)<br>[`Map_Null_Key.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Null_Key.js) | These operations are implemented by JavaScriptRuntime.Map with insertion-order storage and SameValueZero-style key comparison for common numeric cases. |
+
+### 24.1.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-map.prototype.entries))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Map.prototype.keys / values / entries | Supported with Limitations | [`Map_Keys_Values_Entries.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Keys_Values_Entries.js) | The methods are exposed and work with consumers like Array.from, but they return CLR IEnumerable-backed sequences rather than spec-visible JS iterator objects with .next() and @@iterator. The current test directly covers keys() and values(); entries() is implemented on the same model. |
+
+### 24.1.3.5 ([tc39.es](https://tc39.es/ecma262/#sec-map.prototype.foreach))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Map.prototype.forEach / getOrInsert / getOrInsertComputed | Not Yet Supported |  | Callback iteration and the newer getOrInsert APIs are not implemented on JavaScriptRuntime.Map. |
+
+### 24.1.5.1 ([tc39.es](https://tc39.es/ecma262/#sec-createmapiterator))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Map iteration in for-of and other runtime iterator consumers | Supported with Limitations |  | JavaScriptRuntime.Object.GetIterator falls back to System.Collections.IEnumerable, so Map instances and the enumerable results of keys/values/entries can be consumed by runtime iterator-based operations even though Map.prototype[@@iterator] and JS-visible iterator prototype objects are incomplete. |
 

--- a/docs/ECMA262/24/Section24_2.json
+++ b/docs/ECMA262/24/Section24_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "24.2",
   "title": "Set Objects",
-  "status": "Supported",
+  "status": "Incomplete",
   "specUrl": "https://tc39.es/ecma262/#sec-set-objects",
   "parent": {
     "clause": "24"
@@ -12,224 +12,280 @@
     {
       "clause": "24.2.1",
       "title": "Abstract Operations For Set Objects",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-abstract-operations-for-set-objects"
     },
     {
       "clause": "24.2.1.1",
       "title": "Set Records",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set-records"
     },
     {
       "clause": "24.2.1.2",
       "title": "GetSetRecord ( obj )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-getsetrecord"
     },
     {
       "clause": "24.2.1.3",
       "title": "SetDataHas ( setData , value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-setdatahas"
     },
     {
       "clause": "24.2.1.4",
       "title": "SetDataIndex ( setData , value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-setdataindex"
     },
     {
       "clause": "24.2.1.5",
       "title": "SetDataSize ( setData )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-setdatasize"
     },
     {
       "clause": "24.2.2",
       "title": "The Set Constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-set-constructor"
     },
     {
       "clause": "24.2.2.1",
       "title": "Set ( [ iterable ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-set-iterable"
     },
     {
       "clause": "24.2.3",
       "title": "Properties of the Set Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-set-constructor"
     },
     {
       "clause": "24.2.3.1",
       "title": "Set.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype"
     },
     {
       "clause": "24.2.3.2",
       "title": "get Set [ %Symbol.species% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-set-%symbol.species%"
     },
     {
       "clause": "24.2.4",
       "title": "Properties of the Set Prototype Object",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-set-prototype-object"
     },
     {
       "clause": "24.2.4.1",
       "title": "Set.prototype.add ( value )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.add"
     },
     {
       "clause": "24.2.4.2",
       "title": "Set.prototype.clear ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.clear"
     },
     {
       "clause": "24.2.4.3",
       "title": "Set.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.constructor"
     },
     {
       "clause": "24.2.4.4",
       "title": "Set.prototype.delete ( value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.delete"
     },
     {
       "clause": "24.2.4.5",
       "title": "Set.prototype.difference ( other )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.difference"
     },
     {
       "clause": "24.2.4.6",
       "title": "Set.prototype.entries ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.entries"
     },
     {
       "clause": "24.2.4.7",
       "title": "Set.prototype.forEach ( callback [ , thisArg ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.foreach"
     },
     {
       "clause": "24.2.4.8",
       "title": "Set.prototype.has ( value )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.has"
     },
     {
       "clause": "24.2.4.9",
       "title": "Set.prototype.intersection ( other )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.intersection"
     },
     {
       "clause": "24.2.4.10",
       "title": "Set.prototype.isDisjointFrom ( other )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.isdisjointfrom"
     },
     {
       "clause": "24.2.4.11",
       "title": "Set.prototype.isSubsetOf ( other )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.issubsetof"
     },
     {
       "clause": "24.2.4.12",
       "title": "Set.prototype.isSupersetOf ( other )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.issupersetof"
     },
     {
       "clause": "24.2.4.13",
       "title": "Set.prototype.keys ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.keys"
     },
     {
       "clause": "24.2.4.14",
       "title": "get Set.prototype.size",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-set.prototype.size"
     },
     {
       "clause": "24.2.4.15",
       "title": "Set.prototype.symmetricDifference ( other )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference"
     },
     {
       "clause": "24.2.4.16",
       "title": "Set.prototype.union ( other )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.union"
     },
     {
       "clause": "24.2.4.17",
       "title": "Set.prototype.values ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.values"
     },
     {
       "clause": "24.2.4.18",
       "title": "Set.prototype [ %Symbol.iterator% ] ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype-%symbol.iterator%"
     },
     {
       "clause": "24.2.4.19",
       "title": "Set.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "24.2.5",
       "title": "Properties of Set Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-set-instances"
     },
     {
       "clause": "24.2.6",
       "title": "Set Iterator Objects",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-set-iterator-objects"
     },
     {
       "clause": "24.2.6.1",
       "title": "CreateSetIterator ( set , kind )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-createsetiterator"
     },
     {
       "clause": "24.2.6.2",
       "title": "The %SetIteratorPrototype% Object",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-%setiteratorprototype%-object"
     },
     {
       "clause": "24.2.6.2.1",
       "title": "%SetIteratorPrototype%.next ( )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-%setiteratorprototype%.next"
     },
     {
       "clause": "24.2.6.2.2",
       "title": "%SetIteratorPrototype% [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-%setiteratorprototype%-%symbol.tostringtag%"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "24.2.2.1",
+        "feature": "new Set()",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-set-iterable",
+        "testScripts": [
+          "Js2IL.Tests/Node/Util/JavaScript/Require_Util_Types_Expanded.js"
+        ],
+        "notes": "Parameterless construction succeeds and produces a JavaScriptRuntime.Set instance that other runtime services can recognize."
+      },
+      {
+        "clause": "24.2.2.1",
+        "feature": "new Set(iterable)",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-set-iterable",
+        "notes": "JavaScriptRuntime.Set exposes only a parameterless constructor, so iterable initialization is not available."
+      },
+      {
+        "clause": "24.2.3.1",
+        "feature": "Set constructor value and Set.prototype surface",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-set.prototype",
+        "notes": "Like Map, Set is compiler-recognized in new expressions but is not currently exposed as a first-class global constructor value with readable prototype properties."
+      },
+      {
+        "clause": "24.2.4",
+        "feature": "Implemented Set members: add, has, size",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-set-prototype-object",
+        "notes": "JavaScriptRuntime.Set supports insertion-ordered storage with add/has methods and a size property. There is currently no dedicated Js2IL.Tests/Set suite covering these members."
+      },
+      {
+        "clause": "24.2.4.2",
+        "feature": "Missing core Set prototype members (clear, delete, entries, forEach, keys, values, @@iterator)",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.clear",
+        "notes": "These prototype members are not implemented on JavaScriptRuntime.Set. The Set object itself is still iterable in runtime control-flow helpers via IEnumerable fallback."
+      },
+      {
+        "clause": "24.2.4.5",
+        "feature": "New Set methods (difference, intersection, isDisjointFrom, isSubsetOf, isSupersetOf, symmetricDifference, union)",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-set.prototype.difference",
+        "notes": "The ES2025 Set operation methods are not implemented."
+      },
+      {
+        "clause": "24.2.6.1",
+        "feature": "Set iteration in for-of and other runtime iterator consumers",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-createsetiterator",
+        "notes": "Set implements System.Collections.IEnumerable, so JavaScriptRuntime.Object.GetIterator can wrap it for runtime iteration. Direct JS-visible Set iterator methods and prototype surface remain incomplete."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/24/Section24_2.md
+++ b/docs/ECMA262/24/Section24_2.md
@@ -1,10 +1,95 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 24.2: Set Objects
 
 [Back to Section24](Section24.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 24.2 | Set Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-set-objects) |
+| 24.2 | Set Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-set-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 24.2.1 | Abstract Operations For Set Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-set-objects) |
+| 24.2.1.1 | Set Records | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set-records) |
+| 24.2.1.2 | GetSetRecord ( obj ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-getsetrecord) |
+| 24.2.1.3 | SetDataHas ( setData , value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-setdatahas) |
+| 24.2.1.4 | SetDataIndex ( setData , value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-setdataindex) |
+| 24.2.1.5 | SetDataSize ( setData ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-setdatasize) |
+| 24.2.2 | The Set Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-set-constructor) |
+| 24.2.2.1 | Set ( [ iterable ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-set-iterable) |
+| 24.2.3 | Properties of the Set Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-set-constructor) |
+| 24.2.3.1 | Set.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype) |
+| 24.2.3.2 | get Set [ %Symbol.species% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-set-%symbol.species%) |
+| 24.2.4 | Properties of the Set Prototype Object | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-set-prototype-object) |
+| 24.2.4.1 | Set.prototype.add ( value ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.add) |
+| 24.2.4.2 | Set.prototype.clear ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.clear) |
+| 24.2.4.3 | Set.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.constructor) |
+| 24.2.4.4 | Set.prototype.delete ( value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.delete) |
+| 24.2.4.5 | Set.prototype.difference ( other ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.difference) |
+| 24.2.4.6 | Set.prototype.entries ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.entries) |
+| 24.2.4.7 | Set.prototype.forEach ( callback [ , thisArg ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.foreach) |
+| 24.2.4.8 | Set.prototype.has ( value ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.has) |
+| 24.2.4.9 | Set.prototype.intersection ( other ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.intersection) |
+| 24.2.4.10 | Set.prototype.isDisjointFrom ( other ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.isdisjointfrom) |
+| 24.2.4.11 | Set.prototype.isSubsetOf ( other ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.issubsetof) |
+| 24.2.4.12 | Set.prototype.isSupersetOf ( other ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.issupersetof) |
+| 24.2.4.13 | Set.prototype.keys ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.keys) |
+| 24.2.4.14 | get Set.prototype.size | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-set.prototype.size) |
+| 24.2.4.15 | Set.prototype.symmetricDifference ( other ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference) |
+| 24.2.4.16 | Set.prototype.union ( other ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.union) |
+| 24.2.4.17 | Set.prototype.values ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype.values) |
+| 24.2.4.18 | Set.prototype [ %Symbol.iterator% ] ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype-%symbol.iterator%) |
+| 24.2.4.19 | Set.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set.prototype-%symbol.tostringtag%) |
+| 24.2.5 | Properties of Set Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-set-instances) |
+| 24.2.6 | Set Iterator Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-set-iterator-objects) |
+| 24.2.6.1 | CreateSetIterator ( set , kind ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createsetiterator) |
+| 24.2.6.2 | The %SetIteratorPrototype% Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-%setiteratorprototype%-object) |
+| 24.2.6.2.1 | %SetIteratorPrototype%.next ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-%setiteratorprototype%.next) |
+| 24.2.6.2.2 | %SetIteratorPrototype% [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-%setiteratorprototype%-%symbol.tostringtag%) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 24.2.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-set-iterable))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| new Set() | Supported | [`Require_Util_Types_Expanded.js`](../../../Js2IL.Tests/Node/Util/JavaScript/Require_Util_Types_Expanded.js) | Parameterless construction succeeds and produces a JavaScriptRuntime.Set instance that other runtime services can recognize. |
+| new Set(iterable) | Not Yet Supported |  | JavaScriptRuntime.Set exposes only a parameterless constructor, so iterable initialization is not available. |
+
+### 24.2.3.1 ([tc39.es](https://tc39.es/ecma262/#sec-set.prototype))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Set constructor value and Set.prototype surface | Not Yet Supported |  | Like Map, Set is compiler-recognized in new expressions but is not currently exposed as a first-class global constructor value with readable prototype properties. |
+
+### 24.2.4 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-set-prototype-object))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Implemented Set members: add, has, size | Supported |  | JavaScriptRuntime.Set supports insertion-ordered storage with add/has methods and a size property. There is currently no dedicated Js2IL.Tests/Set suite covering these members. |
+
+### 24.2.4.2 ([tc39.es](https://tc39.es/ecma262/#sec-set.prototype.clear))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Missing core Set prototype members (clear, delete, entries, forEach, keys, values, @@iterator) | Not Yet Supported |  | These prototype members are not implemented on JavaScriptRuntime.Set. The Set object itself is still iterable in runtime control-flow helpers via IEnumerable fallback. |
+
+### 24.2.4.5 ([tc39.es](https://tc39.es/ecma262/#sec-set.prototype.difference))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| New Set methods (difference, intersection, isDisjointFrom, isSubsetOf, isSupersetOf, symmetricDifference, union) | Not Yet Supported |  | The ES2025 Set operation methods are not implemented. |
+
+### 24.2.6.1 ([tc39.es](https://tc39.es/ecma262/#sec-createsetiterator))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Set iteration in for-of and other runtime iterator consumers | Supported with Limitations |  | Set implements System.Collections.IEnumerable, so JavaScriptRuntime.Object.GetIterator can wrap it for runtime iteration. Direct JS-visible Set iterator methods and prototype surface remain incomplete. |
 

--- a/docs/ECMA262/24/Section24_3.json
+++ b/docs/ECMA262/24/Section24_3.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "24.3",
   "title": "WeakMap Objects",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-weakmap-objects",
   "parent": {
     "clause": "24"
@@ -12,86 +12,141 @@
     {
       "clause": "24.3.1",
       "title": "The WeakMap Constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap-constructor"
     },
     {
       "clause": "24.3.1.1",
       "title": "WeakMap ( [ iterable ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap-iterable"
     },
     {
       "clause": "24.3.2",
       "title": "Properties of the WeakMap Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weakmap-constructor"
     },
     {
       "clause": "24.3.2.1",
       "title": "WeakMap.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype"
     },
     {
       "clause": "24.3.3",
       "title": "Properties of the WeakMap Prototype Object",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weakmap-prototype-object"
     },
     {
       "clause": "24.3.3.1",
       "title": "WeakMap.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype.constructor"
     },
     {
       "clause": "24.3.3.2",
       "title": "WeakMap.prototype.delete ( key )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype.delete"
     },
     {
       "clause": "24.3.3.3",
       "title": "WeakMap.prototype.get ( key )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype.get"
     },
     {
       "clause": "24.3.3.4",
       "title": "WeakMap.prototype.getOrInsert ( key , value )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsert"
     },
     {
       "clause": "24.3.3.5",
       "title": "WeakMap.prototype.getOrInsertComputed ( key , callback )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsertcomputed"
     },
     {
       "clause": "24.3.3.6",
       "title": "WeakMap.prototype.has ( key )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype.has"
     },
     {
       "clause": "24.3.3.7",
       "title": "WeakMap.prototype.set ( key , value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype.set"
     },
     {
       "clause": "24.3.3.8",
       "title": "WeakMap.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "24.3.4",
       "title": "Properties of WeakMap Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-weakmap-instances"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "24.3.1.1",
+        "feature": "new WeakMap()",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakmap-iterable",
+        "testScripts": [
+          "Js2IL.Tests/WeakMap/JavaScript/WeakMap_Constructor_Empty.js"
+        ],
+        "notes": "Parameterless construction succeeds and allocates a ConditionalWeakTable-backed collection."
+      },
+      {
+        "clause": "24.3.1.1",
+        "feature": "new WeakMap(iterable)",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakmap-iterable",
+        "notes": "JavaScriptRuntime.WeakMap exposes only a parameterless constructor, so iterable initialization is not available."
+      },
+      {
+        "clause": "24.3.2.1",
+        "feature": "WeakMap constructor value and WeakMap.prototype surface",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype",
+        "notes": "WeakMap is compiler-recognized in new expressions but is not exposed as a first-class global constructor value with readable prototype properties."
+      },
+      {
+        "clause": "24.3.3",
+        "feature": "WeakMap.prototype.set / get / has / delete",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weakmap-prototype-object",
+        "testScripts": [
+          "Js2IL.Tests/WeakMap/JavaScript/WeakMap_Set_Get_Basic.js",
+          "Js2IL.Tests/WeakMap/JavaScript/WeakMap_Has_Basic.js",
+          "Js2IL.Tests/WeakMap/JavaScript/WeakMap_Delete_Basic.js",
+          "Js2IL.Tests/WeakMap/JavaScript/WeakMap_Object_Keys.js"
+        ],
+        "notes": "Core WeakMap flows work for the object keys used in tests. The runtime only rejects null, so it does not fully enforce ECMAScript's object-only weak-key restrictions for every non-null primitive or boxed value."
+      },
+      {
+        "clause": "24.3.3.4",
+        "feature": "WeakMap.prototype.getOrInsert / getOrInsertComputed",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsert",
+        "notes": "The newer WeakMap insertion helpers are not implemented."
+      },
+      {
+        "clause": "24.3.3.8",
+        "feature": "WeakMap.prototype[@@toStringTag]",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakmap.prototype-%symbol.tostringtag%",
+        "notes": "WeakMap instances do not currently expose a symbol-keyed toStringTag property."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/24/Section24_3.md
+++ b/docs/ECMA262/24/Section24_3.md
@@ -1,10 +1,66 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 24.3: WeakMap Objects
 
 [Back to Section24](Section24.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 24.3 | WeakMap Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weakmap-objects) |
+| 24.3 | WeakMap Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakmap-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 24.3.1 | The WeakMap Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakmap-constructor) |
+| 24.3.1.1 | WeakMap ( [ iterable ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakmap-iterable) |
+| 24.3.2 | Properties of the WeakMap Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weakmap-constructor) |
+| 24.3.2.1 | WeakMap.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype) |
+| 24.3.3 | Properties of the WeakMap Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weakmap-prototype-object) |
+| 24.3.3.1 | WeakMap.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype.constructor) |
+| 24.3.3.2 | WeakMap.prototype.delete ( key ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype.delete) |
+| 24.3.3.3 | WeakMap.prototype.get ( key ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype.get) |
+| 24.3.3.4 | WeakMap.prototype.getOrInsert ( key , value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsert) |
+| 24.3.3.5 | WeakMap.prototype.getOrInsertComputed ( key , callback ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsertcomputed) |
+| 24.3.3.6 | WeakMap.prototype.has ( key ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype.has) |
+| 24.3.3.7 | WeakMap.prototype.set ( key , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype.set) |
+| 24.3.3.8 | WeakMap.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype-%symbol.tostringtag%) |
+| 24.3.4 | Properties of WeakMap Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-weakmap-instances) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 24.3.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-weakmap-iterable))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| new WeakMap() | Supported | [`WeakMap_Constructor_Empty.js`](../../../Js2IL.Tests/WeakMap/JavaScript/WeakMap_Constructor_Empty.js) | Parameterless construction succeeds and allocates a ConditionalWeakTable-backed collection. |
+| new WeakMap(iterable) | Not Yet Supported |  | JavaScriptRuntime.WeakMap exposes only a parameterless constructor, so iterable initialization is not available. |
+
+### 24.3.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| WeakMap constructor value and WeakMap.prototype surface | Not Yet Supported |  | WeakMap is compiler-recognized in new expressions but is not exposed as a first-class global constructor value with readable prototype properties. |
+
+### 24.3.3 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weakmap-prototype-object))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| WeakMap.prototype.set / get / has / delete | Supported with Limitations | [`WeakMap_Set_Get_Basic.js`](../../../Js2IL.Tests/WeakMap/JavaScript/WeakMap_Set_Get_Basic.js)<br>[`WeakMap_Has_Basic.js`](../../../Js2IL.Tests/WeakMap/JavaScript/WeakMap_Has_Basic.js)<br>[`WeakMap_Delete_Basic.js`](../../../Js2IL.Tests/WeakMap/JavaScript/WeakMap_Delete_Basic.js)<br>[`WeakMap_Object_Keys.js`](../../../Js2IL.Tests/WeakMap/JavaScript/WeakMap_Object_Keys.js) | Core WeakMap flows work for the object keys used in tests. The runtime only rejects null, so it does not fully enforce ECMAScript's object-only weak-key restrictions for every non-null primitive or boxed value. |
+
+### 24.3.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsert))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| WeakMap.prototype.getOrInsert / getOrInsertComputed | Not Yet Supported |  | The newer WeakMap insertion helpers are not implemented. |
+
+### 24.3.3.8 ([tc39.es](https://tc39.es/ecma262/#sec-weakmap.prototype-%symbol.tostringtag%))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| WeakMap.prototype[@@toStringTag] | Not Yet Supported |  | WeakMap instances do not currently expose a symbol-keyed toStringTag property. |
 

--- a/docs/ECMA262/24/Section24_4.json
+++ b/docs/ECMA262/24/Section24_4.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "24.4",
   "title": "WeakSet Objects",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-weakset-objects",
   "parent": {
     "clause": "24"
@@ -12,68 +12,115 @@
     {
       "clause": "24.4.1",
       "title": "The WeakSet Constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakset-constructor"
     },
     {
       "clause": "24.4.1.1",
       "title": "WeakSet ( [ iterable ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakset-iterable"
     },
     {
       "clause": "24.4.2",
       "title": "Properties of the WeakSet Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weakset-constructor"
     },
     {
       "clause": "24.4.2.1",
       "title": "WeakSet.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weakset.prototype"
     },
     {
       "clause": "24.4.3",
       "title": "Properties of the WeakSet Prototype Object",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weakset-prototype-object"
     },
     {
       "clause": "24.4.3.1",
       "title": "WeakSet.prototype.add ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakset.prototype.add"
     },
     {
       "clause": "24.4.3.2",
       "title": "WeakSet.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weakset.prototype.constructor"
     },
     {
       "clause": "24.4.3.3",
       "title": "WeakSet.prototype.delete ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakset.prototype.delete"
     },
     {
       "clause": "24.4.3.4",
       "title": "WeakSet.prototype.has ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-weakset.prototype.has"
     },
     {
       "clause": "24.4.3.5",
       "title": "WeakSet.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weakset.prototype-%symbol.tostringtag%"
     },
     {
       "clause": "24.4.4",
       "title": "Properties of WeakSet Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-weakset-instances"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "24.4.1.1",
+        "feature": "new WeakSet()",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakset-iterable",
+        "testScripts": [
+          "Js2IL.Tests/WeakSet/JavaScript/WeakSet_Constructor_Empty.js"
+        ],
+        "notes": "Parameterless construction succeeds and allocates a ConditionalWeakTable-backed collection."
+      },
+      {
+        "clause": "24.4.1.1",
+        "feature": "new WeakSet(iterable)",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakset-iterable",
+        "notes": "JavaScriptRuntime.WeakSet exposes only a parameterless constructor, so iterable initialization is not available."
+      },
+      {
+        "clause": "24.4.2.1",
+        "feature": "WeakSet constructor value and WeakSet.prototype surface",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakset.prototype",
+        "notes": "WeakSet is compiler-recognized in new expressions but is not exposed as a first-class global constructor value with readable prototype properties."
+      },
+      {
+        "clause": "24.4.3",
+        "feature": "WeakSet.prototype.add / has / delete",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weakset-prototype-object",
+        "testScripts": [
+          "Js2IL.Tests/WeakSet/JavaScript/WeakSet_Add_Has_Basic.js",
+          "Js2IL.Tests/WeakSet/JavaScript/WeakSet_Delete_Basic.js",
+          "Js2IL.Tests/WeakSet/JavaScript/WeakSet_Object_Values.js"
+        ],
+        "notes": "Core WeakSet flows work for the object values used in tests. The runtime only rejects null, so it does not fully enforce ECMAScript's object-only weak-value restrictions for every non-null primitive or boxed value."
+      },
+      {
+        "clause": "24.4.3.5",
+        "feature": "WeakSet.prototype[@@toStringTag]",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-weakset.prototype-%symbol.tostringtag%",
+        "notes": "WeakSet instances do not currently expose a symbol-keyed toStringTag property."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/24/Section24_4.md
+++ b/docs/ECMA262/24/Section24_4.md
@@ -1,10 +1,57 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 24.4: WeakSet Objects
 
 [Back to Section24](Section24.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 24.4 | WeakSet Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weakset-objects) |
+| 24.4 | WeakSet Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakset-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 24.4.1 | The WeakSet Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakset-constructor) |
+| 24.4.1.1 | WeakSet ( [ iterable ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakset-iterable) |
+| 24.4.2 | Properties of the WeakSet Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weakset-constructor) |
+| 24.4.2.1 | WeakSet.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakset.prototype) |
+| 24.4.3 | Properties of the WeakSet Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weakset-prototype-object) |
+| 24.4.3.1 | WeakSet.prototype.add ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakset.prototype.add) |
+| 24.4.3.2 | WeakSet.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakset.prototype.constructor) |
+| 24.4.3.3 | WeakSet.prototype.delete ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakset.prototype.delete) |
+| 24.4.3.4 | WeakSet.prototype.has ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakset.prototype.has) |
+| 24.4.3.5 | WeakSet.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakset.prototype-%symbol.tostringtag%) |
+| 24.4.4 | Properties of WeakSet Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-weakset-instances) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 24.4.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-weakset-iterable))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| new WeakSet() | Supported | [`WeakSet_Constructor_Empty.js`](../../../Js2IL.Tests/WeakSet/JavaScript/WeakSet_Constructor_Empty.js) | Parameterless construction succeeds and allocates a ConditionalWeakTable-backed collection. |
+| new WeakSet(iterable) | Not Yet Supported |  | JavaScriptRuntime.WeakSet exposes only a parameterless constructor, so iterable initialization is not available. |
+
+### 24.4.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-weakset.prototype))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| WeakSet constructor value and WeakSet.prototype surface | Not Yet Supported |  | WeakSet is compiler-recognized in new expressions but is not exposed as a first-class global constructor value with readable prototype properties. |
+
+### 24.4.3 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weakset-prototype-object))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| WeakSet.prototype.add / has / delete | Supported with Limitations | [`WeakSet_Add_Has_Basic.js`](../../../Js2IL.Tests/WeakSet/JavaScript/WeakSet_Add_Has_Basic.js)<br>[`WeakSet_Delete_Basic.js`](../../../Js2IL.Tests/WeakSet/JavaScript/WeakSet_Delete_Basic.js)<br>[`WeakSet_Object_Values.js`](../../../Js2IL.Tests/WeakSet/JavaScript/WeakSet_Object_Values.js) | Core WeakSet flows work for the object values used in tests. The runtime only rejects null, so it does not fully enforce ECMAScript's object-only weak-value restrictions for every non-null primitive or boxed value. |
+
+### 24.4.3.5 ([tc39.es](https://tc39.es/ecma262/#sec-weakset.prototype-%symbol.tostringtag%))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| WeakSet.prototype[@@toStringTag] | Not Yet Supported |  | WeakSet instances do not currently expose a symbol-keyed toStringTag property. |
 

--- a/docs/ECMA262/24/Section24_5.json
+++ b/docs/ECMA262/24/Section24_5.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "24.5",
   "title": "Abstract Operations for Keyed Collections",
-  "status": "Untracked",
+  "status": "Incomplete",
   "specUrl": "https://tc39.es/ecma262/#sec-abstract-operations-for-keyed-collections",
   "parent": {
     "clause": "24"
@@ -12,13 +12,22 @@
     {
       "clause": "24.5.1",
       "title": "CanonicalizeKeyedCollectionKey ( key )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-canonicalizekeyedcollectionkey"
     }
   ],
   "support": {
     "entries": [
-      
+      {
+        "clause": "24.5.1",
+        "feature": "CanonicalizeKeyedCollectionKey behavior",
+        "status": "Incomplete",
+        "specUrl": "https://tc39.es/ecma262/#sec-canonicalizekeyedcollectionkey",
+        "testScripts": [
+          "Js2IL.Tests/Map/JavaScript/Map_Null_Key.js"
+        ],
+        "notes": "Map uses a null sentinel plus a SameValueZero-style comparer to support common key cases such as null and NaN, but JS2IL does not implement a shared CanonicalizeKeyedCollectionKey abstraction across Map, Set, WeakMap, and WeakSet, and full canonical storage behavior such as normalizing -0 to +0 in observable results remains incomplete."
+      }
     ]
   }
 }

--- a/docs/ECMA262/24/Section24_5.md
+++ b/docs/ECMA262/24/Section24_5.md
@@ -4,13 +4,25 @@
 
 [Back to Section24](Section24.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 24.5 | Abstract Operations for Keyed Collections | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-keyed-collections) |
+| 24.5 | Abstract Operations for Keyed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-keyed-collections) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 24.5.1 | CanonicalizeKeyedCollectionKey ( key ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-canonicalizekeyedcollectionkey) |
+| 24.5.1 | CanonicalizeKeyedCollectionKey ( key ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-canonicalizekeyedcollectionkey) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 24.5.1 ([tc39.es](https://tc39.es/ecma262/#sec-canonicalizekeyedcollectionkey))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| CanonicalizeKeyedCollectionKey behavior | Incomplete | [`Map_Null_Key.js`](../../../Js2IL.Tests/Map/JavaScript/Map_Null_Key.js) | Map uses a null sentinel plus a SameValueZero-style comparer to support common key cases such as null and NaN, but JS2IL does not implement a shared CanonicalizeKeyedCollectionKey abstraction across Map, Set, WeakMap, and WeakSet, and full canonical storage behavior such as normalizing -0 to +0 in observable results remains incomplete. |
 

--- a/docs/ECMA262/25/Section25.md
+++ b/docs/ECMA262/25/Section25.md
@@ -4,6 +4,8 @@ Covers structured data features such as JSON and binary data abstractions.
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/25/Section25_1.md
+++ b/docs/ECMA262/25/Section25_1.md
@@ -1,10 +1,58 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 25.1: ArrayBuffer Objects
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 25.1 | ArrayBuffer Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 25.1.1 | Notation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-notation) |
+| 25.1.2 | Fixed-length and Resizable ArrayBuffer Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-fixed-length-and-resizable-arraybuffer-objects) |
+| 25.1.3 | Abstract Operations For ArrayBuffer Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-arraybuffer-objects) |
+| 25.1.3.1 | AllocateArrayBuffer ( constructor , byteLength [ , maxByteLength ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-allocatearraybuffer) |
+| 25.1.3.2 | ArrayBufferByteLength ( arrayBuffer , order ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybufferbytelength) |
+| 25.1.3.3 | ArrayBufferCopyAndDetach ( arrayBuffer , newLength , preserveResizability ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffercopyanddetach) |
+| 25.1.3.4 | IsDetachedBuffer ( arrayBuffer ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isdetachedbuffer) |
+| 25.1.3.5 | DetachArrayBuffer ( arrayBuffer [ , key ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-detacharraybuffer) |
+| 25.1.3.6 | CloneArrayBuffer ( srcBuffer , srcByteOffset , srcLength ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-clonearraybuffer) |
+| 25.1.3.7 | GetArrayBufferMaxByteLengthOption ( options ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getarraybuffermaxbytelengthoption) |
+| 25.1.3.8 | HostResizeArrayBuffer ( buffer , newByteLength ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hostresizearraybuffer) |
+| 25.1.3.9 | IsFixedLengthArrayBuffer ( arrayBuffer ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isfixedlengtharraybuffer) |
+| 25.1.3.10 | IsUnsignedElementType ( type ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isunsignedelementtype) |
+| 25.1.3.11 | IsUnclampedIntegerElementType ( type ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isunclampedintegerelementtype) |
+| 25.1.3.12 | IsBigIntElementType ( type ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isbigintelementtype) |
+| 25.1.3.13 | IsNoTearConfiguration ( type , order ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isnotearconfiguration) |
+| 25.1.3.14 | RawBytesToNumeric ( type , rawBytes , isLittleEndian ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-rawbytestonumeric) |
+| 25.1.3.15 | GetRawBytesFromSharedBlock ( block , byteIndex , type , isTypedArray , order ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getrawbytesfromsharedblock) |
+| 25.1.3.16 | GetValueFromBuffer ( arrayBuffer , byteIndex , type , isTypedArray , order [ , isLittleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getvaluefrombuffer) |
+| 25.1.3.17 | NumericToRawBytes ( type , value , isLittleEndian ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-numerictorawbytes) |
+| 25.1.3.18 | SetValueInBuffer ( arrayBuffer , byteIndex , type , value , isTypedArray , order [ , isLittleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-setvalueinbuffer) |
+| 25.1.3.19 | GetModifySetValueInBuffer ( arrayBuffer , byteIndex , type , value , op ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getmodifysetvalueinbuffer) |
+| 25.1.4 | The ArrayBuffer Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-constructor) |
+| 25.1.4.1 | ArrayBuffer ( length [ , options ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-length) |
+| 25.1.5 | Properties of the ArrayBuffer Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-constructor) |
+| 25.1.5.1 | ArrayBuffer.isView ( arg ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.isview) |
+| 25.1.5.2 | ArrayBuffer.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype) |
+| 25.1.5.3 | get ArrayBuffer [ %Symbol.species% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer-%symbol.species%) |
+| 25.1.6 | Properties of the ArrayBuffer Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-prototype-object) |
+| 25.1.6.1 | get ArrayBuffer.prototype.byteLength | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength) |
+| 25.1.6.2 | ArrayBuffer.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.constructor) |
+| 25.1.6.3 | get ArrayBuffer.prototype.detached | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.detached) |
+| 25.1.6.4 | get ArrayBuffer.prototype.maxByteLength | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.maxbytelength) |
+| 25.1.6.5 | get ArrayBuffer.prototype.resizable | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable) |
+| 25.1.6.6 | ArrayBuffer.prototype.resize ( newLength ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize) |
+| 25.1.6.7 | ArrayBuffer.prototype.slice ( start , end ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice) |
+| 25.1.6.8 | ArrayBuffer.prototype.transfer ( [ newLength ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfer) |
+| 25.1.6.9 | ArrayBuffer.prototype.transferToFixedLength ( [ newLength ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfertofixedlength) |
+| 25.1.6.10 | ArrayBuffer.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%) |
+| 25.1.7 | Properties of ArrayBuffer Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-instances) |
+| 25.1.8 | Resizable ArrayBuffer Guidelines | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-resizable-arraybuffer-guidelines) |
 

--- a/docs/ECMA262/25/Section25_2.md
+++ b/docs/ECMA262/25/Section25_2.md
@@ -1,10 +1,38 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 25.2: SharedArrayBuffer Objects
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 25.2 | SharedArrayBuffer Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 25.2.1 | Fixed-length and Growable SharedArrayBuffer Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-fixed-length-and-growable-sharedarraybuffer-objects) |
+| 25.2.2 | Abstract Operations for SharedArrayBuffer Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-sharedarraybuffer-objects) |
+| 25.2.2.1 | AllocateSharedArrayBuffer ( constructor , byteLength [ , maxByteLength ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-allocatesharedarraybuffer) |
+| 25.2.2.2 | IsSharedArrayBuffer ( obj ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-issharedarraybuffer) |
+| 25.2.2.3 | IsGrowableSharedArrayBuffer ( obj ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isgrowablesharedarraybuffer) |
+| 25.2.2.4 | HostGrowSharedArrayBuffer ( buffer , newByteLength ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hostgrowsharedarraybuffer) |
+| 25.2.3 | The SharedArrayBuffer Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer-constructor) |
+| 25.2.3.1 | SharedArrayBuffer ( length [ , options ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer-length) |
+| 25.2.4 | Properties of the SharedArrayBuffer Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-sharedarraybuffer-constructor) |
+| 25.2.4.1 | SharedArrayBuffer.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype) |
+| 25.2.4.2 | get SharedArrayBuffer [ %Symbol.species% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer-%symbol.species%) |
+| 25.2.5 | Properties of the SharedArrayBuffer Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-sharedarraybuffer-prototype-object) |
+| 25.2.5.1 | get SharedArrayBuffer.prototype.byteLength | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength) |
+| 25.2.5.2 | SharedArrayBuffer.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.constructor) |
+| 25.2.5.3 | SharedArrayBuffer.prototype.grow ( newLength ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.grow) |
+| 25.2.5.4 | get SharedArrayBuffer.prototype.growable | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.growable) |
+| 25.2.5.5 | get SharedArrayBuffer.prototype.maxByteLength | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.maxbytelength) |
+| 25.2.5.6 | SharedArrayBuffer.prototype.slice ( start , end ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.slice) |
+| 25.2.5.7 | SharedArrayBuffer.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype-%symbol.tostringtag%) |
+| 25.2.6 | Properties of SharedArrayBuffer Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-sharedarraybuffer-instances) |
+| 25.2.7 | Growable SharedArrayBuffer Guidelines | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-growable-sharedarraybuffer-guidelines) |
 

--- a/docs/ECMA262/25/Section25_3.md
+++ b/docs/ECMA262/25/Section25_3.md
@@ -1,10 +1,57 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 25.3: DataView Objects
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 25.3 | DataView Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 25.3.1 | Abstract Operations For DataView Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-dataview-objects) |
+| 25.3.1.1 | DataView With Buffer Witness Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview-with-buffer-witness-records) |
+| 25.3.1.2 | MakeDataViewWithBufferWitnessRecord ( obj , order ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-makedataviewwithbufferwitnessrecord) |
+| 25.3.1.3 | GetViewByteLength ( viewRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getviewbytelength) |
+| 25.3.1.4 | IsViewOutOfBounds ( viewRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isviewoutofbounds) |
+| 25.3.1.5 | GetViewValue ( view , requestIndex , isLittleEndian , type ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getviewvalue) |
+| 25.3.1.6 | SetViewValue ( view , requestIndex , isLittleEndian , type , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-setviewvalue) |
+| 25.3.2 | The DataView Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview-constructor) |
+| 25.3.2.1 | DataView ( buffer [ , byteOffset [ , byteLength ] ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength) |
+| 25.3.3 | Properties of the DataView Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor) |
+| 25.3.3.1 | DataView.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype) |
+| 25.3.4 | Properties of the DataView Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-prototype-object) |
+| 25.3.4.1 | get DataView.prototype.buffer | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.buffer) |
+| 25.3.4.2 | get DataView.prototype.byteLength | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.bytelength) |
+| 25.3.4.3 | get DataView.prototype.byteOffset | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset) |
+| 25.3.4.4 | DataView.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.constructor) |
+| 25.3.4.5 | DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64) |
+| 25.3.4.6 | DataView.prototype.getBigUint64 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64) |
+| 25.3.4.7 | DataView.prototype.getFloat16 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat16) |
+| 25.3.4.8 | DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32) |
+| 25.3.4.9 | DataView.prototype.getFloat64 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64) |
+| 25.3.4.10 | DataView.prototype.getInt8 ( byteOffset ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getint8) |
+| 25.3.4.11 | DataView.prototype.getInt16 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getint16) |
+| 25.3.4.12 | DataView.prototype.getInt32 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getint32) |
+| 25.3.4.13 | DataView.prototype.getUint8 ( byteOffset ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getuint8) |
+| 25.3.4.14 | DataView.prototype.getUint16 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getuint16) |
+| 25.3.4.15 | DataView.prototype.getUint32 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getuint32) |
+| 25.3.4.16 | DataView.prototype.setBigInt64 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64) |
+| 25.3.4.17 | DataView.prototype.setBigUint64 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64) |
+| 25.3.4.18 | DataView.prototype.setFloat16 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setfloat16) |
+| 25.3.4.19 | DataView.prototype.setFloat32 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setfloat32) |
+| 25.3.4.20 | DataView.prototype.setFloat64 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setfloat64) |
+| 25.3.4.21 | DataView.prototype.setInt8 ( byteOffset , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setint8) |
+| 25.3.4.22 | DataView.prototype.setInt16 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setint16) |
+| 25.3.4.23 | DataView.prototype.setInt32 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setint32) |
+| 25.3.4.24 | DataView.prototype.setUint8 ( byteOffset , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint8) |
+| 25.3.4.25 | DataView.prototype.setUint16 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint16) |
+| 25.3.4.26 | DataView.prototype.setUint32 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint32) |
+| 25.3.4.27 | DataView.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%) |
+| 25.3.5 | Properties of DataView Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-dataview-instances) |
 

--- a/docs/ECMA262/25/Section25_4.md
+++ b/docs/ECMA262/25/Section25_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 25.4 | The Atomics Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-atomics-object) |

--- a/docs/ECMA262/25/Section25_5.md
+++ b/docs/ECMA262/25/Section25_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 25.5 | The JSON Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-json-object) |

--- a/docs/ECMA262/26/Section26.md
+++ b/docs/ECMA262/26/Section26.md
@@ -4,6 +4,8 @@ Covers memory-management related features such as WeakRef and FinalizationRegist
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/26/Section26_1.md
+++ b/docs/ECMA262/26/Section26_1.md
@@ -1,10 +1,28 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 26.1: WeakRef Objects
 
 [Back to Section26](Section26.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 26.1 | WeakRef Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 26.1.1 | The WeakRef Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref-constructor) |
+| 26.1.1.1 | WeakRef ( target ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref-target) |
+| 26.1.2 | Properties of the WeakRef Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-constructor) |
+| 26.1.2.1 | WeakRef.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype) |
+| 26.1.3 | Properties of the WeakRef Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object) |
+| 26.1.3.1 | WeakRef.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype.constructor) |
+| 26.1.3.2 | WeakRef.prototype.deref ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype.deref) |
+| 26.1.3.3 | WeakRef.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype-%symbol.tostringtag%) |
+| 26.1.4 | WeakRef Abstract Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weakref-abstract-operations) |
+| 26.1.4.1 | WeakRefDeref ( weakRef ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-weakrefderef) |
+| 26.1.5 | Properties of WeakRef Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-weak-ref-instances) |
 

--- a/docs/ECMA262/26/Section26_2.md
+++ b/docs/ECMA262/26/Section26_2.md
@@ -1,10 +1,27 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 26.2: FinalizationRegistry Objects
 
 [Back to Section26](Section26.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 26.2 | FinalizationRegistry Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry-objects) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 26.2.1 | The FinalizationRegistry Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry-constructor) |
+| 26.2.1.1 | FinalizationRegistry ( cleanupCallback ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry-cleanup-callback) |
+| 26.2.2 | Properties of the FinalizationRegistry Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-constructor) |
+| 26.2.2.1 | FinalizationRegistry.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype) |
+| 26.2.3 | Properties of the FinalizationRegistry Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object) |
+| 26.2.3.1 | FinalizationRegistry.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.constructor) |
+| 26.2.3.2 | FinalizationRegistry.prototype.register ( target , heldValue [ , unregisterToken ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.register) |
+| 26.2.3.3 | FinalizationRegistry.prototype.unregister ( unregisterToken ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister) |
+| 26.2.3.4 | FinalizationRegistry.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype-%symbol.tostringtag%) |
+| 26.2.4 | Properties of FinalizationRegistry Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-finalization-registry-instances) |
 

--- a/docs/ECMA262/27/Section27.md
+++ b/docs/ECMA262/27/Section27.md
@@ -4,6 +4,8 @@ Covers control abstraction objects, including promises and generator/async contr
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/27/Section27_1.md
+++ b/docs/ECMA262/27/Section27_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 27.1 | Iteration | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteration) |

--- a/docs/ECMA262/27/Section27_2.md
+++ b/docs/ECMA262/27/Section27_2.md
@@ -2,6 +2,8 @@
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 27.2 | Promise Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise-objects) |

--- a/docs/ECMA262/27/Section27_3.md
+++ b/docs/ECMA262/27/Section27_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _Lists clause numbers/titles/links only (no spec text) in the index above. See appendix for extracted spec text._
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/27/Section27_4.md
+++ b/docs/ECMA262/27/Section27_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _Lists clause numbers/titles/links only (no spec text)._
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/27/Section27_5.md
+++ b/docs/ECMA262/27/Section27_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _Lists clause numbers/titles/links only (no spec text)._
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/27/Section27_6.md
+++ b/docs/ECMA262/27/Section27_6.md
@@ -4,6 +4,8 @@
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _Lists clause numbers/titles/links only (no spec text)._
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/27/Section27_7.md
+++ b/docs/ECMA262/27/Section27_7.md
@@ -4,6 +4,8 @@
 
 [Back to Section27](Section27.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 27.7 | AsyncFunction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-async-function-objects) |

--- a/docs/ECMA262/28/Section28.md
+++ b/docs/ECMA262/28/Section28.md
@@ -4,6 +4,8 @@ Covers reflection capabilities, including Proxy/Reflect and meta-level operation
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/28/Section28_1.md
+++ b/docs/ECMA262/28/Section28_1.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 28.1: The Reflect Object
 
 [Back to Section28](Section28.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 28.1 | The Reflect Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect-object) |
-

--- a/docs/ECMA262/28/Section28_2.md
+++ b/docs/ECMA262/28/Section28_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section28](Section28.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 28.2 | Proxy Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-proxy-objects) |

--- a/docs/ECMA262/28/Section28_3.md
+++ b/docs/ECMA262/28/Section28_3.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 28.3: Module Namespace Objects
 
 [Back to Section28](Section28.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 28.3 | Module Namespace Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-objects) |
-

--- a/docs/ECMA262/29/Section29.md
+++ b/docs/ECMA262/29/Section29.md
@@ -4,6 +4,8 @@ Defines the ECMAScript memory model, including SharedArrayBuffer and atomic oper
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/29/Section29_1.md
+++ b/docs/ECMA262/29/Section29_1.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.1: Memory Model Fundamentals
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.1 | Memory Model Fundamentals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-memory-model-fundamentals) |
-

--- a/docs/ECMA262/29/Section29_10.md
+++ b/docs/ECMA262/29/Section29_10.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.10: Data Race Freedom
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.10 | Data Race Freedom | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-data-race-freedom) |
-

--- a/docs/ECMA262/29/Section29_11.md
+++ b/docs/ECMA262/29/Section29_11.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.11: Shared Memory Guidelines
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.11 | Shared Memory Guidelines | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-shared-memory-guidelines) |
-

--- a/docs/ECMA262/29/Section29_2.md
+++ b/docs/ECMA262/29/Section29_2.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.2: Agent Events Records
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.2 | Agent Events Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-agent-event-records) |
-

--- a/docs/ECMA262/29/Section29_3.md
+++ b/docs/ECMA262/29/Section29_3.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.3: Chosen Value Records
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.3 | Chosen Value Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-chosen-value-records) |
-

--- a/docs/ECMA262/29/Section29_4.md
+++ b/docs/ECMA262/29/Section29_4.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.4: Candidate Executions
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.4 | Candidate Executions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-candidate-executions) |
-

--- a/docs/ECMA262/29/Section29_5.md
+++ b/docs/ECMA262/29/Section29_5.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.5: Abstract Operations for the Memory Model
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.5 | Abstract Operations for the Memory Model | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-the-memory-model) |
-

--- a/docs/ECMA262/29/Section29_6.md
+++ b/docs/ECMA262/29/Section29_6.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.6: Relations of Candidate Executions
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.6 | Relations of Candidate Executions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-relations-of-candidate-executions) |
-

--- a/docs/ECMA262/29/Section29_7.md
+++ b/docs/ECMA262/29/Section29_7.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.7: Properties of Valid Executions
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.7 | Properties of Valid Executions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-valid-executions) |
-

--- a/docs/ECMA262/29/Section29_8.md
+++ b/docs/ECMA262/29/Section29_8.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.8: Races
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.8 | Races | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-races) |
-

--- a/docs/ECMA262/29/Section29_9.md
+++ b/docs/ECMA262/29/Section29_9.md
@@ -1,10 +1,11 @@
-﻿<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 29.9: Data Races
 
 [Back to Section29](Section29.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 29.9 | Data Races | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-data-races) |
-

--- a/docs/ECMA262/3/Section3.md
+++ b/docs/ECMA262/3/Section3.md
@@ -4,6 +4,8 @@ Lists the normative references that ECMAScript relies on.
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 3 | Normative References | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-normative-references) |

--- a/docs/ECMA262/4/Section4.md
+++ b/docs/ECMA262/4/Section4.md
@@ -4,6 +4,8 @@ Provides a high-level overview of ECMAScript, typical host environments, and cor
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/4/Section4_1.md
+++ b/docs/ECMA262/4/Section4_1.md
@@ -1,10 +1,11 @@
-<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 4.1: Web Scripting
 
 [Back to Section4](Section4.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 4.1 | Web Scripting | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-web-scripting) |
-

--- a/docs/ECMA262/4/Section4_2.md
+++ b/docs/ECMA262/4/Section4_2.md
@@ -1,10 +1,11 @@
-<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 4.2: Hosts and Implementations
 
 [Back to Section4](Section4.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 4.2 | Hosts and Implementations | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-hosts-and-implementations) |
-

--- a/docs/ECMA262/4/Section4_3.md
+++ b/docs/ECMA262/4/Section4_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section4](Section4.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 4.3 | ECMAScript Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-overview) |

--- a/docs/ECMA262/4/Section4_4.md
+++ b/docs/ECMA262/4/Section4_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section4](Section4.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 4.4 | Terms and Definitions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions) |

--- a/docs/ECMA262/4/Section4_5.md
+++ b/docs/ECMA262/4/Section4_5.md
@@ -1,10 +1,11 @@
-<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
+<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
 
 # Section 4.5: Organization of This Specification
 
 [Back to Section4](Section4.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 4.5 | Organization of This Specification | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-organization-of-this-specification) |
-

--- a/docs/ECMA262/5/Section5.md
+++ b/docs/ECMA262/5/Section5.md
@@ -4,6 +4,8 @@ Explains the notational conventions used throughout the spec (algorithms, gramma
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/5/Section5_1.md
+++ b/docs/ECMA262/5/Section5_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section5](Section5.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 5.1 | Syntactic and Lexical Grammars | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-syntactic-and-lexical-grammars) |

--- a/docs/ECMA262/5/Section5_2.md
+++ b/docs/ECMA262/5/Section5_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section5](Section5.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 5.2 | Algorithm Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions) |

--- a/docs/ECMA262/6/Section6.md
+++ b/docs/ECMA262/6/Section6.md
@@ -4,6 +4,8 @@ Defines ECMAScript data types and values (primitives, objects) and the core conc
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/6/Section6_1.md
+++ b/docs/ECMA262/6/Section6_1.md
@@ -2,6 +2,8 @@
 
 [Back to Section6](Section6.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 6.1 | ECMAScript Language Types | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-types) |

--- a/docs/ECMA262/6/Section6_2.md
+++ b/docs/ECMA262/6/Section6_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section6](Section6.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 6.2 | ECMAScript Specification Types | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-specification-types) |

--- a/docs/ECMA262/7/Section7.md
+++ b/docs/ECMA262/7/Section7.md
@@ -4,6 +4,8 @@ Specifies abstract operations: the reusable algorithmic building blocks used thr
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/7/Section7_1.md
+++ b/docs/ECMA262/7/Section7_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 Type conversion in JS2IL is implemented on an as-needed basis for supported language features and intrinsics. Some conversions are partial/minimal implementations intended to support specific call sites (e.g., BigInt(value)).
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/7/Section7_2.md
+++ b/docs/ECMA262/7/Section7_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 7.2 | Testing and Comparison Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-testing-and-comparison-operations) |

--- a/docs/ECMA262/7/Section7_3.md
+++ b/docs/ECMA262/7/Section7_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 7.3 | Operations on Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-objects) |

--- a/docs/ECMA262/7/Section7_4.md
+++ b/docs/ECMA262/7/Section7_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 7.4 | Operations on Iterator Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-iterator-objects) |

--- a/docs/ECMA262/8/Section8.md
+++ b/docs/ECMA262/8/Section8.md
@@ -4,6 +4,8 @@ Defines syntax-directed operations, linking grammar productions to static semant
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry

--- a/docs/ECMA262/8/Section8_1.md
+++ b/docs/ECMA262/8/Section8_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL lowers runtime evaluation semantics for the supported JavaScript subset through its HIR/LIR/IL pipeline; unsupported grammar and early-error cases are rejected in parse/validation stages.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/8/Section8_2.md
+++ b/docs/ECMA262/8/Section8_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 8.2 | Scope Analysis | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-scope-analysis) |

--- a/docs/ECMA262/8/Section8_3.md
+++ b/docs/ECMA262/8/Section8_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 8.3 | Labels | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-labels) |

--- a/docs/ECMA262/8/Section8_4.md
+++ b/docs/ECMA262/8/Section8_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 8.4 | Function Name Inference | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference) |

--- a/docs/ECMA262/8/Section8_5.md
+++ b/docs/ECMA262/8/Section8_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 8.5 | Contains | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-contains) |

--- a/docs/ECMA262/8/Section8_6.md
+++ b/docs/ECMA262/8/Section8_6.md
@@ -4,6 +4,8 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 8.6 | Miscellaneous | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous) |

--- a/docs/ECMA262/9/Section9.md
+++ b/docs/ECMA262/9/Section9.md
@@ -4,13 +4,15 @@ Covers executable code, environments, realms, and execution contexts that underp
 
 [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 _This section is split into subsection documents for readability._
 
 ## Section Entry
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 9 | Executable Code and Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) |
+| 9 | Executable Code and Execution Contexts | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) |
 
 ## Subsections
 

--- a/docs/ECMA262/9/Section9_1.md
+++ b/docs/ECMA262/9/Section9_1.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL models lexical/function/global environments through compiler-managed scope structures and runtime helpers rather than first-class ECMA-262 Environment Record objects.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/9/Section9_10.md
+++ b/docs/ECMA262/9/Section9_10.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.10 | ClearKeptObjects ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#ClearKeptObjects) |

--- a/docs/ECMA262/9/Section9_11.md
+++ b/docs/ECMA262/9/Section9_11.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.11 | AddToKeptObjects ( value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#AddToKeptObjects) |

--- a/docs/ECMA262/9/Section9_12.md
+++ b/docs/ECMA262/9/Section9_12.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.12 | CleanupFinalizationRegistry ( finalizationRegistry ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#CleanupFinalizationRegistry) |

--- a/docs/ECMA262/9/Section9_13.md
+++ b/docs/ECMA262/9/Section9_13.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.13 | CanBeHeldWeakly ( v ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#CanBeHeldWeakly) |

--- a/docs/ECMA262/9/Section9_2.md
+++ b/docs/ECMA262/9/Section9_2.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.2 | PrivateEnvironment Records | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-privateenvironment-records) |

--- a/docs/ECMA262/9/Section9_3.md
+++ b/docs/ECMA262/9/Section9_3.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.3 | Realms | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-code-realms) |

--- a/docs/ECMA262/9/Section9_4.md
+++ b/docs/ECMA262/9/Section9_4.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.4 | Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-execution-contexts) |

--- a/docs/ECMA262/9/Section9_5.md
+++ b/docs/ECMA262/9/Section9_5.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.5 | Jobs and Host Operations to Enqueue Jobs | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-jobs) |

--- a/docs/ECMA262/9/Section9_6.md
+++ b/docs/ECMA262/9/Section9_6.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.6 | Agents | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-agents) |

--- a/docs/ECMA262/9/Section9_7.md
+++ b/docs/ECMA262/9/Section9_7.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 JS2IL currently runs with a single host/runtime agent model, effectively treating execution as one agent cluster.
 
 | Clause | Title | Status | Link |

--- a/docs/ECMA262/9/Section9_8.md
+++ b/docs/ECMA262/9/Section9_8.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.8 | Forward Progress | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-forward-progress) |

--- a/docs/ECMA262/9/Section9_9.md
+++ b/docs/ECMA262/9/Section9_9.md
@@ -4,6 +4,8 @@
 
 [Back to Section9](Section9.md) | [Back to Index](../Index.md)
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 9.9 | Processing Model of WeakRef and FinalizationRegistry Targets | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-weakref-processing-model) |

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -19,6 +19,8 @@ Notes:
 - `Partially Supported` is deprecated legacy wording and is treated as `Supported with Limitations`.
 - Prototype-chain design/strategy: see [PrototypeChainSupport.md](../PrototypeChainSupport.md).
 
+> Last generated (UTC): 2026-03-07T01:50:59Z
+
 ## Summary
 - Total clauses indexed: **2176**
 - Clauses with tracked status: **104** (Supported: **98**, Supported with Limitations: **5**, Not Yet Supported: **1**)
@@ -36,13 +38,13 @@ Notes:
 | 6 | ECMAScript Data Types and Values | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section6.md](6/Section6.md) |
 | 7 | Abstract Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section7.md](7/Section7.md) |
 | 8 | Syntax-Directed Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section8.md](8/Section8.md) |
-| 9 | Executable Code and Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section9.md](9/Section9.md) |
+| 9 | Executable Code and Execution Contexts | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section9.md](9/Section9.md) |
 | 10 | Ordinary and Exotic Objects Behaviours | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-and-exotic-objects-behaviours) | [Section10.md](10/Section10.md) |
 | 11 | ECMAScript Language: Source Text | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-source-code) | [Section11.md](11/Section11.md) |
 | 12 | ECMAScript Language: Lexical Grammar | Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar) | [Section12.md](12/Section12.md) |
 | 13 | ECMAScript Language: Expressions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-expressions) | [Section13.md](13/Section13.md) |
-| 14 | ECMAScript Language: Statements and Declarations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) | [Section14.md](14/Section14.md) |
-| 15 | ECMAScript Language: Functions and Classes | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) | [Section15.md](15/Section15.md) |
+| 14 | ECMAScript Language: Statements and Declarations | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) | [Section14.md](14/Section14.md) |
+| 15 | ECMAScript Language: Functions and Classes | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) | [Section15.md](15/Section15.md) |
 | 16 | ECMAScript Language: Scripts and Modules | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-scripts-and-modules) | [Section16.md](16/Section16.md) |
 | 17 | Error Handling and Language Extensions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-error-handling-and-language-extensions) | [Section17.md](17/Section17.md) |
 | 18 | ECMAScript Standard Built-in Objects | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects) | [Section18.md](18/Section18.md) |
@@ -50,8 +52,8 @@ Notes:
 | 20 | Fundamental Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-fundamental-objects) | [Section20.md](20/Section20.md) |
 | 21 | Numbers and Dates | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-numbers-and-dates) | [Section21.md](21/Section21.md) |
 | 22 | Text Processing | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-text-processing) | [Section22.md](22/Section22.md) |
-| 23 | Indexed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) | [Section23.md](23/Section23.md) |
-| 24 | Keyed Collections | Supported | [tc39.es](https://tc39.es/ecma262/#sec-keyed-collections) | [Section24.md](24/Section24.md) |
+| 23 | Indexed Collections | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) | [Section23.md](23/Section23.md) |
+| 24 | Keyed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-keyed-collections) | [Section24.md](24/Section24.md) |
 | 25 | Structured Data | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-structured-data) | [Section25.md](25/Section25.md) |
 | 26 | Managing Memory | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-managing-memory) | [Section26.md](26/Section26.md) |
 | 27 | Control Abstraction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) | [Section27.md](27/Section27.md) |

--- a/scripts/ECMA262/generateEcma262SectionMarkdown.js
+++ b/scripts/ECMA262/generateEcma262SectionMarkdown.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { buildGeneratedTimestampLine } = require('./generatedMarkdownMetadata');
 
 const DEFAULT_ROOT = path.resolve(__dirname, '..', '..', 'docs', 'ECMA262');
 const AUTO_GENERATED_MARKER = '<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->';
@@ -206,7 +207,7 @@ function getSpecUrlForClause(doc, clause) {
   return '';
 }
 
-function render(doc, sectionClause, mdPath, repoRootDir) {
+function render(doc, sectionClause, mdPath, repoRootDir, generatedAt) {
   const clause = requireString(doc, 'clause');
   const title = requireString(doc, 'title');
   const status = normalizeLegacyStatus(requireString(doc, 'status'));
@@ -231,6 +232,8 @@ function render(doc, sectionClause, mdPath, repoRootDir) {
   lines.push(`# Section ${clause}: ${title}`);
   lines.push('');
   lines.push(`[Back to Section${parentClause}](${parentDoc}) | [Back to Index](../Index.md)`);
+  lines.push('');
+  lines.push(buildGeneratedTimestampLine(generatedAt));
   lines.push('');
 
   if (doc.intro && typeof doc.intro === 'string' && doc.intro.trim().length > 0) {
@@ -387,7 +390,8 @@ function main() {
 
   const doc = JSON.parse(readText(jsonPath));
   const repoRootDir = path.resolve(__dirname, '..', '..');
-  const lines = render(doc, `${parsed.parent}.${parsed.sub}`, mdPath, repoRootDir);
+  const generatedAt = new Date();
+  const lines = render(doc, `${parsed.parent}.${parsed.sub}`, mdPath, repoRootDir, generatedAt);
   const changed = writeTextPreserveEol(mdPath, lines);
 
   console.log(`${changed ? 'Generated' : 'Up-to-date'} ${path.relative(path.resolve(__dirname, '..', '..'), mdPath)}`);

--- a/scripts/ECMA262/generateMissingEcma262SectionJson.js
+++ b/scripts/ECMA262/generateMissingEcma262SectionJson.js
@@ -16,6 +16,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { isGeneratedTimestampLine } = require('./generatedMarkdownMetadata');
 
 const DEFAULT_ROOT = path.resolve(__dirname, '..', '..', 'docs', 'ECMA262');
 
@@ -173,6 +174,7 @@ function parseSectionDocFromMarkdown(mdPath, mdText, verbose) {
         .slice(backIdx + 1, tableIdx)
         .filter((l) => l.trim().length > 0)
         .filter((l) => !l.startsWith('<!-- AUTO-GENERATED:'))
+        .filter((l) => !isGeneratedTimestampLine(l))
         .join(eol)
         .trim();
       if (chunk.length > 0) intro = chunk;

--- a/scripts/ECMA262/generatedMarkdownMetadata.js
+++ b/scripts/ECMA262/generatedMarkdownMetadata.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const GENERATED_TIMESTAMP_PREFIX = '> Last generated (UTC): ';
+
+function formatGeneratedTimestamp(date = new Date()) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new Error('Expected a valid Date for generated markdown metadata.');
+  }
+
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function buildGeneratedTimestampLine(date = new Date()) {
+  return `${GENERATED_TIMESTAMP_PREFIX}${formatGeneratedTimestamp(date)}`;
+}
+
+function isGeneratedTimestampLine(line) {
+  return typeof line === 'string' && line.trim().startsWith(GENERATED_TIMESTAMP_PREFIX);
+}
+
+module.exports = {
+  buildGeneratedTimestampLine,
+  isGeneratedTimestampLine,
+};

--- a/scripts/ECMA262/rollupEcma262Statuses.js
+++ b/scripts/ECMA262/rollupEcma262Statuses.js
@@ -17,6 +17,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { buildGeneratedTimestampLine, isGeneratedTimestampLine } = require('./generatedMarkdownMetadata');
 
 const DEFAULT_ROOT = path.resolve(__dirname, '..', '..', 'docs', 'ECMA262');
 
@@ -206,6 +207,20 @@ function asSpecLink(url) {
   return u ? `[tc39.es](${u})` : '';
 }
 
+function upsertGeneratedTimestampBeforeSummary(lines, generatedAt) {
+  const existingIndex = lines.findIndex(isGeneratedTimestampLine);
+  if (existingIndex >= 0) {
+    lines.splice(existingIndex, 1);
+    if (existingIndex < lines.length && lines[existingIndex] === '') {
+      lines.splice(existingIndex, 1);
+    }
+  }
+
+  const summaryIndex = findLineIndex(lines, '## Summary');
+  const insertIndex = summaryIndex >= 0 ? summaryIndex : lines.length;
+  lines.splice(insertIndex, 0, buildGeneratedTimestampLine(generatedAt), '');
+}
+
 function isNumericDirent(d) {
   return d && d.isDirectory && d.isDirectory() && /^\d+$/.test(d.name);
 }
@@ -260,7 +275,7 @@ function findExistingSectionEntry(sectionLines, sectionNumber) {
   return null;
 }
 
-function updateSectionHubMarkdown(sectionDir, sectionNumber, subsectionRows) {
+function updateSectionHubMarkdown(sectionDir, sectionNumber, subsectionRows, generatedAt) {
   const sectionPath = path.join(sectionDir, `Section${sectionNumber}.md`);
   if (!fs.existsSync(sectionPath)) return { changed: false, status: null };
 
@@ -297,6 +312,8 @@ function updateSectionHubMarkdown(sectionDir, sectionNumber, subsectionRows) {
   const out = [];
   out.push(...headerLines);
   out.push('');
+  out.push(buildGeneratedTimestampLine(generatedAt));
+  out.push('');
   out.push('_This section is split into subsection documents for readability._');
   out.push('');
   out.push('## Section Entry');
@@ -321,7 +338,7 @@ function updateSectionHubMarkdown(sectionDir, sectionNumber, subsectionRows) {
   return { changed, status: sectionRollupStatus };
 }
 
-function updateIndexMarkdown(rootDir, sectionStatusByNumber) {
+function updateIndexMarkdown(rootDir, sectionStatusByNumber, generatedAt) {
   const indexPath = path.join(rootDir, 'Index.md');
   if (!fs.existsSync(indexPath)) return false;
 
@@ -330,8 +347,6 @@ function updateIndexMarkdown(rootDir, sectionStatusByNumber) {
 
   const sectionsHeaderIndex = findLineIndex(indexLines, '| Section | Title | Status | Spec | Document |');
   if (sectionsHeaderIndex < 0) return false;
-
-  let anyChange = false;
 
   for (let i = sectionsHeaderIndex + 2; i < indexLines.length; i++) {
     const line = indexLines[i];
@@ -347,14 +362,11 @@ function updateIndexMarkdown(rootDir, sectionStatusByNumber) {
     if (!cells || cells.length < 5) continue;
 
     const newStatus = sectionStatusByNumber[n];
-    if (cells[2] !== newStatus) {
-      cells[2] = newStatus;
-      indexLines[i] = `| ${cells.join(' | ')} |`;
-      anyChange = true;
-    }
+    cells[2] = newStatus;
+    indexLines[i] = `| ${cells.join(' | ')} |`;
   }
 
-  if (!anyChange) return false;
+  upsertGeneratedTimestampBeforeSummary(indexLines, generatedAt);
   return writeLinesPreserveEol(indexPath, indexLines);
 }
 
@@ -370,6 +382,7 @@ function main() {
     throw new Error(`ECMA262 docs root not found: ${rootDir}`);
   }
 
+  const generatedAt = new Date();
   const sectionDirs = listNumericSectionDirs(rootDir);
 
   const sectionStatusByNumber = {};
@@ -427,14 +440,14 @@ function main() {
       return aSub - bSub;
     });
 
-    const hub = updateSectionHubMarkdown(sectionDir, sectionNumber, subsectionRows);
+    const hub = updateSectionHubMarkdown(sectionDir, sectionNumber, subsectionRows, generatedAt);
     if (hub.status) {
       sectionStatusByNumber[String(sectionNumber)] = hub.status;
     }
     if (hub.changed) changedSectionCount++;
   }
 
-  const indexChanged = updateIndexMarkdown(rootDir, sectionStatusByNumber);
+  const indexChanged = updateIndexMarkdown(rootDir, sectionStatusByNumber, generatedAt);
 
   console.log(
     `Rollup complete. Updated sections: ${changedSectionCount}. Index updated: ${indexChanged ? 'yes' : 'no'}.`

--- a/scripts/ECMA262/splitEcma262SectionsIntoSubsections.js
+++ b/scripts/ECMA262/splitEcma262SectionsIntoSubsections.js
@@ -17,6 +17,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { buildGeneratedTimestampLine, isGeneratedTimestampLine } = require('./generatedMarkdownMetadata');
 
 const DEFAULT_ROOT = path.resolve(__dirname, '..', '..', 'docs', 'ECMA262');
 const AUTO_GENERATED_MARKER = '<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->';
@@ -129,6 +130,42 @@ function getRollupStatus(statuses) {
   return 'Untracked';
 }
 
+function upsertGeneratedTimestampBeforeSummary(lines, generatedAt) {
+  const existingIndex = lines.findIndex(isGeneratedTimestampLine);
+  if (existingIndex >= 0) {
+    lines.splice(existingIndex, 1);
+    if (existingIndex < lines.length && lines[existingIndex] === '') {
+      lines.splice(existingIndex, 1);
+    }
+  }
+
+  const summaryIndex = findLineIndex(lines, '## Summary');
+  const insertIndex = summaryIndex >= 0 ? summaryIndex : lines.length;
+  lines.splice(insertIndex, 0, buildGeneratedTimestampLine(generatedAt), '');
+}
+
+function upsertGeneratedTimestampAfterBackLink(lines, generatedAt) {
+  const existingIndex = lines.findIndex(isGeneratedTimestampLine);
+  if (existingIndex >= 0) {
+    lines.splice(existingIndex, 1);
+    if (existingIndex < lines.length && lines[existingIndex] === '') {
+      lines.splice(existingIndex, 1);
+    }
+  }
+
+  const backIndex = lines.findIndex((line) => line.includes('[Back to Index]('));
+  if (backIndex < 0) return false;
+
+  let insertIndex = backIndex + 1;
+  if (insertIndex >= lines.length || lines[insertIndex] !== '') {
+    lines.splice(insertIndex, 0, '');
+  }
+
+  insertIndex = backIndex + 2;
+  lines.splice(insertIndex, 0, buildGeneratedTimestampLine(generatedAt), '');
+  return true;
+}
+
 function getSubsectionDocTableRowCount(filePath) {
   if (!fs.existsSync(filePath)) return 0;
 
@@ -227,6 +264,7 @@ function listSubsectionFiles(sectionDir, sectionNumber) {
 function main() {
   const args = parseArgs(process.argv);
   const rootDir = path.resolve(args.root && args.root.trim().length > 0 ? args.root : DEFAULT_ROOT);
+  const generatedAt = new Date();
 
   const indexPath = path.join(rootDir, 'Index.md');
   const sectionIndex = getSectionIndex(indexPath);
@@ -241,6 +279,12 @@ function main() {
 
     const sectionNumber = parseInt(mSection[1], 10);
     const sectionDir = path.dirname(sectionPath);
+
+    const existingSection = readLines(sectionPath);
+    const existingSectionLines = existingSection.lines.slice();
+    if (upsertGeneratedTimestampAfterBackLink(existingSectionLines, generatedAt)) {
+      writeLinesPreserveEol(sectionPath, existingSectionLines);
+    }
 
     // If this section still has the full clause table, generate subsection docs.
     const sectionRead = readLines(sectionPath);
@@ -289,7 +333,16 @@ function main() {
           const subTitle = subTitleRow ? subTitleRow.Title : subRows[0].Title;
 
           const subPath = path.join(sectionDir, `Section${sectionNumber}_${sub}.md`);
-          if (!shouldOverwriteSubsectionDoc(subPath)) continue;
+          if (!shouldOverwriteSubsectionDoc(subPath)) {
+            if (fs.existsSync(subPath)) {
+              const existingSub = readLines(subPath);
+              const existingSubLines = existingSub.lines.slice();
+              if (upsertGeneratedTimestampAfterBackLink(existingSubLines, generatedAt)) {
+                writeLinesPreserveEol(subPath, existingSubLines);
+              }
+            }
+            continue;
+          }
 
           const content = [];
           content.push(AUTO_GENERATED_MARKER);
@@ -297,6 +350,8 @@ function main() {
           content.push(`# Section ${subClause}: ${subTitle}`);
           content.push('');
           content.push(`[Back to Section${sectionNumber}](Section${sectionNumber}.md) | [Back to Index](../Index.md)`);
+          content.push('');
+          content.push(buildGeneratedTimestampLine(generatedAt));
           content.push('');
           content.push('| Clause | Title | Status | Link |');
           content.push('|---:|---|---|---|');
@@ -334,6 +389,12 @@ function main() {
       const subClause = `${sectionNumber}.${sf.sub}`;
       const subPath = path.join(sectionDir, sf.fileName);
 
+      const existingSub = readLines(subPath);
+      const existingSubLines = existingSub.lines.slice();
+      if (upsertGeneratedTimestampAfterBackLink(existingSubLines, generatedAt)) {
+        writeLinesPreserveEol(subPath, existingSubLines);
+      }
+
       const subLines = readLines(subPath).lines;
       const subHeaderIndex = findLineIndex(subLines, '| Clause | Title | Status | Link |');
       if (subHeaderIndex < 0) continue;
@@ -369,6 +430,8 @@ function main() {
 
     const out = [];
     out.push(...headerLines);
+    out.push('');
+    out.push(buildGeneratedTimestampLine(generatedAt));
     out.push('');
     out.push('_This section is split into subsection documents for readability._');
     out.push('');
@@ -415,6 +478,7 @@ function main() {
         indexLines[i] = `| ${cells.join(' | ')} |`;
       }
 
+      upsertGeneratedTimestampBeforeSummary(indexLines, generatedAt);
       writeLinesPreserveEol(indexPath, indexLines);
     }
   }


### PR DESCRIPTION
## Summary
- audit the ECMA-262 section 24 coverage docs against the current implementation and tests
- update section 24 JSON/markdown status rollups and support notes
- add a visible last-generated UTC timestamp to generated ECMA-262 markdown and refresh generated docs

## Validation
- dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2IL.Tests.Map"
- dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2IL.Tests.WeakMap"
- dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2IL.Tests.WeakSet"
- dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Require_Util_Types_Expanded"
- node scripts\ECMA262\generateEcma262SectionMarkdown.js --section 24.1
- node scripts\ECMA262\rollupEcma262Statuses.js
- npm --silent run generate:ecma262-subsections
- node scripts\ECMA262\generateMissingEcma262SectionJson.js