### PR TITLE
feat(node): expand util essentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- runtime/tests/docs: expand Node `util` essentials for issue #787 by adding runtime-backed `util.types` checks for ArrayBuffer/DataView/common typed arrays, exposing compatibility shims for unsupported typed-array flavors, improving `util.inspect` formatting for typed arrays and binary views, and adding focused Node util coverage plus refreshed module/backlog docs.
 - runtime/spec/tests/docs: expose `Array.prototype.entries` / `keys` / `values` / `%Symbol.iterator%` for issue #780, reuse that iterator surface for `for..of` and array spread, extend `Array.from(...)` coverage for iterator sources, add focused Array execution/generator coverage, and refresh ECMA-262 §23.1 tracking.
 - runtime/tests/docs: audit symbol ecosystem coverage for issue #779 by honoring `Symbol.isConcatSpreadable` in `Array.prototype.concat`, adding symbol-key descriptor/enumeration coverage, documenting ordinary-object symbol reflection ordering, and adding custom `Symbol.toStringTag` coverage.
 - compiler/runtime/spec/tests/docs: add Stage 1 `Function(...)` / `new Function(...)` support for compile-time string-literal sources by parsing and compiling synthetic callables with isolated global-scope semantics, wiring `anonymous`/`.length` defaults, surfacing runtime `Error`/`SyntaxError` for unsupported or invalid sources, adding focused Function execution/generator coverage, and updating ECMA-262 tracking for issue #778.

--- a/JavaScriptRuntime/Node/Util.cs
+++ b/JavaScriptRuntime/Node/Util.cs
@@ -430,6 +430,21 @@ namespace JavaScriptRuntime.Node
             dict["isSet"] = new Func<object?, bool>(v => v is JavaScriptRuntime.Set);
             dict["isProxy"] = new Func<object?, bool>(v => v is JavaScriptRuntime.Proxy);
             dict["isTypedArray"] = new Func<object?, bool>(v => v is JavaScriptRuntime.TypedArrayBase || v is JavaScriptRuntime.Node.Buffer);
+            dict["isAnyArrayBuffer"] = new Func<object?, bool>(v => v is ArrayBuffer);
+            dict["isArrayBuffer"] = new Func<object?, bool>(v => v is ArrayBuffer);
+            dict["isDataView"] = new Func<object?, bool>(v => v is DataView);
+            dict["isInt8Array"] = new Func<object?, bool>(_ => false);
+            dict["isUint8Array"] = new Func<object?, bool>(v => v is Uint8Array || v is JavaScriptRuntime.Node.Buffer);
+            dict["isUint8ClampedArray"] = new Func<object?, bool>(_ => false);
+            dict["isInt16Array"] = new Func<object?, bool>(_ => false);
+            dict["isUint16Array"] = new Func<object?, bool>(_ => false);
+            dict["isInt32Array"] = new Func<object?, bool>(v => v is Int32Array);
+            dict["isUint32Array"] = new Func<object?, bool>(_ => false);
+            dict["isFloat32Array"] = new Func<object?, bool>(_ => false);
+            dict["isFloat64Array"] = new Func<object?, bool>(v => v is Float64Array);
+            dict["isBigInt64Array"] = new Func<object?, bool>(_ => false);
+            dict["isBigUint64Array"] = new Func<object?, bool>(_ => false);
+            dict["isSharedArrayBuffer"] = new Func<object?, bool>(_ => false);
 
             return typesObj;
         }
@@ -474,6 +489,60 @@ namespace JavaScriptRuntime.Node
             if (value is Delegate)
             {
                 return "[Function]";
+            }
+
+            if (value is ArrayBuffer arrayBuffer)
+            {
+                return $"ArrayBuffer {{ byteLength: {DotNet2JSConversions.ToString(arrayBuffer.byteLength)} }}";
+            }
+
+            if (value is DataView dataView)
+            {
+                if (visited.Contains(value))
+                {
+                    return "[Circular]";
+                }
+
+                if (currentDepth >= maxDepth)
+                {
+                    return "[DataView]";
+                }
+
+                visited.Add(value);
+                var inspectedBuffer = InspectValue(dataView.buffer, maxDepth, currentDepth + 1, visited);
+                visited.Remove(value);
+                return $"DataView {{ byteLength: {DotNet2JSConversions.ToString(dataView.byteLength)}, byteOffset: {DotNet2JSConversions.ToString(dataView.byteOffset)}, buffer: {inspectedBuffer} }}";
+            }
+
+            if (value is TypedArrayBase typedArray)
+            {
+                if (visited.Contains(value))
+                {
+                    return "[Circular]";
+                }
+
+                if (currentDepth >= maxDepth)
+                {
+                    return $"[{value.GetType().Name}]";
+                }
+
+                visited.Add(value);
+                var elements = new List<string>();
+                var length = (int)typedArray.length;
+
+                for (int i = 0; i < System.Math.Min(length, 100); i++)
+                {
+                    elements.Add(DotNet2JSConversions.ToString(typedArray[(double)i]));
+                }
+
+                visited.Remove(value);
+
+                if (length > 100)
+                {
+                    elements.Add($"... {length - 100} more items");
+                }
+
+                return $"{value.GetType().Name}({length}) [ {string.Join(", ", elements)} ]";
             }
 
             if (value is JavaScriptRuntime.Array arr)

