### PR TITLE
fix(runtime): model keyed collection constructors as function objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## Unreleased
 
 - compiler/debug/tests/docs: fix rewritten ES module Portable PDB sequence points by mapping both top-level rewrites and nested user-authored callable bodies back to the original source coordinates, hiding generated interop helper code, extending source-mapped stack-trace coverage for rewritten import/export flows, and documenting the remaining debugger limitations.
+- runtime/spec/tests: close issue #935 by wiring keyed-collection constructor values into the `Function.prototype` / `Object.prototype` chain like real built-in function objects, preserving their constructor/prototype descriptor surface, extending focused Map/Set/WeakMap/WeakSet reflective coverage, and documenting that broader constructor-object fidelity for other built-ins remains follow-up work.
 
 ## v0.9.6 - 2026-04-02
 

--- a/Js2IL.Tests/Map/JavaScript/Map_Constructor_Prototype_Surface.js
+++ b/Js2IL.Tests/Map/JavaScript/Map_Constructor_Prototype_Surface.js
@@ -2,6 +2,9 @@
 
 console.log(globalThis.Map === Map);
 console.log(Map.prototype.constructor === Map);
+console.log(Map instanceof Function);
+console.log(Object.getPrototypeOf(Map) === Function.prototype);
+console.log(Object.getPrototypeOf(Map.prototype) === Object.prototype);
 
 var descriptor = Object.getOwnPropertyDescriptor(Map, "prototype");
 console.log(descriptor.writable);

--- a/Js2IL.Tests/Map/Snapshots/ExecutionTests.Map_Constructor_Prototype_Surface.verified.txt
+++ b/Js2IL.Tests/Map/Snapshots/ExecutionTests.Map_Constructor_Prototype_Surface.verified.txt
@@ -1,5 +1,8 @@
 ﻿true
 true
+true
+true
+true
 false
 false
 false

--- a/Js2IL.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Prototype_Surface.verified.txt
+++ b/Js2IL.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Prototype_Surface.verified.txt
@@ -11,14 +11,14 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Block_L19C4
+		.class nested private auto ansi beforefieldinit Block_L22C4
 			extends [System.Runtime]System.Object
 		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x238d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -27,18 +27,18 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L19C4::.ctor
+			} // end of method Block_L22C4::.ctor
 
-		} // end of class Block_L19C4
+		} // end of class Block_L22C4
 
-		.class nested private auto ansi beforefieldinit Block_L23C12
+		.class nested private auto ansi beforefieldinit Block_L26C12
 			extends [System.Runtime]System.Object
 		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x2396
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,16 +47,16 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L23C12::.ctor
+			} // end of method Block_L26C12::.ctor
 
-		} // end of class Block_L23C12
+		} // end of class Block_L26C12
 
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x2384
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 625 (0x271)
+		// Code size: 790 (0x316)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Prototype_Surface/Scope,
@@ -131,166 +131,211 @@
 		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0076: pop
 		IL_0077: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
-		IL_007c: ldstr "prototype"
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0086: stloc.s 9
-		IL_0088: ldloc.s 9
-		IL_008a: stloc.1
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0090: ldloc.1
-		IL_0091: ldstr "writable"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a0: pop
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a6: ldloc.1
-		IL_00a7: ldstr "enumerable"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b6: pop
-		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bc: ldloc.1
-		IL_00bd: ldstr "configurable"
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cc: pop
-		IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
-		IL_00d2: stloc.s 10
-		IL_00d4: ldloc.s 10
-		IL_00d6: stloc.2
-		IL_00d7: ldloc.2
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_00dd: stloc.s 9
-		IL_00df: ldloc.s 9
-		IL_00e1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
-		IL_00e6: ldstr "prototype"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f5: stloc.s 7
-		IL_00f7: ldloc.s 7
-		IL_00f9: box [System.Runtime]System.Boolean
-		IL_00fe: stloc.s 8
-		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0105: ldloc.s 8
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: ldloc.2
-		IL_010e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
-		IL_0113: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0118: stloc.s 7
-		IL_011a: ldloc.s 7
-		IL_011c: box [System.Runtime]System.Boolean
-		IL_0121: stloc.s 8
-		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0128: ldloc.s 8
-		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012f: pop
-		IL_0130: ldloc.2
-		IL_0131: ldstr "constructor"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
-		IL_0140: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0145: stloc.s 7
-		IL_0147: ldloc.s 7
-		IL_0149: box [System.Runtime]System.Boolean
-		IL_014e: stloc.s 8
-		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0155: ldloc.s 8
-		IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015c: pop
-		IL_015d: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
-		IL_0162: ldstr "prototype"
+		IL_007c: call class [System.Runtime]System.Func`3<object[], object, class [System.Runtime]System.Delegate> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Function()
+		IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0086: stloc.s 7
+		IL_0088: ldloc.s 7
+		IL_008a: box [System.Runtime]System.Boolean
+		IL_008f: stloc.s 8
+		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0096: ldloc.s 8
+		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009d: pop
+		IL_009e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_00a8: stloc.s 9
+		IL_00aa: ldloc.s 9
+		IL_00ac: call class [System.Runtime]System.Func`3<object[], object, class [System.Runtime]System.Delegate> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Function()
+		IL_00b1: ldstr "prototype"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00c0: stloc.s 7
+		IL_00c2: ldloc.s 7
+		IL_00c4: box [System.Runtime]System.Boolean
+		IL_00c9: stloc.s 8
+		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d0: ldloc.s 8
+		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d7: pop
+		IL_00d8: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+		IL_00dd: ldstr "prototype"
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_00ec: stloc.s 9
+		IL_00ee: ldloc.s 9
+		IL_00f0: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_00f5: ldstr "prototype"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0104: stloc.s 7
+		IL_0106: ldloc.s 7
+		IL_0108: box [System.Runtime]System.Boolean
+		IL_010d: stloc.s 8
+		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0114: ldloc.s 8
+		IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011b: pop
+		IL_011c: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+		IL_0121: ldstr "prototype"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_012b: stloc.s 9
+		IL_012d: ldloc.s 9
+		IL_012f: stloc.1
+		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0135: ldloc.1
+		IL_0136: ldstr "writable"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0145: pop
+		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014b: ldloc.1
+		IL_014c: ldstr "enumerable"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015b: pop
+		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0161: ldloc.1
+		IL_0162: ldstr "configurable"
 		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016c: ldstr "set"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0176: stloc.s 9
