### PR TITLE
fix(packaging): improve NuGet package pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here.
 - packaging/hosting/tests/docs: add the new `Js2IL.SDK` NuGet package for issue #846, shipping an in-process MSBuild task plus `build\Js2IL.SDK.props` / `.targets` so host projects can declare `Js2ILCompile` items, compile JavaScript during `dotnet build`, and consume the generated module assembly without shelling out to the `js2il` tool.
 - packaging/hosting/samples/docs: migrate the hosting samples for issue #847 from the legacy `compiler\*.proj` shell-out flow onto direct `Js2IL.SDK` usage, move packaged sample content from the `js2il` tool nupkg into the `Js2IL.SDK` nupkg, and clarify when to use `js2il`, `Js2IL.Core`, and `Js2IL.SDK`.
 - release/tooling/docs: close issue #848 by teaching tagged release builds to pack and publish coordinated `JavaScriptRuntime`, `js2il`, `Js2IL.Core`, and `Js2IL.SDK` packages, adding a `npm run release:validate` gate that pairs packed-tool canaries with local SDK package-consumption tests, and staging `samples/Directory.Build.props` so release commits preserve aligned package versions.
+- packaging/nuget/docs/tests: close issue #849 by expanding the packaged `Js2IL.Core` / `Js2IL.SDK` README copy, cross-linking the `js2il`, `Js2IL.Core`, and `Js2IL.SDK` package pages, adding package-project URLs/tags for discoverability, and asserting the shipped nuspec/readme metadata in focused package tests before first publish.
 
 ## v0.9.0 - 2026-03-13
 

--- a/Js2IL.Tests/Js2ILSdkPackageTests.cs
+++ b/Js2IL.Tests/Js2ILSdkPackageTests.cs
@@ -22,10 +22,8 @@ public class Js2ILSdkPackageTests
             var sdkPackagePath = Path.Combine(feedDir, $"Js2IL.SDK.{packageVersion}.nupkg");
             Assert.True(File.Exists(sdkPackagePath), $"Expected package was not produced: {sdkPackagePath}");
 
-            using var archive = ZipFile.OpenRead(sdkPackagePath);
-            var entryNames = archive.Entries
-                .Select(entry => entry.FullName)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var package = ReadPackedPackage(sdkPackagePath);
+            var entryNames = package.EntryNames;
 
             Assert.Contains("build/Js2IL.SDK.props", entryNames);
             Assert.Contains("build/Js2IL.SDK.targets", entryNames);
@@ -47,21 +45,32 @@ public class Js2ILSdkPackageTests
             Assert.DoesNotContain("samples/Hosting.Domino/compiler/HostedDomino.proj", entryNames);
             Assert.DoesNotContain(entryNames, name => name.Contains("/js2il/", StringComparison.OrdinalIgnoreCase));
 
-            var nuspecEntry = archive.Entries.Single(entry => entry.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase));
-            using var nuspecStream = nuspecEntry.Open();
-            var nuspec = XDocument.Load(nuspecStream);
-            XNamespace ns = nuspec.Root!.Name.Namespace;
+            AssertPackagePageMetadata(
+                package,
+                expectedId: "Js2IL.SDK",
+                expectedDescription: "MSBuild SDK package for compiling JavaScript sources into .NET assemblies during dotnet build.",
+                expectedProjectUrl: "https://github.com/tomacox74/js2il/blob/master/docs/hosting/Index.md",
+                requiredTags:
+                [
+                    "compiler",
+                    "msbuild",
+                    "sdk",
+                    "hosting"
+                ],
+                requiredReadmeLinks:
+                [
+                    "https://www.nuget.org/packages/js2il",
+                    "https://www.nuget.org/packages/Js2IL.Core",
+                    "https://www.nuget.org/packages/Js2IL.SDK",
+                    "https://www.nuget.org/packages/JavaScriptRuntime"
+                ]);
 
-            var dependencyIds = nuspec
-                .Descendants(ns + "dependency")
-                .Select(element => (string?)element.Attribute("id"))
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .Cast<string>()
-                .ToArray();
+            var dependencyIds = GetDependencyIds(package.Nuspec);
 
             Assert.Contains("Js2IL.Core", dependencyIds, StringComparer.Ordinal);
             Assert.DoesNotContain("js2il", dependencyIds, StringComparer.OrdinalIgnoreCase);
 
