### PR TITLE
ci: benchmark published packages

### DIFF
--- a/.github/workflows/benchmarkdotnet-suite.yml
+++ b/.github/workflows/benchmarkdotnet-suite.yml
@@ -12,6 +12,10 @@ on:
         description: 'Benchmark mode (default/phased/all)'
         required: false
         default: 'all'
+      js2il_package_version:
+        description: 'Published Js2IL package version to benchmark (for example 0.9.5)'
+        required: false
+        default: ''
   release:
     types: [published]
 
@@ -36,9 +40,72 @@ jobs:
         with:
           dotnet-version: '10.0.x'
       
-      - name: Build Projects
+      - name: Determine js2il benchmark package mode
+        shell: bash
+        env:
+          INPUT_JS2IL_PACKAGE_VERSION: ${{ github.event.inputs.js2il_package_version || '' }}
         run: |
-          dotnet build -c Release
+          set -euo pipefail
+
+          package_version=""
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            package_version="${{ github.event.release.tag_name }}"
+          elif [ -n "$INPUT_JS2IL_PACKAGE_VERSION" ]; then
+            package_version="$INPUT_JS2IL_PACKAGE_VERSION"
+          elif [ "${GITHUB_REF_TYPE:-}" = "tag" ] && [[ "${GITHUB_REF_NAME}" == v* ]]; then
+            package_version="${GITHUB_REF_NAME}"
+          fi
+
+          package_version="${package_version#v}"
+
+          if [ -n "$package_version" ]; then
+            echo "Using published Js2IL packages version: $package_version"
+            echo "USE_PUBLISHED_JS2IL_PACKAGES=true" >> "$GITHUB_ENV"
+            echo "JS2IL_PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
+          else
+            echo "Using checked-out source tree projects for Js2IL benchmarks"
+            echo "USE_PUBLISHED_JS2IL_PACKAGES=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Restore benchmark project
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${USE_PUBLISHED_JS2IL_PACKAGES}" = "true" ]; then
+            tries=20
+            delay=30
+
+            for i in $(seq 1 $tries); do
+              if dotnet restore tests/performance/Benchmarks/Benchmarks.csproj \
+                -p:UsePublishedJs2ILPackages=true \
+                -p:Js2ILPackageVersion="${JS2IL_PACKAGE_VERSION}"; then
+                echo "Restored Js2IL benchmark packages ${JS2IL_PACKAGE_VERSION}"
+                exit 0
+              fi
+
+              echo "Attempt $i/$tries: Js2IL benchmark packages ${JS2IL_PACKAGE_VERSION} not available yet on NuGet; waiting ${delay}s..."
+              sleep $delay
+            done
+
+            echo "Failed to restore Js2IL benchmark packages ${JS2IL_PACKAGE_VERSION} from NuGet after $tries attempts" >&2
+            exit 1
+          fi
+
+          dotnet restore tests/performance/Benchmarks/Benchmarks.csproj
+
+      - name: Build benchmark project
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MSBUILD_ARGS=()
+          if [ "${USE_PUBLISHED_JS2IL_PACKAGES}" = "true" ]; then
+            MSBUILD_ARGS+=(-p:UsePublishedJs2ILPackages=true -p:Js2ILPackageVersion="${JS2IL_PACKAGE_VERSION}")
+          fi
+
+          dotnet build tests/performance/Benchmarks/Benchmarks.csproj -c Release --no-restore "${MSBUILD_ARGS[@]}"
       
       - name: Shutdown build server
         run: |
@@ -47,12 +114,13 @@ jobs:
       
       - name: Run BenchmarkDotNet Suite
         id: benchmark
+        shell: bash
         env:
           BENCHMARK_MODE: ${{ github.event.inputs.mode || 'all' }}
           BENCHMARK_FILTER: ${{ github.event.inputs.benchmark_filter || '*' }}
         run: |
-          cd tests/performance/Benchmarks
-          
+          set -euo pipefail
+
           MODE_ARG=""
           if [ "$BENCHMARK_MODE" = "phased" ]; then
             MODE_ARG="--phased"
@@ -66,9 +134,14 @@ jobs:
           fi
           DOTNET_ARGS+=(--filter "$BENCHMARK_FILTER" --exporters json)
 
-          dotnet run -c Release -- "${DOTNET_ARGS[@]}"
+          MSBUILD_ARGS=()
+          if [ "${USE_PUBLISHED_JS2IL_PACKAGES}" = "true" ]; then
+            MSBUILD_ARGS+=(-p:UsePublishedJs2ILPackages=true -p:Js2ILPackageVersion="${JS2IL_PACKAGE_VERSION}")
+          fi
 