-		IL_0178: ldloc.s 9
-		IL_017a: ldstr "call"
-		IL_017f: ldloc.2
-		IL_0180: ldstr "answer"
-		IL_0185: ldc.r8 42
-		IL_018e: box [System.Runtime]System.Double
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0198: pop
-		IL_0199: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
-		IL_019e: ldstr "prototype"
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a8: ldstr "get"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b2: ldstr "call"
-		IL_01b7: ldloc.2
-		IL_01b8: ldstr "answer"
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01c2: stloc.s 9
-		IL_01c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c9: ldloc.s 9
-		IL_01cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d0: pop
+		IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0171: pop
+		IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
+		IL_0177: stloc.s 10
+		IL_0179: ldloc.s 10
+		IL_017b: stloc.2
+		IL_017c: ldloc.2
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0182: stloc.s 9
+		IL_0184: ldloc.s 9
+		IL_0186: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+		IL_018b: ldstr "prototype"
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0195: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_019a: stloc.s 7
+		IL_019c: ldloc.s 7
+		IL_019e: box [System.Runtime]System.Boolean
+		IL_01a3: stloc.s 8
+		IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01aa: ldloc.s 8
+		IL_01ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b1: pop
+		IL_01b2: ldloc.2
+		IL_01b3: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+		IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_01bd: stloc.s 7
+		IL_01bf: ldloc.s 7
+		IL_01c1: box [System.Runtime]System.Boolean
+		IL_01c6: stloc.s 8
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cd: ldloc.s 8
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: ldloc.2
+		IL_01d6: ldstr "constructor"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e0: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+		IL_01e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01ea: stloc.s 7
+		IL_01ec: ldloc.s 7
+		IL_01ee: box [System.Runtime]System.Boolean
+		IL_01f3: stloc.s 8
+		IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fa: ldloc.s 8
+		IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0201: pop
+		IL_0202: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+		IL_0207: ldstr "prototype"
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0211: ldstr "set"
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021b: stloc.s 9
+		IL_021d: ldloc.s 9
+		IL_021f: ldstr "call"
+		IL_0224: ldloc.2
+		IL_0225: ldstr "answer"
+		IL_022a: ldc.r8 42
+		IL_0233: box [System.Runtime]System.Double
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_023d: pop
+		IL_023e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+		IL_0243: ldstr "prototype"
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024d: ldstr "get"
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0257: ldstr "call"
+		IL_025c: ldloc.2
+		IL_025d: ldstr "answer"
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0267: stloc.s 9
+		IL_0269: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_026e: ldloc.s 9
+		IL_0270: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0275: pop
 		.try
 		{
-			IL_01d1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
-			IL_01d6: stloc.3
-			IL_01d7: ldloc.3
-			IL_01d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
-			IL_01e2: pop
-			IL_01e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01e8: ldstr "no-throw"
-			IL_01ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01f2: pop
-			IL_01f3: leave IL_0270
+			IL_0276: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Map()
+			IL_027b: stloc.3
+			IL_027c: ldloc.3
+			IL_027d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
+			IL_0287: pop
+			IL_0288: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_028d: ldstr "no-throw"
+			IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0297: pop
+			IL_0298: leave IL_0315
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01f8: stloc.s 4
-			IL_01fa: ldloc.s 4
-			IL_01fc: dup
-			IL_01fd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0202: dup
-			IL_0203: brtrue IL_0219
+			IL_029d: stloc.s 4
+			IL_029f: ldloc.s 4
+			IL_02a1: dup
+			IL_02a2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02a7: dup
+			IL_02a8: brtrue IL_02be
 
-			IL_0208: pop
-			IL_0209: dup
-			IL_020a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_020f: dup
-			IL_0210: brtrue IL_0226
+			IL_02ad: pop
+			IL_02ae: dup
+			IL_02af: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02b4: dup
+			IL_02b5: brtrue IL_02cb
 
-			IL_0215: pop
-			IL_0216: pop
-			IL_0217: rethrow
+			IL_02ba: pop
+			IL_02bb: pop
+			IL_02bc: rethrow
 
-			IL_0219: pop
-			IL_021a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_021f: stloc.s 5
-			IL_0221: br IL_0229
+			IL_02be: pop
+			IL_02bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02c4: stloc.s 5
+			IL_02c6: br IL_02ce
 
-			IL_0226: pop
-			IL_0227: stloc.s 5
+			IL_02cb: pop
+			IL_02cc: stloc.s 5
 
-			IL_0229: ldloc.s 5
-			IL_022b: stloc.s 9
-			IL_022d: ldloc.s 9
-			IL_022f: stloc.s 6
-			IL_0231: ldloc.s 6
-			IL_0233: ldstr "name"
-			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023d: ldstr ": "
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0247: stloc.s 11
-			IL_0249: ldloc.s 11
-			IL_024b: ldloc.s 6
-			IL_024d: ldstr "message"
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_025c: stloc.s 11
-			IL_025e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0263: ldloc.s 11
-			IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_026a: pop
-			IL_026b: leave IL_0270
+			IL_02ce: ldloc.s 5
+			IL_02d0: stloc.s 9
+			IL_02d2: ldloc.s 9
+			IL_02d4: stloc.s 6
+			IL_02d6: ldloc.s 6
+			IL_02d8: ldstr "name"
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e2: ldstr ": "
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ec: stloc.s 11
+			IL_02ee: ldloc.s 11
+			IL_02f0: ldloc.s 6
+			IL_02f2: ldstr "message"
+			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0301: stloc.s 11
+			IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0308: ldloc.s 11
+			IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_030f: pop
+			IL_0310: leave IL_0315
 		} // end handler
 
-		IL_0270: ret
+		IL_0315: ret
 	} // end of method Map_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Prototype_Surface