+            using var archive = ZipFile.OpenRead(sdkPackagePath);
             var targetsEntry = archive.GetEntry("build/Js2IL.SDK.targets");
             Assert.NotNull(targetsEntry);
             using var targetsReader = new StreamReader(targetsEntry!.Open());
@@ -94,12 +103,60 @@ public class Js2ILSdkPackageTests
             var toolPackagePath = Path.Combine(feedDir, $"js2il.{packageVersion}.nupkg");
             Assert.True(File.Exists(toolPackagePath), $"Expected package was not produced: {toolPackagePath}");
 
-            using var archive = ZipFile.OpenRead(toolPackagePath);
-            var entryNames = archive.Entries
-                .Select(entry => entry.FullName)
-                .ToArray();
+            var package = ReadPackedPackage(toolPackagePath);
+            var entryNames = package.EntryNames.ToArray();
 
             Assert.DoesNotContain(entryNames, name => name.StartsWith("samples/", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains("README.md", entryNames);
+            Assert.Contains("icon.jpg", entryNames);
+            Assert.Contains("https://www.nuget.org/packages/Js2IL.Core", package.ReadmeText, StringComparison.Ordinal);
+            Assert.Contains("https://www.nuget.org/packages/Js2IL.SDK", package.ReadmeText, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { Directory.Delete(tempRoot, recursive: true); } catch { /* ignore */ }
+        }
+    }
+
+    [Fact]
+    public void Pack_Js2ILCore_ContainsReadmeIconAndDiscoverabilityMetadata()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "js2il-sdk-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var repoRoot = FindRepoRoot();
+            var feedDir = Path.Combine(tempRoot, "feed");
+            Directory.CreateDirectory(feedDir);
+
+            var packageVersion = PackLocalFeed(repoRoot, feedDir);
+            var corePackagePath = Path.Combine(feedDir, $"Js2IL.Core.{packageVersion}.nupkg");
+            Assert.True(File.Exists(corePackagePath), $"Expected package was not produced: {corePackagePath}");
+
+            var package = ReadPackedPackage(corePackagePath);
+
+            AssertPackagePageMetadata(
+                package,
+                expectedId: "Js2IL.Core",
+                expectedDescription: "Reusable js2il compiler library for embedding JavaScript-to-.NET compilation in custom .NET tools and hosts.",
+                expectedProjectUrl: "https://github.com/tomacox74/js2il/blob/master/docs/hosting/Index.md",
+                requiredTags:
+                [
+                    "compiler",
+                    "library",
+                    "hosting"
+                ],
+                requiredReadmeLinks:
+                [
+                    "https://www.nuget.org/packages/js2il",
+                    "https://www.nuget.org/packages/Js2IL.Core",
+                    "https://www.nuget.org/packages/Js2IL.SDK",
+                    "https://www.nuget.org/packages/JavaScriptRuntime"
+                ]);
+
+            var dependencyIds = GetDependencyIds(package.Nuspec);
+            Assert.Contains("JavaScriptRuntime", dependencyIds, StringComparer.Ordinal);
         }
         finally
         {
@@ -392,6 +449,103 @@ public class Js2ILSdkPackageTests
         return version!;
     }
 
