### PR TITLE
docs(hosting): close out package validation

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Build and run Hosting.Domino sample
         run: |
           set -euo pipefail
-          output=$(dotnet run --project samples/Hosting.Domino/host/Hosting.Domino.csproj -c Release -p:JavaScriptRuntimePackageVersion="$TOOL_VERSION" 2>&1) || { echo "$output"; exit 1; }
+          output=$(dotnet run --project samples/Hosting.Domino/host/Hosting.Domino.csproj -c Release -p:Js2ILRuntimePackageVersion="$TOOL_VERSION" 2>&1) || { echo "$output"; exit 1; }
           echo "Program output:"
           echo "$output"
           echo "$output" | grep -i "title=JS2IL Domino Sample"
@@ -114,7 +114,7 @@ jobs:
       - name: Build and run Hosting.Basic sample
         run: |
           set -euo pipefail
-          output=$(dotnet run --project samples/Hosting.Basic/host/Hosting.Basic.csproj -c Release -p:JavaScriptRuntimePackageVersion="$TOOL_VERSION" 2>&1) || { echo "$output"; exit 1; }
+          output=$(dotnet run --project samples/Hosting.Basic/host/Hosting.Basic.csproj -c Release -p:Js2ILRuntimePackageVersion="$TOOL_VERSION" 2>&1) || { echo "$output"; exit 1; }
           echo "Program output:"
           echo "$output"
           echo "$output" | grep "version="
@@ -123,7 +123,7 @@ jobs:
       - name: Build and run Hosting.Typed sample
         run: |
           set -euo pipefail
-          output=$(dotnet run --project samples/Hosting.Typed/host/Hosting.Typed.csproj -c Release -p:JavaScriptRuntimePackageVersion="$TOOL_VERSION" 2>&1) || { echo "$output"; exit 1; }
+          output=$(dotnet run --project samples/Hosting.Typed/host/Hosting.Typed.csproj -c Release -p:Js2ILRuntimePackageVersion="$TOOL_VERSION" 2>&1) || { echo "$output"; exit 1; }
           echo "Program output:"
           echo "$output"
           echo "$output" | grep "version="

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -130,7 +130,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $output = dotnet run --project samples/Hosting.Domino/host/Hosting.Domino.csproj -c Release -p:JavaScriptRuntimePackageVersion="$env:TOOL_VERSION" 2>&1
+          $output = dotnet run --project samples/Hosting.Domino/host/Hosting.Domino.csproj -c Release -p:Js2ILRuntimePackageVersion="$env:TOOL_VERSION" 2>&1
           if ($LASTEXITCODE -ne 0) { $output; exit 1 }
           "Program output:" | Write-Output
           $output | Write-Output
@@ -142,7 +142,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $output = dotnet run --project samples/Hosting.Basic/host/Hosting.Basic.csproj -c Release -p:JavaScriptRuntimePackageVersion="$env:TOOL_VERSION" 2>&1
+          $output = dotnet run --project samples/Hosting.Basic/host/Hosting.Basic.csproj -c Release -p:Js2ILRuntimePackageVersion="$env:TOOL_VERSION" 2>&1
           if ($LASTEXITCODE -ne 0) { $output; exit 1 }
           "Program output:" | Write-Output
           $output | Write-Output
@@ -154,7 +154,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $output = dotnet run --project samples/Hosting.Typed/host/Hosting.Typed.csproj -c Release -p:JavaScriptRuntimePackageVersion="$env:TOOL_VERSION" 2>&1
+          $output = dotnet run --project samples/Hosting.Typed/host/Hosting.Typed.csproj -c Release -p:Js2ILRuntimePackageVersion="$env:TOOL_VERSION" 2>&1
           if ($LASTEXITCODE -ne 0) { $output; exit 1 }
           "Program output:" | Write-Output
           $output | Write-Output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+- docs/samples/workflows: close issue #850 and umbrella #439 by aligning the hosting sample docs and release smoke workflows with the `Js2IL.Runtime` package name and documenting the coordinated restore/build/post-publish validation matrix for the packaged hosting flow.
 
 ## v0.9.2 - 2026-03-14
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ This command currently does two things:
 - runs the PR canary suite against a freshly packed local `js2il` tool
 - runs the focused `Js2ILSdkPackageTests` suite, which packs `Js2IL.Runtime`, `Js2IL.Core`, and `Js2IL.SDK` into a local feed and verifies the SDK consumption path
 
