### PR TITLE
docs(ecma262): audit section 10 coverage

### DIFF
--- a/docs/ECMA262/10/Section10.md
+++ b/docs/ECMA262/10/Section10.md
@@ -4,7 +4,7 @@ Defines ordinary and exotic object behaviors, including internal methods/slots a
 
 [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-03-07T02:30:25Z
 
 _This section is split into subsection documents for readability._
 
@@ -18,8 +18,9 @@ _This section is split into subsection documents for readability._
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 10.1 | Ordinary Object Internal Methods and Internal Slots | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots) | [Section10_1.md](Section10_1.md) |
+| 10.1 | Ordinary Object Internal Methods and Internal Slots | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots) | [Section10_1.md](Section10_1.md) |
 | 10.2 | ECMAScript Function Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-function-objects) | [Section10_2.md](Section10_2.md) |
-| 10.3 | Built-in Function Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects) | [Section10_3.md](Section10_3.md) |
-| 10.4 | Built-in Exotic Object Internal Methods and Slots | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-exotic-object-internal-methods-and-slots) | [Section10_4.md](Section10_4.md) |
-| 10.5 | Proxy Object Internal Methods and Internal Slots | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots) | [Section10_5.md](Section10_5.md) |
+| 10.3 | Built-in Function Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects) | [Section10_3.md](Section10_3.md) |
+| 10.4 | Built-in Exotic Object Internal Methods and Slots | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-built-in-exotic-object-internal-methods-and-slots) | [Section10_4.md](Section10_4.md) |
+| 10.5 | Proxy Object Internal Methods and Internal Slots | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots) | [Section10_5.md](Section10_5.md) |
+

--- a/docs/ECMA262/10/Section10_1.json
+++ b/docs/ECMA262/10/Section10_1.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "10.1",
   "title": "Ordinary Object Internal Methods and Internal Slots",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots",
   "parent": {
     "clause": "10"
@@ -36,61 +36,61 @@
     {
       "clause": "10.1.3",
       "title": "[[IsExtensible]] ( )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible"
     },
     {
       "clause": "10.1.3.1",
       "title": "OrdinaryIsExtensible ( O )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinaryisextensible"
     },
     {
       "clause": "10.1.4",
       "title": "[[PreventExtensions]] ( )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions"
     },
     {
       "clause": "10.1.4.1",
       "title": "OrdinaryPreventExtensions ( O )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinarypreventextensions"
     },
     {
       "clause": "10.1.5",
       "title": "[[GetOwnProperty]] ( P )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p"
     },
     {
       "clause": "10.1.5.1",
       "title": "OrdinaryGetOwnProperty ( O , P )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinarygetownproperty"
     },
     {
       "clause": "10.1.6",
       "title": "[[DefineOwnProperty]] ( P , Desc )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc"
     },
     {
       "clause": "10.1.6.1",
       "title": "OrdinaryDefineOwnProperty ( O , P , Desc )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinarydefineownproperty"
     },
     {
       "clause": "10.1.6.2",
       "title": "IsCompatiblePropertyDescriptor ( Extensible , Desc , Current )",
-      "status": "Not Yet Supported",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-iscompatiblepropertydescriptor"
     },
     {
       "clause": "10.1.6.3",
       "title": "ValidateAndApplyPropertyDescriptor ( O , P , extensible , Desc , current )",
-      "status": "Not Yet Supported",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor"
     },
     {
@@ -132,31 +132,31 @@
     {
       "clause": "10.1.9.2",
       "title": "OrdinarySetWithOwnDescriptor ( O , P , V , Receiver , ownDesc )",
-      "status": "Not Yet Supported",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor"
     },
     {
       "clause": "10.1.10",
       "title": "[[Delete]] ( P )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p"
     },
     {
       "clause": "10.1.10.1",
       "title": "OrdinaryDelete ( O , P )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinarydelete"
     },
     {
       "clause": "10.1.11",
       "title": "[[OwnPropertyKeys]] ( )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys"
     },
     {
       "clause": "10.1.11.1",
       "title": "OrdinaryOwnPropertyKeys ( O )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinaryownpropertykeys"
     },
     {
@@ -188,58 +188,86 @@
     "entries": [
       {
         "clause": "10.1.1",
-        "feature": "Ordinary object property get/set (object literals + host objects)",
-        "status": "Supported with Limitations",
-        "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots",
-        "testScripts": [
-          "Js2IL.Tests/Literals/JavaScript/ObjectLiteral_PropertyAssign.js",
-          "Js2IL.Tests/Variable/JavaScript/Variable_AssignmentTargets_MemberAndIndex.js",
-          "Js2IL.Tests/BinaryOperator/JavaScript/BinaryOperator_In_Object_OwnAndMissing.js"
-        ],
-        "notes": "Supports a pragmatic subset of [[Get]]/[[Set]]/[[HasProperty]] over ExpandoObject/object literals and reflection-backed host objects. Prototype-chain lookup is supported when prototype-chain mode is enabled. Full internal-slot and descriptor mechanics are not implemented."
-      },
-      {
-        "clause": "10.1.1",
-        "feature": "[[GetPrototypeOf]]/[[SetPrototypeOf]] (prototype chain storage + lookup)",
+        "feature": "Prototype access and mutation via Object.getPrototypeOf/Object.setPrototypeOf",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof",
         "testScripts": [
           "Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js"
         ],
-        "notes": "JS2IL does not implement ECMAScript internal slots directly; instead, when prototype-chain mode is enabled, JavaScriptRuntime.PrototypeChain stores an optional prototype reference in a side-table and runtime property helpers walk that chain on misses. Extensibility/invariant checks and exotic objects are not modeled."
+        "notes": "JS2IL stores an optional [[Prototype]] in the PrototypeChain side-table and only enables prototype-chain semantics when code exercises them. Null-prototype objects and explicit prototype mutation work, but ordinary/exotic invariants are not enforced."
       },
       {
-        "clause": "10.1.6",
-        "feature": "Property existence and enumeration in ordinary objects",
+        "clause": "10.1.3",
+        "feature": "Object.preventExtensions / Object.isExtensible / Object.seal / Object.freeze",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible",
+        "testScripts": [
+          "Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js"
+        ],
+        "notes": "Integrity APIs are backed by a simplified ObjectIntegrityState plus descriptor rewrites for existing own properties. They cover the common preventExtensions/seal/freeze checks, but do not model every descriptor invariant or exotic-object edge case from the specification."
+      },
+      {
+        "clause": "10.1.5",
+        "feature": "Property descriptor APIs (defineProperty, defineProperties, getOwnPropertyDescriptor(s))",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p",
+        "testScripts": [
+          "Js2IL.Tests/Object/JavaScript/ObjectDefineProperty_Accessor.js",
+          "Js2IL.Tests/Object/JavaScript/Object_DefineProperties_Basic.js",
+          "Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyDescriptors_Basic.js",
+          "Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js",
+          "Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js"
+        ],
+        "notes": "Descriptors are stored in PropertyDescriptorStore and support common data/accessor scenarios, non-enumerable properties, and non-extensible object checks. Validation is still a best-effort subset of IsCompatiblePropertyDescriptor / ValidateAndApplyPropertyDescriptor rather than a full spec implementation."
+      },
+      {
+        "clause": "10.1.7",
+        "feature": "Property lookup, assignment, and membership on ordinary objects",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p",
+        "testScripts": [
+          "Js2IL.Tests/BinaryOperator/JavaScript/BinaryOperator_In_Object_OwnAndMissing.js",
+          "Js2IL.Tests/Object/JavaScript/Object_HasOwn_Basic.js",
+          "Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js",
+          "Js2IL.Tests/Variable/JavaScript/Variable_AssignmentTargets_MemberAndIndex.js"
+        ],
+        "notes": "Ordinary-style [[HasProperty]], [[Get]], and [[Set]] work over JsObject/ExpandoObject/IDictionary receivers, reflection-backed host objects, descriptor-backed accessors, and opt-in prototype chains. Descriptor validation, receiver substitution, and exotic-object corner cases remain incomplete."
+      },
+      {
+        "clause": "10.1.10",
+        "feature": "Deleting ordinary object properties",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p",
+        "testScripts": [
+          "Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Mutation_DeleteAndAdd.js",
+          "Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js"
+        ],
+        "notes": "delete removes configurable properties from dictionary-backed objects and respects non-configurable descriptors. Arrays, typed arrays, strings, and CLR-backed objects still use simplified no-op behavior rather than full ordinary-object deletion semantics."
+      },
+      {
+        "clause": "10.1.11",
+        "feature": "Own key enumeration and reflection helpers",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-ordinaryownpropertykeys",
         "testScripts": [
-          "Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Object_Basic.js",
-          "Js2IL.Tests/BinaryOperator/JavaScript/BinaryOperator_In_Object_OwnAndMissing.js"
+          "Js2IL.Tests/Object/JavaScript/Object_Keys_Basic.js",
+          "Js2IL.Tests/Object/JavaScript/Object_Values_Basic.js",
+          "Js2IL.Tests/Object/JavaScript/Object_Entries_Basic.js",
+          "Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyNames_Basic.js"
         ],
-        "notes": "Supports a for-in style enumerable key iteration and basic key presence checks. Ordering, symbols, and descriptor attributes are not fully aligned with spec."
+        "notes": "Object.keys/values/entries/getOwnPropertyNames enumerate own keys and descriptor-backed enumerability for ordinary objects. Ordering and symbol-key behavior are pragmatic rather than fully ECMA-262 compliant."
       },
       {
         "clause": "10.1.12",
-        "feature": "Object creation from object literals and JSON.parse",
+        "feature": "Object.create and constructor-based ordinary object creation",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-ordinaryobjectcreate",
         "testScripts": [
-          "Js2IL.Tests/Literals/JavaScript/ObjectLiteral.js",
-          "Js2IL.Tests/JSON/JavaScript/JSON_Parse_SimpleObject.js"
+          "Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js",
+          "Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js",
+          "Js2IL.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js"
         ],
-        "notes": "Creates runtime objects for literals/JSON, but does not implement prototype selection and descriptor initialization per spec."
-      },
-      {
-        "clause": "10.1.13",
-        "feature": "Create-from-constructor patterns used by built-ins and user code",
-        "status": "Supported with Limitations",
-        "specUrl": "https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor",
-        "testScripts": [
-          "Js2IL.Tests/Array/JavaScript/Array_Map_Basic.js",
-          "Js2IL.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js"
-        ],
-        "notes": "Many built-ins are implemented directly in the runtime rather than via species/prototype mechanics, so behavior may differ from spec for custom constructors and @@species."
+        "notes": "Object.create handles null and explicit prototypes, and function construction consults constructor.prototype when instantiating delegate-backed functions. newTarget-based default prototype selection and other constructor-side abstract operations are still simplified."
       }
     ]
   }

--- a/docs/ECMA262/10/Section10_1.md
+++ b/docs/ECMA262/10/Section10_1.md
@@ -4,11 +4,11 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-03-07T02:30:25Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 10.1 | Ordinary Object Internal Methods and Internal Slots | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots) |
+| 10.1 | Ordinary Object Internal Methods and Internal Slots | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots) |
 
 ## Subclauses
 