+    private static PackedPackage ReadPackedPackage(string packagePath)
+    {
+        using var archive = ZipFile.OpenRead(packagePath);
+
+        var entryNames = archive.Entries
+            .Select(entry => entry.FullName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var nuspecEntry = archive.Entries.Single(entry => entry.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase));
+        using var nuspecStream = nuspecEntry.Open();
+        var nuspec = XDocument.Load(nuspecStream);
+
+        var readmeEntry = archive.GetEntry("README.md");
+        Assert.NotNull(readmeEntry);
+
+        using var readmeReader = new StreamReader(readmeEntry!.Open());
+        var readmeText = readmeReader.ReadToEnd();
+
+        return new PackedPackage(entryNames, readmeText, nuspec);
+    }
+
+    private static void AssertPackagePageMetadata(
+        PackedPackage package,
+        string expectedId,
+        string expectedDescription,
+        string expectedProjectUrl,
+        string[] requiredTags,
+        string[] requiredReadmeLinks)
+    {
+        Assert.Contains("README.md", package.EntryNames);
+        Assert.Contains("icon.jpg", package.EntryNames);
+
+        Assert.Equal(expectedId, GetMetadataValue(package.Nuspec, "id"));
+        Assert.Equal(expectedDescription, GetMetadataValue(package.Nuspec, "description"));
+        Assert.Equal("README.md", GetMetadataValue(package.Nuspec, "readme"));
+        Assert.Equal("icon.jpg", GetMetadataValue(package.Nuspec, "icon"));
+        Assert.Equal(expectedProjectUrl, GetMetadataValue(package.Nuspec, "projectUrl"));
+        Assert.Equal("https://github.com/tomacox74/js2il", GetRepositoryUrl(package.Nuspec));
+        Assert.Equal("git", GetRepositoryType(package.Nuspec));
+
+        var tags = GetMetadataValue(package.Nuspec, "tags");
+        foreach (var tag in requiredTags)
+        {
+            Assert.Contains(tag, tags, StringComparison.OrdinalIgnoreCase);
+        }
+
+        foreach (var link in requiredReadmeLinks)
+        {
+            Assert.Contains(link, package.ReadmeText, StringComparison.Ordinal);
+        }
+    }
+
+    private static string[] GetDependencyIds(XDocument nuspec)
+    {
+        XNamespace ns = nuspec.Root!.Name.Namespace;
+        return nuspec
+            .Descendants(ns + "dependency")
+            .Select(element => (string?)element.Attribute("id"))
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Cast<string>()
+            .ToArray();
+    }
+
+    private static string GetMetadataValue(XDocument nuspec, string elementName)
+    {
+        XNamespace ns = nuspec.Root!.Name.Namespace;
+        var value = nuspec
+            .Descendants(ns + elementName)
+            .Select(element => element.Value)
+            .FirstOrDefault();
+
+        Assert.False(string.IsNullOrWhiteSpace(value), $"Could not find <{elementName}> in nuspec.");
+        return value!;
+    }
+
+    private static string GetRepositoryUrl(XDocument nuspec)
+    {
+        XNamespace ns = nuspec.Root!.Name.Namespace;
+        var repository = nuspec.Descendants(ns + "repository").FirstOrDefault();
+        Assert.NotNull(repository);
+
+        var url = (string?)repository!.Attribute("url");
+        Assert.False(string.IsNullOrWhiteSpace(url), "Could not find repository url in nuspec.");
+        return url!;
+    }
+
+    private static string GetRepositoryType(XDocument nuspec)
+    {
+        XNamespace ns = nuspec.Root!.Name.Namespace;
+        var repository = nuspec.Descendants(ns + "repository").FirstOrDefault();
+        Assert.NotNull(repository);
+
+        var type = (string?)repository!.Attribute("type");
+        Assert.False(string.IsNullOrWhiteSpace(type), "Could not find repository type in nuspec.");
+        return type!;
+    }
+
     private static string FindRepoRoot()
     {
         var start = new DirectoryInfo(Path.GetDirectoryName(typeof(Js2ILSdkPackageTests).Assembly.Location)!);
@@ -433,4 +587,6 @@ public class Js2ILSdkPackageTests
         var stdErr = stderrTask.GetAwaiter().GetResult();
         return (process.ExitCode, stdOut, stdErr);
     }
+
+    private sealed record PackedPackage(HashSet<string> EntryNames, string ReadmeText, XDocument Nuspec);
 }

--- a/docs/Js2IL.Core.NuGet.README.md
+++ b/docs/Js2IL.Core.NuGet.README.md
@@ -2,15 +2,85 @@
 
 `Js2IL.Core` is the referenceable NuGet package for the reusable js2il compiler library.
 
-It ships the `Js2IL.Compiler.dll` assembly so build tasks, hosts, and other .NET tooling can compile JavaScript to .NET assemblies without shelling out to the `js2il` CLI tool.
+It ships the `Js2IL.Compiler.dll` assembly and compiler dependencies so custom .NET tools, build tasks, test harnesses, and hosts can compile JavaScript to .NET assemblies without shelling out to the `js2il` CLI tool.
 
-The public entry points are the existing `Js2IL.Compiler`, `Js2IL.CompilerOptions`, and `Js2IL.CompilerServices` types in the `Js2IL` namespace.
+The primary entry points are the existing `Js2IL.Compiler`, `Js2IL.CompilerOptions`, and `Js2IL.CompilerServices` types in the `Js2IL` namespace.
 
 ## Which package should I use?
 