--- a/Js2IL.Tests/Node/Util/ExecutionTests.cs
+++ b/Js2IL.Tests/Node/Util/ExecutionTests.cs
@@ -49,5 +49,13 @@ namespace Js2IL.Tests.Node.Util
         [Fact]
         public Task Require_Util_Types_Expanded()
             => ExecutionTest(nameof(Require_Util_Types_Expanded));
+
+        [Fact]
+        public Task Require_Util_Types_TypedBinary()
+            => ExecutionTest(nameof(Require_Util_Types_TypedBinary));
+
+        [Fact]
+        public Task Require_Util_Inspect_TypedBinary()
+            => ExecutionTest(nameof(Require_Util_Inspect_TypedBinary));
     }
 }

--- a/Js2IL.Tests/Node/Util/GeneratorTests.cs
+++ b/Js2IL.Tests/Node/Util/GeneratorTests.cs
@@ -49,5 +49,13 @@ namespace Js2IL.Tests.Node.Util
         [Fact]
         public Task Require_Util_Types_Expanded()
             => GenerateTest(nameof(Require_Util_Types_Expanded));
+
+        [Fact]
+        public Task Require_Util_Types_TypedBinary()
+            => GenerateTest(nameof(Require_Util_Types_TypedBinary));
+
+        [Fact]
+        public Task Require_Util_Inspect_TypedBinary()
+            => GenerateTest(nameof(Require_Util_Inspect_TypedBinary));
     }
 }

--- a/Js2IL.Tests/Node/Util/JavaScript/Require_Util_Format_Basic.js
+++ b/Js2IL.Tests/Node/Util/JavaScript/Require_Util_Format_Basic.js
@@ -14,3 +14,5 @@ console.log(util.format('%j', circ));
 console.log(util.format('a', 1, { b: 2 }));
 console.log(util.format({ a: 1 }, { b: 2 }));
 console.log(util.format('x%y', 1));
+console.log(util.format('%o', new Uint8Array([1, 2, 3])));
+console.log(util.format('%O', new DataView(new ArrayBuffer(6), 1, 4)));

--- a/Js2IL.Tests/Node/Util/JavaScript/Require_Util_Inspect_TypedBinary.js
+++ b/Js2IL.Tests/Node/Util/JavaScript/Require_Util_Inspect_TypedBinary.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const util = require('util');
+
+const ints = new Int32Array([10, 20, 30]);
+const bytes = new Uint8Array([1, 2, 255]);
+const arrayBuffer = new ArrayBuffer(6);
+const dataView = new DataView(arrayBuffer, 1, 4);
+const circular = { data: ints };
+circular.self = circular;
+
+console.log(util.inspect(ints));
+console.log(util.inspect(bytes));
+console.log(util.inspect(arrayBuffer));
+console.log(util.inspect(dataView));
+console.log(util.inspect(circular, { depth: 1 }));

--- a/Js2IL.Tests/Node/Util/JavaScript/Require_Util_Types_TypedBinary.js
+++ b/Js2IL.Tests/Node/Util/JavaScript/Require_Util_Types_TypedBinary.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const util = require('util');
+
+const arrayBuffer = new ArrayBuffer(8);
+const dataView = new DataView(arrayBuffer, 2, 4);
+
+console.log(util.types.isArrayBuffer(arrayBuffer));
+console.log(util.types.isArrayBuffer(new Uint8Array(4)));
+console.log(util.types.isAnyArrayBuffer(arrayBuffer));
+console.log(util.types.isDataView(dataView));
+console.log(util.types.isDataView(arrayBuffer));
+console.log(util.types.isInt32Array(new Int32Array([1, 2, 3])));
+console.log(util.types.isUint8Array(new Uint8Array([1, 2, 3])));
+console.log(util.types.isUint8Array(Buffer.from([1, 2, 3])));
+console.log(util.types.isFloat64Array(new Float64Array([1.5, 2.5])));
+console.log(util.types.isUint16Array(new Uint8Array([1, 2, 3])));
+console.log(util.types.isSharedArrayBuffer(arrayBuffer));

--- a/Js2IL.Tests/Node/Util/Snapshots/ExecutionTests.Require_Util_Format_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/ExecutionTests.Require_Util_Format_Basic.verified.txt
@@ -6,3 +6,5 @@
 a 1 { b: 2 }
 { a: 1 } { b: 2 }
 x%y 1
+Uint8Array(3) [ 1, 2, 3 ]
+DataView { byteLength: 4, byteOffset: 1, buffer: ArrayBuffer { byteLength: 6 } }

--- a/Js2IL.Tests/Node/Util/Snapshots/ExecutionTests.Require_Util_Inspect_TypedBinary.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/ExecutionTests.Require_Util_Inspect_TypedBinary.verified.txt
@@ -1,0 +1,5 @@
+﻿Int32Array(3) [ 10, 20, 30 ]
+Uint8Array(3) [ 1, 2, 255 ]
+ArrayBuffer { byteLength: 6 }
+DataView { byteLength: 4, byteOffset: 1, buffer: ArrayBuffer { byteLength: 6 } }
+{ data: [Int32Array], self: [Circular] }

--- a/Js2IL.Tests/Node/Util/Snapshots/ExecutionTests.Require_Util_Types_TypedBinary.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/ExecutionTests.Require_Util_Types_TypedBinary.verified.txt
@@ -1,0 +1,11 @@
+﻿true
+false
+true
+true
+false
+true
+true
+true
+true
+false
+false

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Format_Basic.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Format_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2204
+			// Method begins at RVA 0x22c5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,14 +40,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 424 (0x1a8)
+		// Code size: 617 (0x269)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Format_Basic/Scope,
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.DataView
 		)
 
 		IL_0000: newobj instance void Modules.Require_Util_Format_Basic/Scope::.ctor()
