### PR TITLE
perf: optimize stopwatch runtime hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-- perf/runtime/benchmarks: speed up stopwatch-style constructor-function hot paths by fast-pathing dictionary-backed delegate member calls/property reads in `ObjectRuntime` and caching delegate invoke metadata in `Closure`, improving local `stopwatch-modern` execute-lane Dry benchmark results from about `1.144 s / 191,391.58 KB` to `442.4 ms / 87,508.57 KB`.
+- perf/runtime/benchmarks: speed up stopwatch-style constructor-function hot paths by fast-pathing dictionary-backed delegate member calls/property reads in `JavaScriptRuntime.Object` and caching delegate invoke metadata in `Closure`, improving local `stopwatch-modern` execute-lane Dry benchmark results from about `1.144 s / 191,391.58 KB` to `442.4 ms / 87,508.57 KB`.
 
 ## v0.8.27 - 2026-03-07
 

--- a/JavaScriptRuntime/Closure.cs
+++ b/JavaScriptRuntime/Closure.cs
@@ -185,7 +185,7 @@ namespace JavaScriptRuntime
             {
                 var delegateType = del.GetType();
                 var invoke = delegateType.GetMethod("Invoke")
-                    ?? throw new ArgumentException($"Delegate type '{delegateType}' does not define Invoke().", nameof(del));
+                    ?? throw new ArgumentException($"Delegate type '{delegateType}' does not define Invoke().", "target");
                 var parameters = invoke.GetParameters();
                 var abi = JsCallableScopeAbiResolver.Resolve(del);
                 bool hasScopes = abi.HasExplicitScopePayload;

--- a/JavaScriptRuntime/Object.cs
+++ b/JavaScriptRuntime/Object.cs
@@ -1994,12 +1994,18 @@ namespace JavaScriptRuntime
                 return false;
             }
 
+            if (!dictionary.TryGetValue(memberName, out var dictionaryValue))
+            {
+                return false;
+            }
+
             if (PropertyDescriptorStore.TryGetOwn(receiver, memberName, out _))
             {
                 return false;
             }
 
-            return dictionary.TryGetValue(memberName, out value);
+            value = dictionaryValue;
+            return true;
         }
 
         private static object InvokeMemberDelegate(object receiver, Delegate member, object?[] callArgs)
@@ -2007,14 +2013,59 @@ namespace JavaScriptRuntime
             var previousThis = RuntimeServices.SetCurrentThis(receiver);
             try
             {
-                return callArgs.Length switch
-                {
-                    0 => Closure.InvokeWithArgs0(member, System.Array.Empty<object>()),
-                    1 => Closure.InvokeWithArgs1(member, System.Array.Empty<object>(), callArgs[0]),
-                    2 => Closure.InvokeWithArgs2(member, System.Array.Empty<object>(), callArgs[0], callArgs[1]),
-                    3 => Closure.InvokeWithArgs3(member, System.Array.Empty<object>(), callArgs[0], callArgs[1], callArgs[2]),
-                    _ => Closure.InvokeWithArgs(member, System.Array.Empty<object>(), callArgs)
-                };
+                return Closure.InvokeWithArgs(member, System.Array.Empty<object>(), callArgs);
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
+        }
+
+        private static object InvokeMemberDelegate0(object receiver, Delegate member)
+        {
+            var previousThis = RuntimeServices.SetCurrentThis(receiver);
+            try
+            {
+                return Closure.InvokeWithArgs0(member, System.Array.Empty<object>());
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
+        }
+
+        private static object InvokeMemberDelegate1(object receiver, Delegate member, object? a0)
+        {
+            var previousThis = RuntimeServices.SetCurrentThis(receiver);
+            try
+            {
+                return Closure.InvokeWithArgs1(member, System.Array.Empty<object>(), a0);
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
+        }
+
+        private static object InvokeMemberDelegate2(object receiver, Delegate member, object? a0, object? a1)
+        {
+            var previousThis = RuntimeServices.SetCurrentThis(receiver);
+            try
+            {
+                return Closure.InvokeWithArgs2(member, System.Array.Empty<object>(), a0, a1);
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
+        }
+
+        private static object InvokeMemberDelegate3(object receiver, Delegate member, object? a0, object? a1, object? a2)
+        {
+            var previousThis = RuntimeServices.SetCurrentThis(receiver);
+            try
+            {
+                return Closure.InvokeWithArgs3(member, System.Array.Empty<object>(), a0, a1, a2);
             }
             finally
             {
@@ -2054,7 +2105,7 @@ namespace JavaScriptRuntime
             {
                 if (directMemberValue is Delegate directMember)
                 {
-                    return InvokeMemberDelegate(receiver, directMember, System.Array.Empty<object>());
+                    return InvokeMemberDelegate0(receiver, directMember);
                 }
 
                 throw new TypeError($"{methodName} is not a function");
@@ -2104,7 +2155,7 @@ namespace JavaScriptRuntime
             {
                 if (directMemberValue is Delegate directMember)
                 {
-                    return InvokeMemberDelegate(receiver, directMember, new object?[] { a0! });
+                    return InvokeMemberDelegate1(receiver, directMember, a0);
                 }
 
                 throw new TypeError($"{methodName} is not a function");
@@ -2154,7 +2205,7 @@ namespace JavaScriptRuntime
             {
                 if (directMemberValue is Delegate directMember)
                 {
-                    return InvokeMemberDelegate(receiver, directMember, new object?[] { a0!, a1! });
+                    return InvokeMemberDelegate2(receiver, directMember, a0, a1);
                 }
 
                 throw new TypeError($"{methodName} is not a function");
@@ -2204,7 +2255,7 @@ namespace JavaScriptRuntime
             {
                 if (directMemberValue is Delegate directMember)
                 {
-                    return InvokeMemberDelegate(receiver, directMember, new object?[] { a0!, a1!, a2! });
+                    return InvokeMemberDelegate3(receiver, directMember, a0, a1, a2);
                 }
 
                 throw new TypeError($"{methodName} is not a function");


### PR DESCRIPTION
## Summary
- add fast dictionary-backed own-property and delegate member-call paths for stopwatch-style object instances
- cache delegate invoke metadata to cut repeated reflection and ABI inspection in hot closure invocations

## Validation
- dotnet build .\tests\performance\Benchmarks\Benchmarks.csproj -c Release
- dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Js2IL.Tests.Function.ExecutionTests|FullyQualifiedName~Js2IL.Tests.Object.ExecutionTests|FullyQualifiedName~Js2IL.Tests.Date.ExecutionTests"
- dotnet run --project .\tests\performance\Benchmarks\Benchmarks.csproj -c Release -- --phased --filter "*stopwatch-modern*" --job Dry

## Benchmark notes
- js2il execute (pre-compiled): ~1.144 s / 191,391.58 KB -> ~442.4 ms / 87,508.57 KB in the filtered Dry run
- managed allocation in the execute lane dropped by ~103,883 KB (~54.3%)
- the filtered benchmark still shares setup that preloads all scenarios, so the numbers are most useful for relative comparison