### PR TITLE
ci: add explicit workflow run names

### DIFF
--- a/.github/workflows/canary-smoke.yml
+++ b/.github/workflows/canary-smoke.yml
@@ -1,4 +1,5 @@
 name: Canary Smoke
+run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.release.tag_name || github.event.inputs.branch || github.head_ref || github.ref_name }}
 
 on:
   pull_request:

--- a/.github/workflows/differential.yml
+++ b/.github/workflows/differential.yml
@@ -1,4 +1,5 @@
 name: Differential Tests
+run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.release.tag_name || github.event.inputs.branch || github.head_ref || github.ref_name }}
 
 # Bounded differential test suite – Node.js vs JS2IL
 #

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,7 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.release.tag_name || github.event.inputs.branch || github.head_ref || github.ref_name }}
 
 on:
   push:

--- a/.github/workflows/performance-comparison.yml
+++ b/.github/workflows/performance-comparison.yml
@@ -1,4 +1,5 @@
 name: Performance Comparison
+run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.release.tag_name || github.event.inputs.branch || github.head_ref || github.ref_name }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-tool.yml
+++ b/.github/workflows/publish-tool.yml
@@ -1,4 +1,5 @@
 name: Publish coordinated packages
+run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.release.tag_name || github.event.inputs.branch || github.head_ref || github.ref_name }}
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.release.tag_name || github.event.inputs.branch || github.head_ref || github.ref_name }}
 
 on:
   push:


### PR DESCRIPTION
## Summary
- add explicit `run-name` values to workflows that were falling back to identical merge-commit titles in GitHub Actions
- make `.NET`, `Release`, `Publish coordinated packages`, and `Canary Smoke` easier to distinguish when they run on the same push
- apply the same pattern to `Differential Tests` and `Performance Comparison` so future runs stay easy to identify

## Validation
- `dotnet build js2il.sln -c Release --nologo`