@@ -167,7 +170,54 @@
 		IL_01a0: ldloc.3
 		IL_01a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_01a6: pop
-		IL_01a7: ret
+		IL_01a7: ldc.i4.3
+		IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01ad: dup
+		IL_01ae: ldc.r8 1
+		IL_01b7: box [System.Runtime]System.Double
+		IL_01bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01c1: dup
+		IL_01c2: ldc.r8 2
+		IL_01cb: box [System.Runtime]System.Double
+		IL_01d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01d5: dup
+		IL_01d6: ldc.r8 3
+		IL_01df: box [System.Runtime]System.Double
+		IL_01e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_01ee: stloc.s 5
+		IL_01f0: ldloc.1
+		IL_01f1: ldstr "format"
+		IL_01f6: ldstr "%o"
+		IL_01fb: ldloc.s 5
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0202: stloc.3
+		IL_0203: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0208: ldloc.3
+		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020e: pop
+		IL_020f: ldc.r8 6
+		IL_0218: box [System.Runtime]System.Double
+		IL_021d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
+		IL_0222: stloc.s 6
+		IL_0224: ldloc.s 6
+		IL_0226: ldc.r8 1
+		IL_022f: box [System.Runtime]System.Double
+		IL_0234: ldc.r8 4
+		IL_023d: box [System.Runtime]System.Double
+		IL_0242: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object, object)
+		IL_0247: stloc.s 7
+		IL_0249: ldloc.1
+		IL_024a: ldstr "format"
+		IL_024f: ldstr "%O"
+		IL_0254: ldloc.s 7
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_025b: stloc.3
+		IL_025c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0261: ldloc.3
+		IL_0262: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0267: pop
+		IL_0268: ret
 	} // end of method Require_Util_Format_Basic::__js_module_init__
 
 } // end of class Modules.Require_Util_Format_Basic