@@ -302,7 +347,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22fb
+		// Method begins at RVA 0x239f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/Set/JavaScript/Set_Constructor_Prototype_Surface.js
+++ b/Js2IL.Tests/Set/JavaScript/Set_Constructor_Prototype_Surface.js
@@ -2,6 +2,9 @@
 
 console.log(globalThis.Set === Set);
 console.log(Set.prototype.constructor === Set);
+console.log(Set instanceof Function);
+console.log(Object.getPrototypeOf(Set) === Function.prototype);
+console.log(Object.getPrototypeOf(Set.prototype) === Object.prototype);
 
 var descriptor = Object.getOwnPropertyDescriptor(Set, "prototype");
 console.log(descriptor.writable);

--- a/Js2IL.Tests/Set/Snapshots/ExecutionTests.Set_Constructor_Prototype_Surface.verified.txt
+++ b/Js2IL.Tests/Set/Snapshots/ExecutionTests.Set_Constructor_Prototype_Surface.verified.txt
@@ -1,5 +1,8 @@
 ﻿true
 true
+true
+true
+true
 false
 false
 false

--- a/Js2IL.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Prototype_Surface.verified.txt
+++ b/Js2IL.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Prototype_Surface.verified.txt
@@ -11,14 +11,14 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Block_L19C4
+		.class nested private auto ansi beforefieldinit Block_L22C4
 			extends [System.Runtime]System.Object
 		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d5
+				// Method begins at RVA 0x2379
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -27,18 +27,18 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L19C4::.ctor
+			} // end of method Block_L22C4::.ctor
 
-		} // end of class Block_L19C4
+		} // end of class Block_L22C4
 
-		.class nested private auto ansi beforefieldinit Block_L23C12
+		.class nested private auto ansi beforefieldinit Block_L26C12
 			extends [System.Runtime]System.Object
 		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22de
+				// Method begins at RVA 0x2382
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,16 +47,16 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L23C12::.ctor
+			} // end of method Block_L26C12::.ctor
 
-		} // end of class Block_L23C12
+		} // end of class Block_L26C12
 
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22cc
+			// Method begins at RVA 0x2370
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 607 (0x25f)
+		// Code size: 772 (0x304)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Constructor_Prototype_Surface/Scope,
@@ -131,162 +131,207 @@
 		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0076: pop
 		IL_0077: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
-		IL_007c: ldstr "prototype"
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0086: stloc.s 9
-		IL_0088: ldloc.s 9
-		IL_008a: stloc.1
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0090: ldloc.1
-		IL_0091: ldstr "writable"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a0: pop
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a6: ldloc.1
-		IL_00a7: ldstr "enumerable"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b6: pop
-		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bc: ldloc.1
-		IL_00bd: ldstr "configurable"
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cc: pop
-		IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
-		IL_00d2: stloc.s 10
-		IL_00d4: ldloc.s 10
-		IL_00d6: stloc.2
-		IL_00d7: ldloc.2
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_00dd: stloc.s 9
-		IL_00df: ldloc.s 9
-		IL_00e1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
-		IL_00e6: ldstr "prototype"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f5: stloc.s 7
-		IL_00f7: ldloc.s 7
-		IL_00f9: box [System.Runtime]System.Boolean
-		IL_00fe: stloc.s 8
-		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0105: ldloc.s 8
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: ldloc.2
-		IL_010e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
-		IL_0113: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0118: stloc.s 7
-		IL_011a: ldloc.s 7
-		IL_011c: box [System.Runtime]System.Boolean
-		IL_0121: stloc.s 8
-		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0128: ldloc.s 8
-		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012f: pop
-		IL_0130: ldloc.2
-		IL_0131: ldstr "constructor"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
-		IL_0140: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0145: stloc.s 7
-		IL_0147: ldloc.s 7
-		IL_0149: box [System.Runtime]System.Boolean
-		IL_014e: stloc.s 8
-		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0155: ldloc.s 8
-		IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015c: pop
-		IL_015d: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
-		IL_0162: ldstr "prototype"
+		IL_007c: call class [System.Runtime]System.Func`3<object[], object, class [System.Runtime]System.Delegate> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Function()
+		IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0086: stloc.s 7
+		IL_0088: ldloc.s 7
+		IL_008a: box [System.Runtime]System.Boolean
+		IL_008f: stloc.s 8
+		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0096: ldloc.s 8
+		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009d: pop
+		IL_009e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_00a8: stloc.s 9
+		IL_00aa: ldloc.s 9
+		IL_00ac: call class [System.Runtime]System.Func`3<object[], object, class [System.Runtime]System.Delegate> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Function()
+		IL_00b1: ldstr "prototype"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00c0: stloc.s 7
+		IL_00c2: ldloc.s 7
+		IL_00c4: box [System.Runtime]System.Boolean
+		IL_00c9: stloc.s 8
+		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d0: ldloc.s 8
+		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d7: pop
+		IL_00d8: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+		IL_00dd: ldstr "prototype"
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_00ec: stloc.s 9
+		IL_00ee: ldloc.s 9
+		IL_00f0: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_00f5: ldstr "prototype"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0104: stloc.s 7
+		IL_0106: ldloc.s 7
+		IL_0108: box [System.Runtime]System.Boolean
+		IL_010d: stloc.s 8
+		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0114: ldloc.s 8
+		IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011b: pop
+		IL_011c: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+		IL_0121: ldstr "prototype"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_012b: stloc.s 9
+		IL_012d: ldloc.s 9
+		IL_012f: stloc.1
+		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0135: ldloc.1
+		IL_0136: ldstr "writable"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0145: pop
+		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014b: ldloc.1
+		IL_014c: ldstr "enumerable"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015b: pop
+		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0161: ldloc.1
+		IL_0162: ldstr "configurable"
 		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016c: ldstr "add"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0176: ldstr "call"