@@ -18,27 +18,27 @@
 | 10.1.1.1 | OrdinaryGetPrototypeOf ( O ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinarygetprototypeof) |
 | 10.1.2 | [[SetPrototypeOf]] ( V ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v) |
 | 10.1.2.1 | OrdinarySetPrototypeOf ( O , V ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinarysetprototypeof) |
-| 10.1.3 | [[IsExtensible]] ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible) |
-| 10.1.3.1 | OrdinaryIsExtensible ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryisextensible) |
-| 10.1.4 | [[PreventExtensions]] ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions) |
-| 10.1.4.1 | OrdinaryPreventExtensions ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinarypreventextensions) |
-| 10.1.5 | [[GetOwnProperty]] ( P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p) |
-| 10.1.5.1 | OrdinaryGetOwnProperty ( O , P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinarygetownproperty) |
-| 10.1.6 | [[DefineOwnProperty]] ( P , Desc ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc) |
-| 10.1.6.1 | OrdinaryDefineOwnProperty ( O , P , Desc ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinarydefineownproperty) |
-| 10.1.6.2 | IsCompatiblePropertyDescriptor ( Extensible , Desc , Current ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iscompatiblepropertydescriptor) |
-| 10.1.6.3 | ValidateAndApplyPropertyDescriptor ( O , P , extensible , Desc , current ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor) |
+| 10.1.3 | [[IsExtensible]] ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible) |
+| 10.1.3.1 | OrdinaryIsExtensible ( O ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryisextensible) |
+| 10.1.4 | [[PreventExtensions]] ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions) |
+| 10.1.4.1 | OrdinaryPreventExtensions ( O ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinarypreventextensions) |
+| 10.1.5 | [[GetOwnProperty]] ( P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p) |
+| 10.1.5.1 | OrdinaryGetOwnProperty ( O , P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinarygetownproperty) |
+| 10.1.6 | [[DefineOwnProperty]] ( P , Desc ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc) |
+| 10.1.6.1 | OrdinaryDefineOwnProperty ( O , P , Desc ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinarydefineownproperty) |
+| 10.1.6.2 | IsCompatiblePropertyDescriptor ( Extensible , Desc , Current ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-iscompatiblepropertydescriptor) |
+| 10.1.6.3 | ValidateAndApplyPropertyDescriptor ( O , P , extensible , Desc , current ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor) |
 | 10.1.7 | [[HasProperty]] ( P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p) |
 | 10.1.7.1 | OrdinaryHasProperty ( O , P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryhasproperty) |
 | 10.1.8 | [[Get]] ( P , Receiver ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver) |
 | 10.1.8.1 | OrdinaryGet ( O , P , Receiver ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryget) |
 | 10.1.9 | [[Set]] ( P , V , Receiver ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver) |
 | 10.1.9.1 | OrdinarySet ( O , P , V , Receiver ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryset) |
-| 10.1.9.2 | OrdinarySetWithOwnDescriptor ( O , P , V , Receiver , ownDesc ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor) |
-| 10.1.10 | [[Delete]] ( P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p) |
-| 10.1.10.1 | OrdinaryDelete ( O , P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinarydelete) |
-| 10.1.11 | [[OwnPropertyKeys]] ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys) |
-| 10.1.11.1 | OrdinaryOwnPropertyKeys ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys) |
+| 10.1.9.2 | OrdinarySetWithOwnDescriptor ( O , P , V , Receiver , ownDesc ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor) |
+| 10.1.10 | [[Delete]] ( P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p) |
+| 10.1.10.1 | OrdinaryDelete ( O , P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinarydelete) |
+| 10.1.11 | [[OwnPropertyKeys]] ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys) |
+| 10.1.11.1 | OrdinaryOwnPropertyKeys ( O ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys) |
 | 10.1.12 | OrdinaryObjectCreate ( proto [ , additionalInternalSlotsList ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryobjectcreate) |
 | 10.1.13 | OrdinaryCreateFromConstructor ( constructor , intrinsicDefaultProto [ , internalSlotsList ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor) |
 | 10.1.14 | GetPrototypeFromConstructor ( constructor , intrinsicDefaultProto ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getprototypefromconstructor) |
@@ -52,24 +52,41 @@ Feature-level support tracking with test script references.
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| [[GetPrototypeOf]]/[[SetPrototypeOf]] (prototype chain storage + lookup) | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) | JS2IL does not implement ECMAScript internal slots directly; instead, when prototype-chain mode is enabled, JavaScriptRuntime.PrototypeChain stores an optional prototype reference in a side-table and runtime property helpers walk that chain on misses. Extensibility/invariant checks and exotic objects are not modeled. |
-| Ordinary object property get/set (object literals + host objects) | Supported with Limitations | [`ObjectLiteral_PropertyAssign.js`](../../../Js2IL.Tests/Literals/JavaScript/ObjectLiteral_PropertyAssign.js)<br>[`Variable_AssignmentTargets_MemberAndIndex.js`](../../../Js2IL.Tests/Variable/JavaScript/Variable_AssignmentTargets_MemberAndIndex.js)<br>[`BinaryOperator_In_Object_OwnAndMissing.js`](../../../Js2IL.Tests/BinaryOperator/JavaScript/BinaryOperator_In_Object_OwnAndMissing.js) | Supports a pragmatic subset of [[Get]]/[[Set]]/[[HasProperty]] over ExpandoObject/object literals and reflection-backed host objects. Prototype-chain lookup is supported when prototype-chain mode is enabled. Full internal-slot and descriptor mechanics are not implemented. |
+| Prototype access and mutation via Object.getPrototypeOf/Object.setPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) | JS2IL stores an optional [[Prototype]] in the PrototypeChain side-table and only enables prototype-chain semantics when code exercises them. Null-prototype objects and explicit prototype mutation work, but ordinary/exotic invariants are not enforced. |
 
-### 10.1.6 ([tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc))
+### 10.1.3 ([tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Property existence and enumeration in ordinary objects | Supported with Limitations | [`ControlFlow_ForIn_Object_Basic.js`](../../../Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Object_Basic.js)<br>[`BinaryOperator_In_Object_OwnAndMissing.js`](../../../Js2IL.Tests/BinaryOperator/JavaScript/BinaryOperator_In_Object_OwnAndMissing.js) | Supports a for-in style enumerable key iteration and basic key presence checks. Ordering, symbols, and descriptor attributes are not fully aligned with spec. |
+| Object.preventExtensions / Object.isExtensible / Object.seal / Object.freeze | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js) | Integrity APIs are backed by a simplified ObjectIntegrityState plus descriptor rewrites for existing own properties. They cover the common preventExtensions/seal/freeze checks, but do not model every descriptor invariant or exotic-object edge case from the specification. |
+
+### 10.1.5 ([tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Property descriptor APIs (defineProperty, defineProperties, getOwnPropertyDescriptor(s)) | Supported with Limitations | [`ObjectDefineProperty_Accessor.js`](../../../Js2IL.Tests/Object/JavaScript/ObjectDefineProperty_Accessor.js)<br>[`Object_DefineProperties_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/Object_DefineProperties_Basic.js)<br>[`Object_GetOwnPropertyDescriptors_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyDescriptors_Basic.js)<br>[`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js) | Descriptors are stored in PropertyDescriptorStore and support common data/accessor scenarios, non-enumerable properties, and non-extensible object checks. Validation is still a best-effort subset of IsCompatiblePropertyDescriptor / ValidateAndApplyPropertyDescriptor rather than a full spec implementation. |
+
+### 10.1.7 ([tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Property lookup, assignment, and membership on ordinary objects | Supported with Limitations | [`BinaryOperator_In_Object_OwnAndMissing.js`](../../../Js2IL.Tests/BinaryOperator/JavaScript/BinaryOperator_In_Object_OwnAndMissing.js)<br>[`Object_HasOwn_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/Object_HasOwn_Basic.js)<br>[`PrototypeChain_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js)<br>[`Variable_AssignmentTargets_MemberAndIndex.js`](../../../Js2IL.Tests/Variable/JavaScript/Variable_AssignmentTargets_MemberAndIndex.js) | Ordinary-style [[HasProperty]], [[Get]], and [[Set]] work over JsObject/ExpandoObject/IDictionary receivers, reflection-backed host objects, descriptor-backed accessors, and opt-in prototype chains. Descriptor validation, receiver substitution, and exotic-object corner cases remain incomplete. |
+
+### 10.1.10 ([tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Deleting ordinary object properties | Supported with Limitations | [`ControlFlow_ForIn_Mutation_DeleteAndAdd.js`](../../../Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Mutation_DeleteAndAdd.js)<br>[`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js) | delete removes configurable properties from dictionary-backed objects and respects non-configurable descriptors. Arrays, typed arrays, strings, and CLR-backed objects still use simplified no-op behavior rather than full ordinary-object deletion semantics. |
+
+### 10.1.11 ([tc39.es](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Own key enumeration and reflection helpers | Supported with Limitations | [`Object_Keys_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/Object_Keys_Basic.js)<br>[`Object_Values_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/Object_Values_Basic.js)<br>[`Object_Entries_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/Object_Entries_Basic.js)<br>[`Object_GetOwnPropertyNames_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyNames_Basic.js) | Object.keys/values/entries/getOwnPropertyNames enumerate own keys and descriptor-backed enumerability for ordinary objects. Ordering and symbol-key behavior are pragmatic rather than fully ECMA-262 compliant. |
 
 ### 10.1.12 ([tc39.es](https://tc39.es/ecma262/#sec-ordinaryobjectcreate))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Object creation from object literals and JSON.parse | Supported with Limitations | [`ObjectLiteral.js`](../../../Js2IL.Tests/Literals/JavaScript/ObjectLiteral.js)<br>[`JSON_Parse_SimpleObject.js`](../../../Js2IL.Tests/JSON/JavaScript/JSON_Parse_SimpleObject.js) | Creates runtime objects for literals/JSON, but does not implement prototype selection and descriptor initialization per spec. |