@@ -179,7 +229,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220d
+		// Method begins at RVA 0x22ce
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_TypedBinary.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_TypedBinary.verified.txt
@@ -1,0 +1,210 @@
+﻿// IL code: Require_Util_Inspect_TypedBinary
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Require_Util_Inspect_TypedBinary
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2216
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 442 (0x1ba)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Require_Util_Inspect_TypedBinary/Scope,
+			[1] object,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[7] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		)
+
+		IL_0000: newobj instance void Modules.Require_Util_Inspect_TypedBinary/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.1
+		IL_0007: ldstr "util"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 7
+		IL_0013: ldloc.s 7
+		IL_0015: stloc.1
+		IL_0016: ldc.i4.3
+		IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_001c: dup
+		IL_001d: ldc.r8 10
+		IL_0026: box [System.Runtime]System.Double
+		IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0030: dup
+		IL_0031: ldc.r8 20
+		IL_003a: box [System.Runtime]System.Double
+		IL_003f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0044: dup
+		IL_0045: ldc.r8 30
+		IL_004e: box [System.Runtime]System.Double
+		IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0058: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_005d: stloc.s 8
+		IL_005f: ldloc.s 8
+		IL_0061: stloc.2
+		IL_0062: ldc.i4.3
+		IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0068: dup
+		IL_0069: ldc.r8 1
+		IL_0072: box [System.Runtime]System.Double
+		IL_0077: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_007c: dup
+		IL_007d: ldc.r8 2
+		IL_0086: box [System.Runtime]System.Double
+		IL_008b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0090: dup
+		IL_0091: ldc.r8 255
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_00a9: stloc.s 9
+		IL_00ab: ldloc.s 9
+		IL_00ad: stloc.3
+		IL_00ae: ldc.r8 6
+		IL_00b7: box [System.Runtime]System.Double
+		IL_00bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
+		IL_00c1: stloc.s 10
+		IL_00c3: ldloc.s 10
+		IL_00c5: stloc.s 4
+		IL_00c7: ldloc.s 4
+		IL_00c9: ldc.r8 1
+		IL_00d2: box [System.Runtime]System.Double
+		IL_00d7: ldc.r8 4
+		IL_00e0: box [System.Runtime]System.Double
+		IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object, object)
+		IL_00ea: stloc.s 11
+		IL_00ec: ldloc.s 11
+		IL_00ee: stloc.s 5
+		IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00f5: dup
+		IL_00f6: ldstr "data"
+		IL_00fb: ldloc.2
+		IL_00fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0101: stloc.s 12
+		IL_0103: ldloc.s 12
+		IL_0105: stloc.s 6
+		IL_0107: ldloc.s 6
+		IL_0109: ldstr "self"
+		IL_010e: ldloc.s 6
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_0115: pop
+		IL_0116: ldloc.1
+		IL_0117: ldstr "inspect"
+		IL_011c: ldloc.2
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0122: stloc.s 7
+		IL_0124: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0129: ldloc.s 7
+		IL_012b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0130: pop
+		IL_0131: ldloc.1
+		IL_0132: ldstr "inspect"
+		IL_0137: ldloc.3
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_013d: stloc.s 7
+		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0144: ldloc.s 7
+		IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014b: pop
+		IL_014c: ldloc.1
+		IL_014d: ldstr "inspect"
+		IL_0152: ldloc.s 4
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0159: stloc.s 7
+		IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0160: ldloc.s 7
+		IL_0162: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0167: pop
+		IL_0168: ldloc.1
+		IL_0169: ldstr "inspect"
+		IL_016e: ldloc.s 5
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0175: stloc.s 7
+		IL_0177: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017c: ldloc.s 7
+		IL_017e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0183: pop
+		IL_0184: ldloc.1
+		IL_0185: ldstr "inspect"
+		IL_018a: ldloc.s 6
+		IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0191: dup
+		IL_0192: ldstr "depth"
+		IL_0197: ldc.r8 1
+		IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01aa: stloc.s 7
+		IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b1: ldloc.s 7
+		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b8: pop
+		IL_01b9: ret
+	} // end of method Require_Util_Inspect_TypedBinary::__js_module_init__
+
+} // end of class Modules.Require_Util_Inspect_TypedBinary
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x221f
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Require_Util_Inspect_TypedBinary::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_TypedBinary.verified.txt
+++ b/Js2IL.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_TypedBinary.verified.txt
@@ -1,0 +1,322 @@
+﻿// IL code: Require_Util_Types_TypedBinary
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Require_Util_Types_TypedBinary
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x23d5
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 889 (0x379)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Require_Util_Types_TypedBinary/Scope,
+			[1] object,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[4] object,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array
+		)
+
+		IL_0000: newobj instance void Modules.Require_Util_Types_TypedBinary/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.1
+		IL_0007: ldstr "util"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 4
+		IL_0013: ldloc.s 4
+		IL_0015: stloc.1
+		IL_0016: ldc.r8 8
+		IL_001f: box [System.Runtime]System.Double
+		IL_0024: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
+		IL_0029: stloc.s 5
+		IL_002b: ldloc.s 5
+		IL_002d: stloc.2
+		IL_002e: ldloc.2
+		IL_002f: ldc.r8 2
+		IL_0038: box [System.Runtime]System.Double
+		IL_003d: ldc.r8 4
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object, object)
+		IL_0050: stloc.s 6
+		IL_0052: ldloc.s 6
+		IL_0054: stloc.3
+		IL_0055: ldloc.1
+		IL_0056: ldstr "types"
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0060: ldstr "isArrayBuffer"
+		IL_0065: ldloc.2
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_006b: stloc.s 4
+		IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0072: ldloc.s 4
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0079: pop
+		IL_007a: ldloc.1
+		IL_007b: ldstr "types"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0085: stloc.s 4
+		IL_0087: ldc.r8 4
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_009a: stloc.s 7
+		IL_009c: ldloc.s 4
+		IL_009e: ldstr "isArrayBuffer"
+		IL_00a3: ldloc.s 7
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00aa: stloc.s 4
+		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b1: ldloc.s 4
+		IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b8: pop
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "types"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c4: ldstr "isAnyArrayBuffer"
+		IL_00c9: ldloc.2
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00cf: stloc.s 4
+		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d6: ldloc.s 4
+		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00dd: pop
+		IL_00de: ldloc.1
+		IL_00df: ldstr "types"
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e9: ldstr "isDataView"
+		IL_00ee: ldloc.3
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f4: stloc.s 4
+		IL_00f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fb: ldloc.s 4
+		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0102: pop
+		IL_0103: ldloc.1
+		IL_0104: ldstr "types"
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010e: ldstr "isDataView"
+		IL_0113: ldloc.2
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0119: stloc.s 4
+		IL_011b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0120: ldloc.s 4
+		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0127: pop
+		IL_0128: ldloc.1
+		IL_0129: ldstr "types"
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0133: stloc.s 4
+		IL_0135: ldc.i4.3
+		IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_013b: dup
+		IL_013c: ldc.r8 1
+		IL_0145: box [System.Runtime]System.Double
+		IL_014a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_014f: dup
+		IL_0150: ldc.r8 2
+		IL_0159: box [System.Runtime]System.Double
+		IL_015e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0163: dup
+		IL_0164: ldc.r8 3
+		IL_016d: box [System.Runtime]System.Double
+		IL_0172: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0177: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_017c: stloc.s 8
+		IL_017e: ldloc.s 4
+		IL_0180: ldstr "isInt32Array"
+		IL_0185: ldloc.s 8
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_018c: stloc.s 4
+		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0193: ldloc.s 4
+		IL_0195: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019a: pop
+		IL_019b: ldloc.1
+		IL_019c: ldstr "types"
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a6: stloc.s 4
+		IL_01a8: ldc.i4.3
+		IL_01a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01ae: dup
+		IL_01af: ldc.r8 1
+		IL_01b8: box [System.Runtime]System.Double
+		IL_01bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01c2: dup
+		IL_01c3: ldc.r8 2
+		IL_01cc: box [System.Runtime]System.Double
+		IL_01d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01d6: dup
+		IL_01d7: ldc.r8 3
+		IL_01e0: box [System.Runtime]System.Double
+		IL_01e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_01ef: stloc.s 7
+		IL_01f1: ldloc.s 4
+		IL_01f3: ldstr "isUint8Array"
+		IL_01f8: ldloc.s 7
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01ff: stloc.s 4
+		IL_0201: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0206: ldloc.s 4
+		IL_0208: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020d: pop
+		IL_020e: ldloc.1
+		IL_020f: ldstr "types"
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0219: stloc.s 4
+		IL_021b: ldc.i4.3
+		IL_021c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0221: dup
+		IL_0222: ldc.r8 1
+		IL_022b: box [System.Runtime]System.Double
+		IL_0230: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0235: dup
+		IL_0236: ldc.r8 2
+		IL_023f: box [System.Runtime]System.Double
+		IL_0244: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0249: dup
+		IL_024a: ldc.r8 3
+		IL_0253: box [System.Runtime]System.Double
+		IL_0258: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_025d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0262: stloc.s 9
+		IL_0264: ldloc.s 4
+		IL_0266: ldstr "isUint8Array"
+		IL_026b: ldloc.s 9
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0272: stloc.s 4
+		IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0279: ldloc.s 4
+		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0280: pop
+		IL_0281: ldloc.1
+		IL_0282: ldstr "types"
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028c: stloc.s 4
+		IL_028e: ldc.i4.2
+		IL_028f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0294: dup
+		IL_0295: ldc.r8 1.5
+		IL_029e: box [System.Runtime]System.Double
+		IL_02a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02a8: dup
+		IL_02a9: ldc.r8 2.5
+		IL_02b2: box [System.Runtime]System.Double
+		IL_02b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Float64Array::.ctor(object)
+		IL_02c1: stloc.s 10
+		IL_02c3: ldloc.s 4
+		IL_02c5: ldstr "isFloat64Array"
+		IL_02ca: ldloc.s 10
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02d1: stloc.s 4
+		IL_02d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d8: ldloc.s 4
+		IL_02da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02df: pop
+		IL_02e0: ldloc.1
+		IL_02e1: ldstr "types"
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02eb: stloc.s 4
+		IL_02ed: ldc.i4.3
+		IL_02ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02f3: dup
+		IL_02f4: ldc.r8 1
+		IL_02fd: box [System.Runtime]System.Double
+		IL_0302: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0307: dup
+		IL_0308: ldc.r8 2
+		IL_0311: box [System.Runtime]System.Double
+		IL_0316: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_031b: dup
+		IL_031c: ldc.r8 3
+		IL_0325: box [System.Runtime]System.Double
+		IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_032f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_0334: stloc.s 7
+		IL_0336: ldloc.s 4
+		IL_0338: ldstr "isUint16Array"
+		IL_033d: ldloc.s 7
+		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0344: stloc.s 4
+		IL_0346: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_034b: ldloc.s 4
+		IL_034d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0352: pop
+		IL_0353: ldloc.1
+		IL_0354: ldstr "types"
+		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_035e: ldstr "isSharedArrayBuffer"
+		IL_0363: ldloc.2
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0369: stloc.s 4
+		IL_036b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0370: ldloc.s 4
+		IL_0372: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0377: pop
+		IL_0378: ret
+	} // end of method Require_Util_Types_TypedBinary::__js_module_init__
+
+} // end of class Modules.Require_Util_Types_TypedBinary
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x23de
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Require_Util_Types_TypedBinary::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/docs/nodejs/Index.md
+++ b/docs/nodejs/Index.md
@@ -4,7 +4,7 @@
 
 **Target Node.js Version:** `22.x LTS`
 