-		IL_017b: ldloc.2
-		IL_017c: ldstr "value"
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0186: pop
-		IL_0187: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
-		IL_018c: ldstr "prototype"
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0196: ldstr "has"
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a0: ldstr "call"
-		IL_01a5: ldloc.2
-		IL_01a6: ldstr "value"
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01b0: stloc.s 9
-		IL_01b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b7: ldloc.s 9
-		IL_01b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01be: pop
+		IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0171: pop
+		IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
+		IL_0177: stloc.s 10
+		IL_0179: ldloc.s 10
+		IL_017b: stloc.2
+		IL_017c: ldloc.2
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0182: stloc.s 9
+		IL_0184: ldloc.s 9
+		IL_0186: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+		IL_018b: ldstr "prototype"
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0195: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_019a: stloc.s 7
+		IL_019c: ldloc.s 7
+		IL_019e: box [System.Runtime]System.Boolean
+		IL_01a3: stloc.s 8
+		IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01aa: ldloc.s 8
+		IL_01ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b1: pop
+		IL_01b2: ldloc.2
+		IL_01b3: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+		IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_01bd: stloc.s 7
+		IL_01bf: ldloc.s 7
+		IL_01c1: box [System.Runtime]System.Boolean
+		IL_01c6: stloc.s 8
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cd: ldloc.s 8
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: ldloc.2
+		IL_01d6: ldstr "constructor"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e0: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+		IL_01e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01ea: stloc.s 7
+		IL_01ec: ldloc.s 7
+		IL_01ee: box [System.Runtime]System.Boolean
+		IL_01f3: stloc.s 8
+		IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fa: ldloc.s 8
+		IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0201: pop
+		IL_0202: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+		IL_0207: ldstr "prototype"
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0211: ldstr "add"
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021b: ldstr "call"
+		IL_0220: ldloc.2
+		IL_0221: ldstr "value"
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_022b: pop
+		IL_022c: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+		IL_0231: ldstr "prototype"
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023b: ldstr "has"
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0245: ldstr "call"
+		IL_024a: ldloc.2
+		IL_024b: ldstr "value"
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0255: stloc.s 9
+		IL_0257: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025c: ldloc.s 9
+		IL_025e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0263: pop
 		.try
 		{
-			IL_01bf: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
-			IL_01c4: stloc.3
-			IL_01c5: ldloc.3
-			IL_01c6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
-			IL_01d0: pop
-			IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01d6: ldstr "no-throw"
-			IL_01db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01e0: pop
-			IL_01e1: leave IL_025e
+			IL_0264: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Set()
+			IL_0269: stloc.3
+			IL_026a: ldloc.3
+			IL_026b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
+			IL_0275: pop
+			IL_0276: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_027b: ldstr "no-throw"
+			IL_0280: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0285: pop
+			IL_0286: leave IL_0303
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01e6: stloc.s 4
-			IL_01e8: ldloc.s 4
-			IL_01ea: dup
-			IL_01eb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01f0: dup
-			IL_01f1: brtrue IL_0207
+			IL_028b: stloc.s 4
+			IL_028d: ldloc.s 4
+			IL_028f: dup
+			IL_0290: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0295: dup
+			IL_0296: brtrue IL_02ac
 
-			IL_01f6: pop
-			IL_01f7: dup
-			IL_01f8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01fd: dup
-			IL_01fe: brtrue IL_0214
+			IL_029b: pop
+			IL_029c: dup
+			IL_029d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02a2: dup
+			IL_02a3: brtrue IL_02b9
 
-			IL_0203: pop
-			IL_0204: pop
-			IL_0205: rethrow
+			IL_02a8: pop
+			IL_02a9: pop
+			IL_02aa: rethrow
 
-			IL_0207: pop
-			IL_0208: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_020d: stloc.s 5
-			IL_020f: br IL_0217
+			IL_02ac: pop
+			IL_02ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02b2: stloc.s 5
+			IL_02b4: br IL_02bc
 
-			IL_0214: pop
-			IL_0215: stloc.s 5
+			IL_02b9: pop
+			IL_02ba: stloc.s 5
 
-			IL_0217: ldloc.s 5
-			IL_0219: stloc.s 9
-			IL_021b: ldloc.s 9
-			IL_021d: stloc.s 6
-			IL_021f: ldloc.s 6
-			IL_0221: ldstr "name"
-			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_022b: ldstr ": "
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0235: stloc.s 11
-			IL_0237: ldloc.s 11
-			IL_0239: ldloc.s 6
-			IL_023b: ldstr "message"
-			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_024a: stloc.s 11
-			IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0251: ldloc.s 11
-			IL_0253: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0258: pop
-			IL_0259: leave IL_025e
+			IL_02bc: ldloc.s 5
+			IL_02be: stloc.s 9
+			IL_02c0: ldloc.s 9
+			IL_02c2: stloc.s 6
+			IL_02c4: ldloc.s 6
+			IL_02c6: ldstr "name"
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d0: ldstr ": "
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02da: stloc.s 11
+			IL_02dc: ldloc.s 11
+			IL_02de: ldloc.s 6
+			IL_02e0: ldstr "message"
+			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ef: stloc.s 11
+			IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02f6: ldloc.s 11
+			IL_02f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02fd: pop
+			IL_02fe: leave IL_0303
 		} // end handler
 
-		IL_025e: ret
+		IL_0303: ret
 	} // end of method Set_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Prototype_Surface
@@ -298,7 +343,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e7
+		// Method begins at RVA 0x238b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/WeakMap/JavaScript/WeakMap_Constructor_Prototype_Surface.js
+++ b/Js2IL.Tests/WeakMap/JavaScript/WeakMap_Constructor_Prototype_Surface.js
@@ -2,6 +2,9 @@
 
 console.log(globalThis.WeakMap === WeakMap);
 console.log(WeakMap.prototype.constructor === WeakMap);
+console.log(WeakMap instanceof Function);
+console.log(Object.getPrototypeOf(WeakMap) === Function.prototype);
+console.log(Object.getPrototypeOf(WeakMap.prototype) === Object.prototype);
 
 var descriptor = Object.getOwnPropertyDescriptor(WeakMap, "prototype");
 console.log(descriptor.writable);

--- a/Js2IL.Tests/WeakMap/Snapshots/ExecutionTests.WeakMap_Constructor_Prototype_Surface.verified.txt
+++ b/Js2IL.Tests/WeakMap/Snapshots/ExecutionTests.WeakMap_Constructor_Prototype_Surface.verified.txt
@@ -1,5 +1,8 @@
 ﻿true
 true