-
-### 10.1.13 ([tc39.es](https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor))
-
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Create-from-constructor patterns used by built-ins and user code | Supported with Limitations | [`Array_Map_Basic.js`](../../../Js2IL.Tests/Array/JavaScript/Array_Map_Basic.js)<br>[`Int32Array_Construct_Length.js`](../../../Js2IL.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js) | Many built-ins are implemented directly in the runtime rather than via species/prototype mechanics, so behavior may differ from spec for custom constructors and @@species. |
+| Object.create and constructor-based ordinary object creation | Supported with Limitations | [`ObjectCreate_WithPropertyDescriptors.js`](../../../Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`Function_Prototype_ObjectCreate_ObjectPrototype.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js) | Object.create handles null and explicit prototypes, and function construction consults constructor.prototype when instantiating delegate-backed functions. newTarget-based default prototype selection and other constructor-side abstract operations are still simplified. |
 

--- a/docs/ECMA262/10/Section10_2.json
+++ b/docs/ECMA262/10/Section10_2.json
@@ -90,13 +90,13 @@
     {
       "clause": "10.2.9",
       "title": "SetFunctionName ( F , name [ , prefix ] )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-setfunctionname"
     },
     {
       "clause": "10.2.10",
       "title": "SetFunctionLength ( F , length )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-setfunctionlength"
     },
     {
@@ -110,46 +110,45 @@
     "entries": [
       {
         "clause": "10.2.1",
-        "feature": "Calling functions with parameters and return values",
+        "feature": "Function calls, this binding, and arguments snapshots",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist",
         "testScripts": [
-          "Js2IL.Tests/Function/JavaScript/Function_HelloWorld.js",
-          "Js2IL.Tests/Function/JavaScript/Function_GlobalFunctionWithMultipleParameters.js",
           "Js2IL.Tests/Function/JavaScript/Function_Arguments_Basics.js",
-          "Js2IL.Tests/Function/JavaScript/Function_Arguments_NoFalsePositive_ObjectLiteralKey.js",
-          "Js2IL.Tests/Function/JavaScript/Function_Arguments_ComputedKey_TriggersBinding.js",
-          "Js2IL.Tests/Function/JavaScript/Function_ReturnsStaticValueAndLogs.js"
-        ],
-        "notes": "Supports basic calling convention and return semantics for supported language subset. Non-arrow functions have a minimal implicit `arguments` binding (materialized lazily when referenced) that captures the full runtime call-site argument list (including extras) as a JS Array snapshot. Arrow functions capture `arguments` lexically from the nearest enclosing non-arrow function. Limitations: does not implement mapped-arguments aliasing or the full spec Arguments Exotic Object behaviors."
-      },
-      {
-        "clause": "10.2.1",
-        "feature": "this binding for methods and non-arrow functions",
-        "status": "Supported with Limitations",
-        "specUrl": "https://tc39.es/ecma262/#sec-prepareforordinarycall",
-        "testScripts": [
+          "Js2IL.Tests/Function/JavaScript/Function_Call_Basic.js",
           "Js2IL.Tests/Function/JavaScript/Function_ObjectLiteralMethod_ThisBinding.js",
           "Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_ReturnsThis_IsSelf_Log.js"
         ],
-        "notes": "Supports this binding for object-literal and class method calls. Arrow functions use lexical this; strict-mode and environment-record edge cases may differ from spec."
+        "notes": "Delegate-backed user functions support ordinary calls, receiver-sensitive method calls, lexical this for arrow functions, and a lazily materialized arguments array when the binding is referenced. The runtime still does not implement the full Arguments Exotic Object or every environment-record edge case from the spec."
       },
       {
         "clause": "10.2.2",
-        "feature": "Constructing with class constructors (new) and constructor return override",
+        "feature": "Constructor calls and new.target-aware function execution",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget",
         "testScripts": [
-          "Js2IL.Tests/Classes/JavaScript/Classes_DeclareEmptyClass.js",
+          "Js2IL.Tests/Function/JavaScript/Function_NewTarget_NewVsCall.js",
+          "Js2IL.Tests/Function/JavaScript/Function_NewTarget_Arrow_Inherits.js",
           "Js2IL.Tests/Classes/JavaScript/Classes_Constructor_ReturnObjectOverridesThis.js",
-          "Js2IL.Tests/CommonJS/JavaScript/CommonJS_Export_ClassWithConstructor.js",
-          "Js2IL.Tests/Hosting/JavaScript/ctorPadding.js"
+          "Js2IL.Tests/Classes/JavaScript/Classes_DeclareEmptyClass.js"
         ],
-        "notes": "Supports constructor calls for supported class subset, including dynamic-new-on-value patterns where the constructor is held in a variable. Missing arguments are permitted and are treated as undefined/null during constructor activation. newTarget/super/inheritance and many exotic construction behaviors are not implemented."
+        "notes": "JS2IL constructs delegate-backed functions and class constructors by creating an instance, binding this, and forwarding a newTarget value into the call path. Constructor return override works, but super/inheritance semantics and full OrdinaryCreateFromConstructor behavior remain incomplete."
+      },
+      {
+        "clause": "10.2.5",
+        "feature": "Function prototype objects and constructor-style metadata",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-makeconstructor",
+        "testScripts": [
+          "Js2IL.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js",
+          "Js2IL.Tests/Function/JavaScript/Function_Prototype_Bind_PropertyExists.js",
+          "Js2IL.Tests/Function/JavaScript/Function_Prototype_ToString_Basic.js"
+        ],
+        "notes": "Delegate-backed functions lazily synthesize prototype, constructor, name, length, and toString metadata so common library patterns continue to work. These properties are inferred from CLR delegates rather than being installed through the exact SetFunctionName / SetFunctionLength / MakeConstructor abstract-operation flow."
       },
       {
         "clause": "10.2.11",
-        "feature": "Closures and function declaration instantiation",
+        "feature": "Function declaration instantiation and closures",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-functiondeclarationinstantiation",
         "testScripts": [
@@ -157,7 +156,7 @@
           "Js2IL.Tests/Function/JavaScript/Function_NestedFunctionAccessesMultipleScopes.js",
           "Js2IL.Tests/Function/JavaScript/Function_ClosureEscapesScope_ObjectLiteralProperty.js"
         ],
-        "notes": "Closure semantics are implemented via scope-as-class instances and parent scope capture. A minimal implicit `arguments` binding is supported for non-arrow functions when referenced, including lexical capture from nested arrow functions. Limitations: mapped arguments aliasing and several environment-record details are not implemented."
+        "notes": "Scope-as-class lowering gives functions stable lexical captures and nested-scope access. Parameter environments, rest/arguments interactions, and strict-mode corner cases are supported only to the extent needed by the current compiler/runtime feature set."
       }
     ]
   }

--- a/docs/ECMA262/10/Section10_2.md
+++ b/docs/ECMA262/10/Section10_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-03-07T02:30:25Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -27,8 +27,8 @@
 | 10.2.6 | MakeClassConstructor ( F ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-makeclassconstructor) |
 | 10.2.7 | MakeMethod ( F , homeObject ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-makemethod) |
 | 10.2.8 | DefineMethodProperty ( homeObject , key , closure , enumerable ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-definemethodproperty) |
-| 10.2.9 | SetFunctionName ( F , name [ , prefix ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-setfunctionname) |
-| 10.2.10 | SetFunctionLength ( F , length ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-setfunctionlength) |
+| 10.2.9 | SetFunctionName ( F , name [ , prefix ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-setfunctionname) |
+| 10.2.10 | SetFunctionLength ( F , length ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-setfunctionlength) |
 | 10.2.11 | FunctionDeclarationInstantiation ( func , argumentsList ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation) |
 
 ## Support
@@ -39,18 +39,23 @@ Feature-level support tracking with test script references.
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Calling functions with parameters and return values | Supported with Limitations | [`Function_HelloWorld.js`](../../../Js2IL.Tests/Function/JavaScript/Function_HelloWorld.js)<br>[`Function_GlobalFunctionWithMultipleParameters.js`](../../../Js2IL.Tests/Function/JavaScript/Function_GlobalFunctionWithMultipleParameters.js)<br>[`Function_Arguments_Basics.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Arguments_Basics.js)<br>[`Function_Arguments_NoFalsePositive_ObjectLiteralKey.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Arguments_NoFalsePositive_ObjectLiteralKey.js)<br>[`Function_Arguments_ComputedKey_TriggersBinding.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Arguments_ComputedKey_TriggersBinding.js)<br>[`Function_ReturnsStaticValueAndLogs.js`](../../../Js2IL.Tests/Function/JavaScript/Function_ReturnsStaticValueAndLogs.js) | Supports basic calling convention and return semantics for supported language subset. Non-arrow functions have a minimal implicit `arguments` binding (materialized lazily when referenced) that captures the full runtime call-site argument list (including extras) as a JS Array snapshot. Arrow functions capture `arguments` lexically from the nearest enclosing non-arrow function. Limitations: does not implement mapped-arguments aliasing or the full spec Arguments Exotic Object behaviors. |
-| this binding for methods and non-arrow functions | Supported with Limitations | [`Function_ObjectLiteralMethod_ThisBinding.js`](../../../Js2IL.Tests/Function/JavaScript/Function_ObjectLiteralMethod_ThisBinding.js)<br>[`Classes_ClassMethod_ReturnsThis_IsSelf_Log.js`](../../../Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_ReturnsThis_IsSelf_Log.js) | Supports this binding for object-literal and class method calls. Arrow functions use lexical this; strict-mode and environment-record edge cases may differ from spec. |
+| Function calls, this binding, and arguments snapshots | Supported with Limitations | [`Function_Arguments_Basics.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Arguments_Basics.js)<br>[`Function_Call_Basic.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Call_Basic.js)<br>[`Function_ObjectLiteralMethod_ThisBinding.js`](../../../Js2IL.Tests/Function/JavaScript/Function_ObjectLiteralMethod_ThisBinding.js)<br>[`Classes_ClassMethod_ReturnsThis_IsSelf_Log.js`](../../../Js2IL.Tests/Classes/JavaScript/Classes_ClassMethod_ReturnsThis_IsSelf_Log.js) | Delegate-backed user functions support ordinary calls, receiver-sensitive method calls, lexical this for arrow functions, and a lazily materialized arguments array when the binding is referenced. The runtime still does not implement the full Arguments Exotic Object or every environment-record edge case from the spec. |
 
 ### 10.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Constructing with class constructors (new) and constructor return override | Supported with Limitations | [`Classes_DeclareEmptyClass.js`](../../../Js2IL.Tests/Classes/JavaScript/Classes_DeclareEmptyClass.js)<br>[`Classes_Constructor_ReturnObjectOverridesThis.js`](../../../Js2IL.Tests/Classes/JavaScript/Classes_Constructor_ReturnObjectOverridesThis.js)<br>[`CommonJS_Export_ClassWithConstructor.js`](../../../Js2IL.Tests/CommonJS/JavaScript/CommonJS_Export_ClassWithConstructor.js)<br>[`ctorPadding.js`](../../../Js2IL.Tests/Hosting/JavaScript/ctorPadding.js) | Supports constructor calls for supported class subset, including dynamic-new-on-value patterns where the constructor is held in a variable. Missing arguments are permitted and are treated as undefined/null during constructor activation. newTarget/super/inheritance and many exotic construction behaviors are not implemented. |