+After the GitHub release is published, the `windows-smoke` and `linux-smoke` workflows install the tagged `js2il` tool from NuGet and build/run the `Hosting.Domino`, `Hosting.Basic`, and `Hosting.Typed` samples against the matching `Js2IL.SDK` / `Js2IL.Runtime` version.
+
+For the full restore/build/post-publish validation matrix used to close issues `#850` and `#439`, see [docs/hosting/PackagingValidation.md](docs/hosting/PackagingValidation.md).
+
 #### 4. Commit Version Bump
 
 Commit the changes on the release branch:

--- a/docs/hosting/Index.md
+++ b/docs/hosting/Index.md
@@ -76,3 +76,7 @@ The repo includes runnable `Js2IL.SDK`-based samples:
 - `samples/Hosting.Basic`
 - `samples/Hosting.Typed`
 - `samples/Hosting.Domino`
+
+## Validation and release smoke
+
+- [Hosting/NuGet package validation](PackagingValidation.md)

--- a/docs/hosting/PackagingValidation.md
+++ b/docs/hosting/PackagingValidation.md
@@ -1,0 +1,91 @@
+# Hosting/NuGet package validation
+
+This document is the audit trail for the coordinated package migration tracked by issues `#850` and `#439`.
+
+The package split is considered release-ready only when the following package flows are validated together:
+
+- `js2il` - dotnet tool for CLI users
+- `Js2IL.Core` - reusable compiler library
+- `Js2IL.SDK` - MSBuild integration for `Js2ILCompile`
+- `Js2IL.Runtime` - runtime and hosting package
+
+## Pre-publish validation
+
+### Coordinated release gate
+
+`npm run release:validate` is the required local gate before a release commit is created.
+
+It currently runs:
+
+- `npm run diff:test:canary:packed`
+- `dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2ILSdkPackageTests" --nologo`
+
+`scripts\release.js` invokes this command before it creates the release commit, so coordinated package regressions fail before the tag is cut.
+
+### `Js2IL.Core` restore/consumption coverage
+
+`Js2IL.Tests\Js2ILSdkPackageTests.cs` covers the referenceable compiler package with:
+
+- `Pack_Js2ILCore_ContainsReadmeIconAndDiscoverabilityMetadata`
+  - packs a local feed
+  - verifies package metadata, README links, and dependencies
+
+### `Js2IL.SDK` restore/build integration coverage
+
+`Js2IL.Tests\Js2ILSdkPackageTests.cs` covers the SDK package with:
+
+- `Pack_Js2ILSdk_ContainsBuildAssetsSamplesAndCoreDependency`
+  - verifies `.props` / `.targets`, task assets, bundled samples, and the `Js2IL.Core` dependency
+- `Build_WithLocalJs2ILSdkPackage_CompilesAndRunsHostedModule`
+  - restores the package from a local feed, builds a consumer project, and runs the generated module
+- `Build_ExtractedHostingBasicSample_WithLocalJs2ILSdkPackage_CompilesAndRuns`
+  - extracts `Js2IL.SDK` from the packed `.nupkg`, then builds/runs `samples\Hosting.Basic`
+- `Build_ExtractedHostingTypedSample_WithLocalJs2ILSdkPackage_CompilesAndRuns`
+  - extracts `Js2IL.SDK` from the packed `.nupkg`, then builds/runs `samples\Hosting.Typed`
+
+### Package boundary and discoverability checks
+
+The same focused package suite also verifies:
+
+- `Pack_Js2ILTool_DoesNotShipHostingSamples`
+  - ensures the `js2il` tool package stays separate from the SDK-hosted samples
+- `Pack_Js2ILRuntime_ContainsReadmeIconAndDiscoverabilityMetadata`
+  - verifies the runtime package metadata/readme surface used by hosting consumers
+
+## Post-publish smoke validation
+
+The published-package smoke flow is covered by:
+
+- `.github\workflows\windows-smoke.yml`
+- `.github\workflows\linux-smoke.yml`
+
+These workflows:
+
+- determine the tagged release version
+- install the tagged `js2il` tool from NuGet
+- compile and run `tests\simple.js`
+- build and run the hosted sample apps:
+  - `samples\Hosting.Domino`
+  - `samples\Hosting.Basic`
+  - `samples\Hosting.Typed`
+
+Each hosted sample restores `Js2IL.SDK` and `Js2IL.Runtime` at the tagged version, so the release smoke validates the actual end-user NuGet flow rather than a source-only shortcut.
+
+## Umbrella issue `#439` completion audit
+
+The umbrella packaging migration is complete because the dependent slices are now in place:
+
+- `#845`
+  - `Js2IL.Core` exists and ships `Js2IL.Compiler.dll`
+- `#846`
+  - `Js2IL.SDK` exists as the MSBuild/task package and depends on `Js2IL.Core`
+- `#847`
+  - hosting samples and docs migrated to `Js2IL.SDK`, and sample package content ships from `Js2IL.SDK`
+- `#848`
+  - tagged releases pack and publish `js2il`, `Js2IL.Core`, `Js2IL.SDK`, and `Js2IL.Runtime` together with aligned versions
+- `#849`
+  - the NuGet.org package pages, ownership, readmes, icons, and package cross-links were verified after first publish
+- `#850`
+  - restore/build/post-publish validation is covered by the release gate and smoke workflows above
+
+With these checks in place, the coordinated Hosting/NuGet migration tracked by issue `#439` is satisfied.