+true
+true
+true
 false
 false
 false

--- a/Js2IL.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Constructor_Prototype_Surface.verified.txt
+++ b/Js2IL.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Constructor_Prototype_Surface.verified.txt
@@ -11,14 +11,14 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Block_L20C4
+		.class nested private auto ansi beforefieldinit Block_L23C4
 			extends [System.Runtime]System.Object
 		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x238d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -27,18 +27,18 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L20C4::.ctor
+			} // end of method Block_L23C4::.ctor
 
-		} // end of class Block_L20C4
+		} // end of class Block_L23C4
 
-		.class nested private auto ansi beforefieldinit Block_L24C12
+		.class nested private auto ansi beforefieldinit Block_L27C12
 			extends [System.Runtime]System.Object
 		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x2396
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,16 +47,16 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L24C12::.ctor
+			} // end of method Block_L27C12::.ctor
 
-		} // end of class Block_L24C12
+		} // end of class Block_L27C12
 
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x2384
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 625 (0x271)
+		// Code size: 790 (0x316)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Constructor_Prototype_Surface/Scope,
@@ -132,168 +132,213 @@
 		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0076: pop
 		IL_0077: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
-		IL_007c: ldstr "prototype"
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0086: stloc.s 10
-		IL_0088: ldloc.s 10
-		IL_008a: stloc.1
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0090: ldloc.1
-		IL_0091: ldstr "writable"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a0: pop
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a6: ldloc.1
-		IL_00a7: ldstr "enumerable"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b6: pop
-		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bc: ldloc.1
-		IL_00bd: ldstr "configurable"
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cc: pop
-		IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
-		IL_00d2: stloc.s 11
-		IL_00d4: ldloc.s 11
-		IL_00d6: stloc.2
-		IL_00d7: ldloc.2
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_00dd: stloc.s 10
-		IL_00df: ldloc.s 10
-		IL_00e1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
-		IL_00e6: ldstr "prototype"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f5: stloc.s 8
-		IL_00f7: ldloc.s 8
-		IL_00f9: box [System.Runtime]System.Boolean
-		IL_00fe: stloc.s 9
-		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0105: ldloc.s 9
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: ldloc.2
-		IL_010e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
-		IL_0113: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0118: stloc.s 8
-		IL_011a: ldloc.s 8
-		IL_011c: box [System.Runtime]System.Boolean
-		IL_0121: stloc.s 9
-		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0128: ldloc.s 9
-		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012f: pop
-		IL_0130: ldloc.2
-		IL_0131: ldstr "constructor"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
-		IL_0140: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0145: stloc.s 8
-		IL_0147: ldloc.s 8
-		IL_0149: box [System.Runtime]System.Boolean
-		IL_014e: stloc.s 9
-		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0155: ldloc.s 9
-		IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015c: pop
-		IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0162: stloc.3
-		IL_0163: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
-		IL_0168: ldstr "prototype"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0172: ldstr "set"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017c: stloc.s 10
-		IL_017e: ldloc.s 10
-		IL_0180: ldstr "call"
-		IL_0185: ldloc.2
-		IL_0186: ldloc.3
-		IL_0187: ldc.r8 7
-		IL_0190: box [System.Runtime]System.Double
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_019a: pop
-		IL_019b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
-		IL_01a0: ldstr "prototype"
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01aa: ldstr "get"
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b4: ldstr "call"
-		IL_01b9: ldloc.2
-		IL_01ba: ldloc.3
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01c0: stloc.s 10
-		IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c7: ldloc.s 10
-		IL_01c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ce: pop
+		IL_007c: call class [System.Runtime]System.Func`3<object[], object, class [System.Runtime]System.Delegate> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Function()
+		IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0086: stloc.s 8
+		IL_0088: ldloc.s 8
+		IL_008a: box [System.Runtime]System.Boolean
+		IL_008f: stloc.s 9
+		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0096: ldloc.s 9
+		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009d: pop
+		IL_009e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_00a8: stloc.s 10
+		IL_00aa: ldloc.s 10
+		IL_00ac: call class [System.Runtime]System.Func`3<object[], object, class [System.Runtime]System.Delegate> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Function()
+		IL_00b1: ldstr "prototype"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00c0: stloc.s 8
+		IL_00c2: ldloc.s 8
+		IL_00c4: box [System.Runtime]System.Boolean
+		IL_00c9: stloc.s 9
+		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d0: ldloc.s 9
+		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d7: pop
+		IL_00d8: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+		IL_00dd: ldstr "prototype"
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_00ec: stloc.s 10
+		IL_00ee: ldloc.s 10
+		IL_00f0: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_00f5: ldstr "prototype"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0104: stloc.s 8
+		IL_0106: ldloc.s 8
+		IL_0108: box [System.Runtime]System.Boolean
+		IL_010d: stloc.s 9
+		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0114: ldloc.s 9
+		IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011b: pop
+		IL_011c: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+		IL_0121: ldstr "prototype"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_012b: stloc.s 10
+		IL_012d: ldloc.s 10
+		IL_012f: stloc.1
+		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0135: ldloc.1
+		IL_0136: ldstr "writable"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0145: pop
+		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014b: ldloc.1
+		IL_014c: ldstr "enumerable"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015b: pop
+		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0161: ldloc.1
+		IL_0162: ldstr "configurable"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0171: pop
+		IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
+		IL_0177: stloc.s 11
+		IL_0179: ldloc.s 11
+		IL_017b: stloc.2
+		IL_017c: ldloc.2
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0182: stloc.s 10
+		IL_0184: ldloc.s 10
+		IL_0186: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+		IL_018b: ldstr "prototype"
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0195: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_019a: stloc.s 8
+		IL_019c: ldloc.s 8
+		IL_019e: box [System.Runtime]System.Boolean
+		IL_01a3: stloc.s 9
+		IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01aa: ldloc.s 9
+		IL_01ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b1: pop
+		IL_01b2: ldloc.2
+		IL_01b3: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+		IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_01bd: stloc.s 8
+		IL_01bf: ldloc.s 8
+		IL_01c1: box [System.Runtime]System.Boolean
+		IL_01c6: stloc.s 9
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cd: ldloc.s 9
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: ldloc.2
+		IL_01d6: ldstr "constructor"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e0: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+		IL_01e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01ea: stloc.s 8
+		IL_01ec: ldloc.s 8
+		IL_01ee: box [System.Runtime]System.Boolean
+		IL_01f3: stloc.s 9
+		IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fa: ldloc.s 9
+		IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0201: pop
+		IL_0202: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0207: stloc.3
+		IL_0208: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+		IL_020d: ldstr "prototype"
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0217: ldstr "set"
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0221: stloc.s 10
+		IL_0223: ldloc.s 10
+		IL_0225: ldstr "call"
+		IL_022a: ldloc.2
+		IL_022b: ldloc.3
+		IL_022c: ldc.r8 7
+		IL_0235: box [System.Runtime]System.Double
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_023f: pop
+		IL_0240: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+		IL_0245: ldstr "prototype"
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024f: ldstr "get"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0259: ldstr "call"
+		IL_025e: ldloc.2
+		IL_025f: ldloc.3
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0265: stloc.s 10
+		IL_0267: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_026c: ldloc.s 10
+		IL_026e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0273: pop
 		.try
 		{
-			IL_01cf: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
-			IL_01d4: stloc.s 4
-			IL_01d6: ldloc.s 4
-			IL_01d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
-			IL_01e2: pop
-			IL_01e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01e8: ldstr "no-throw"
-			IL_01ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01f2: pop
-			IL_01f3: leave IL_0270
+			IL_0274: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakMap()
+			IL_0279: stloc.s 4
+			IL_027b: ldloc.s 4
+			IL_027d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
+			IL_0287: pop
+			IL_0288: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_028d: ldstr "no-throw"
+			IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0297: pop
+			IL_0298: leave IL_0315
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01f8: stloc.s 5
-			IL_01fa: ldloc.s 5
-			IL_01fc: dup
-			IL_01fd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0202: dup
-			IL_0203: brtrue IL_0219
+			IL_029d: stloc.s 5
+			IL_029f: ldloc.s 5
+			IL_02a1: dup
+			IL_02a2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02a7: dup
+			IL_02a8: brtrue IL_02be
 
-			IL_0208: pop
-			IL_0209: dup
-			IL_020a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_020f: dup
-			IL_0210: brtrue IL_0226
+			IL_02ad: pop
+			IL_02ae: dup
+			IL_02af: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02b4: dup
+			IL_02b5: brtrue IL_02cb
 
-			IL_0215: pop
-			IL_0216: pop
-			IL_0217: rethrow
+			IL_02ba: pop
+			IL_02bb: pop
+			IL_02bc: rethrow
 
-			IL_0219: pop
-			IL_021a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_021f: stloc.s 6
-			IL_0221: br IL_0229
+			IL_02be: pop
+			IL_02bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02c4: stloc.s 6
+			IL_02c6: br IL_02ce
 
-			IL_0226: pop
-			IL_0227: stloc.s 6
+			IL_02cb: pop
+			IL_02cc: stloc.s 6
 
-			IL_0229: ldloc.s 6
-			IL_022b: stloc.s 10
-			IL_022d: ldloc.s 10
-			IL_022f: stloc.s 7
-			IL_0231: ldloc.s 7
-			IL_0233: ldstr "name"
-			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023d: ldstr ": "
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0247: stloc.s 12
-			IL_0249: ldloc.s 12
-			IL_024b: ldloc.s 7
-			IL_024d: ldstr "message"
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_025c: stloc.s 12
-			IL_025e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0263: ldloc.s 12
-			IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_026a: pop
-			IL_026b: leave IL_0270
+			IL_02ce: ldloc.s 6
+			IL_02d0: stloc.s 10
+			IL_02d2: ldloc.s 10
+			IL_02d4: stloc.s 7
+			IL_02d6: ldloc.s 7
+			IL_02d8: ldstr "name"
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e2: ldstr ": "
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ec: stloc.s 12
+			IL_02ee: ldloc.s 12
+			IL_02f0: ldloc.s 7
+			IL_02f2: ldstr "message"
+			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0301: stloc.s 12
+			IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0308: ldloc.s 12
+			IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_030f: pop
+			IL_0310: leave IL_0315
 		} // end handler
 