+| Constructor calls and new.target-aware function execution | Supported with Limitations | [`Function_NewTarget_NewVsCall.js`](../../../Js2IL.Tests/Function/JavaScript/Function_NewTarget_NewVsCall.js)<br>[`Function_NewTarget_Arrow_Inherits.js`](../../../Js2IL.Tests/Function/JavaScript/Function_NewTarget_Arrow_Inherits.js)<br>[`Classes_Constructor_ReturnObjectOverridesThis.js`](../../../Js2IL.Tests/Classes/JavaScript/Classes_Constructor_ReturnObjectOverridesThis.js)<br>[`Classes_DeclareEmptyClass.js`](../../../Js2IL.Tests/Classes/JavaScript/Classes_DeclareEmptyClass.js) | JS2IL constructs delegate-backed functions and class constructors by creating an instance, binding this, and forwarding a newTarget value into the call path. Constructor return override works, but super/inheritance semantics and full OrdinaryCreateFromConstructor behavior remain incomplete. |
+
+### 10.2.5 ([tc39.es](https://tc39.es/ecma262/#sec-makeconstructor))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Function prototype objects and constructor-style metadata | Supported with Limitations | [`Function_Prototype_ObjectCreate_ObjectPrototype.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js)<br>[`Function_Prototype_Bind_PropertyExists.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Prototype_Bind_PropertyExists.js)<br>[`Function_Prototype_ToString_Basic.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Prototype_ToString_Basic.js) | Delegate-backed functions lazily synthesize prototype, constructor, name, length, and toString metadata so common library patterns continue to work. These properties are inferred from CLR delegates rather than being installed through the exact SetFunctionName / SetFunctionLength / MakeConstructor abstract-operation flow. |
 
 ### 10.2.11 ([tc39.es](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Closures and function declaration instantiation | Supported with Limitations | [`Function_ClosureMutatesOuterVariable.js`](../../../Js2IL.Tests/Function/JavaScript/Function_ClosureMutatesOuterVariable.js)<br>[`Function_NestedFunctionAccessesMultipleScopes.js`](../../../Js2IL.Tests/Function/JavaScript/Function_NestedFunctionAccessesMultipleScopes.js)<br>[`Function_ClosureEscapesScope_ObjectLiteralProperty.js`](../../../Js2IL.Tests/Function/JavaScript/Function_ClosureEscapesScope_ObjectLiteralProperty.js) | Closure semantics are implemented via scope-as-class instances and parent scope capture. A minimal implicit `arguments` binding is supported for non-arrow functions when referenced, including lexical capture from nested arrow functions. Limitations: mapped arguments aliasing and several environment-record details are not implemented. |
+| Function declaration instantiation and closures | Supported with Limitations | [`Function_ClosureMutatesOuterVariable.js`](../../../Js2IL.Tests/Function/JavaScript/Function_ClosureMutatesOuterVariable.js)<br>[`Function_NestedFunctionAccessesMultipleScopes.js`](../../../Js2IL.Tests/Function/JavaScript/Function_NestedFunctionAccessesMultipleScopes.js)<br>[`Function_ClosureEscapesScope_ObjectLiteralProperty.js`](../../../Js2IL.Tests/Function/JavaScript/Function_ClosureEscapesScope_ObjectLiteralProperty.js) | Scope-as-class lowering gives functions stable lexical captures and nested-scope access. Parameter environments, rest/arguments interactions, and strict-mode corner cases are supported only to the extent needed by the current compiler/runtime feature set. |
 

--- a/docs/ECMA262/10/Section10_3.json
+++ b/docs/ECMA262/10/Section10_3.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "10.3",
   "title": "Built-in Function Objects",