--- a/samples/Hosting.Basic/README.md
+++ b/samples/Hosting.Basic/README.md
@@ -7,7 +7,7 @@ Minimal end-to-end hosting sample:
 ## Layout
 
 - `compiler/JavaScript/` – source JS module compiled by the host project
-- `host/` – C# console app that restores `Js2IL.SDK` + `JavaScriptRuntime`, builds the JS module, and calls exports
+- `host/` – C# console app that restores `Js2IL.SDK` + `Js2IL.Runtime`, builds the JS module, and calls exports
 
 ## Prerequisites
 

--- a/samples/Hosting.Domino/README.md
+++ b/samples/Hosting.Domino/README.md
@@ -5,7 +5,7 @@ This sample demonstrates compiling and hosting a real npm package: `@mixmark-io/
 It is split into two parts:
 
 - `compiler/` – the npm manifest/lock file plus restored package contents consumed during build.
-- `host/` – a C# console app that restores `Js2IL.SDK` + `JavaScriptRuntime`, runs `npm ci`, compiles the package entry into a .NET assembly, and parses an included HTML document.
+- `host/` – a C# console app that restores `Js2IL.SDK` + `Js2IL.Runtime`, runs `npm ci`, compiles the package entry into a .NET assembly, and parses an included HTML document.
 
 ## Prerequisites
 

--- a/samples/Hosting.Typed/README.md
+++ b/samples/Hosting.Typed/README.md
@@ -8,7 +8,7 @@ Typed hosting sample demonstrating:
 ## Layout
 
 - `compiler/JavaScript/` – source JS module compiled by the host project
-- `host/` – C# console app that restores `Js2IL.SDK` + `JavaScriptRuntime`, builds the JS module, and calls exports
+- `host/` – C# console app that restores `Js2IL.SDK` + `Js2IL.Runtime`, builds the JS module, and calls exports
 
 ## Prerequisites
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -11,6 +11,6 @@ These samples demonstrate consuming **compiled** JavaScript modules as a .NET li
 Each sample is split into two parts:
 
 - `compiler/` – the JavaScript source inputs consumed during `dotnet build`. `Hosting.Domino` also keeps its npm manifest/lock file here so the host project can restore the package before compiling it.
-- `host/` – a C# console app that restores `Js2IL.SDK` and `JavaScriptRuntime`, compiles the JavaScript input via `Js2ILCompile`, and calls into the resulting module assembly using `Js2IL.Runtime` hosting APIs.
+- `host/` – a C# console app that restores `Js2IL.SDK` and `Js2IL.Runtime`, compiles the JavaScript input via `Js2ILCompile`, and calls into the resulting module assembly using `Js2IL.Runtime` hosting APIs.
 
 No separate `js2il` CLI shell-out project is required.


### PR DESCRIPTION
## Summary
- add an explicit Hosting/NuGet validation audit doc that maps issues #850 and #439 to the existing release gate, package tests, and post-publish smoke workflows
- align the hosted sample docs with the `Js2IL.Runtime` package name
- switch the release smoke workflows to `Js2ILRuntimePackageVersion` so the published-package validation uses the current package naming

## Validation
- `dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2ILSdkPackageTests" --nologo`
- `npm run release:validate`

Closes #850
Closes #439