-		IL_0270: ret
+		IL_0315: ret
 	} // end of method WeakMap_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.WeakMap_Constructor_Prototype_Surface
@@ -305,7 +350,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22fb
+		// Method begins at RVA 0x239f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/Js2IL.Tests/WeakSet/JavaScript/WeakSet_Constructor_Prototype_Surface.js
+++ b/Js2IL.Tests/WeakSet/JavaScript/WeakSet_Constructor_Prototype_Surface.js
@@ -2,6 +2,9 @@
 
 console.log(globalThis.WeakSet === WeakSet);
 console.log(WeakSet.prototype.constructor === WeakSet);
+console.log(WeakSet instanceof Function);
+console.log(Object.getPrototypeOf(WeakSet) === Function.prototype);
+console.log(Object.getPrototypeOf(WeakSet.prototype) === Object.prototype);
 
 var descriptor = Object.getOwnPropertyDescriptor(WeakSet, "prototype");
 console.log(descriptor.writable);

--- a/Js2IL.Tests/WeakSet/Snapshots/ExecutionTests.WeakSet_Constructor_Prototype_Surface.verified.txt
+++ b/Js2IL.Tests/WeakSet/Snapshots/ExecutionTests.WeakSet_Constructor_Prototype_Surface.verified.txt
@@ -1,5 +1,8 @@
 ﻿true
 true
+true
+true
+true
 false
 false
 false

--- a/Js2IL.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Constructor_Prototype_Surface.verified.txt
+++ b/Js2IL.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Constructor_Prototype_Surface.verified.txt
@@ -11,14 +11,14 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Block_L20C4
+		.class nested private auto ansi beforefieldinit Block_L23C4
 			extends [System.Runtime]System.Object
 		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d5