-  "status": "Untracked",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-built-in-function-objects",
   "parent": {
     "clause": "10"
@@ -12,26 +12,66 @@
     {
       "clause": "10.3.1",
       "title": "[[Call]] ( thisArgument , argumentsList )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist"
     },
     {
       "clause": "10.3.2",
       "title": "[[Construct]] ( argumentsList , newTarget )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-built-in-function-objects-construct-argumentslist-newtarget"
     },
     {
       "clause": "10.3.3",
       "title": "BuiltinCallOrConstruct ( F , thisArgument , argumentsList , newTarget )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-builtincallorconstruct"
     },
     {
       "clause": "10.3.4",
       "title": "CreateBuiltinFunction ( behaviour , length , name , additionalInternalSlotsList [ , realm [ , prototype [ , prefix [ , async ] ] ] ] )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-createbuiltinfunction"
     }
-  ]
+  ],
+  "intro": "JS2IL exposes many ECMAScript built-ins as CLR-backed delegates or intrinsic runtime constructors. That gives everyday built-in call/construct behavior for the implemented subset, but built-in function objects are not created through the full ECMA-262 realm/prototype/length/name machinery.",
+  "support": {
+    "entries": [
+      {
+        "clause": "10.3.1",
+        "feature": "Built-in callable dispatch for Array/Object/Function helpers",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist",
+        "testScripts": [
+          "Js2IL.Tests/Array/JavaScript/Array_PrototypeMethods_ArrayLike_Call.js",
+          "Js2IL.Tests/Object/JavaScript/Object_Keys_Basic.js",
+          "Js2IL.Tests/Function/JavaScript/Function_Apply_Basic.js"
+        ],
+        "notes": "Implemented built-ins are surfaced as delegates and CLR instance/static methods, then invoked through the same Closure dispatch machinery as user functions. Realm-specific callable creation, full Function.prototype inheritance, and exhaustive built-in coverage are still incomplete."
+      },
+      {
+        "clause": "10.3.2",
+        "feature": "Constructible built-ins such as Array, Object, Int32Array, and Proxy",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-built-in-function-objects-construct-argumentslist-newtarget",
+        "testScripts": [
+          "Js2IL.Tests/Array/JavaScript/Array_Callable_Construct.js",
+          "Js2IL.Tests/Array/JavaScript/Array_New_Length.js",
+          "Js2IL.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js",
+          "Js2IL.Tests/Proxy/JavaScript/Proxy_GetTrap_OverridesProperty.js"
+        ],
+        "notes": "The implemented subset of built-ins can usually be called/constructed directly through dedicated intrinsic lowering or runtime helpers. First-class constructor values are still uneven (for example the global Function constructor remains intentionally unsupported), so constructibility is not uniform across all built-in function objects."
+      },
+      {
+        "clause": "10.3.4",
+        "feature": "Intrinsic built-in registration and prototype wiring",
+        "status": "Incomplete",
+        "specUrl": "https://tc39.es/ecma262/#sec-createbuiltinfunction",
+        "testScripts": [
+          "Js2IL.Tests/Function/JavaScript/Function_Prototype_Bind_PropertyExists.js"
+        ],
+        "notes": "Built-ins are discovered through IntrinsicObject attributes and selectively wired onto GlobalThis/prototype objects, which is sufficient for many library patterns. The engine does not yet implement CreateBuiltinFunction in the full spec sense with realms, exact length/name attributes, and uniform constructor/call behavior across every intrinsic."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/10/Section10_3.md
+++ b/docs/ECMA262/10/Section10_3.md
@@ -4,18 +4,42 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-03-07T02:30:25Z
+
+JS2IL exposes many ECMAScript built-ins as CLR-backed delegates or intrinsic runtime constructors. That gives everyday built-in call/construct behavior for the implemented subset, but built-in function objects are not created through the full ECMA-262 realm/prototype/length/name machinery.
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 10.3 | Built-in Function Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects) |
+| 10.3 | Built-in Function Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 10.3.1 | [[Call]] ( thisArgument , argumentsList ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist) |
-| 10.3.2 | [[Construct]] ( argumentsList , newTarget ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects-construct-argumentslist-newtarget) |
-| 10.3.3 | BuiltinCallOrConstruct ( F , thisArgument , argumentsList , newTarget ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-builtincallorconstruct) |
-| 10.3.4 | CreateBuiltinFunction ( behaviour , length , name , additionalInternalSlotsList [ , realm [ , prototype [ , prefix [ , async ] ] ] ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-createbuiltinfunction) |
+| 10.3.1 | [[Call]] ( thisArgument , argumentsList ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist) |
+| 10.3.2 | [[Construct]] ( argumentsList , newTarget ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects-construct-argumentslist-newtarget) |
+| 10.3.3 | BuiltinCallOrConstruct ( F , thisArgument , argumentsList , newTarget ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-builtincallorconstruct) |
+| 10.3.4 | CreateBuiltinFunction ( behaviour , length , name , additionalInternalSlotsList [ , realm [ , prototype [ , prefix [ , async ] ] ] ] ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-createbuiltinfunction) |
+
+## Support
+
+Feature-level support tracking with test script references.
+
+### 10.3.1 ([tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Built-in callable dispatch for Array/Object/Function helpers | Supported with Limitations | [`Array_PrototypeMethods_ArrayLike_Call.js`](../../../Js2IL.Tests/Array/JavaScript/Array_PrototypeMethods_ArrayLike_Call.js)<br>[`Object_Keys_Basic.js`](../../../Js2IL.Tests/Object/JavaScript/Object_Keys_Basic.js)<br>[`Function_Apply_Basic.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Apply_Basic.js) | Implemented built-ins are surfaced as delegates and CLR instance/static methods, then invoked through the same Closure dispatch machinery as user functions. Realm-specific callable creation, full Function.prototype inheritance, and exhaustive built-in coverage are still incomplete. |
+
+### 10.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-built-in-function-objects-construct-argumentslist-newtarget))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Constructible built-ins such as Array, Object, Int32Array, and Proxy | Supported with Limitations | [`Array_Callable_Construct.js`](../../../Js2IL.Tests/Array/JavaScript/Array_Callable_Construct.js)<br>[`Array_New_Length.js`](../../../Js2IL.Tests/Array/JavaScript/Array_New_Length.js)<br>[`Int32Array_Construct_Length.js`](../../../Js2IL.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js)<br>[`Proxy_GetTrap_OverridesProperty.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_GetTrap_OverridesProperty.js) | The implemented subset of built-ins can usually be called/constructed directly through dedicated intrinsic lowering or runtime helpers. First-class constructor values are still uneven (for example the global Function constructor remains intentionally unsupported), so constructibility is not uniform across all built-in function objects. |
+
+### 10.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-createbuiltinfunction))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Intrinsic built-in registration and prototype wiring | Incomplete | [`Function_Prototype_Bind_PropertyExists.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Prototype_Bind_PropertyExists.js) | Built-ins are discovered through IntrinsicObject attributes and selectively wired onto GlobalThis/prototype objects, which is sufficient for many library patterns. The engine does not yet implement CreateBuiltinFunction in the full spec sense with realms, exact length/name attributes, and uniform constructor/call behavior across every intrinsic. |
 

--- a/docs/ECMA262/10/Section10_4.json
+++ b/docs/ECMA262/10/Section10_4.json
@@ -2,9 +2,9 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "10.4",
   "title": "Built-in Exotic Object Internal Methods and Slots",
-  "status": "Untracked",
+  "status": "Incomplete",
   "specUrl": "https://tc39.es/ecma262/#sec-built-in-exotic-object-internal-methods-and-slots",
-  "intro": "This section covers spec-defined *exotic objects* and their internal methods/slots (Bound Function, Array, String, Arguments, TypedArray, etc.). JS2IL currently does not attempt to model these internal-method details as specified. For the intrinsic function-scope `arguments` binding, JS2IL implements a minimal behavior tracked under Section 10.2 (non-arrow functions materialize `arguments` lazily as a JS Array snapshot; arrow functions capture `arguments` lexically). The full spec **Arguments Exotic Object** behavior (including mapped-arguments aliasing) remains not implemented.",
+  "intro": "JS2IL implements a pragmatic subset of spec-defined exotic-object behavior for the features it currently supports. Arrays, bound functions, typed arrays, and namespace imports expose useful observable behavior, but the engine does not model true exotic internal methods/slots with full ECMA-262 invariants.",
   "parent": {
     "clause": "10"
   },
@@ -13,91 +13,91 @@
     {
       "clause": "10.4.1",
       "title": "Bound Function Exotic Objects",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-bound-function-exotic-objects"
     },
     {
       "clause": "10.4.1.1",
       "title": "[[Call]] ( thisArgument , argumentsList )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist"
     },
     {
       "clause": "10.4.1.2",
       "title": "[[Construct]] ( argumentsList , newTarget )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-bound-function-exotic-objects-construct-argumentslist-newtarget"
     },
     {
       "clause": "10.4.1.3",
       "title": "BoundFunctionCreate ( targetFunction , boundThis , boundArgs )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-boundfunctioncreate"
     },
     {
       "clause": "10.4.2",
       "title": "Array Exotic Objects",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-array-exotic-objects"
     },
     {
       "clause": "10.4.2.1",
       "title": "[[DefineOwnProperty]] ( P , Desc )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-array-exotic-objects-defineownproperty-p-desc"
     },
     {
       "clause": "10.4.2.2",
       "title": "ArrayCreate ( length [ , proto ] )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-arraycreate"
     },
     {
       "clause": "10.4.2.3",
       "title": "ArraySpeciesCreate ( originalArray , length )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-arrayspeciescreate"
     },
     {
       "clause": "10.4.2.4",
       "title": "ArraySetLength ( A , Desc )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-arraysetlength"
     },
     {
       "clause": "10.4.3",
       "title": "String Exotic Objects",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-string-exotic-objects"
     },
     {
       "clause": "10.4.3.1",
       "title": "[[GetOwnProperty]] ( P )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-string-exotic-objects-getownproperty-p"
     },
     {
       "clause": "10.4.3.2",
       "title": "[[DefineOwnProperty]] ( P , Desc )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc"
     },
     {
       "clause": "10.4.3.3",
       "title": "[[OwnPropertyKeys]] ( )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys"
     },
     {
       "clause": "10.4.3.4",
       "title": "StringCreate ( value , prototype )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-stringcreate"
     },
     {
       "clause": "10.4.3.5",
       "title": "StringGetOwnProperty ( S , P )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-stringgetownproperty"
     },
     {
@@ -163,228 +163,287 @@
     {
       "clause": "10.4.5",
       "title": "TypedArray Exotic Objects",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-exotic-objects"
     },
     {
       "clause": "10.4.5.1",
       "title": "[[PreventExtensions]] ( )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-preventextensions"
     },
     {
       "clause": "10.4.5.2",
       "title": "[[GetOwnProperty]] ( P )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-getownproperty"
     },
     {
       "clause": "10.4.5.3",
       "title": "[[HasProperty]] ( P )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-hasproperty"
     },
     {
       "clause": "10.4.5.4",
       "title": "[[DefineOwnProperty]] ( P , Desc )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-defineownproperty"
     },
     {
       "clause": "10.4.5.5",
       "title": "[[Get]] ( P , Receiver )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-get"
     },
     {
       "clause": "10.4.5.6",
       "title": "[[Set]] ( P , V , Receiver )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-set"
     },
     {
       "clause": "10.4.5.7",
       "title": "[[Delete]] ( P )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-delete"
     },
     {
       "clause": "10.4.5.8",
       "title": "[[OwnPropertyKeys]] ( )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-ownpropertykeys"
     },
     {
       "clause": "10.4.5.9",
       "title": "TypedArray With Buffer Witness Records",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarray-with-buffer-witness-records"
     },
     {
       "clause": "10.4.5.10",
       "title": "MakeTypedArrayWithBufferWitnessRecord ( obj , order )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-maketypedarraywithbufferwitnessrecord"
     },
     {
       "clause": "10.4.5.11",
       "title": "TypedArrayCreate ( prototype )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarraycreate"
     },
     {
       "clause": "10.4.5.12",
       "title": "TypedArrayByteLength ( taRecord )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarraybytelength"
     },
     {
       "clause": "10.4.5.13",
       "title": "TypedArrayLength ( taRecord )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarraylength"
     },
     {
       "clause": "10.4.5.14",
       "title": "IsTypedArrayOutOfBounds ( taRecord )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-istypedarrayoutofbounds"
     },
     {
       "clause": "10.4.5.15",
       "title": "IsTypedArrayFixedLength ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-istypedarrayfixedlength"
     },
     {
       "clause": "10.4.5.16",
       "title": "IsValidIntegerIndex ( O , index )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isvalidintegerindex"
     },
     {
       "clause": "10.4.5.17",
       "title": "TypedArrayGetElement ( O , index )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarraygetelement"
     },
     {
       "clause": "10.4.5.18",
       "title": "TypedArraySetElement ( O , index , value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-typedarraysetelement"
     },
     {
       "clause": "10.4.5.19",
       "title": "IsArrayBufferViewOutOfBounds ( O )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-isarraybufferviewoutofbounds"
     },
     {
       "clause": "10.4.6",
       "title": "Module Namespace Exotic Objects",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects"
     },
     {
       "clause": "10.4.6.1",
       "title": "[[GetPrototypeOf]] ( )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getprototypeof"
     },
     {
       "clause": "10.4.6.2",
       "title": "[[SetPrototypeOf]] ( V )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-setprototypeof-v"
     },
     {
       "clause": "10.4.6.3",
       "title": "[[IsExtensible]] ( )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-isextensible"
     },
     {
       "clause": "10.4.6.4",
       "title": "[[PreventExtensions]] ( )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions"
     },
     {
       "clause": "10.4.6.5",
       "title": "[[GetOwnProperty]] ( P )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getownproperty-p"
     },
     {
       "clause": "10.4.6.6",
       "title": "[[DefineOwnProperty]] ( P , Desc )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc"
     },
     {
       "clause": "10.4.6.7",
       "title": "[[HasProperty]] ( P )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-hasproperty-p"
     },
     {
       "clause": "10.4.6.8",
       "title": "[[Get]] ( P , Receiver )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver"
     },
     {
       "clause": "10.4.6.9",
       "title": "[[Set]] ( P , V , Receiver )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-set-p-v-receiver"
     },
     {
       "clause": "10.4.6.10",
       "title": "[[Delete]] ( P )",
-      "status": "Untracked",
+      "status": "Incomplete",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-delete-p"
     },
     {
       "clause": "10.4.6.11",
       "title": "[[OwnPropertyKeys]] ( )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys"
     },
     {
       "clause": "10.4.6.12",
       "title": "ModuleNamespaceCreate ( module , exports )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-modulenamespacecreate"
     },
     {
       "clause": "10.4.7",
       "title": "Immutable Prototype Exotic Objects",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects"
     },
     {
       "clause": "10.4.7.1",
       "title": "[[SetPrototypeOf]] ( V )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects-setprototypeof-v"
     },
     {
       "clause": "10.4.7.2",
       "title": "SetImmutablePrototype ( O , V )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-set-immutable-prototype"
     }
   ],
   "support": {
     "entries": [
       {
+        "clause": "10.4.1",
+        "feature": "Bound functions created by Function.prototype.bind",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-bound-function-exotic-objects",
+        "testScripts": [
+          "Js2IL.Tests/Function/JavaScript/Function_Bind_Basic_PartialApplication.js",
+          "Js2IL.Tests/Function/JavaScript/Function_Bind_ThisBinding_IgnoresCallReceiver.js",
+          "Js2IL.Tests/Function/JavaScript/Function_Prototype_Bind_PropertyExists.js"
+        ],
+        "notes": "bind creates wrapper delegates with captured this/arguments and remembers the original target for metadata lookups. Bound call semantics are useful in practice, but bound-function construction and true [[BoundTargetFunction]] / [[BoundArguments]] slot semantics remain incomplete."
+      },
+      {
+        "clause": "10.4.2",
+        "feature": "Array exotic indexing and length behavior",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-array-exotic-objects",
+        "testScripts": [
+          "Js2IL.Tests/Array/JavaScript/Array_New_Length.js",
+          "Js2IL.Tests/Array/JavaScript/Array_New_MultipleArgs.js",
+          "Js2IL.Tests/Array/JavaScript/Array_Length_Set_Fractional_ThrowsRangeError.js"
+        ],
+        "notes": "Arrays support numeric element access, length-based construction, and range-checked length writes that truncate or extend the backing store. The specialized [[DefineOwnProperty]] / ArraySpeciesCreate machinery is still only partially modeled."
+      },
+      {
         "clause": "10.4.4",
-        "feature": "Arguments Exotic Objects (mapped/unmapped semantics)",
+        "feature": "Arguments objects are plain arrays, not Arguments Exotic Objects",
         "status": "Not Yet Supported",
         "specUrl": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
-        "notes": "JS2IL does not implement the spec Arguments Exotic Object internal methods (including mapped-arguments aliasing). The compiler/runtime currently materialize a minimal function-scope `arguments` value as a JavaScriptRuntime.Array snapshot when referenced; see Section 10.2 tracking for the supported subset."
+        "testScripts": [
+          "Js2IL.Tests/Function/JavaScript/Function_Arguments_Basics.js",
+          "Js2IL.Tests/Function/JavaScript/Function_Arguments_ComputedKey_TriggersBinding.js"
+        ],
+        "notes": "When referenced, non-arrow functions materialize a JavaScriptRuntime.Array snapshot of the runtime arguments list. Mapped-arguments aliasing, Arguments Exotic Object internal methods, and the accessor helpers from 10.4.4.7 are not implemented."
+      },
+      {
+        "clause": "10.4.5",
+        "feature": "Int32Array construction, element access, and integer-index semantics",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-typedarray-exotic-objects",
+        "testScripts": [
+          "Js2IL.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js",
+          "Js2IL.Tests/TypedArray/JavaScript/Int32Array_Index_Assign.js",
+          "Js2IL.Tests/TypedArray/JavaScript/Int32Array_FromArray_CopyAndCoerce.js",
+          "Js2IL.Tests/TypedArray/JavaScript/Int32Array_NaN_Index_NoOp.js"
+        ],
+        "notes": "JS2IL currently implements only Int32Array, with construction from length/iterables, integer index reads and writes, and pragmatic out-of-bounds handling. It does not model ArrayBuffer-backed typed-array witness records, detach/out-of-bounds abstract operations, or the full family of typed array exotics."
+      },
+      {
+        "clause": "10.4.6",
+        "feature": "Namespace import interop objects with live getter properties",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-module-namespace-exotic-objects",
+        "testScripts": [
+          "Js2IL.Tests/Import/JavaScript/Import_Namespace_Esm_Basic.js",
+          "Js2IL.Tests/Import/JavaScript/Import_Namespace_FromCjs_Stable.js"
+        ],
+        "notes": "JSImport namespace lowering rewrites imports to a helper that builds a plain object with accessor descriptors for live reads of exported members. That captures common namespace-import behavior, but the result is not a true Module Namespace Exotic Object with the full non-extensible, non-configurable invariant set from the spec."
+      },
+      {
+        "clause": "10.4.7",
+        "feature": "Immutable prototype exotic invariants",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects",
+        "notes": "JS2IL does not currently model any object with a dedicated immutable-prototype exotic internal method. Prototype mutation is handled through the ordinary PrototypeChain side-table instead."
       }
     ]
   }

--- a/docs/ECMA262/10/Section10_4.md
+++ b/docs/ECMA262/10/Section10_4.md
@@ -4,33 +4,33 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-03-07T02:30:25Z
 
-This section covers spec-defined *exotic objects* and their internal methods/slots (Bound Function, Array, String, Arguments, TypedArray, etc.). JS2IL currently does not attempt to model these internal-method details as specified. For the intrinsic function-scope `arguments` binding, JS2IL implements a minimal behavior tracked under Section 10.2 (non-arrow functions materialize `arguments` lazily as a JS Array snapshot; arrow functions capture `arguments` lexically). The full spec **Arguments Exotic Object** behavior (including mapped-arguments aliasing) remains not implemented.
+JS2IL implements a pragmatic subset of spec-defined exotic-object behavior for the features it currently supports. Arrays, bound functions, typed arrays, and namespace imports expose useful observable behavior, but the engine does not model true exotic internal methods/slots with full ECMA-262 invariants.
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 10.4 | Built-in Exotic Object Internal Methods and Slots | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-exotic-object-internal-methods-and-slots) |
+| 10.4 | Built-in Exotic Object Internal Methods and Slots | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-built-in-exotic-object-internal-methods-and-slots) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 10.4.1 | Bound Function Exotic Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-bound-function-exotic-objects) |
-| 10.4.1.1 | [[Call]] ( thisArgument , argumentsList ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist) |
-| 10.4.1.2 | [[Construct]] ( argumentsList , newTarget ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-bound-function-exotic-objects-construct-argumentslist-newtarget) |
-| 10.4.1.3 | BoundFunctionCreate ( targetFunction , boundThis , boundArgs ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-boundfunctioncreate) |
-| 10.4.2 | Array Exotic Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-array-exotic-objects) |
-| 10.4.2.1 | [[DefineOwnProperty]] ( P , Desc ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-array-exotic-objects-defineownproperty-p-desc) |
-| 10.4.2.2 | ArrayCreate ( length [ , proto ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraycreate) |
-| 10.4.2.3 | ArraySpeciesCreate ( originalArray , length ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arrayspeciescreate) |
-| 10.4.2.4 | ArraySetLength ( A , Desc ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraysetlength) |
-| 10.4.3 | String Exotic Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-exotic-objects) |
-| 10.4.3.1 | [[GetOwnProperty]] ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-exotic-objects-getownproperty-p) |
-| 10.4.3.2 | [[DefineOwnProperty]] ( P , Desc ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc) |
-| 10.4.3.3 | [[OwnPropertyKeys]] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys) |
-| 10.4.3.4 | StringCreate ( value , prototype ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-stringcreate) |
-| 10.4.3.5 | StringGetOwnProperty ( S , P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-stringgetownproperty) |
+| 10.4.1 | Bound Function Exotic Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-bound-function-exotic-objects) |
+| 10.4.1.1 | [[Call]] ( thisArgument , argumentsList ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist) |
+| 10.4.1.2 | [[Construct]] ( argumentsList , newTarget ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-bound-function-exotic-objects-construct-argumentslist-newtarget) |
+| 10.4.1.3 | BoundFunctionCreate ( targetFunction , boundThis , boundArgs ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-boundfunctioncreate) |
+| 10.4.2 | Array Exotic Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-array-exotic-objects) |
+| 10.4.2.1 | [[DefineOwnProperty]] ( P , Desc ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-array-exotic-objects-defineownproperty-p-desc) |
+| 10.4.2.2 | ArrayCreate ( length [ , proto ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraycreate) |
+| 10.4.2.3 | ArraySpeciesCreate ( originalArray , length ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arrayspeciescreate) |
+| 10.4.2.4 | ArraySetLength ( A , Desc ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraysetlength) |
+| 10.4.3 | String Exotic Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-string-exotic-objects) |
+| 10.4.3.1 | [[GetOwnProperty]] ( P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-string-exotic-objects-getownproperty-p) |
+| 10.4.3.2 | [[DefineOwnProperty]] ( P , Desc ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc) |
+| 10.4.3.3 | [[OwnPropertyKeys]] ( ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys) |
+| 10.4.3.4 | StringCreate ( value , prototype ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-stringcreate) |
+| 10.4.3.5 | StringGetOwnProperty ( S , P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-stringgetownproperty) |
 | 10.4.4 | Arguments Exotic Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arguments-exotic-objects) |
 | 10.4.4.1 | [[GetOwnProperty]] ( P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arguments-exotic-objects-getownproperty-p) |
 | 10.4.4.2 | [[DefineOwnProperty]] ( P , Desc ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arguments-exotic-objects-defineownproperty-p-desc) |