-**Generated:** `2026-03-06T06:03:03Z`
+**Generated:** `2026-03-09T09:35:07Z`
 
 ## Summary
 

--- a/docs/nodejs/util.json
+++ b/docs/nodejs/util.json
@@ -7,7 +7,7 @@
   "docsUrl": "https://nodejs.org/api/util.html",
   "nodeVersionTarget": "22.x LTS",
   "implementation": "JavaScriptRuntime/Node/Util.cs",
-  "notes": "Provides essential utility functions for promisifying callbacks, prototype inheritance, type checking, and object inspection.",
+  "notes": "Provides essential utility functions for promisifying callbacks, prototype inheritance, placeholder formatting, Node-style object inspection, and type checking for common runtime-backed binary/object shapes.",
   "apis": [
     {
       "name": "promisify(callback)",
@@ -72,7 +72,7 @@
       "name": "types",
       "kind": "property",
       "status": "partial",
-      "notes": "Provides type-checking functions. Supported checks: isArray, isDate, isError, isFunction, isPromise, isRegExp, isString, isNumber, isBoolean, isUndefined, isNull, isObject, isBigInt, isSymbol, isAsyncFunction, isMap, isSet, isProxy, isTypedArray. Additional Node.js type checks (ArrayBuffer/DataView/most TypedArray flavors, shared buffers, etc.) are not yet implemented.",
+      "notes": "Provides type-checking functions. Supported checks: isArray, isDate, isError, isFunction, isPromise, isRegExp, isString, isNumber, isBoolean, isUndefined, isNull, isObject, isBigInt, isSymbol, isAsyncFunction, isMap, isSet, isProxy, isTypedArray, isAnyArrayBuffer, isArrayBuffer, isDataView, isUint8Array, isInt32Array, and isFloat64Array. Compatibility shims for unsupported runtime types such as SharedArrayBuffer and non-implemented typed-array flavors are also exposed and currently return false.",
       "docs": "https://nodejs.org/api/util.html#utiltypes",
       "tests": [
         {
@@ -92,6 +92,10 @@
           "file": "Js2IL.Tests/Node/Util/ExecutionTests.cs"
         },
         {
+          "name": "Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Types_TypedBinary",
+          "file": "Js2IL.Tests/Node/Util/ExecutionTests.cs"
+        },
+        {
           "name": "Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Types_IsPromise",
           "file": "Js2IL.Tests/Node/Util/GeneratorTests.cs"
         },
@@ -106,6 +110,10 @@
         {
           "name": "Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Types_Expanded",
           "file": "Js2IL.Tests/Node/Util/GeneratorTests.cs"
+        },
+        {
+          "name": "Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Types_TypedBinary",
+          "file": "Js2IL.Tests/Node/Util/GeneratorTests.cs"
         }
       ]
     },
@@ -113,7 +121,7 @@
       "name": "inspect(value[, options])",
       "kind": "function",
       "status": "partial",
-      "notes": "Provides basic object inspection for debugging. Supports depth limiting and handles circular references. Options supported: depth, showHidden, colors (parsed but colors not applied to output). Supports Node's custom inspect hook via util.inspect.custom (Symbol.for('nodejs.util.inspect.custom')).",
+      "notes": "Provides basic object inspection for debugging. Supports depth limiting, circular references, typed-array/ArrayBuffer/DataView formatting, and Node's custom inspect hook via util.inspect.custom (Symbol.for('nodejs.util.inspect.custom')). Options supported: depth, showHidden, colors (parsed but colors not applied to output).",
       "docs": "https://nodejs.org/api/util.html#utilinspectobject-options",
       "tests": [
         {
@@ -129,6 +137,10 @@
           "file": "Js2IL.Tests/Node/Util/ExecutionTests.cs"
         },
         {
+          "name": "Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Inspect_TypedBinary",
+          "file": "Js2IL.Tests/Node/Util/ExecutionTests.cs"
+        },
+        {
           "name": "Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Inspect_Basic",
           "file": "Js2IL.Tests/Node/Util/GeneratorTests.cs"
         },
@@ -138,6 +150,10 @@
         },
         {
           "name": "Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Inspect_Custom",
+          "file": "Js2IL.Tests/Node/Util/GeneratorTests.cs"
+        },
+        {
+          "name": "Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Inspect_TypedBinary",
           "file": "Js2IL.Tests/Node/Util/GeneratorTests.cs"
         }
       ]