+				// Method begins at RVA 0x2379
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -27,18 +27,18 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L20C4::.ctor
+			} // end of method Block_L23C4::.ctor
 
-		} // end of class Block_L20C4
+		} // end of class Block_L23C4
 
-		.class nested private auto ansi beforefieldinit Block_L24C12
+		.class nested private auto ansi beforefieldinit Block_L27C12
 			extends [System.Runtime]System.Object
 		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22de
+				// Method begins at RVA 0x2382
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,16 +47,16 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L24C12::.ctor
+			} // end of method Block_L27C12::.ctor
 
-		} // end of class Block_L24C12
+		} // end of class Block_L27C12
 
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22cc
+			// Method begins at RVA 0x2370
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 607 (0x25f)
+		// Code size: 772 (0x304)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Constructor_Prototype_Surface/Scope,
@@ -132,164 +132,209 @@
 		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0076: pop
 		IL_0077: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
-		IL_007c: ldstr "prototype"
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0086: stloc.s 10
-		IL_0088: ldloc.s 10
-		IL_008a: stloc.1
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0090: ldloc.1
-		IL_0091: ldstr "writable"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a0: pop
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a6: ldloc.1
-		IL_00a7: ldstr "enumerable"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b6: pop
-		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bc: ldloc.1
-		IL_00bd: ldstr "configurable"
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cc: pop
-		IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakSet::.ctor()
-		IL_00d2: stloc.s 11
-		IL_00d4: ldloc.s 11
-		IL_00d6: stloc.2
-		IL_00d7: ldloc.2
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_00dd: stloc.s 10
-		IL_00df: ldloc.s 10
-		IL_00e1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
-		IL_00e6: ldstr "prototype"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f5: stloc.s 8
-		IL_00f7: ldloc.s 8
-		IL_00f9: box [System.Runtime]System.Boolean
-		IL_00fe: stloc.s 9
-		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0105: ldloc.s 9
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: ldloc.2
-		IL_010e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
-		IL_0113: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0118: stloc.s 8
-		IL_011a: ldloc.s 8
-		IL_011c: box [System.Runtime]System.Boolean
-		IL_0121: stloc.s 9
-		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0128: ldloc.s 9
-		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012f: pop
-		IL_0130: ldloc.2
-		IL_0131: ldstr "constructor"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
-		IL_0140: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0145: stloc.s 8
-		IL_0147: ldloc.s 8
-		IL_0149: box [System.Runtime]System.Boolean
-		IL_014e: stloc.s 9
-		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0155: ldloc.s 9
-		IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015c: pop
-		IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0162: stloc.3
-		IL_0163: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
-		IL_0168: ldstr "prototype"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0172: ldstr "add"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017c: ldstr "call"
-		IL_0181: ldloc.2
-		IL_0182: ldloc.3
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0188: pop
-		IL_0189: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
-		IL_018e: ldstr "prototype"
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0198: ldstr "has"
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a2: ldstr "call"
-		IL_01a7: ldloc.2
-		IL_01a8: ldloc.3
-		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01ae: stloc.s 10
-		IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b5: ldloc.s 10
-		IL_01b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01bc: pop
+		IL_007c: call class [System.Runtime]System.Func`3<object[], object, class [System.Runtime]System.Delegate> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Function()
+		IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0086: stloc.s 8
+		IL_0088: ldloc.s 8
+		IL_008a: box [System.Runtime]System.Boolean
+		IL_008f: stloc.s 9
+		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0096: ldloc.s 9
+		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009d: pop
+		IL_009e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_00a8: stloc.s 10
+		IL_00aa: ldloc.s 10
+		IL_00ac: call class [System.Runtime]System.Func`3<object[], object, class [System.Runtime]System.Delegate> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Function()
+		IL_00b1: ldstr "prototype"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00c0: stloc.s 8
+		IL_00c2: ldloc.s 8
+		IL_00c4: box [System.Runtime]System.Boolean
+		IL_00c9: stloc.s 9
+		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d0: ldloc.s 9
+		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d7: pop
+		IL_00d8: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+		IL_00dd: ldstr "prototype"
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_00ec: stloc.s 10
+		IL_00ee: ldloc.s 10
+		IL_00f0: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_00f5: ldstr "prototype"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0104: stloc.s 8
+		IL_0106: ldloc.s 8
+		IL_0108: box [System.Runtime]System.Boolean
+		IL_010d: stloc.s 9
+		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0114: ldloc.s 9
+		IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011b: pop
+		IL_011c: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+		IL_0121: ldstr "prototype"
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_012b: stloc.s 10
+		IL_012d: ldloc.s 10
+		IL_012f: stloc.1
+		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0135: ldloc.1
+		IL_0136: ldstr "writable"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0145: pop
+		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014b: ldloc.1
+		IL_014c: ldstr "enumerable"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015b: pop
+		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0161: ldloc.1
+		IL_0162: ldstr "configurable"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0171: pop
+		IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakSet::.ctor()
+		IL_0177: stloc.s 11
+		IL_0179: ldloc.s 11
+		IL_017b: stloc.2
+		IL_017c: ldloc.2
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0182: stloc.s 10
+		IL_0184: ldloc.s 10
+		IL_0186: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+		IL_018b: ldstr "prototype"
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0195: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_019a: stloc.s 8
+		IL_019c: ldloc.s 8
+		IL_019e: box [System.Runtime]System.Boolean
+		IL_01a3: stloc.s 9
+		IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01aa: ldloc.s 9
+		IL_01ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b1: pop
+		IL_01b2: ldloc.2
+		IL_01b3: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+		IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_01bd: stloc.s 8
+		IL_01bf: ldloc.s 8
+		IL_01c1: box [System.Runtime]System.Boolean
+		IL_01c6: stloc.s 9
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cd: ldloc.s 9
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: ldloc.2
+		IL_01d6: ldstr "constructor"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e0: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+		IL_01e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01ea: stloc.s 8
+		IL_01ec: ldloc.s 8
+		IL_01ee: box [System.Runtime]System.Boolean
+		IL_01f3: stloc.s 9
+		IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fa: ldloc.s 9
+		IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0201: pop
+		IL_0202: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0207: stloc.3
+		IL_0208: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+		IL_020d: ldstr "prototype"
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0217: ldstr "add"
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0221: ldstr "call"
+		IL_0226: ldloc.2
+		IL_0227: ldloc.3
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_022d: pop
+		IL_022e: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+		IL_0233: ldstr "prototype"
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023d: ldstr "has"
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0247: ldstr "call"
+		IL_024c: ldloc.2
+		IL_024d: ldloc.3
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0253: stloc.s 10
+		IL_0255: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025a: ldloc.s 10
+		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0261: pop
 		.try
 		{
-			IL_01bd: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
-			IL_01c2: stloc.s 4
-			IL_01c4: ldloc.s 4
-			IL_01c6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
-			IL_01d0: pop
-			IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01d6: ldstr "no-throw"
-			IL_01db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01e0: pop
-			IL_01e1: leave IL_025e
+			IL_0262: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_WeakSet()
+			IL_0267: stloc.s 4
+			IL_0269: ldloc.s 4
+			IL_026b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
+			IL_0275: pop
+			IL_0276: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_027b: ldstr "no-throw"
+			IL_0280: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0285: pop
+			IL_0286: leave IL_0303
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01e6: stloc.s 5
-			IL_01e8: ldloc.s 5
-			IL_01ea: dup
-			IL_01eb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01f0: dup
-			IL_01f1: brtrue IL_0207
+			IL_028b: stloc.s 5
+			IL_028d: ldloc.s 5
+			IL_028f: dup
+			IL_0290: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0295: dup
+			IL_0296: brtrue IL_02ac
 
-			IL_01f6: pop
-			IL_01f7: dup
-			IL_01f8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01fd: dup
-			IL_01fe: brtrue IL_0214
+			IL_029b: pop
+			IL_029c: dup
+			IL_029d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02a2: dup
+			IL_02a3: brtrue IL_02b9
 
-			IL_0203: pop
-			IL_0204: pop
-			IL_0205: rethrow
+			IL_02a8: pop
+			IL_02a9: pop
+			IL_02aa: rethrow
 
-			IL_0207: pop
-			IL_0208: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_020d: stloc.s 6
-			IL_020f: br IL_0217
+			IL_02ac: pop
+			IL_02ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02b2: stloc.s 6
+			IL_02b4: br IL_02bc
 
-			IL_0214: pop
-			IL_0215: stloc.s 6
+			IL_02b9: pop
+			IL_02ba: stloc.s 6
 
-			IL_0217: ldloc.s 6
-			IL_0219: stloc.s 10
-			IL_021b: ldloc.s 10
-			IL_021d: stloc.s 7
-			IL_021f: ldloc.s 7
-			IL_0221: ldstr "name"
-			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_022b: ldstr ": "
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0235: stloc.s 12
-			IL_0237: ldloc.s 12
-			IL_0239: ldloc.s 7
-			IL_023b: ldstr "message"
-			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_024a: stloc.s 12
-			IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0251: ldloc.s 12
-			IL_0253: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0258: pop
-			IL_0259: leave IL_025e
+			IL_02bc: ldloc.s 6
+			IL_02be: stloc.s 10
+			IL_02c0: ldloc.s 10
+			IL_02c2: stloc.s 7
+			IL_02c4: ldloc.s 7
+			IL_02c6: ldstr "name"
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d0: ldstr ": "
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02da: stloc.s 12
+			IL_02dc: ldloc.s 12
+			IL_02de: ldloc.s 7
+			IL_02e0: ldstr "message"
+			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ef: stloc.s 12
+			IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02f6: ldloc.s 12
+			IL_02f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02fd: pop
+			IL_02fe: leave IL_0303
 		} // end handler
 