@@ -41,50 +41,80 @@ This section covers spec-defined *exotic objects* and their internal methods/slo
 | 10.4.4.7 | CreateMappedArgumentsObject ( func , formals , argumentsList , env ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-createmappedargumentsobject) |
 | 10.4.4.7.1 | MakeArgGetter ( name , env ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-makearggetter) |
 | 10.4.4.7.2 | MakeArgSetter ( name , env ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-makeargsetter) |
-| 10.4.5 | TypedArray Exotic Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-exotic-objects) |
-| 10.4.5.1 | [[PreventExtensions]] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-preventextensions) |
-| 10.4.5.2 | [[GetOwnProperty]] ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-getownproperty) |
-| 10.4.5.3 | [[HasProperty]] ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-hasproperty) |
-| 10.4.5.4 | [[DefineOwnProperty]] ( P , Desc ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-defineownproperty) |
-| 10.4.5.5 | [[Get]] ( P , Receiver ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-get) |
-| 10.4.5.6 | [[Set]] ( P , V , Receiver ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-set) |
-| 10.4.5.7 | [[Delete]] ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-delete) |
-| 10.4.5.8 | [[OwnPropertyKeys]] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-ownpropertykeys) |
-| 10.4.5.9 | TypedArray With Buffer Witness Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-with-buffer-witness-records) |
-| 10.4.5.10 | MakeTypedArrayWithBufferWitnessRecord ( obj , order ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-maketypedarraywithbufferwitnessrecord) |
-| 10.4.5.11 | TypedArrayCreate ( prototype ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarraycreate) |
-| 10.4.5.12 | TypedArrayByteLength ( taRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarraybytelength) |
-| 10.4.5.13 | TypedArrayLength ( taRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarraylength) |
-| 10.4.5.14 | IsTypedArrayOutOfBounds ( taRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-istypedarrayoutofbounds) |
-| 10.4.5.15 | IsTypedArrayFixedLength ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-istypedarrayfixedlength) |
-| 10.4.5.16 | IsValidIntegerIndex ( O , index ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isvalidintegerindex) |
-| 10.4.5.17 | TypedArrayGetElement ( O , index ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarraygetelement) |
-| 10.4.5.18 | TypedArraySetElement ( O , index , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-typedarraysetelement) |
-| 10.4.5.19 | IsArrayBufferViewOutOfBounds ( O ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isarraybufferviewoutofbounds) |
-| 10.4.6 | Module Namespace Exotic Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects) |
-| 10.4.6.1 | [[GetPrototypeOf]] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getprototypeof) |
-| 10.4.6.2 | [[SetPrototypeOf]] ( V ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-setprototypeof-v) |
-| 10.4.6.3 | [[IsExtensible]] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-isextensible) |
-| 10.4.6.4 | [[PreventExtensions]] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions) |
-| 10.4.6.5 | [[GetOwnProperty]] ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getownproperty-p) |
-| 10.4.6.6 | [[DefineOwnProperty]] ( P , Desc ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc) |
-| 10.4.6.7 | [[HasProperty]] ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-hasproperty-p) |
-| 10.4.6.8 | [[Get]] ( P , Receiver ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver) |
-| 10.4.6.9 | [[Set]] ( P , V , Receiver ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-set-p-v-receiver) |
-| 10.4.6.10 | [[Delete]] ( P ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-delete-p) |
-| 10.4.6.11 | [[OwnPropertyKeys]] ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys) |
-| 10.4.6.12 | ModuleNamespaceCreate ( module , exports ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-modulenamespacecreate) |
-| 10.4.7 | Immutable Prototype Exotic Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects) |
-| 10.4.7.1 | [[SetPrototypeOf]] ( V ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects-setprototypeof-v) |
-| 10.4.7.2 | SetImmutablePrototype ( O , V ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-set-immutable-prototype) |
+| 10.4.5 | TypedArray Exotic Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-exotic-objects) |
+| 10.4.5.1 | [[PreventExtensions]] ( ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-preventextensions) |
+| 10.4.5.2 | [[GetOwnProperty]] ( P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-getownproperty) |
+| 10.4.5.3 | [[HasProperty]] ( P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-hasproperty) |
+| 10.4.5.4 | [[DefineOwnProperty]] ( P , Desc ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-defineownproperty) |
+| 10.4.5.5 | [[Get]] ( P , Receiver ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-get) |
+| 10.4.5.6 | [[Set]] ( P , V , Receiver ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-set) |
+| 10.4.5.7 | [[Delete]] ( P ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-delete) |
+| 10.4.5.8 | [[OwnPropertyKeys]] ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-ownpropertykeys) |
+| 10.4.5.9 | TypedArray With Buffer Witness Records | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-typedarray-with-buffer-witness-records) |
+| 10.4.5.10 | MakeTypedArrayWithBufferWitnessRecord ( obj , order ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-maketypedarraywithbufferwitnessrecord) |
+| 10.4.5.11 | TypedArrayCreate ( prototype ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-typedarraycreate) |
+| 10.4.5.12 | TypedArrayByteLength ( taRecord ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-typedarraybytelength) |
+| 10.4.5.13 | TypedArrayLength ( taRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-typedarraylength) |
+| 10.4.5.14 | IsTypedArrayOutOfBounds ( taRecord ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-istypedarrayoutofbounds) |
+| 10.4.5.15 | IsTypedArrayFixedLength ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-istypedarrayfixedlength) |
+| 10.4.5.16 | IsValidIntegerIndex ( O , index ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isvalidintegerindex) |
+| 10.4.5.17 | TypedArrayGetElement ( O , index ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-typedarraygetelement) |
+| 10.4.5.18 | TypedArraySetElement ( O , index , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-typedarraysetelement) |
+| 10.4.5.19 | IsArrayBufferViewOutOfBounds ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-isarraybufferviewoutofbounds) |
+| 10.4.6 | Module Namespace Exotic Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects) |
+| 10.4.6.1 | [[GetPrototypeOf]] ( ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getprototypeof) |
+| 10.4.6.2 | [[SetPrototypeOf]] ( V ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-setprototypeof-v) |
+| 10.4.6.3 | [[IsExtensible]] ( ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-isextensible) |
+| 10.4.6.4 | [[PreventExtensions]] ( ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions) |
+| 10.4.6.5 | [[GetOwnProperty]] ( P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getownproperty-p) |
+| 10.4.6.6 | [[DefineOwnProperty]] ( P , Desc ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc) |
+| 10.4.6.7 | [[HasProperty]] ( P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-hasproperty-p) |
+| 10.4.6.8 | [[Get]] ( P , Receiver ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver) |
+| 10.4.6.9 | [[Set]] ( P , V , Receiver ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-set-p-v-receiver) |
+| 10.4.6.10 | [[Delete]] ( P ) | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-delete-p) |
+| 10.4.6.11 | [[OwnPropertyKeys]] ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys) |
+| 10.4.6.12 | ModuleNamespaceCreate ( module , exports ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-modulenamespacecreate) |
+| 10.4.7 | Immutable Prototype Exotic Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects) |
+| 10.4.7.1 | [[SetPrototypeOf]] ( V ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects-setprototypeof-v) |
+| 10.4.7.2 | SetImmutablePrototype ( O , V ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-set-immutable-prototype) |
 
 ## Support
 
 Feature-level support tracking with test script references.
 
