### PR TITLE
docs(ecma262): normalize section 29 hub formatting

### DIFF
--- a/docs/ECMA262/29/Section29.md
+++ b/docs/ECMA262/29/Section29.md
@@ -1,31 +1,31 @@
-﻿# Section 29: Memory Model
-
-Defines the ECMAScript memory model, including SharedArrayBuffer and atomic operation semantics.
-
-[Back to Index](../Index.md)
-
-> Last generated (UTC): 2026-03-15T19:43:49Z
-
-_This section is split into subsection documents for readability._
-
-## Section Entry
-
-| Clause | Title | Status | Link |
-|---:|---|---|---|
-| 29 | Memory Model | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-memory-model) |
-
-## Subsections
-
-| Subsection | Title | Status | Spec | Document |
-|---:|---|---|---|---|
-| 29.1 | Memory Model Fundamentals | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-memory-model-fundamentals) | [Section29_1.md](Section29_1.md) |
-| 29.2 | Agent Events Records | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-agent-event-records) | [Section29_2.md](Section29_2.md) |
-| 29.3 | Chosen Value Records | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-chosen-value-records) | [Section29_3.md](Section29_3.md) |
-| 29.4 | Candidate Executions | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-candidate-executions) | [Section29_4.md](Section29_4.md) |
-| 29.5 | Abstract Operations for the Memory Model | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-the-memory-model) | [Section29_5.md](Section29_5.md) |
-| 29.6 | Relations of Candidate Executions | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-relations-of-candidate-executions) | [Section29_6.md](Section29_6.md) |
-| 29.7 | Properties of Valid Executions | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-valid-executions) | [Section29_7.md](Section29_7.md) |
-| 29.8 | Races | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-races) | [Section29_8.md](Section29_8.md) |
-| 29.9 | Data Races | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-data-races) | [Section29_9.md](Section29_9.md) |
-| 29.10 | Data Race Freedom | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-data-race-freedom) | [Section29_10.md](Section29_10.md) |
-| 29.11 | Shared Memory Guidelines | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-shared-memory-guidelines) | [Section29_11.md](Section29_11.md) |
+﻿# Section 29: Memory Model
+
+Defines the ECMAScript memory model, including SharedArrayBuffer and atomic operation semantics.
+
+[Back to Index](../Index.md)
+
+> Last generated (UTC): 2026-03-15T19:43:49Z
+
+_This section is split into subsection documents for readability._
+
+## Section Entry
+
+| Clause | Title | Status | Link |
+|---:|---|---|---|
+| 29 | Memory Model | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-memory-model) |
+
+## Subsections
+
+| Subsection | Title | Status | Spec | Document |
+|---:|---|---|---|---|
+| 29.1 | Memory Model Fundamentals | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-memory-model-fundamentals) | [Section29_1.md](Section29_1.md) |
+| 29.2 | Agent Events Records | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-agent-event-records) | [Section29_2.md](Section29_2.md) |
+| 29.3 | Chosen Value Records | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-chosen-value-records) | [Section29_3.md](Section29_3.md) |
+| 29.4 | Candidate Executions | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-candidate-executions) | [Section29_4.md](Section29_4.md) |
+| 29.5 | Abstract Operations for the Memory Model | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-the-memory-model) | [Section29_5.md](Section29_5.md) |
+| 29.6 | Relations of Candidate Executions | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-relations-of-candidate-executions) | [Section29_6.md](Section29_6.md) |
+| 29.7 | Properties of Valid Executions | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-valid-executions) | [Section29_7.md](Section29_7.md) |
+| 29.8 | Races | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-races) | [Section29_8.md](Section29_8.md) |
+| 29.9 | Data Races | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-data-races) | [Section29_9.md](Section29_9.md) |
+| 29.10 | Data Race Freedom | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-data-race-freedom) | [Section29_10.md](Section29_10.md) |
+| 29.11 | Shared Memory Guidelines | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-shared-memory-guidelines) | [Section29_11.md](Section29_11.md) |


### PR DESCRIPTION
## Summary
- normalize `docs/ECMA262/29/Section29.md` line endings so the hub page renders its tables correctly on GitHub
- preserve the already-merged Section 29 audit content; this follow-up only fixes markdown formatting

## Validation
- inspected the raw bytes for `docs/ECMA262/29/Section29.md` before and after the fix (`CRCRLF` count went from 31 to 0)
- reopened the markdown locally to confirm the section-entry and subsection tables render as normal rows again