-		IL_025e: ret
+		IL_0303: ret
 	} // end of method WeakSet_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.WeakSet_Constructor_Prototype_Surface
@@ -301,7 +346,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e7
+		// Method begins at RVA 0x238b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -109,9 +109,12 @@ namespace JavaScriptRuntime
 
         static GlobalThis()
         {
+            PrototypeChain.SetPrototype(JavaScriptRuntime.Function.Prototype, _objectPrototypeValue);
+
             // Attach minimal prototypes to callable globals so patterns like
             // `Function.prototype.apply.bind(Array.prototype.push)` work even when code only
             // references GlobalThis static properties and never touches the globalThis object.
+            ConfigureBuiltinFunctionObject(_functionConstructorValue);
             PropertyDescriptorStore.DefineOrUpdate(_functionConstructorValue, "prototype", new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
@@ -789,6 +792,9 @@ namespace JavaScriptRuntime
 
         private static void ConfigureCollectionIntrinsicSurface(object constructorValue, object prototypeValue)
         {
+            ConfigureBuiltinFunctionObject(constructorValue);
+            PrototypeChain.SetPrototype(prototypeValue, _objectPrototypeValue);
+
             PropertyDescriptorStore.DefineOrUpdate(constructorValue, "prototype", new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
@@ -805,6 +811,11 @@ namespace JavaScriptRuntime
                 Writable = true,
                 Value = constructorValue
             });
+        }
+
+        private static void ConfigureBuiltinFunctionObject(object functionValue)
+        {
+            PrototypeChain.SetPrototype(functionValue, JavaScriptRuntime.Function.Prototype);
         }
     }
 }


### PR DESCRIPTION
## Summary
- model keyed-collection constructor values as real function objects by wiring their constructor delegates to `Function.prototype` and their prototype objects to `Object.prototype`
- extend the existing Map/Set/WeakMap/WeakSet constructor-surface tests to lock in the reflective behavior and refresh the affected Verify snapshots
- note in the changelog that broader constructor-object fidelity for other built-ins remains follow-up work

## Testing
- `dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2IL.Tests.Map.|FullyQualifiedName~Js2IL.Tests.Set.|FullyQualifiedName~Js2IL.Tests.WeakMap.|FullyQualifiedName~Js2IL.Tests.WeakSet." --nologo`

Closes #935