+### 10.4.1 ([tc39.es](https://tc39.es/ecma262/#sec-bound-function-exotic-objects))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Bound functions created by Function.prototype.bind | Supported with Limitations | [`Function_Bind_Basic_PartialApplication.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Bind_Basic_PartialApplication.js)<br>[`Function_Bind_ThisBinding_IgnoresCallReceiver.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Bind_ThisBinding_IgnoresCallReceiver.js)<br>[`Function_Prototype_Bind_PropertyExists.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Prototype_Bind_PropertyExists.js) | bind creates wrapper delegates with captured this/arguments and remembers the original target for metadata lookups. Bound call semantics are useful in practice, but bound-function construction and true [[BoundTargetFunction]] / [[BoundArguments]] slot semantics remain incomplete. |
+
+### 10.4.2 ([tc39.es](https://tc39.es/ecma262/#sec-array-exotic-objects))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Array exotic indexing and length behavior | Supported with Limitations | [`Array_New_Length.js`](../../../Js2IL.Tests/Array/JavaScript/Array_New_Length.js)<br>[`Array_New_MultipleArgs.js`](../../../Js2IL.Tests/Array/JavaScript/Array_New_MultipleArgs.js)<br>[`Array_Length_Set_Fractional_ThrowsRangeError.js`](../../../Js2IL.Tests/Array/JavaScript/Array_Length_Set_Fractional_ThrowsRangeError.js) | Arrays support numeric element access, length-based construction, and range-checked length writes that truncate or extend the backing store. The specialized [[DefineOwnProperty]] / ArraySpeciesCreate machinery is still only partially modeled. |
+
 ### 10.4.4 ([tc39.es](https://tc39.es/ecma262/#sec-arguments-exotic-objects))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| Arguments Exotic Objects (mapped/unmapped semantics) | Not Yet Supported |  | JS2IL does not implement the spec Arguments Exotic Object internal methods (including mapped-arguments aliasing). The compiler/runtime currently materialize a minimal function-scope `arguments` value as a JavaScriptRuntime.Array snapshot when referenced; see Section 10.2 tracking for the supported subset. |