-          if [ ! -d "BenchmarkDotNet.Artifacts/results" ] || ! compgen -G "BenchmarkDotNet.Artifacts/results/*.json" > /dev/null; then
+          dotnet run --project tests/performance/Benchmarks/Benchmarks.csproj -c Release --no-build "${MSBUILD_ARGS[@]}" -- "${DOTNET_ARGS[@]}"
+
+          if [ ! -d "tests/performance/Benchmarks/BenchmarkDotNet.Artifacts/results" ] || ! compgen -G "tests/performance/Benchmarks/BenchmarkDotNet.Artifacts/results/*.json" > /dev/null; then
             echo "BenchmarkDotNet produced no result artifacts; failing workflow."
             exit 1
           fi

--- a/tests/performance/Benchmarks/Benchmarks.csproj
+++ b/tests/performance/Benchmarks/Benchmarks.csproj
@@ -6,7 +6,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <UsePublishedJs2ILPackages Condition="'$(UsePublishedJs2ILPackages)' == ''">false</UsePublishedJs2ILPackages>
   </PropertyGroup>
+
+  <Target Name="ValidatePublishedJs2ILPackageVersion"
+          BeforeTargets="CollectPackageReferences"
+          Condition="'$(UsePublishedJs2ILPackages)' == 'true' and '$(Js2ILPackageVersion)' == ''">
+    <Error Text="Set Js2ILPackageVersion when UsePublishedJs2ILPackages=true." />
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
@@ -17,9 +24,19 @@
     <None Include="Scenarios\**\*.js" CopyToOutputDirectory="PreserveNewest" LinkBase="Scenarios" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Js2IL.Core\Js2IL.Core.csproj" />
-    <ProjectReference Include="..\..\..\src\JavaScriptRuntime\JavaScriptRuntime.csproj" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(UsePublishedJs2ILPackages)' == 'true'">
+      <ItemGroup>
+        <PackageReference Include="Js2IL.Core" Version="$(Js2ILPackageVersion)" />
+        <PackageReference Include="Js2IL.Runtime" Version="$(Js2ILPackageVersion)" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Js2IL.Core\Js2IL.Core.csproj" />
+        <ProjectReference Include="..\..\..\src\JavaScriptRuntime\JavaScriptRuntime.csproj" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
 </Project>

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -78,6 +78,8 @@ cd tests/performance/Benchmarks
 dotnet build -c Release
 ```
 
+By default this project references the checked-out `src\Js2IL.Core` and `src\JavaScriptRuntime` projects so local benchmark runs measure your current working tree. To benchmark a published package set instead, pass `-p:UsePublishedJs2ILPackages=true -p:Js2ILPackageVersion=<version>` to `dotnet restore`, `dotnet build`, or `dotnet run`.
+
 ### Run Benchmarks
 
 #### Default: Cross-Runtime Comparison
@@ -220,14 +222,11 @@ Both are maintained for different use cases:
 
 ## CI Integration
 
-(To be implemented in Phase 5)
+The repository ships a `BenchmarkDotNet Performance Suite` workflow for CI benchmarking:
 
-The BenchmarkDotNet suite will be integrated into CI as informational-only:
-
-- Run reduced scenario set in CI
-- Upload structured artifacts
-- No hard PR gating initially
-- Optional nightly extended runs
+- Release-triggered runs restore `Js2IL.Core` and `Js2IL.Runtime` from NuGet using the published release version, with retry logic to wait for NuGet indexing.
+- Manual `workflow_dispatch` runs use the checked-out source tree by default, but can benchmark a published package version by setting the `js2il_package_version` input.
+- Structured BenchmarkDotNet artifacts are uploaded, and the JSON results can be ingested into Supabase for historical tracking.
 
 ## Future Enhancements
 


### PR DESCRIPTION
## Summary
- run release-triggered BenchmarkDotNet builds against the published Js2IL NuGet packages instead of source-tree project references
- keep local source-tree benchmarking as the default, with an opt-in package version for workflow_dispatch
- wait for NuGet indexing before the release benchmark workflow restores the tagged package version

## Validation
- dotnet build .\tests\performance\Benchmarks\Benchmarks.csproj -c Release --nologo
- dotnet build .\tests\performance\Benchmarks\Benchmarks.csproj -c Release --nologo -p:UsePublishedJs2ILPackages=true -p:Js2ILPackageVersion=0.9.5
- dotnet run --project .\tests\performance\Benchmarks\Benchmarks.csproj -c Release --no-build -p:UsePublishedJs2ILPackages=true -p:Js2ILPackageVersion=0.9.5 -- --validate