--- a/docs/nodejs/util.md
+++ b/docs/nodejs/util.md
@@ -15,7 +15,7 @@
 
 ## Notes
 
-Provides essential utility functions for promisifying callbacks, prototype inheritance, type checking, and object inspection.
+Provides essential utility functions for promisifying callbacks, prototype inheritance, placeholder formatting, Node-style object inspection, and type checking for common runtime-backed binary/object shapes.
 
 ## APIs
 
@@ -57,26 +57,30 @@ Formats a string using placeholders like %s, %d/%i, %f, %j, %o/%O, and %% and ap
 
 ### types
 
-Provides type-checking functions. Supported checks: isArray, isDate, isError, isFunction, isPromise, isRegExp, isString, isNumber, isBoolean, isUndefined, isNull, isObject, isBigInt, isSymbol, isAsyncFunction, isMap, isSet, isProxy, isTypedArray. Additional Node.js type checks (ArrayBuffer/DataView/most TypedArray flavors, shared buffers, etc.) are not yet implemented.
+Provides type-checking functions. Supported checks: isArray, isDate, isError, isFunction, isPromise, isRegExp, isString, isNumber, isBoolean, isUndefined, isNull, isObject, isBigInt, isSymbol, isAsyncFunction, isMap, isSet, isProxy, isTypedArray, isAnyArrayBuffer, isArrayBuffer, isDataView, isUint8Array, isInt32Array, and isFloat64Array. Compatibility shims for unsupported runtime types such as SharedArrayBuffer and non-implemented typed-array flavors are also exposed and currently return false.
 
 **Tests:**
 - `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Types_IsPromise` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
 - `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Types_IsArray` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
 - `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Types_IsFunction` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
 - `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Types_Expanded` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
+- `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Types_TypedBinary` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
 - `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Types_IsPromise` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)
 - `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Types_IsArray` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)
 - `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Types_IsFunction` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)
 - `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Types_Expanded` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)
+- `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Types_TypedBinary` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)
 
 ### inspect(value[, options])
 
-Provides basic object inspection for debugging. Supports depth limiting and handles circular references. Options supported: depth, showHidden, colors (parsed but colors not applied to output). Supports Node's custom inspect hook via util.inspect.custom (Symbol.for('nodejs.util.inspect.custom')).
+Provides basic object inspection for debugging. Supports depth limiting, circular references, typed-array/ArrayBuffer/DataView formatting, and Node's custom inspect hook via util.inspect.custom (Symbol.for('nodejs.util.inspect.custom')). Options supported: depth, showHidden, colors (parsed but colors not applied to output).
 
 **Tests:**
 - `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Inspect_Basic` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
 - `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Inspect_Object` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
 - `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Inspect_Custom` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
+- `Js2IL.Tests.Node.Util.ExecutionTests.Require_Util_Inspect_TypedBinary` (`Js2IL.Tests/Node/Util/ExecutionTests.cs`)
 - `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Inspect_Basic` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)
 - `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Inspect_Object` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)
 - `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Inspect_Custom` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)
+- `Js2IL.Tests.Node.Util.GeneratorTests.Require_Util_Inspect_TypedBinary` (`Js2IL.Tests/Node/Util/GeneratorTests.cs`)