+| Arguments objects are plain arrays, not Arguments Exotic Objects | Not Yet Supported | [`Function_Arguments_Basics.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Arguments_Basics.js)<br>[`Function_Arguments_ComputedKey_TriggersBinding.js`](../../../Js2IL.Tests/Function/JavaScript/Function_Arguments_ComputedKey_TriggersBinding.js) | When referenced, non-arrow functions materialize a JavaScriptRuntime.Array snapshot of the runtime arguments list. Mapped-arguments aliasing, Arguments Exotic Object internal methods, and the accessor helpers from 10.4.4.7 are not implemented. |
+
+### 10.4.5 ([tc39.es](https://tc39.es/ecma262/#sec-typedarray-exotic-objects))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Int32Array construction, element access, and integer-index semantics | Supported with Limitations | [`Int32Array_Construct_Length.js`](../../../Js2IL.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js)<br>[`Int32Array_Index_Assign.js`](../../../Js2IL.Tests/TypedArray/JavaScript/Int32Array_Index_Assign.js)<br>[`Int32Array_FromArray_CopyAndCoerce.js`](../../../Js2IL.Tests/TypedArray/JavaScript/Int32Array_FromArray_CopyAndCoerce.js)<br>[`Int32Array_NaN_Index_NoOp.js`](../../../Js2IL.Tests/TypedArray/JavaScript/Int32Array_NaN_Index_NoOp.js) | JS2IL currently implements only Int32Array, with construction from length/iterables, integer index reads and writes, and pragmatic out-of-bounds handling. It does not model ArrayBuffer-backed typed-array witness records, detach/out-of-bounds abstract operations, or the full family of typed array exotics. |
+
+### 10.4.6 ([tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Namespace import interop objects with live getter properties | Supported with Limitations | [`Import_Namespace_Esm_Basic.js`](../../../Js2IL.Tests/Import/JavaScript/Import_Namespace_Esm_Basic.js)<br>[`Import_Namespace_FromCjs_Stable.js`](../../../Js2IL.Tests/Import/JavaScript/Import_Namespace_FromCjs_Stable.js) | JSImport namespace lowering rewrites imports to a helper that builds a plain object with accessor descriptors for live reads of exported members. That captures common namespace-import behavior, but the result is not a true Module Namespace Exotic Object with the full non-extensible, non-configurable invariant set from the spec. |
+
+### 10.4.7 ([tc39.es](https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Immutable prototype exotic invariants | Not Yet Supported |  | JS2IL does not currently model any object with a dedicated immutable-prototype exotic internal method. Prototype mutation is handled through the ordinary PrototypeChain side-table instead. |
 

--- a/docs/ECMA262/10/Section10_5.json
+++ b/docs/ECMA262/10/Section10_5.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "10.5",
   "title": "Proxy Object Internal Methods and Internal Slots",
-  "status": "Supported with Limitations",
+  "status": "Incomplete",
   "specUrl": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots",
   "parent": {
     "clause": "10"
@@ -103,35 +103,55 @@
   "support": {
     "entries": [
       {
-        "clause": "10.5.8",
-        "feature": "get trap (handler.get)",
-        "status": "Supported with Limitations",
-        "specUrl": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver",
-        "testScripts": [
-          "Js2IL.Tests/Proxy/JavaScript/Proxy_GetTrap_OverridesProperty.js"
-        ],
-        "notes": "Routes basic property reads through handler.get(target, propertyKey, receiver) when present; does not implement full invariants/edge-case behaviors."
-      },
-      {
-        "clause": "10.5.9",
-        "feature": "set trap (handler.set)",
-        "status": "Supported with Limitations",
-        "specUrl": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver",
-        "testScripts": [
-          "Js2IL.Tests/Proxy/JavaScript/Proxy_SetTrap_InterceptsWrites.js"
-        ],
-        "notes": "Routes basic property writes through handler.set(target, propertyKey, value, receiver) when present; does not implement full invariants/edge-case behaviors."
-      },
-      {
         "clause": "10.5.7",
-        "feature": "has trap (handler.has)",
+        "feature": "Proxy has trap (handler.has)",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p",
         "testScripts": [
           "Js2IL.Tests/Proxy/JavaScript/Proxy_HasTrap_AffectsInOperator.js"
         ],
-        "notes": "Routes the in operator through handler.has(target, propertyKey) when present; does not implement full invariants/edge-case behaviors."
+        "notes": "The in operator routes through handler.has(target, propertyKey) when present. Proxy invariants and descriptor-based validation are not enforced."
+      },
+      {
+        "clause": "10.5.8",
+        "feature": "Proxy get trap (handler.get)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver",
+        "testScripts": [
+          "Js2IL.Tests/Proxy/JavaScript/Proxy_GetTrap_OverridesProperty.js"
+        ],
+        "notes": "Property reads call handler.get(target, propertyKey, receiver) before falling back to the target. Non-configurable target invariants and other edge cases are not checked."
+      },
+      {
+        "clause": "10.5.9",
+        "feature": "Proxy set trap (handler.set)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver",
+        "testScripts": [
+          "Js2IL.Tests/Proxy/JavaScript/Proxy_SetTrap_InterceptsWrites.js"
+        ],
+        "notes": "Property writes call handler.set(target, propertyKey, value, receiver) before falling back to the target. The return value is not validated against target descriptors or other proxy invariants."
+      },
+      {
+        "clause": "10.5.15",
+        "feature": "new Proxy(target, handler)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-proxycreate",
+        "testScripts": [
+          "Js2IL.Tests/Proxy/JavaScript/Proxy_GetTrap_OverridesProperty.js",
+          "Js2IL.Tests/Proxy/JavaScript/Proxy_SetTrap_InterceptsWrites.js",
+          "Js2IL.Tests/Proxy/JavaScript/Proxy_HasTrap_AffectsInOperator.js"
+        ],
+        "notes": "ProxyCreate is implemented as a minimal holder object that stores the target and handler and lets get/set/has route through them. apply, construct, ownKeys, deleteProperty, getPrototypeOf, setPrototypeOf, and revocation are still missing."
+      },
+      {
+        "clause": "10.5.10",
+        "feature": "Advanced proxy traps and revocation",
+        "status": "Not Yet Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p",
+        "notes": "deleteProperty, ownKeys, getPrototypeOf, setPrototypeOf, isExtensible, preventExtensions, apply, construct, and ValidateNonRevokedProxy/revocable proxy semantics are not implemented yet."
       }
     ]
-  }
+  },
+  "intro": "JS2IL currently implements only the core get, set, and has proxy traps needed by existing workloads. The remaining proxy internal methods still fall back to missing or ordinary-object behavior, so proxy support is useful but far from complete."
 }

--- a/docs/ECMA262/10/Section10_5.md
+++ b/docs/ECMA262/10/Section10_5.md
@@ -4,11 +4,13 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-03-07T02:30:25Z
+
+JS2IL currently implements only the core get, set, and has proxy traps needed by existing workloads. The remaining proxy internal methods still fall back to missing or ordinary-object behavior, so proxy support is useful but far from complete.
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 10.5 | Proxy Object Internal Methods and Internal Slots | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots) |
+| 10.5 | Proxy Object Internal Methods and Internal Slots | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots) |
 
 ## Subclauses
 
@@ -38,17 +40,29 @@ Feature-level support tracking with test script references.
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| has trap (handler.has) | Supported with Limitations | [`Proxy_HasTrap_AffectsInOperator.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_HasTrap_AffectsInOperator.js) | Routes the in operator through handler.has(target, propertyKey) when present; does not implement full invariants/edge-case behaviors. |
+| Proxy has trap (handler.has) | Supported with Limitations | [`Proxy_HasTrap_AffectsInOperator.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_HasTrap_AffectsInOperator.js) | The in operator routes through handler.has(target, propertyKey) when present. Proxy invariants and descriptor-based validation are not enforced. |
 
 ### 10.5.8 ([tc39.es](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| get trap (handler.get) | Supported with Limitations | [`Proxy_GetTrap_OverridesProperty.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_GetTrap_OverridesProperty.js) | Routes basic property reads through handler.get(target, propertyKey, receiver) when present; does not implement full invariants/edge-case behaviors. |
+| Proxy get trap (handler.get) | Supported with Limitations | [`Proxy_GetTrap_OverridesProperty.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_GetTrap_OverridesProperty.js) | Property reads call handler.get(target, propertyKey, receiver) before falling back to the target. Non-configurable target invariants and other edge cases are not checked. |
 
 ### 10.5.9 ([tc39.es](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver))
 
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
-| set trap (handler.set) | Supported with Limitations | [`Proxy_SetTrap_InterceptsWrites.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_SetTrap_InterceptsWrites.js) | Routes basic property writes through handler.set(target, propertyKey, value, receiver) when present; does not implement full invariants/edge-case behaviors. |
+| Proxy set trap (handler.set) | Supported with Limitations | [`Proxy_SetTrap_InterceptsWrites.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_SetTrap_InterceptsWrites.js) | Property writes call handler.set(target, propertyKey, value, receiver) before falling back to the target. The return value is not validated against target descriptors or other proxy invariants. |
+
+### 10.5.10 ([tc39.es](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Advanced proxy traps and revocation | Not Yet Supported |  | deleteProperty, ownKeys, getPrototypeOf, setPrototypeOf, isExtensible, preventExtensions, apply, construct, and ValidateNonRevokedProxy/revocable proxy semantics are not implemented yet. |
+
+### 10.5.15 ([tc39.es](https://tc39.es/ecma262/#sec-proxycreate))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| new Proxy(target, handler) | Supported with Limitations | [`Proxy_GetTrap_OverridesProperty.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_GetTrap_OverridesProperty.js)<br>[`Proxy_SetTrap_InterceptsWrites.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_SetTrap_InterceptsWrites.js)<br>[`Proxy_HasTrap_AffectsInOperator.js`](../../../Js2IL.Tests/Proxy/JavaScript/Proxy_HasTrap_AffectsInOperator.js) | ProxyCreate is implemented as a minimal holder object that stores the target and handler and lets get/set/has route through them. apply, construct, ownKeys, deleteProperty, getPrototypeOf, setPrototypeOf, and revocation are still missing. |
 

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -19,7 +19,7 @@ Notes:
 - `Partially Supported` is deprecated legacy wording and is treated as `Supported with Limitations`.
 - Prototype-chain design/strategy: see [PrototypeChainSupport.md](../PrototypeChainSupport.md).
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-03-07T02:30:25Z
 
 ## Summary
 - Total clauses indexed: **2176**
@@ -38,13 +38,13 @@ Notes:
 | 6 | ECMAScript Data Types and Values | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section6.md](6/Section6.md) |
 | 7 | Abstract Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section7.md](7/Section7.md) |
 | 8 | Syntax-Directed Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section8.md](8/Section8.md) |
-| 9 | Executable Code and Execution Contexts | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section9.md](9/Section9.md) |
+| 9 | Executable Code and Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section9.md](9/Section9.md) |
 | 10 | Ordinary and Exotic Objects Behaviours | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-and-exotic-objects-behaviours) | [Section10.md](10/Section10.md) |
 | 11 | ECMAScript Language: Source Text | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-source-code) | [Section11.md](11/Section11.md) |
 | 12 | ECMAScript Language: Lexical Grammar | Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar) | [Section12.md](12/Section12.md) |
 | 13 | ECMAScript Language: Expressions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-expressions) | [Section13.md](13/Section13.md) |
-| 14 | ECMAScript Language: Statements and Declarations | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) | [Section14.md](14/Section14.md) |
-| 15 | ECMAScript Language: Functions and Classes | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) | [Section15.md](15/Section15.md) |
+| 14 | ECMAScript Language: Statements and Declarations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) | [Section14.md](14/Section14.md) |
+| 15 | ECMAScript Language: Functions and Classes | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) | [Section15.md](15/Section15.md) |
 | 16 | ECMAScript Language: Scripts and Modules | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-scripts-and-modules) | [Section16.md](16/Section16.md) |
 | 17 | Error Handling and Language Extensions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-error-handling-and-language-extensions) | [Section17.md](17/Section17.md) |
 | 18 | ECMAScript Standard Built-in Objects | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects) | [Section18.md](18/Section18.md) |
@@ -52,11 +52,12 @@ Notes:
 | 20 | Fundamental Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-fundamental-objects) | [Section20.md](20/Section20.md) |
 | 21 | Numbers and Dates | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-numbers-and-dates) | [Section21.md](21/Section21.md) |
 | 22 | Text Processing | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-text-processing) | [Section22.md](22/Section22.md) |
-| 23 | Indexed Collections | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) | [Section23.md](23/Section23.md) |
+| 23 | Indexed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) | [Section23.md](23/Section23.md) |
 | 24 | Keyed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-keyed-collections) | [Section24.md](24/Section24.md) |
 | 25 | Structured Data | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-structured-data) | [Section25.md](25/Section25.md) |
 | 26 | Managing Memory | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-managing-memory) | [Section26.md](26/Section26.md) |
 | 27 | Control Abstraction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) | [Section27.md](27/Section27.md) |
 | 28 | Reflection | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-reflection) | [Section28.md](28/Section28.md) |
 | 29 | Memory Model | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-memory-model) | [Section29.md](29/Section29.md) |
+
 


### PR DESCRIPTION
## Summary
- audit ECMA-262 section 10 coverage against the current JS2IL implementation
- update section 10 JSON statuses/support notes and regenerate section markdown
- refresh the ECMA-262 index rollup for the section 10 status changes

## Testing
- dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2IL.Tests.Object|FullyQualifiedName~Js2IL.Tests.Function|FullyQualifiedName~Js2IL.Tests.Proxy|FullyQualifiedName~Js2IL.Tests.TypedArray|FullyQualifiedName~Js2IL.Tests.Import"