-- `Js2IL.Core`
+- [`Js2IL.Core`](https://www.nuget.org/packages/Js2IL.Core)
   - Use this when you want to embed the compiler directly in your own .NET code.
-- `Js2IL.SDK`
-  - Use this when you want MSBuild to compile JavaScript during `dotnet build`.
-- `js2il`
+- [`Js2IL.SDK`](https://www.nuget.org/packages/Js2IL.SDK)
+  - Use this when your project should compile JavaScript during `dotnet build`.
+- [`js2il`](https://www.nuget.org/packages/js2il)
   - Use this when you want the command-line tool for manual or ad-hoc compilation.
+- [`JavaScriptRuntime`](https://www.nuget.org/packages/JavaScriptRuntime)
+  - Use this when your host application needs the runtime support library used by generated assemblies.
+
+Official releases publish `JavaScriptRuntime`, `js2il`, `Js2IL.Core`, and `Js2IL.SDK` together at the same version. Keep the versions aligned when you mix them in one workflow.
+
+## Install
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Js2IL.Core" Version="VERSION" />
+</ItemGroup>
+```
+
+## Basic usage
+
+```csharp
+using Js2IL;
+using Microsoft.Extensions.DependencyInjection;
+
+var options = new CompilerOptions
+{
+    OutputDirectory = @"C:\code\out",
+    Verbose = true,
+    EmitPdb = true
+};
+
+using var services = CompilerServices.BuildServiceProvider(options);
+var compiler = services.GetRequiredService<Compiler>();
+
+if (!compiler.Compile(@"C:\code\sample.js"))
+{
+    throw new InvalidOperationException("Compilation failed.");
+}
+```
+
+`Compiler.Compile(...)` returns `true` on success and writes the generated files to `CompilerOptions.OutputDirectory`. If `OutputDirectory` is omitted, JS2IL writes next to the input file.
+
+## What gets generated?
+
+Given an input like `C:\code\sample.js`, JS2IL emits the following into the output directory:
+
+- `sample.dll`
+  - The compiled .NET assembly for your JavaScript.
+- `sample.runtimeconfig.json`
+  - Runtime configuration for the `dotnet` host.
+- `JavaScriptRuntime.dll` (+ optional `JavaScriptRuntime.pdb`)
+  - The runtime support library required to execute the generated assembly.
+
+## Useful options
+
+- `OutputDirectory`
+  - Where generated files are written. If omitted, output is written next to the input file.
+- `Verbose`
+  - Enables compiler progress logging.
+- `DiagnosticFilePath`
+  - Writes compiler diagnostics to a text file.
+- `AnalyzeUnused`
+  - Reports unused functions, properties, and variables.
+- `StrictMode`
+  - Controls how missing `"use strict"` directive prologues are reported.
+- `EmitPdb`
+  - Emits Portable PDB symbols next to the generated assembly.
+- `GenerateModuleExportContracts`
+  - Emits typed CommonJS export contracts for .NET hosting scenarios.
+
+## Links
+
+- Hosting docs: https://github.com/tomacox74/js2il/blob/master/docs/hosting/Index.md
+- Source, issues, docs: https://github.com/tomacox74/js2il
+- License: Apache-2.0

--- a/docs/Js2IL.SDK.NuGet.README.md
+++ b/docs/Js2IL.SDK.NuGet.README.md
@@ -6,12 +6,14 @@ It imports MSBuild props/targets, invokes `Js2IL.Core` in-process, and exposes t
 
 ## Which package should I use?
 
-- `Js2IL.SDK`
+- [`Js2IL.SDK`](https://www.nuget.org/packages/Js2IL.SDK)
   - Use this when your project should compile JavaScript during `dotnet build`.
-- `js2il`
+- [`js2il`](https://www.nuget.org/packages/js2il)
   - Use this when you want the standalone CLI/global tool for manual compilation.
-- `Js2IL.Core`
+- [`Js2IL.Core`](https://www.nuget.org/packages/Js2IL.Core)
   - Use this when you need the compiler as a reusable .NET library.
+- [`JavaScriptRuntime`](https://www.nuget.org/packages/JavaScriptRuntime)
+  - Use this when your host application needs the runtime support library used by compiled modules.
 
 Official releases publish `JavaScriptRuntime`, `js2il`, `Js2IL.Core`, and `Js2IL.SDK` together at the same version. When validating a local feed for SDK consumers, also pack `JavaScriptRuntime` into that feed because host projects reference it directly.
 
@@ -111,3 +113,9 @@ If you are validating a locally packed prerelease feed instead of NuGet.org, pac
   - The host project references `Js2IL.SDK` directly and declares a `Js2ILCompile` item that points at `compiler\JavaScript\*.js`.
 - `samples\Hosting.Domino`
   - The host project keeps `npm ci`, then compiles the restored entry file under `compiler\node_modules\@mixmark-io\domino\lib\index.js` with `RootModuleId="@mixmark-io/domino"` so `JsEngine.LoadModule(..., "@mixmark-io/domino")` continues to work.
+
+## Links
+
+- Hosting docs: https://github.com/tomacox74/js2il/blob/master/docs/hosting/Index.md
+- Source, issues, docs: https://github.com/tomacox74/js2il
+- License: Apache-2.0

--- a/docs/NuGet.README.md
+++ b/docs/NuGet.README.md
@@ -25,12 +25,14 @@ dotnet tool uninstall --global js2il
 
 ## Which package should I use?
 
-- `js2il`
+- [`js2il`](https://www.nuget.org/packages/js2il)
   - The global CLI tool for ad-hoc/manual JavaScript compilation from a terminal.
-- `Js2IL.SDK`
+- [`Js2IL.SDK`](https://www.nuget.org/packages/Js2IL.SDK)
   - The MSBuild/NuGet integration for host projects that should compile JavaScript during `dotnet build`.
-- `Js2IL.Core`
+- [`Js2IL.Core`](https://www.nuget.org/packages/Js2IL.Core)
   - The reusable compiler library for custom tooling, build tasks, or other programmatic .NET integration.
+- [`JavaScriptRuntime`](https://www.nuget.org/packages/JavaScriptRuntime)
+  - The runtime support library used by generated assemblies and .NET hosting scenarios.
 
 Official releases publish `JavaScriptRuntime`, `js2il`, `Js2IL.Core`, and `Js2IL.SDK` together at the same version. When you mix these packages in one workflow, keep the versions aligned.
 
@@ -106,7 +108,8 @@ The `js2il` tool package no longer carries the hosted C# samples. Those samples 
 See:
 
 - the repo `samples\` directory
-- `Js2IL.SDK` package README: `https://github.com/tomacox74/js2il/blob/master/docs/Js2IL.SDK.NuGet.README.md`
+- `Js2IL.SDK` package page: `https://www.nuget.org/packages/Js2IL.SDK`
+- `Js2IL.Core` package page: `https://www.nuget.org/packages/Js2IL.Core`
 
 ## Links
 

--- a/src/Js2IL.Core/Js2IL.Core.csproj
+++ b/src/Js2IL.Core/Js2IL.Core.csproj
@@ -12,13 +12,14 @@
     <Version>0.9.0</Version>
     <Authors>tomacox74</Authors>
     <Company></Company>
-    <Description>Reusable js2il compiler library for programmatic JavaScript-to-.NET compilation.</Description>
+    <Description>Reusable js2il compiler library for embedding JavaScript-to-.NET compilation in custom .NET tools and hosts.</Description>
+    <PackageProjectUrl>https://github.com/tomacox74/js2il/blob/master/docs/hosting/Index.md</PackageProjectUrl>
     <RepositoryUrl>https://github.com/tomacox74/js2il</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.jpg</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageTags>javascript;js;il;ecma-335;dotnet;compiler;library</PackageTags>
+    <PackageTags>javascript;js;il;ecma-335;dotnet;compiler;library;hosting</PackageTags>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/Js2IL.SDK/Js2IL.SDK.csproj
+++ b/src/Js2IL.SDK/Js2IL.SDK.csproj
@@ -9,13 +9,14 @@
     <Version>0.9.0</Version>
     <Authors>tomacox74</Authors>
     <Company></Company>
-    <Description>MSBuild SDK package for compiling JavaScript sources to .NET assemblies with js2il.</Description>
+    <Description>MSBuild SDK package for compiling JavaScript sources into .NET assemblies during dotnet build.</Description>
+    <PackageProjectUrl>https://github.com/tomacox74/js2il/blob/master/docs/hosting/Index.md</PackageProjectUrl>
     <RepositoryUrl>https://github.com/tomacox74/js2il</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.jpg</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageTags>javascript;js;il;ecma-335;dotnet;compiler;msbuild;sdk</PackageTags>
+    <PackageTags>javascript;js;il;ecma-335;dotnet;compiler;msbuild;sdk;hosting</PackageTags>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
 


### PR DESCRIPTION
Fixes #849.

- expand the packaged Js2IL.Core / Js2IL.SDK README copy and package-page cross-links
- add package-project URLs and discoverability tags for the new package pages
- assert nuspec/readme metadata in focused package tests before first publish