--- a/docs/tracking-issues/IssueTriage-2026-03-06.md
+++ b/docs/tracking-issues/IssueTriage-2026-03-06.md
@@ -3,26 +3,25 @@
 This file captures a point-in-time prioritized list of open issues/PRs and the current active item being addressed.
 
 Synced to:
-- Repo: `master` @ `eca5bed8` (post-merge state through PR #824 / issue #779)
+- Repo: `master` @ `755c6c02` (current post-PR-825 review branch-off point)
 - GitHub: open issues/PRs state as of 2026-03-09 (refreshed in-place)
 
 ## Current active item
-**Issue #780** (OPEN; active work is now on `copilot/gh-780-array-iterator-methods`, with PR #825 open for review):
-- https://github.com/tomacox74/js2il/issues/780
-- PR: https://github.com/tomacox74/js2il/pull/825
-
-Rationale:
-- #779 is now closed via merged PR #824, so #780 becomes the next unfinished ranked medium-priority ECMA-262 item from the prior sequence.
-- The current branch exposes `Array.prototype.entries` / `keys` / `values` / `%Symbol.iterator%`, routes array spread and `for..of` through the same iterator surface, extends `Array.from(...)` iterator-source handling, and updates related ECMA-262 docs/tests.
-- PR #825 is open, so this now reads as active landing/review work rather than an unstarted backlog item.
-
-## Recommended next item after #780
-**Issue #787** (OPEN):
+**Issue #787** (OPEN; active work is now on `copilot/gh-787-node-util-essentials`):
 - https://github.com/tomacox74/js2il/issues/787
 
 Rationale:
-- Once the Array iterator work lands, #787 becomes the next unfinished medium-priority item in the overall ranked list.
-- It targets pragmatic Node utility surface area with broad ecosystem leverage and still ranks ahead of the lower-priority WeakRef/finalization work.
+- #780 remains active in PR #825 review, so the next ranked unfinished issue after the current active PR becomes #787 from the triage ordering.
+- `util.format` already had a baseline, making #787 a good slice for expanding `util.types` breadth and `util.inspect` parity around runtime-backed binary/object shapes with focused Node test/doc coverage.
+- The new branch targets a self-contained Node module surface with high transitive ecosystem leverage.
+
+## Recommended next item after #787
+**Issue #788** (OPEN):
+- https://github.com/tomacox74/js2il/issues/788
+
+Rationale:
+- Once the util essentials follow-up lands, #788 becomes the next unfinished medium-priority Node compatibility item in the overall ranked list.
+- It builds on the recently expanded CommonJS/process/stream/fs groundwork and has similarly strong ecosystem leverage.
 
 ## Recently completed since the previous snapshot
 - **#779** (priority:medium) ECMA-262: Symbol ecosystem completeness audit (well-known symbols + symbol-key introspection semantics) — CLOSED via PR #824 on 2026-03-09
@@ -65,52 +64,50 @@ Rationale:
 ## Top 10 open issues after the current active item (excluding #772, which still looks like hygiene work)
 (Heuristic ranking using `priority:*` labels + module/spec/perf keywords in titles/labels; recommendation-only.)
 
-1. #787 (priority:medium) node: expand util essentials (format, inspect parity, util.types breadth)
-   - https://github.com/tomacox74/js2il/issues/787
-2. #788 (priority:medium) node: expand child_process beyond sync (spawn/exec/execFile, stdio pipes)
+1. #788 (priority:medium) node: expand child_process beyond sync (spawn/exec/execFile, stdio pipes)
    - https://github.com/tomacox74/js2il/issues/788
-3. #789 (priority:medium) node: implement url/querystring baseline (URL, URLSearchParams, parse/stringify)
+2. #789 (priority:medium) node: implement url/querystring baseline (URL, URLSearchParams, parse/stringify)
    - https://github.com/tomacox74/js2il/issues/789
-4. #790 (priority:medium) node: implement crypto minimum practical subset (createHash, randomBytes, webcrypto bridge)
+3. #790 (priority:medium) node: implement crypto minimum practical subset (createHash, randomBytes, webcrypto bridge)
    - https://github.com/tomacox74/js2il/issues/790
-5. #583 (priority:medium) Quality: add real-world canary corpus smoke tests (bounded) for ecosystem stability
+4. #583 (priority:medium) Quality: add real-world canary corpus smoke tests (bounded) for ecosystem stability
    - https://github.com/tomacox74/js2il/issues/583
    - Current signal: PR #820 landed an initial bounded smoke gate, but the issue remains open for broader corpus/artifact follow-up.
-6. #781 (priority:low) ECMA-262: Implement WeakRef + FinalizationRegistry host cleanup model
+5. #781 (priority:low) ECMA-262: Implement WeakRef + FinalizationRegistry host cleanup model
    - https://github.com/tomacox74/js2il/issues/781
-7. #791 (priority:low) node: add ESM interop baseline (import.meta.url + Node-style ESM resolution plan)
+6. #791 (priority:low) node: add ESM interop baseline (import.meta.url + Node-style ESM resolution plan)
    - https://github.com/tomacox74/js2il/issues/791
-8. #792 (priority:low) node: add http/https/net/tls baseline plan (client/server skeleton)
+7. #792 (priority:low) node: add http/https/net/tls baseline plan (client/server skeleton)
    - https://github.com/tomacox74/js2il/issues/792
-9. #727 Function length/name should be descriptor-backed own properties
+8. #727 Function length/name should be descriptor-backed own properties
    - https://github.com/tomacox74/js2il/issues/727
-10. #728 Complete bound function semantics for constructor/new-target and metadata
+9. #728 Complete bound function semantics for constructor/new-target and metadata
    - https://github.com/tomacox74/js2il/issues/728
+10. #419 Hosting: support mutable CommonJS exports (Node-like)
+   - https://github.com/tomacox74/js2il/issues/419
 
 ## Remaining open issues
-11. #419 Hosting: support mutable CommonJS exports (Node-like)
-    - https://github.com/tomacox74/js2il/issues/419
-12. #439 Hosting: publish referenceable library/build NuGet package
+11. #439 Hosting: publish referenceable library/build NuGet package
     - https://github.com/tomacox74/js2il/issues/439
-13. #451 perf(il): expand typed temps/locals to reduce casts/boxing
+12. #451 perf(il): expand typed temps/locals to reduce casts/boxing
     - https://github.com/tomacox74/js2il/issues/451
-14. #737 perf: callsite-based typed parameter specialization for non-exported functions
+13. #737 perf: callsite-based typed parameter specialization for non-exported functions
     - https://github.com/tomacox74/js2il/issues/737
-15. #738 perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations
+14. #738 perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations
     - https://github.com/tomacox74/js2il/issues/738
-16. #740 perf(prime): keep sieve loop math in typed locals with fallback
+15. #740 perf(prime): keep sieve loop math in typed locals with fallback
     - https://github.com/tomacox74/js2il/issues/740
-17. #742 perf(prime): trim timing/config coercion overhead in main path
+16. #742 perf(prime): trim timing/config coercion overhead in main path
     - https://github.com/tomacox74/js2il/issues/742
-18. #743 perf(prime): add Prime perf acceptance gate and reporting
+17. #743 perf(prime): add Prime perf acceptance gate and reporting
     - https://github.com/tomacox74/js2il/issues/743
-19. #746 perf: make dromaeo-object-regexp faster than Jint prepared
+18. #746 perf: make dromaeo-object-regexp faster than Jint prepared
     - https://github.com/tomacox74/js2il/issues/746
-20. #747 perf(regexp): cache Regex instances by source+flags
+19. #747 perf(regexp): cache Regex instances by source+flags
     - https://github.com/tomacox74/js2il/issues/747
-21. #748 perf(dispatch): add RegExp fast paths in Object.CallMember1/2
+20. #748 perf(dispatch): add RegExp fast paths in Object.CallMember1/2
     - https://github.com/tomacox74/js2il/issues/748
-22. #768 Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)
+21. #768 Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)
     - https://github.com/tomacox74/js2il/issues/768
 
 ## Open PRs (for context)

--- a/docs/tracking-issues/NodeGapPopularityBacklog.md
+++ b/docs/tracking-issues/NodeGapPopularityBacklog.md
@@ -35,7 +35,7 @@
 | 2 | [Expand `path` module parity (normalize/parse/format/extname/isAbsolute, posix/win32)](https://github.com/tomacox74/js2il/issues/784) | `path` | Merged (PR #797) |
 | 3 | [Expand `fs` module parity (callbacks, buffers, mkdir/copyFile/readFile/writeFile)](https://github.com/tomacox74/js2il/issues/785) | `fs` | Merged (PR #800) |
 | 4 | [Expand `stream` module (Duplex/Transform/PassThrough + basic backpressure)](https://github.com/tomacox74/js2il/issues/786) | `stream` | In review (PR #803) |
-| 5 | [Expand `util` essentials (format, inspect parity, util.types breadth)](https://github.com/tomacox74/js2il/issues/787) | `util` | In review (PR #804) |
+| 5 | [Expand `util` essentials (format, inspect parity, util.types breadth)](https://github.com/tomacox74/js2il/issues/787) | `util` | In progress on `copilot/gh-787-node-util-essentials` |
 | 6 | [Expand `child_process` beyond sync (spawn/exec/execFile, stdio pipes)](https://github.com/tomacox74/js2il/issues/788) | `child_process` | Partial |
 | 7 | [Implement `url`/`querystring` baseline (URL, URLSearchParams, parse/stringify)](https://github.com/tomacox74/js2il/issues/789) | `url`, `querystring` | Not Yet Supported |
 | 8 | [Implement `crypto` minimum practical subset (createHash, randomBytes, webcrypto bridge)](https://github.com/tomacox74/js2il/issues/790) | `crypto` | Not Yet Supported |
@@ -75,7 +75,7 @@
 
 ## Issue 5: Expand `util` Essentials ([#787](https://github.com/tomacox74/js2il/issues/787))
 - Suggested labels: `enhancement`, `modules`, `priority:medium`
-- Status: in review (PR #804): https://github.com/tomacox74/js2il/pull/804
+- Status: in progress on `copilot/gh-787-node-util-essentials`; current slice expands typed-binary `util.types` breadth and `inspect` parity
 - Minimum acceptance:
   - `util.format` baseline + improved `inspect` parity in common cases
   - Expand `util.types` checks as runtime support allows


### PR DESCRIPTION
## Summary
- expand Node util type coverage for ArrayBuffer, DataView, and common runtime-backed typed arrays
- improve util.inspect / util.format coverage for typed binary objects and add focused execution/generator tests
- refresh util module docs plus triage/backlog tracking for issue #787

## Testing
- dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2IL.Tests.Node.Util" --nologo

Closes #787
