### PR TITLE
fix(node): enable extractor network mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-_Nothing yet._
+- node/http/https/scripts/tests/docs: fix WHATWG `URL` + second-argument request-option interop for `http.request(...)` / `https.request(...)` so URL-derived path/query and TLS/client overrides stay aligned with Node call shapes, broaden the ECMA-262 extractor's fallback transport to follow loopback `http://` or `https://` URLs through manual redirects, add focused HTTPS regression coverage plus end-to-end `--url` / `--auto` smoke tests for the real checked-in extractor script, and refresh the HTTPS docs.
 
 ## v0.9.7 - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-- node/http/https/scripts/tests/docs: fix WHATWG `URL` + second-argument request-option interop for `http.request(...)` / `https.request(...)` so URL-derived path/query and TLS/client overrides stay aligned with Node call shapes, broaden the ECMA-262 extractor's fallback transport to follow loopback `http://` or `https://` URLs through manual redirects, add focused HTTPS regression coverage plus end-to-end `--url` / `--auto` smoke tests for the real checked-in extractor script, and refresh the HTTPS docs.
+- node/http/https/tests/docs: fix WHATWG `URL` + second-argument request-option interop for `http.request(...)` / `https.request(...)` so URL-derived path/query and TLS/client overrides stay aligned with Node call shapes, add focused HTTPS regression coverage plus end-to-end `--url` / `--auto` smoke tests for the ECMA-262 extractor network workflow, and refresh the HTTPS docs.
 
 ## v0.9.7 - 2026-04-07
 

--- a/Js2IL.Tests/Integration/ExecutionTests.cs
+++ b/Js2IL.Tests/Integration/ExecutionTests.cs
@@ -1,4 +1,9 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
 using System.Threading.Tasks;
+using JavaScriptRuntime;
+using JavaScriptRuntime.DependencyInjection;
 
 namespace Js2IL.Tests.Integration
 {
@@ -8,5 +13,324 @@ namespace Js2IL.Tests.Integration
 
         [Fact]
         public Task Compile_Performance_Dromaeo_Object_Regexp() => ExecutionTest(nameof(Compile_Performance_Dromaeo_Object_Regexp));
+
+        [Fact]
+        public async Task Compile_Scripts_ExtractEcma262SectionHtml_UrlMode()
+        {
+            await using var server = await LoopbackEcma262Server.StartAsync();
+            using var currentDirectory = new TemporaryCurrentDirectory();
+
+            await ExecutionTest(
+                nameof(Compile_Scripts_ExtractEcma262SectionHtml_UrlMode),
+                additionalScripts: ["Compile_Scripts_ExtractEcma262SectionHtml"],
+                addMocks: services => services.RegisterInstance<IEnvironment>(
+                    new FixedCommandLineEnvironment(
+                        "dotnet",
+                        "extract-url-smoke.dll",
+                        server.RedirectUrl)));
+
+            Assert.Equal(
+                new[]
+                {
+                    LoopbackEcma262Server.RedirectRequestPath,
+                    LoopbackEcma262Server.FinalRequestPath,
+                },
+                server.RequestPaths);
+        }
+
+        [Fact]
+        public async Task Compile_Scripts_ExtractEcma262SectionHtml_AutoMode()
+        {
+            await using var server = await LoopbackEcma262Server.StartAsync();
+            using var currentDirectory = new TemporaryCurrentDirectory();
+
+            await ExecutionTest(
+                nameof(Compile_Scripts_ExtractEcma262SectionHtml_AutoMode),
+                additionalScripts: ["Compile_Scripts_ExtractEcma262SectionHtml"],
+                addMocks: services => services.RegisterInstance<IEnvironment>(
+                    new FixedCommandLineEnvironment(
+                        "dotnet",
+                        "extract-auto-smoke.dll",
+                        server.IndexUrl)));
+
+            Assert.Equal(
+                new[]
+                {
+                    LoopbackEcma262Server.IndexRequestPath,
+                    LoopbackEcma262Server.RedirectRequestPath,
+                    LoopbackEcma262Server.FinalRequestPath,
+                },
+                server.RequestPaths);
+        }
+
+        private sealed class FixedCommandLineEnvironment : IEnvironment
+        {
+            private readonly string[] _args;
+
+            public FixedCommandLineEnvironment(params string[] args)
+            {
+                _args = args;
+            }
+
+            public int ExitCode { get; set; }
+
+            public string[] GetCommandLineArgs() => _args;
+
+            public void Exit(int code)
+            {
+                ExitCode = code;
+            }
+
+            public void Exit()
+            {
+            }
+        }
+
+        private sealed class TemporaryCurrentDirectory : IDisposable
+        {
+            private readonly string _previousCurrentDirectory;
+
+            public string Path { get; }
+
+            public TemporaryCurrentDirectory()
+            {
+                _previousCurrentDirectory = Environment.CurrentDirectory;
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Js2IL.Tests", "Integration", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+                Environment.CurrentDirectory = Path;
+            }
+
+            public void Dispose()
+            {
+                Environment.CurrentDirectory = _previousCurrentDirectory;
+                try
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        private sealed class LoopbackEcma262Server : IAsyncDisposable
+        {
+            internal const string IndexRequestPath = "/multipage/";
+            internal const string RedirectRequestPath = "/multipage/control-abstraction-objects.html";
+            internal const string FinalRequestPath = "/pages/control-abstraction-objects.html";
+
+            private readonly TcpListener _listener;
+            private readonly CancellationTokenSource _cancellationTokenSource = new();
+            private readonly Task _acceptLoopTask;
+            private readonly List<string> _requestPaths = new();
+            private readonly object _gate = new();
+
+            private LoopbackEcma262Server(TcpListener listener)
+            {
+                _listener = listener;
+                _acceptLoopTask = Task.Run(() => AcceptLoopAsync(_cancellationTokenSource.Token));
+            }
+
+            public static Task<LoopbackEcma262Server> StartAsync()
+            {
+                var listener = new TcpListener(IPAddress.Loopback, 0);
+                listener.Start();
+                return Task.FromResult(new LoopbackEcma262Server(listener));
+            }
+
+            public string IndexUrl => $"http://127.0.0.1:{Port}{IndexRequestPath}";
+
+            public string RedirectUrl => $"http://127.0.0.1:{Port}{RedirectRequestPath}";
+
+            public IReadOnlyList<string> RequestPaths
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        return _requestPaths.ToArray();
+                    }
+                }
+            }
+
+            private int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+            public async ValueTask DisposeAsync()
+            {
+                _cancellationTokenSource.Cancel();
+                _listener.Stop();
+
+                try
+                {
+                    await _acceptLoopTask;
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                finally
+                {
+                    _cancellationTokenSource.Dispose();
+                }
+            }
+
+            private async Task AcceptLoopAsync(CancellationToken cancellationToken)
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    TcpClient client;
+                    try
+                    {
+                        client = await _listener.AcceptTcpClientAsync(cancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+
+                    await HandleClientAsync(client, cancellationToken);
+                }
+            }
+
+            private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+            {
+                using var _ = client;
+                using var stream = client.GetStream();
+
+                var requestText = await ReadRequestAsync(stream, cancellationToken);
+                var requestPath = ParseRequestPath(requestText);
+                lock (_gate)
+                {
+                    _requestPaths.Add(requestPath);
+                }
+
+                var response = CreateResponse(requestPath);
+                var bodyBytes = Encoding.UTF8.GetBytes(response.Body);
+
+                var headerBuilder = new StringBuilder();
+                headerBuilder.Append(response.StatusLine).Append("\r\n");
+                headerBuilder.Append("Connection: close\r\n");
+                headerBuilder.Append("Content-Length: ").Append(bodyBytes.Length).Append("\r\n");
+                foreach (var header in response.Headers)
+                {
+                    headerBuilder.Append(header.Key).Append(": ").Append(header.Value).Append("\r\n");
+                }
+
+                headerBuilder.Append("\r\n");
+
+                var headerBytes = Encoding.ASCII.GetBytes(headerBuilder.ToString());
+                await stream.WriteAsync(headerBytes, cancellationToken);
+                if (bodyBytes.Length > 0)
+                {
+                    await stream.WriteAsync(bodyBytes, cancellationToken);
+                }
+
+                await stream.FlushAsync(cancellationToken);
+            }
+
+            private static async Task<string> ReadRequestAsync(NetworkStream stream, CancellationToken cancellationToken)
+            {
+                var bytes = new List<byte>();
+                var buffer = new byte[1];
+                while (true)
+                {
+                    var read = await stream.ReadAsync(buffer, cancellationToken);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    bytes.Add(buffer[0]);
+                    var count = bytes.Count;
+                    if (count >= 4
+                        && bytes[count - 4] == '\r'
+                        && bytes[count - 3] == '\n'
+                        && bytes[count - 2] == '\r'
+                        && bytes[count - 1] == '\n')
+                    {
+                        break;
+                    }
+                }
+
+                return Encoding.ASCII.GetString(bytes.ToArray());
+            }
+
+            private static string ParseRequestPath(string requestText)
+            {
+                var requestLine = requestText.Split("\r\n", StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? string.Empty;
+                var parts = requestLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length < 2)
+                {
+                    return string.Empty;
+                }
+
+                var rawTarget = parts[1];
+                if (Uri.TryCreate(rawTarget, UriKind.Absolute, out var absoluteUri))
+                {
+                    return absoluteUri.PathAndQuery;
+                }
+
+                return rawTarget;
+            }
+
+            private static (string StatusLine, IReadOnlyDictionary<string, string> Headers, string Body) CreateResponse(string requestPath)
+            {
+                return requestPath switch
+                {
+                    IndexRequestPath => (
+                        "HTTP/1.1 200 OK",
+                        new Dictionary<string, string>
+                        {
+                            ["Content-Type"] = "text/html; charset=utf-8",
+                        },
+                        """
+                        <!doctype html>
+                        <html lang="en">
+                        <body>
+                          <a href="control-abstraction-objects.html#sec-generatorfunction-objects">
+                            <span class="secnum">27.3</span>
+                            Generator Function Objects
+                          </a>
+                        </body>
+                        </html>
+                        """),
+                    RedirectRequestPath => (
+                        "HTTP/1.1 302 Found",
+                        new Dictionary<string, string>
+                        {
+                            ["Content-Type"] = "text/plain; charset=utf-8",
+                            ["Location"] = FinalRequestPath,
+                        },
+                        "redirect"),
+                    FinalRequestPath => (
+                        "HTTP/1.1 200 OK",
+                        new Dictionary<string, string>
+                        {
+                            ["Content-Type"] = "text/html; charset=utf-8",
+                        },
+                        """
+                        <!doctype html>
+                        <html lang="en">
+                        <body>
+                          <emu-clause id="sec-generatorfunction-objects">
+                            <h1><span class="secnum">27.3</span> Generator Function Objects</h1>
+                            <p>Loopback extractor body.</p>
+                          </emu-clause>
+                        </body>
+                        </html>
+                        """),
+                    _ => (
+                        "HTTP/1.1 404 Not Found",
+                        new Dictionary<string, string>
+                        {
+                            ["Content-Type"] = "text/plain; charset=utf-8",
+                        },
+                        "not found"),
+                };
+            }
+        }
     }
 }

--- a/Js2IL.Tests/Integration/ExecutionTests.cs
+++ b/Js2IL.Tests/Integration/ExecutionTests.cs
@@ -22,12 +22,22 @@ namespace Js2IL.Tests.Integration
 
             await ExecutionTest(
                 nameof(Compile_Scripts_ExtractEcma262SectionHtml_UrlMode),
-                additionalScripts: ["Compile_Scripts_ExtractEcma262SectionHtml"],
+                additionalScripts:
+                [
+                    "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness",
+                ],
                 addMocks: services => services.RegisterInstance<IEnvironment>(
                     new FixedCommandLineEnvironment(
                         "dotnet",
                         "extract-url-smoke.dll",
-                        server.RedirectUrl)));
+                        "--section",
+                        "27.3",
+                        "--url",
+                        server.RedirectUrl,
+                        "--id",
+                        "sec-generatorfunction-objects",
+                        "--out",
+                        "section-url.html")));
 
             Assert.Equal(
                 new[]
@@ -46,12 +56,21 @@ namespace Js2IL.Tests.Integration
 
             await ExecutionTest(
                 nameof(Compile_Scripts_ExtractEcma262SectionHtml_AutoMode),
-                additionalScripts: ["Compile_Scripts_ExtractEcma262SectionHtml"],
+                additionalScripts:
+                [
+                    "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness",
+                ],
                 addMocks: services => services.RegisterInstance<IEnvironment>(
                     new FixedCommandLineEnvironment(
                         "dotnet",
                         "extract-auto-smoke.dll",
-                        server.IndexUrl)));
+                        "--section",
+                        "27.3",
+                        "--auto",
+                        "--index-url",
+                        server.IndexUrl,
+                        "--out",
+                        "section-auto.html")));
 
             Assert.Equal(
                 new[]

--- a/Js2IL.Tests/Integration/GeneratorTests.cs
+++ b/Js2IL.Tests/Integration/GeneratorTests.cs
@@ -21,11 +21,15 @@ namespace Js2IL.Tests.Integration
 
         [Fact]
         public Task Compile_Scripts_ExtractEcma262SectionHtml_UrlMode()
-            => GenerateTest(nameof(Compile_Scripts_ExtractEcma262SectionHtml_UrlMode), ["Compile_Scripts_ExtractEcma262SectionHtml"]);
+            => GenerateTest(
+                nameof(Compile_Scripts_ExtractEcma262SectionHtml_UrlMode),
+                ["Compile_Scripts_ExtractEcma262SectionHtml_TestHarness"]);
 
         [Fact]
         public Task Compile_Scripts_ExtractEcma262SectionHtml_AutoMode()
-            => GenerateTest(nameof(Compile_Scripts_ExtractEcma262SectionHtml_AutoMode), ["Compile_Scripts_ExtractEcma262SectionHtml"]);
+            => GenerateTest(
+                nameof(Compile_Scripts_ExtractEcma262SectionHtml_AutoMode),
+                ["Compile_Scripts_ExtractEcma262SectionHtml_TestHarness"]);
 
         [Fact]
         public Task Compile_Performance_Dromaeo_Object_Array_Modern() => GenerateTest(nameof(Compile_Performance_Dromaeo_Object_Array_Modern));

--- a/Js2IL.Tests/Integration/GeneratorTests.cs
+++ b/Js2IL.Tests/Integration/GeneratorTests.cs
@@ -20,6 +20,14 @@ namespace Js2IL.Tests.Integration
             => GenerateTest(nameof(Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown), ["node_modules/turndown/index"]);
 
         [Fact]
+        public Task Compile_Scripts_ExtractEcma262SectionHtml_UrlMode()
+            => GenerateTest(nameof(Compile_Scripts_ExtractEcma262SectionHtml_UrlMode), ["Compile_Scripts_ExtractEcma262SectionHtml"]);
+
+        [Fact]
+        public Task Compile_Scripts_ExtractEcma262SectionHtml_AutoMode()
+            => GenerateTest(nameof(Compile_Scripts_ExtractEcma262SectionHtml_AutoMode), ["Compile_Scripts_ExtractEcma262SectionHtml"]);
+
+        [Fact]
         public Task Compile_Performance_Dromaeo_Object_Array_Modern() => GenerateTest(nameof(Compile_Performance_Dromaeo_Object_Array_Modern));
 
         [Fact]

--- a/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_autoMode.js
+++ b/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_autoMode.js
@@ -1,45 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-
-function normalize(text, outFile) {
-  if (text.includes(' -> ')) {
-    text = text.substring(0, text.indexOf(' -> ') + 4) + '<outFile>';
-  }
-
-  return text
-    .replace(new RegExp(outFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '<outFile>')
-    .replace(/127\.0\.0\.1:\d+/g, '127.0.0.1:<port>')
-    .replace(/\r\n/g, '\n');
-}
-
 async function run() {
-  const indexUrl = process.argv[2];
-  const outFile = path.join(process.cwd(), 'section-auto.html');
-  const extractor = require('./Compile_Scripts_ExtractEcma262SectionHtml');
-  const lines = [];
-  const capture = (value) => {
-    lines.push(String(value));
-  };
-
-  await extractor.main([
-    'dotnet',
-    'extractEcma262SectionHtml.js',
-    '--section',
-    '27.3',
-    '--auto',
-    '--index-url',
-    indexUrl,
-    '--out',
-    outFile,
-  ], capture);
-
-  for (const line of lines) {
-    console.log(normalize(line, outFile));
-  }
-
-  console.log(normalize(fs.readFileSync(outFile, 'utf8'), outFile));
+  var harness = require('./Compile_Scripts_ExtractEcma262SectionHtml_TestHarness');
+  await harness.runHarnessCli();
 }
 
 run().catch((err) => {

--- a/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_autoMode.js
+++ b/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_autoMode.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function normalize(text, outFile) {
+  if (text.includes(' -> ')) {
+    text = text.substring(0, text.indexOf(' -> ') + 4) + '<outFile>';
+  }
+
+  return text
+    .replace(new RegExp(outFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '<outFile>')
+    .replace(/127\.0\.0\.1:\d+/g, '127.0.0.1:<port>')
+    .replace(/\r\n/g, '\n');
+}
+
+async function run() {
+  const indexUrl = process.argv[2];
+  const outFile = path.join(process.cwd(), 'section-auto.html');
+  const extractor = require('./Compile_Scripts_ExtractEcma262SectionHtml');
+  const lines = [];
+  const capture = (value) => {
+    lines.push(String(value));
+  };
+
+  await extractor.main([
+    'dotnet',
+    'extractEcma262SectionHtml.js',
+    '--section',
+    '27.3',
+    '--auto',
+    '--index-url',
+    indexUrl,
+    '--out',
+    outFile,
+  ], capture);
+
+  for (const line of lines) {
+    console.log(normalize(line, outFile));
+  }
+
+  console.log(normalize(fs.readFileSync(outFile, 'utf8'), outFile));
+}
+
+run().catch((err) => {
+  console.error(err && err.stack ? err.stack : (err && err.message ? err.message : err));
+  process.exitCode = 1;
+});

--- a/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_testHarness.js
+++ b/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_testHarness.js
@@ -1,0 +1,304 @@
+'use strict';
+
+const fs = require('fs');
+const http = require('node:http');
+const https = require('node:https');
+const path = require('path');
+const { URL: NodeUrl } = require('node:url');
+
+function normalize(text, outFile) {
+  if (text.includes(' -> ')) {
+    text = text.substring(0, text.indexOf(' -> ') + 4) + '<outFile>';
+  }
+
+  return text
+    .replace(new RegExp(outFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '<outFile>')
+    .replace(/127\.0\.0\.1:\d+/g, '127.0.0.1:<port>')
+    .replace(/\r\n/g, '\n');
+}
+
+function parseArgs(argv) {
+  const args = {
+    section: '',
+    url: '',
+    auto: false,
+    indexUrl: '',
+    outFile: '',
+    id: '',
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const value = argv[i];
+
+    if (value === '--section') {
+      args.section = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (value === '--url') {
+      args.url = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (value === '--auto') {
+      args.auto = true;
+      continue;
+    }
+
+    if (value === '--index-url') {
+      args.indexUrl = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (value === '--out') {
+      args.outFile = argv[i + 1] || '';
+      i++;
+      continue;
+    }
+
+    if (value === '--id') {
+      args.id = argv[i + 1] || '';
+      i++;
+    }
+  }
+
+  return args;
+}
+
+function fetchText(urlString, maxRedirects = 5) {
+  return new Promise((resolve, reject) => {
+    let urlObj;
+    try {
+      urlObj = new NodeUrl(urlString);
+    } catch {
+      reject(new Error(`Invalid URL: ${urlString}`));
+      return;
+    }
+
+    const transport = urlObj.protocol === 'https:' ? https : http;
+    const req = transport.request(
+      urlObj,
+      {
+        method: 'GET',
+        headers: {
+          'Accept-Encoding': 'identity',
+          'User-Agent': 'js2il-docs-script',
+        },
+      },
+      (res) => {
+        const status = res.statusCode || 0;
+        const location = res.headers.location;
+
+        if (status >= 300 && status < 400 && location) {
+          if (maxRedirects <= 0) {
+            res.resume();
+            reject(new Error(`Too many redirects fetching ${urlString}`));
+            return;
+          }
+
+          const nextUrl = new NodeUrl(location, urlObj).toString();
+          res.resume();
+          fetchText(nextUrl, maxRedirects - 1).then(resolve, reject);
+          return;
+        }
+
+        if (status < 200 || status >= 300) {
+          res.resume();
+          reject(new Error(`HTTP ${status} fetching ${urlString}`));
+          return;
+        }
+
+        res.setEncoding('utf8');
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve(data);
+        });
+      }
+    );
+
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function findTagNameAt(html, tagStart) {
+  if (tagStart < 0 || html[tagStart] !== '<') {
+    return '';
+  }
+
+  let index = tagStart + 1;
+  while (index < html.length) {
+    const ch = html[index];
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n' || ch === '>' || ch === '/') {
+      break;
+    }
+    index++;
+  }
+
+  return html.substring(tagStart + 1, index);
+}
+
+function extractElementById(html, elementId) {
+  const idDouble = `id="${elementId}"`;
+  const idSingle = `id='${elementId}'`;
+
+  let idIndex = html.indexOf(idDouble);
+  if (idIndex < 0) {
+    idIndex = html.indexOf(idSingle);
+  }
+
+  if (idIndex < 0) {
+    throw new Error(`Could not find id '${elementId}' in input HTML.`);
+  }
+
+  const tagStart = html.lastIndexOf('<', idIndex);
+  if (tagStart < 0) {
+    throw new Error(`Could not locate tag start for id '${elementId}'.`);
+  }
+
+  const tagName = findTagNameAt(html, tagStart);
+  if (!tagName) {
+    throw new Error(`Could not determine tag name for id '${elementId}'.`);
+  }
+
+  const tagRe = new RegExp(`<\\/?${escapeRegExp(tagName)}\\b[^>]*>`, 'gi');
+  tagRe.lastIndex = tagStart;
+
+  let depth = 0;
+  let startIndex = -1;
+
+  while (true) {
+    const match = tagRe.exec(html);
+    if (!match) {
+      break;
+    }
+
+    const token = match[0];
+    if (startIndex < 0) {
+      startIndex = match.index;
+    }
+
+    if (token.startsWith('</')) {
+      depth--;
+      if (depth === 0) {
+        return {
+          tagName,
+          html: html.substring(startIndex, tagRe.lastIndex),
+        };
+      }
+    } else {
+      depth++;
+    }
+  }
+
+  throw new Error(`Could not find a matching closing </${tagName}> for id '${elementId}'.`);
+}
+
+function resolveSectionLinkFromMultipageIndexHtml(indexHtml, section) {
+  const sectionEsc = escapeRegExp(section);
+  const re = new RegExp(
+    `<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*${sectionEsc}\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>`,
+    'i'
+  );
+  const match = re.exec(indexHtml);
+  const href = (match && (match[1] || match[2])) || '';
+  if (!href) {
+    return null;
+  }
+
+  const hashIndex = href.indexOf('#');
+  return {
+    href,
+    filePart: hashIndex >= 0 ? href.substring(0, hashIndex) : href,
+    fragment: hashIndex >= 0 ? href.substring(hashIndex + 1) : '',
+  };
+}
+
+function wrapAsStandaloneHtml(extractedHtml, title, baseHref) {
+  const baseTag = baseHref ? `  <base href="${baseHref}">\n` : '';
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+${baseTag}  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }
+    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }
+    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }
+    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }
+    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }
+  </style>
+  <title>${title}</title>
+</head>
+<body>
+${extractedHtml}
+</body>
+</html>
+`;
+}
+
+async function runHarnessCli() {
+  const args = parseArgs(process.argv);
+  if (!args.section) {
+    throw new Error('Missing required --section (e.g. 27.3).');
+  }
+
+  if (!args.outFile) {
+    throw new Error('Missing required --out <output.html>.');
+  }
+
+  const providedInputs = (args.url ? 1 : 0) + (args.auto ? 1 : 0);
+  if (providedInputs !== 1) {
+    throw new Error('Provide exactly one input mode: --url or --auto.');
+  }
+
+  let html;
+  let elementId = (args.id || '').trim();
+  let baseHref = '';
+
+  if (args.auto) {
+    const indexUrl = args.indexUrl.trim();
+    const indexHtml = await fetchText(indexUrl);
+    const link = resolveSectionLinkFromMultipageIndexHtml(indexHtml, args.section.trim());
+    if (!link) {
+      throw new Error(`Could not find section '${args.section}' in multipage index: ${indexUrl}`);
+    }
+
+    const resolvedUrl = new NodeUrl(link.filePart || link.href, indexUrl).toString();
+    html = await fetchText(resolvedUrl);
+    baseHref = resolvedUrl;
+    if (!elementId) {
+      elementId = link.fragment || '';
+    }
+  } else {
+    const urlString = args.url.trim();
+    html = await fetchText(urlString);
+    baseHref = urlString;
+  }
+
+  if (!elementId) {
+    throw new Error(`Could not infer an element id for section '${args.section}'. Try passing --id sec-... explicitly.`);
+  }
+
+  const extracted = extractElementById(html, elementId);
+  const outPath = path.join(process.cwd(), args.outFile);
+  const outText = wrapAsStandaloneHtml(extracted.html, `ECMA-262 ${args.section}`, baseHref);
+  fs.writeFileSync(outPath, outText, 'utf8');
+
+  console.log(normalize(`Extracted section ${args.section} (id=${elementId}, tag=${extracted.tagName}) -> ${outPath}`, outPath));
+  console.log(normalize(fs.readFileSync(outPath, 'utf8'), outPath));
+}
+
+exports.runHarnessCli = runHarnessCli;

--- a/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_urlMode.js
+++ b/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_urlMode.js
@@ -1,46 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-
-function normalize(text, outFile) {
-  if (text.includes(' -> ')) {
-    text = text.substring(0, text.indexOf(' -> ') + 4) + '<outFile>';
-  }
-
-  return text
-    .replace(new RegExp(outFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '<outFile>')
-    .replace(/127\.0\.0\.1:\d+/g, '127.0.0.1:<port>')
-    .replace(/\r\n/g, '\n');
-}
-
 async function run() {
-  const sourceUrl = process.argv[2];
-  const outFile = path.join(process.cwd(), 'section-url.html');
-  const extractor = require('./Compile_Scripts_ExtractEcma262SectionHtml');
-  const lines = [];
-  const capture = (value) => {
-    lines.push(String(value));
-  };
-
-  await extractor.main([
-    'dotnet',
-    'extractEcma262SectionHtml.js',
-    '--section',
-    '27.3',
-    '--url',
-    sourceUrl,
-    '--id',
-    'sec-generatorfunction-objects',
-    '--out',
-    outFile,
-  ], capture);
-
-  for (const line of lines) {
-    console.log(normalize(line, outFile));
-  }
-
-  console.log(normalize(fs.readFileSync(outFile, 'utf8'), outFile));
+  var harness = require('./Compile_Scripts_ExtractEcma262SectionHtml_TestHarness');
+  await harness.runHarnessCli();
 }
 
 run().catch((err) => {

--- a/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_urlMode.js
+++ b/Js2IL.Tests/Integration/Resources/extractEcma262SectionHtml_urlMode.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function normalize(text, outFile) {
+  if (text.includes(' -> ')) {
+    text = text.substring(0, text.indexOf(' -> ') + 4) + '<outFile>';
+  }
+
+  return text
+    .replace(new RegExp(outFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '<outFile>')
+    .replace(/127\.0\.0\.1:\d+/g, '127.0.0.1:<port>')
+    .replace(/\r\n/g, '\n');
+}
+
+async function run() {
+  const sourceUrl = process.argv[2];
+  const outFile = path.join(process.cwd(), 'section-url.html');
+  const extractor = require('./Compile_Scripts_ExtractEcma262SectionHtml');
+  const lines = [];
+  const capture = (value) => {
+    lines.push(String(value));
+  };
+
+  await extractor.main([
+    'dotnet',
+    'extractEcma262SectionHtml.js',
+    '--section',
+    '27.3',
+    '--url',
+    sourceUrl,
+    '--id',
+    'sec-generatorfunction-objects',
+    '--out',
+    outFile,
+  ], capture);
+
+  for (const line of lines) {
+    console.log(normalize(line, outFile));
+  }
+
+  console.log(normalize(fs.readFileSync(outFile, 'utf8'), outFile));
+}
+
+run().catch((err) => {
+  console.error(err && err.stack ? err.stack : (err && err.message ? err.message : err));
+  process.exitCode = 1;
+});

--- a/Js2IL.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -1,0 +1,26 @@
+﻿Extracted section 27.3 (id=sec-generatorfunction-objects, tag=emu-clause) -> <outFile>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <base href="http://127.0.0.1:<port>/multipage/control-abstraction-objects.html">
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }
+    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }
+    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }
+    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }
+    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }
+  </style>
+  <title>ECMA-262 27.3</title>
+</head>
+<body>
+<emu-clause id="sec-generatorfunction-objects">
+    <h1><span class="secnum">27.3</span> Generator Function Objects</h1>
+    <p>Loopback extractor body.</p>
+  </emu-clause>
+</body>
+</html>
+

--- a/Js2IL.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -1,0 +1,26 @@
+﻿Extracted section 27.3 (id=sec-generatorfunction-objects, tag=emu-clause) -> <outFile>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <base href="http://127.0.0.1:<port>/multipage/control-abstraction-objects.html">
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }
+    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }
+    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }
+    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }
+    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }
+  </style>
+  <title>ECMA-262 27.3</title>
+</head>
+<body>
+<emu-clause id="sec-generatorfunction-objects">
+    <h1><span class="secnum">27.3</span> Generator Function Objects</h1>
+    <p>Loopback extractor body.</p>
+  </emu-clause>
+</body>
+</html>
+

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -7,6 +7,405 @@
 	extends [System.Runtime]System.Object
 {
 	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit run
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 32 53 63 6f 70 65 20 5f 61 77 61 69 74 65
+				64 31 3d 7b 5f 61 77 61 69 74 65 64 31 7d 2c 20
+				5f 61 77 61 69 74 65 64 32 3d 7b 5f 61 77 61 69
+				74 65 64 32 7d 00 00
+			)
+			// Fields
+			.field public object _awaited1
+			.field public object _awaited2
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x408b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2278
+			// Header size: 12
+			// Code size: 255 (0xff)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope,
+				[1] object,
+				[2] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope
+			IL_0008: dup
+			IL_0009: brtrue IL_003b
+
+			IL_000e: pop
+			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::.ctor()
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: ldarg.0
+			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
+			IL_001c: starg.s scopes
+			IL_001e: ldloc.0
+			IL_001f: ldnull
+			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_002b: ldarg.0
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+			IL_0031: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0036: br IL_003c
+
+			IL_003b: stloc.0
+
+			IL_003c: ldloc.0
+			IL_003d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0042: brtrue IL_0053
+
+			IL_0047: ldloc.0
+			IL_0048: ldc.i4.1
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+
+			IL_0053: ldloc.0
+			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0059: ldc.i4.0
+			IL_005a: ble.s IL_0067
+
+			IL_005c: ldloc.0
+			IL_005d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0062: dup
+			IL_0063: ldc.i4.0
+			IL_0064: ldelem.ref
+			IL_0065: stloc.1
+			IL_0066: pop
+
+			IL_0067: ldloc.0
+			IL_0068: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_006d: switch (IL_007a, IL_00cd)
+
+			IL_007a: ldarg.0
+			IL_007b: ldc.i4.1
+			IL_007c: ldelem.ref
+			IL_007d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
+			IL_0082: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
+			IL_0087: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml_TestHarness"
+			IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0091: stloc.2
+			IL_0092: ldloc.2
+			IL_0093: stloc.1
+			IL_0094: ldloc.1
+			IL_0095: ldstr "runHarnessCli"
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_009f: stloc.2
+			IL_00a0: ldloc.0
+			IL_00a1: ldc.i4.1
+			IL_00a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00a7: ldloc.0
+			IL_00a8: ldloc.2
+			IL_00a9: ldarg.0
+			IL_00aa: ldc.i4.1
+			IL_00ab: ldloc.0
+			IL_00ac: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00b6: ldloc.0
+			IL_00b7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00bc: dup
+			IL_00bd: ldc.i4.0
+			IL_00be: ldloc.1
+			IL_00bf: stelem.ref
+			IL_00c0: pop
+			IL_00c1: ldloc.0
+			IL_00c2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00c7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00cc: ret
+
+			IL_00cd: ldloc.0
+			IL_00ce: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::_awaited1
+			IL_00d3: pop
+			IL_00d4: ldloc.0
+			IL_00d5: ldc.i4.m1
+			IL_00d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00db: ldloc.0
+			IL_00dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_00e6: ldarg.0
+			IL_00e7: ldc.i4.1
+			IL_00e8: newarr [System.Runtime]System.Object
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_00f2: pop
+			IL_00f3: ldloc.0
+			IL_00f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00f9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00fe: ret
+		} // end of method run::__js_call__
+
+	} // end of class run
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L8C13
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
+				72 7d 00 00
+			)
+			// Fields
+			.field public object err
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4094
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object err
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2384
+			// Header size: 12
+			// Code size: 175 (0xaf)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[3] bool,
+				[4] object,
+				[5] object,
+				[6] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: stloc.2
+			IL_0006: ldarg.1
+			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_000c: stloc.3
+			IL_000d: ldloc.3
+			IL_000e: brfalse IL_0025
+
+			IL_0013: ldarg.1
+			IL_0014: ldstr "stack"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001e: stloc.s 5
+			IL_0020: br IL_0028
+
+			IL_0025: ldarg.1
+			IL_0026: stloc.s 5
+
+			IL_0028: ldloc.s 5
+			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002f: stloc.3
+			IL_0030: ldloc.3
+			IL_0031: brfalse IL_0047
+
+			IL_0036: ldarg.1
+			IL_0037: ldstr "stack"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0041: stloc.0
+			IL_0042: br IL_008c
+
+			IL_0047: ldarg.1
+			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: brfalse IL_0066
+
+			IL_0054: ldarg.1
+			IL_0055: ldstr "message"
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005f: stloc.s 6
+			IL_0061: br IL_0069
+
+			IL_0066: ldarg.1
+			IL_0067: stloc.s 6
+
+			IL_0069: ldloc.s 6
+			IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: brfalse IL_0088
+
+			IL_0077: ldarg.1
+			IL_0078: ldstr "message"
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0082: stloc.1
+			IL_0083: br IL_008a
+
+			IL_0088: ldarg.1
+			IL_0089: stloc.1
+
+			IL_008a: ldloc.1
+			IL_008b: stloc.0
+
+			IL_008c: ldloc.2
+			IL_008d: ldloc.0
+			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0093: pop
+			IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0099: ldstr "exitCode"
+			IL_009e: ldc.r8 1
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_00ac: pop
+			IL_00ad: ldnull
+			IL_00ae: ret
+		} // end of method ArrowFunction_L8C13::__js_call__
+
+	} // end of class ArrowFunction_L8C13
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 22 53 63 6f 70 65 20 72 65 71 75 69 72 65
+			3d 7b 72 65 71 75 69 72 65 7d 2c 20 72 75 6e 3d
+			7b 72 75 6e 7d 00 00
+		)
+		// Fields
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
+		.field public object run
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x4082
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 101 (0x65)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope,
+			[1] object,
+			[2] object,
+			[3] object
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
+		IL_000d: ldc.i4.1
+		IL_000e: newarr [System.Runtime]System.Object
+		IL_0013: dup
+		IL_0014: ldc.i4.0
+		IL_0015: ldloc.0
+		IL_0016: stelem.ref
+		IL_0017: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
+		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0022: stloc.2
+		IL_0023: ldloc.2
+		IL_0024: stloc.1
+		IL_0025: ldc.i4.1
+		IL_0026: newarr [System.Runtime]System.Object
+		IL_002b: dup
+		IL_002c: ldc.i4.0
+		IL_002d: ldloc.0
+		IL_002e: stelem.ref
+		IL_002f: ldnull
+		IL_0030: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
+		IL_0035: stloc.2
+		IL_0036: ldnull
+		IL_0037: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/ArrowFunction_L8C13::__js_call__(object, object)
+		IL_003d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0042: ldc.i4.1
+		IL_0043: newarr [System.Runtime]System.Object
+		IL_0048: dup
+		IL_0049: ldc.i4.0
+		IL_004a: ldloc.0
+		IL_004b: stelem.ref
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0056: stloc.3
+		IL_0057: ldloc.2
+		IL_0058: ldstr "catch"
+		IL_005d: ldloc.3
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0063: pop
+		IL_0064: ret
+	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_AutoMode::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
+
+.class private auto ansi beforefieldinit Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
 	.class nested public auto ansi abstract sealed beforefieldinit normalize
 		extends [System.Runtime]System.Object
 	{
@@ -15,14 +414,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L7C29
+			.class nested private auto ansi beforefieldinit Block_L10C29
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5920
+					// Method begins at RVA 0x40af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -31,16 +430,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L7C29::.ctor
+				} // end of method Block_L10C29::.ctor
 
-			} // end of class Block_L7C29
+			} // end of class Block_L10C29
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5917
+				// Method begins at RVA 0x40a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +464,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23d4
+			// Method begins at RVA 0x2440
 			// Header size: 12
 			// Code size: 249 (0xf9)
 			.maxstack 8
@@ -158,773 +557,6 @@
 
 	} // end of class normalize
 
-	.class nested public auto ansi abstract sealed beforefieldinit run
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L22C19
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-					01 00 13 53 63 6f 70 65 20 76 61 6c 75 65 3d 7b
-					76 61 6c 75 65 7d 00 00
-				)
-				// Fields
-				.field public object 'value'
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5932
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object[] scopes,
-					object newTarget,
-					object 'value'
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-					01 00 02 00 00 00 00 00
-				)
-				// Method begins at RVA 0x28c4
-				// Header size: 12
-				// Code size: 29 (0x1d)
-				.maxstack 8
-				.locals init (
-					[0] string
-				)
-
-				IL_0000: ldarg.2
-				IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0006: stloc.0
-				IL_0007: ldarg.0
-				IL_0008: ldc.i4.1
-				IL_0009: ldelem.ref
-				IL_000a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope
-				IL_000f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::lines
-				IL_0014: ldloc.0
-				IL_0015: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_001a: pop
-				IL_001b: ldnull
-				IL_001c: ret
-			} // end of method ArrowFunction_L22C19::__js_call__
-
-		} // end of class ArrowFunction_L22C19
-
-		.class nested private auto ansi beforefieldinit Scope
-			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
-		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 13 53 63 6f 70 65 20 6c 69 6e 65 73 3d 7b
-				6c 69 6e 65 73 7d 00 00
-			)
-			// Fields
-			.field public class [JavaScriptRuntime]JavaScriptRuntime.Array lines
-			.field public object _awaited1
-			.field public object _awaited2
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5929
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-		.class nested private auto ansi beforefieldinit Scope_ForOf_L38C7
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L38C28
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5944
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L38C28::.ctor
-
-			} // end of class Block_L38C28
-
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x593b
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope_ForOf_L38C7::.ctor
-
-		} // end of class Scope_ForOf_L38C7
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object[] scopes,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 02 00 00 00 00 00
-			)
-			// Method begins at RVA 0x24dc
-			// Header size: 12
-			// Code size: 782 (0x30e)
-			.maxstack 8
-			.locals init (
-				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope,
-				[1] object,
-				[2] object,
-				[3] object,
-				[4] object,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
-				[6] bool,
-				[7] bool,
-				[8] object,
-				[9] object,
-				[10] object,
-				[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[12] bool
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldc.i4.0
-			IL_0002: ldelem.ref
-			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope
-			IL_0008: dup
-			IL_0009: brtrue IL_003b
-
-			IL_000e: pop
-			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::.ctor()
-			IL_0014: stloc.0
-			IL_0015: ldloc.0
-			IL_0016: ldarg.0
-			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
-			IL_001c: starg.s scopes
-			IL_001e: ldloc.0
-			IL_001f: ldnull
-			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
-			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_002b: ldarg.0
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-			IL_0031: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0036: br IL_003c
-
-			IL_003b: stloc.0
-
-			IL_003c: ldloc.0
-			IL_003d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0042: brtrue IL_0053
-
-			IL_0047: ldloc.0
-			IL_0048: ldc.i4.8
-			IL_0049: newarr [System.Runtime]System.Object
-			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-
-			IL_0053: ldloc.0
-			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0059: ldc.i4.0
-			IL_005a: ble.s IL_0097
-
-			IL_005c: ldloc.0
-			IL_005d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0062: dup
-			IL_0063: ldc.i4.0
-			IL_0064: ldelem.ref
-			IL_0065: stloc.1
-			IL_0066: dup
-			IL_0067: ldc.i4.1
-			IL_0068: ldelem.ref
-			IL_0069: stloc.2
-			IL_006a: dup
-			IL_006b: ldc.i4.2
-			IL_006c: ldelem.ref
-			IL_006d: stloc.3
-			IL_006e: dup
-			IL_006f: ldc.i4.3
-			IL_0070: ldelem.ref
-			IL_0071: stloc.s 4
-			IL_0073: dup
-			IL_0074: ldc.i4.4
-			IL_0075: ldelem.ref
-			IL_0076: castclass [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator
-			IL_007b: stloc.s 5
-			IL_007d: dup
-			IL_007e: ldc.i4.5
-			IL_007f: ldelem.ref
-			IL_0080: unbox.any [System.Runtime]System.Boolean
-			IL_0085: stloc.s 6
-			IL_0087: dup
-			IL_0088: ldc.i4.6
-			IL_0089: ldelem.ref
-			IL_008a: unbox.any [System.Runtime]System.Boolean
-			IL_008f: stloc.s 7
-			IL_0091: dup
-			IL_0092: ldc.i4.7
-			IL_0093: ldelem.ref
-			IL_0094: stloc.s 8
-			IL_0096: pop
-
-			IL_0097: ldloc.0
-			IL_0098: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_009d: switch (IL_00aa, IL_0222)
-
-			IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_00af: ldstr "argv"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b9: ldc.r8 2
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00c7: stloc.1
-			IL_00c8: ldarg.0
-			IL_00c9: ldc.i4.1
-			IL_00ca: ldelem.ref
-			IL_00cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
-			IL_00d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::path
-			IL_00d5: stloc.s 9
-			IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_00dc: ldstr "cwd"
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e6: stloc.s 10
-			IL_00e8: ldloc.s 9
-			IL_00ea: ldstr "join"
-			IL_00ef: ldloc.s 10
-			IL_00f1: ldstr "section-auto.html"
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fb: stloc.s 10
-			IL_00fd: ldloc.s 10
-			IL_00ff: stloc.2
-			IL_0100: ldarg.0
-			IL_0101: ldc.i4.1
-			IL_0102: ldelem.ref
-			IL_0103: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
-			IL_0108: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
-			IL_010d: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml"
-			IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-			IL_0117: stloc.s 10
-			IL_0119: ldloc.s 10
-			IL_011b: stloc.3
-			IL_011c: ldloc.0
-			IL_011d: ldc.i4.0
-			IL_011e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0123: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::lines
-			IL_0128: ldnull
-			IL_0129: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/ArrowFunction_L22C19::__js_call__(object[], object, object)
-			IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0134: ldc.i4.2
-			IL_0135: newarr [System.Runtime]System.Object
-			IL_013a: dup
-			IL_013b: ldc.i4.0
-			IL_013c: ldarg.0
-			IL_013d: ldc.i4.1
-			IL_013e: ldelem.ref
-			IL_013f: stelem.ref
-			IL_0140: dup
-			IL_0141: ldc.i4.1
-			IL_0142: ldloc.0
-			IL_0143: stelem.ref
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_014e: stloc.s 10
-			IL_0150: ldloc.s 10
-			IL_0152: stloc.s 4
-			IL_0154: ldc.i4.s 9
-			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_015b: dup
-			IL_015c: ldstr "dotnet"
-			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0166: dup
-			IL_0167: ldstr "extractEcma262SectionHtml.js"
-			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0171: dup
-			IL_0172: ldstr "--section"
-			IL_0177: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_017c: dup
-			IL_017d: ldstr "27.3"
-			IL_0182: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0187: dup
-			IL_0188: ldstr "--auto"
-			IL_018d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0192: dup
-			IL_0193: ldstr "--index-url"
-			IL_0198: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_019d: dup
-			IL_019e: ldloc.1
-			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01a4: dup
-			IL_01a5: ldstr "--out"
-			IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01af: dup
-			IL_01b0: ldloc.2
-			IL_01b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01b6: stloc.s 11
-			IL_01b8: ldloc.3
-			IL_01b9: ldstr "main"
-			IL_01be: ldloc.s 11
-			IL_01c0: ldloc.s 4
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c7: stloc.s 10
-			IL_01c9: ldloc.0
-			IL_01ca: ldc.i4.1
-			IL_01cb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d0: ldloc.0
-			IL_01d1: ldloc.s 10
-			IL_01d3: ldarg.0
-			IL_01d4: ldc.i4.1
-			IL_01d5: ldloc.0
-			IL_01d6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01e0: ldloc.0
-			IL_01e1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01e6: dup
-			IL_01e7: ldc.i4.0
-			IL_01e8: ldloc.1
-			IL_01e9: stelem.ref
-			IL_01ea: dup
-			IL_01eb: ldc.i4.1
-			IL_01ec: ldloc.2
-			IL_01ed: stelem.ref
-			IL_01ee: dup
-			IL_01ef: ldc.i4.2
-			IL_01f0: ldloc.3
-			IL_01f1: stelem.ref
-			IL_01f2: dup
-			IL_01f3: ldc.i4.3
-			IL_01f4: ldloc.s 4
-			IL_01f6: stelem.ref
-			IL_01f7: dup
-			IL_01f8: ldc.i4.4
-			IL_01f9: ldloc.s 5
-			IL_01fb: stelem.ref
-			IL_01fc: dup
-			IL_01fd: ldc.i4.5
-			IL_01fe: ldloc.s 6
-			IL_0200: box [System.Runtime]System.Boolean
-			IL_0205: stelem.ref
-			IL_0206: dup
-			IL_0207: ldc.i4.6
-			IL_0208: ldloc.s 7
-			IL_020a: box [System.Runtime]System.Boolean
-			IL_020f: stelem.ref
-			IL_0210: dup
-			IL_0211: ldc.i4.7
-			IL_0212: ldloc.s 8
-			IL_0214: stelem.ref
-			IL_0215: pop
-			IL_0216: ldloc.0
-			IL_0217: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_021c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0221: ret
-
-			IL_0222: ldloc.0
-			IL_0223: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::_awaited1
-			IL_0228: pop
-			IL_0229: ldloc.0
-			IL_022a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::lines
-			IL_022f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0234: stloc.s 5
-			IL_0236: ldc.i4.0
-			IL_0237: stloc.s 6
-			IL_0239: ldc.i4.0
-			IL_023a: stloc.s 7
-			.try
-			{
-				// loop start (head: IL_023c)
-					IL_023c: ldloc.s 5
-					IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_0243: stloc.s 10
-					IL_0245: ldloc.s 10
-					IL_0247: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_024c: stloc.s 12
-					IL_024e: ldloc.s 12
-					IL_0250: brtrue IL_028e
-
-					IL_0255: ldloc.s 10
-					IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_025c: stloc.s 10
-					IL_025e: ldloc.s 10
-					IL_0260: stloc.s 8
-					IL_0262: ldnull
-					IL_0263: ldloc.s 8
-					IL_0265: ldloc.2
-					IL_0266: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/normalize::__js_call__(object, object, object)
-					IL_026b: stloc.s 10
-					IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-					IL_0272: ldloc.s 10
-					IL_0274: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-					IL_0279: pop
-					IL_027a: br IL_023c
-				// end loop
-				IL_027f: ldloc.s 5
-				IL_0281: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0286: ldc.i4.1
-				IL_0287: stloc.s 7
-				IL_0289: leave IL_02ac
-
-				IL_028e: ldc.i4.1
-				IL_028f: stloc.s 6
-				IL_0291: leave IL_02ac
-			} // end .try
-			finally
-			{
-				IL_0296: ldloc.s 6
-				IL_0298: brtrue IL_02ab
-
-				IL_029d: ldloc.s 7
-				IL_029f: brtrue IL_02ab
-
-				IL_02a4: ldloc.s 5
-				IL_02a6: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-
-				IL_02ab: endfinally
-			} // end handler
-
-			IL_02ac: ldarg.0
-			IL_02ad: ldc.i4.1
-			IL_02ae: ldelem.ref
-			IL_02af: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
-			IL_02b4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::fs
-			IL_02b9: ldstr "readFileSync"
-			IL_02be: ldloc.2
-			IL_02bf: ldstr "utf8"
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02c9: stloc.s 10
-			IL_02cb: ldnull
-			IL_02cc: ldloc.s 10
-			IL_02ce: ldloc.2
-			IL_02cf: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/normalize::__js_call__(object, object, object)
-			IL_02d4: stloc.s 10
-			IL_02d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02db: ldloc.s 10
-			IL_02dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02e2: pop
-			IL_02e3: ldloc.0
-			IL_02e4: ldc.i4.m1
-			IL_02e5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02ea: ldloc.0
-			IL_02eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02f5: ldarg.0
-			IL_02f6: ldc.i4.1
-			IL_02f7: newarr [System.Runtime]System.Object
-			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0301: pop
-			IL_0302: ldloc.0
-			IL_0303: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0308: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_030d: ret
-		} // end of method run::__js_call__
-
-	} // end of class run
-
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L45C13
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
-				72 7d 00 00
-			)
-			// Fields
-			.field public object err
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x594d
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object err
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x2808
-			// Header size: 12
-			// Code size: 175 (0xaf)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[3] bool,
-				[4] object,
-				[5] object,
-				[6] object
-			)
-
-			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0005: stloc.2
-			IL_0006: ldarg.1
-			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_000c: stloc.3
-			IL_000d: ldloc.3
-			IL_000e: brfalse IL_0025
-
-			IL_0013: ldarg.1
-			IL_0014: ldstr "stack"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.s 5
-			IL_0020: br IL_0028
-
-			IL_0025: ldarg.1
-			IL_0026: stloc.s 5
-
-			IL_0028: ldloc.s 5
-			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002f: stloc.3
-			IL_0030: ldloc.3
-			IL_0031: brfalse IL_0047
-
-			IL_0036: ldarg.1
-			IL_0037: ldstr "stack"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.0
-			IL_0042: br IL_008c
-
-			IL_0047: ldarg.1
-			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_004d: stloc.3
-			IL_004e: ldloc.3
-			IL_004f: brfalse IL_0066
-
-			IL_0054: ldarg.1
-			IL_0055: ldstr "message"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: stloc.s 6
-			IL_0061: br IL_0069
-
-			IL_0066: ldarg.1
-			IL_0067: stloc.s 6
-
-			IL_0069: ldloc.s 6
-			IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0070: stloc.3
-			IL_0071: ldloc.3
-			IL_0072: brfalse IL_0088
-
-			IL_0077: ldarg.1
-			IL_0078: ldstr "message"
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0082: stloc.1
-			IL_0083: br IL_008a
-
-			IL_0088: ldarg.1
-			IL_0089: stloc.1
-
-			IL_008a: ldloc.1
-			IL_008b: stloc.0
-
-			IL_008c: ldloc.2
-			IL_008d: ldloc.0
-			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0093: pop
-			IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0099: ldstr "exitCode"
-			IL_009e: ldc.r8 1
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
-			IL_00ac: pop
-			IL_00ad: ldnull
-			IL_00ae: ret
-		} // end of method ArrowFunction_L45C13::__js_call__
-
-	} // end of class ArrowFunction_L45C13
-
-	.class nested private auto ansi beforefieldinit Scope
-		extends [System.Runtime]System.Object
-	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 4f 53 63 6f 70 65 20 72 65 71 75 69 72 65
-			3d 7b 72 65 71 75 69 72 65 7d 2c 20 66 73 3d 7b
-			66 73 7d 2c 20 70 61 74 68 3d 7b 70 61 74 68 7d
-			2c 20 6e 6f 72 6d 61 6c 69 7a 65 3d 7b 6e 6f 72
-			6d 61 6c 69 7a 65 7d 2c 20 72 75 6e 3d 7b 72 75
-			6e 7d 00 00
-		)
-		// Fields
-		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
-		.field public object fs
-		.field public object path
-		.field public object normalize
-		.field public object run
-
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x590e
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Scope::.ctor
-
-	} // end of class Scope
-
-
-	// Methods
-	.method public hidebysig static 
-		void __js_module_init__ (
-			object exports,
-			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
-			object module,
-			string __filename,
-			string __dirname
-		) cil managed 
-	{
-		// Method begins at RVA 0x2050
-		// Header size: 12
-		// Code size: 169 (0xa9)
-		.maxstack 8
-		.locals init (
-			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope,
-			[1] object,
-			[2] object,
-			[3] object
-		)
-
-		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
-		IL_000d: ldnull
-		IL_000e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/normalize::__js_call__(object, object, object)
-		IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0019: stloc.2
-		IL_001a: ldloc.0
-		IL_001b: ldloc.2
-		IL_001c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::normalize
-		IL_0021: ldc.i4.1
-		IL_0022: newarr [System.Runtime]System.Object
-		IL_0027: dup
-		IL_0028: ldc.i4.0
-		IL_0029: ldloc.0
-		IL_002a: stelem.ref
-		IL_002b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
-		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0036: stloc.2
-		IL_0037: ldloc.2
-		IL_0038: stloc.1
-		IL_0039: ldloc.0
-		IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
-		IL_003f: ldstr "fs"
-		IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0049: stloc.2
-		IL_004a: ldloc.0
-		IL_004b: ldloc.2
-		IL_004c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::fs
-		IL_0051: ldloc.0
-		IL_0052: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
-		IL_0057: ldstr "path"
-		IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0061: stloc.2
-		IL_0062: ldloc.0
-		IL_0063: ldloc.2
-		IL_0064: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::path
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: ldnull
-		IL_0074: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
-		IL_0079: stloc.2
-		IL_007a: ldnull
-		IL_007b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/ArrowFunction_L45C13::__js_call__(object, object)
-		IL_0081: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0086: ldc.i4.1
-		IL_0087: newarr [System.Runtime]System.Object
-		IL_008c: dup
-		IL_008d: ldc.i4.0
-		IL_008e: ldloc.0
-		IL_008f: stelem.ref
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_009a: stloc.3
-		IL_009b: ldloc.2
-		IL_009c: ldstr "catch"
-		IL_00a1: ldloc.3
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a7: pop
-		IL_00a8: ret
-	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_AutoMode::__js_module_init__
-
-} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
-
-.class private auto ansi beforefieldinit Modules.Compile_Scripts_ExtractEcma262SectionHtml
-	extends [System.Runtime]System.Object
-{
-	// Nested Types
 	.class nested public auto ansi abstract sealed beforefieldinit parseArgs
 		extends [System.Runtime]System.Object
 	{
@@ -936,7 +568,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x595f
+				// Method begins at RVA 0x40b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -949,22 +581,22 @@
 
 		} // end of class Scope
 
-		.class nested private auto ansi beforefieldinit Scope_For_L49C7
+		.class nested private auto ansi beforefieldinit Scope_For_L30C7
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L49C40
+			.class nested private auto ansi beforefieldinit Block_L30C40
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L52C38
+				.class nested private auto ansi beforefieldinit Block_L33C31
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x597a
+						// Method begins at RVA 0x40d3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -973,18 +605,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L52C38::.ctor
+					} // end of method Block_L33C31::.ctor
 
-				} // end of class Block_L52C38
+				} // end of class Block_L33C31
 
-				.class nested private auto ansi beforefieldinit Block_L57C41
+				.class nested private auto ansi beforefieldinit Block_L39C27
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5983
+						// Method begins at RVA 0x40dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -993,18 +625,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L57C41::.ctor
+					} // end of method Block_L39C27::.ctor
 
-				} // end of class Block_L57C41
+				} // end of class Block_L39C27
 
-				.class nested private auto ansi beforefieldinit Block_L63C36
+				.class nested private auto ansi beforefieldinit Block_L45C28
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x598c
+						// Method begins at RVA 0x40e5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1013,18 +645,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L63C36::.ctor
+					} // end of method Block_L45C28::.ctor
 
-				} // end of class Block_L63C36
+				} // end of class Block_L45C28
 
-				.class nested private auto ansi beforefieldinit Block_L68C36
+				.class nested private auto ansi beforefieldinit Block_L50C33
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5995
+						// Method begins at RVA 0x40ee
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1033,18 +665,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L68C36::.ctor
+					} // end of method Block_L50C33::.ctor
 
-				} // end of class Block_L68C36
+				} // end of class Block_L50C33
 
-				.class nested private auto ansi beforefieldinit Block_L74C31
+				.class nested private auto ansi beforefieldinit Block_L56C27
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x599e
+						// Method begins at RVA 0x40f7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1053,18 +685,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L74C31::.ctor
+					} // end of method Block_L56C27::.ctor
 
-				} // end of class Block_L74C31
+				} // end of class Block_L56C27
 
-				.class nested private auto ansi beforefieldinit Block_L79C37
+				.class nested private auto ansi beforefieldinit Block_L62C26
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x59a7
+						// Method begins at RVA 0x4100
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1073,256 +705,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L79C37::.ctor
+					} // end of method Block_L62C26::.ctor
 
-				} // end of class Block_L79C37
-
-				.class nested private auto ansi beforefieldinit Block_L85C32
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59b0
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L85C32::.ctor
-
-				} // end of class Block_L85C32
-
-				.class nested private auto ansi beforefieldinit Block_L90C24
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59b9
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L90C24::.ctor
-
-				} // end of class Block_L90C24
-
-				.class nested private auto ansi beforefieldinit Block_L95C29
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59c2
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L95C29::.ctor
-
-				} // end of class Block_L95C29
-
-				.class nested private auto ansi beforefieldinit Block_L101C38
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59cb
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L101C38::.ctor
-
-				} // end of class Block_L101C38
-
-				.class nested private auto ansi beforefieldinit Block_L106C37
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59d4
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L106C37::.ctor
-
-				} // end of class Block_L106C37
-
-				.class nested private auto ansi beforefieldinit Block_L112C32
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59dd
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L112C32::.ctor
-
-				} // end of class Block_L112C32
-
-				.class nested private auto ansi beforefieldinit Block_L117C22
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59e6
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L117C22::.ctor
-
-				} // end of class Block_L117C22
-
-				.class nested private auto ansi beforefieldinit Block_L123C31
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59ef
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L123C31::.ctor
-
-				} // end of class Block_L123C31
-
-				.class nested private auto ansi beforefieldinit Block_L128C24
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59f8
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L128C24::.ctor
-
-				} // end of class Block_L128C24
-
-				.class nested private auto ansi beforefieldinit Block_L133C27
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a01
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L133C27::.ctor
-
-				} // end of class Block_L133C27
-
-				.class nested private auto ansi beforefieldinit Block_L138C24
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a0a
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L138C24::.ctor
-
-				} // end of class Block_L138C24
-
-				.class nested private auto ansi beforefieldinit Block_L144C33
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a13
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L144C33::.ctor
-
-				} // end of class Block_L144C33
+				} // end of class Block_L62C26
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5971
+					// Method begins at RVA 0x40ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1331,16 +723,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L49C40::.ctor
+				} // end of method Block_L30C40::.ctor
 
-			} // end of class Block_L49C40
+			} // end of class Block_L30C40
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5968
+				// Method begins at RVA 0x40c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1349,15 +741,15 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Scope_For_L49C7::.ctor
+			} // end of method Scope_For_L30C7::.ctor
 
-		} // end of class Scope_For_L49C7
+		} // end of class Scope_For_L30C7
 
 
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
 				object argv
 			) cil managed 
@@ -1365,38 +757,24 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x28f0
+			// Method begins at RVA 0x2548
 			// Header size: 12
-			// Code size: 2463 (0x99f)
+			// Code size: 680 (0x2a8)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] float64,
-				[3] object,
-				[4] bool,
+				[1] float64,
+				[2] object,
+				[3] bool,
+				[4] object,
 				[5] object,
 				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
-				[10] object,
-				[11] object,
-				[12] object,
-				[13] object,
-				[14] object,
-				[15] object,
-				[16] object,
-				[17] object,
-				[18] object,
-				[19] object,
-				[20] object,
-				[21] object,
-				[22] object,
-				[23] object,
-				[24] object
+				[10] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -1405,1027 +783,265 @@
 			IL_000b: ldstr ""
 			IL_0010: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0015: dup
-			IL_0016: ldstr "inFile"
+			IL_0016: ldstr "url"
 			IL_001b: ldstr ""
 			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0025: dup
-			IL_0026: ldstr "url"
-			IL_002b: ldstr ""
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0035: dup
-			IL_0036: ldstr "auto"
-			IL_003b: ldc.i4.0
-			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0026: ldstr "auto"
+			IL_002b: ldc.i4.0
+			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0031: dup
+			IL_0032: ldstr "indexUrl"
+			IL_0037: ldstr ""
+			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0041: dup
-			IL_0042: ldstr "indexUrl"
-			IL_0047: ldstr "https://tc39.es/ecma262/multipage/"
+			IL_0042: ldstr "outFile"
+			IL_0047: ldstr ""
 			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0051: dup
-			IL_0052: ldstr "outFile"
+			IL_0052: ldstr "id"
 			IL_0057: ldstr ""
 			IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0061: dup
-			IL_0062: ldstr "id"
-			IL_0067: ldstr ""
-			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0071: dup
-			IL_0072: ldstr "wrap"
-			IL_0077: ldc.i4.1
-			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_007d: dup
-			IL_007e: ldstr "baseHref"
-			IL_0083: ldstr ""
-			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_008d: dup
-			IL_008e: ldstr "help"
-			IL_0093: ldc.i4.0
-			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0099: stloc.0
-			IL_009a: ldc.i4.0
-			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00a0: stloc.1
-			IL_00a1: ldc.r8 2
-			IL_00aa: stloc.2
-			// loop start (head: IL_00ab)
-				IL_00ab: ldloc.2
-				IL_00ac: ldarg.2
-				IL_00ad: ldstr "length"
-				IL_00b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_00b7: clt
-				IL_00b9: brfalse IL_07ec
+			IL_0061: stloc.0
+			IL_0062: ldc.r8 2
+			IL_006b: stloc.1
+			// loop start (head: IL_006c)
+				IL_006c: ldloc.1
+				IL_006d: ldarg.2
+				IL_006e: ldstr "length"
+				IL_0073: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0078: clt
+				IL_007a: brfalse IL_02a6
 
-				IL_00be: ldarg.2
-				IL_00bf: ldloc.2
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00c5: stloc.3
-				IL_00c6: ldloc.3
-				IL_00c7: ldstr "--help"
-				IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00d1: stloc.s 4
-				IL_00d3: ldloc.s 4
-				IL_00d5: box [System.Runtime]System.Boolean
-				IL_00da: stloc.s 5
-				IL_00dc: ldloc.s 5
-				IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00e3: stloc.s 4
-				IL_00e5: ldloc.s 4
-				IL_00e7: brtrue IL_010b
+				IL_007f: ldarg.2
+				IL_0080: ldloc.1
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0086: stloc.2
+				IL_0087: ldloc.2
+				IL_0088: ldstr "--section"
+				IL_008d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0092: stloc.3
+				IL_0093: ldloc.3
+				IL_0094: brfalse IL_00e9
 
-				IL_00ec: ldloc.3
-				IL_00ed: ldstr "-h"
-				IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00f7: stloc.s 4
-				IL_00f9: ldloc.s 4
-				IL_00fb: box [System.Runtime]System.Boolean
-				IL_0100: stloc.s 6
-				IL_0102: ldloc.s 6
-				IL_0104: stloc.s 8
-				IL_0106: br IL_010f
+				IL_0099: ldarg.2
+				IL_009a: ldloc.1
+				IL_009b: ldc.r8 1
+				IL_00a4: add
+				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00aa: stloc.s 4
+				IL_00ac: ldloc.s 4
+				IL_00ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00b3: stloc.3
+				IL_00b4: ldloc.3
+				IL_00b5: brtrue IL_00c6
 
-				IL_010b: ldloc.s 5
-				IL_010d: stloc.s 8
+				IL_00ba: ldstr ""
+				IL_00bf: stloc.s 6
+				IL_00c1: br IL_00ca
 
-				IL_010f: ldloc.s 8
-				IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0116: stloc.s 4
-				IL_0118: ldloc.s 4
-				IL_011a: brfalse IL_0136
+				IL_00c6: ldloc.s 4
+				IL_00c8: stloc.s 6
 
-				IL_011f: ldloc.0
-				IL_0120: ldstr "help"
-				IL_0125: ldc.i4.1
-				IL_0126: box [System.Runtime]System.Boolean
-				IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0130: pop
-				IL_0131: br IL_07db
+				IL_00ca: ldloc.0
+				IL_00cb: ldstr "section"
+				IL_00d0: ldloc.s 6
+				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_00d7: pop
+				IL_00d8: ldloc.1
+				IL_00d9: ldc.r8 1
+				IL_00e2: add
+				IL_00e3: stloc.1
+				IL_00e4: br IL_0295
 
-				IL_0136: ldloc.3
-				IL_0137: ldstr "--section"
-				IL_013c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0141: stloc.s 4
-				IL_0143: ldloc.s 4
-				IL_0145: box [System.Runtime]System.Boolean
-				IL_014a: stloc.s 5
-				IL_014c: ldloc.s 5
-				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0153: stloc.s 4
-				IL_0155: ldloc.s 4
-				IL_0157: brtrue IL_017b
+				IL_00e9: ldloc.2
+				IL_00ea: ldstr "--url"
+				IL_00ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00f4: stloc.3
+				IL_00f5: ldloc.3
+				IL_00f6: brfalse IL_014b
 
-				IL_015c: ldloc.3
-				IL_015d: ldstr "-s"
-				IL_0162: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0167: stloc.s 4
-				IL_0169: ldloc.s 4
-				IL_016b: box [System.Runtime]System.Boolean
-				IL_0170: stloc.s 6
-				IL_0172: ldloc.s 6
-				IL_0174: stloc.s 9
-				IL_0176: br IL_017f
+				IL_00fb: ldarg.2
+				IL_00fc: ldloc.1
+				IL_00fd: ldc.r8 1
+				IL_0106: add
+				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_010c: stloc.s 4
+				IL_010e: ldloc.s 4
+				IL_0110: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0115: stloc.3
+				IL_0116: ldloc.3
+				IL_0117: brtrue IL_0128
 
-				IL_017b: ldloc.s 5
-				IL_017d: stloc.s 9
+				IL_011c: ldstr ""
+				IL_0121: stloc.s 7
+				IL_0123: br IL_012c
 
-				IL_017f: ldloc.s 9
-				IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0186: stloc.s 4
-				IL_0188: ldloc.s 4
-				IL_018a: brfalse IL_01e1
+				IL_0128: ldloc.s 4
+				IL_012a: stloc.s 7
 
-				IL_018f: ldarg.2
-				IL_0190: ldloc.2
-				IL_0191: ldc.r8 1
-				IL_019a: add
-				IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01a0: stloc.s 10
-				IL_01a2: ldloc.s 10
-				IL_01a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01a9: stloc.s 4
-				IL_01ab: ldloc.s 4
-				IL_01ad: brtrue IL_01be
+				IL_012c: ldloc.0
+				IL_012d: ldstr "url"
+				IL_0132: ldloc.s 7
+				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0139: pop
+				IL_013a: ldloc.1
+				IL_013b: ldc.r8 1
+				IL_0144: add
+				IL_0145: stloc.1
+				IL_0146: br IL_0295
 
-				IL_01b2: ldstr ""
-				IL_01b7: stloc.s 11
-				IL_01b9: br IL_01c2
+				IL_014b: ldloc.2
+				IL_014c: ldstr "--auto"
+				IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0156: stloc.3
+				IL_0157: ldloc.3
+				IL_0158: brfalse IL_0174
 
-				IL_01be: ldloc.s 10
-				IL_01c0: stloc.s 11
+				IL_015d: ldloc.0
+				IL_015e: ldstr "auto"
+				IL_0163: ldc.i4.1
+				IL_0164: box [System.Runtime]System.Boolean
+				IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_016e: pop
+				IL_016f: br IL_0295
 
-				IL_01c2: ldloc.0
-				IL_01c3: ldstr "section"
-				IL_01c8: ldloc.s 11
-				IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_01cf: pop
-				IL_01d0: ldloc.2
-				IL_01d1: ldc.r8 1
-				IL_01da: add
-				IL_01db: stloc.2
-				IL_01dc: br IL_07db
+				IL_0174: ldloc.2
+				IL_0175: ldstr "--index-url"
+				IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_017f: stloc.3
+				IL_0180: ldloc.3
+				IL_0181: brfalse IL_01d6
 
-				IL_01e1: ldloc.3
-				IL_01e2: ldstr "startsWith"
-				IL_01e7: ldstr "--section="
-				IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01f1: stloc.s 10
-				IL_01f3: ldloc.s 10
-				IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01fa: stloc.s 4
-				IL_01fc: ldloc.s 4
-				IL_01fe: brfalse IL_0233
+				IL_0186: ldarg.2
+				IL_0187: ldloc.1
+				IL_0188: ldc.r8 1
+				IL_0191: add
+				IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0197: stloc.s 4
+				IL_0199: ldloc.s 4
+				IL_019b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01a0: stloc.3
+				IL_01a1: ldloc.3
+				IL_01a2: brtrue IL_01b3
 
+				IL_01a7: ldstr ""
+				IL_01ac: stloc.s 8
+				IL_01ae: br IL_01b7
+
+				IL_01b3: ldloc.s 4
+				IL_01b5: stloc.s 8
+
+				IL_01b7: ldloc.0
+				IL_01b8: ldstr "indexUrl"
+				IL_01bd: ldloc.s 8
+				IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_01c4: pop
+				IL_01c5: ldloc.1
+				IL_01c6: ldc.r8 1
+				IL_01cf: add
+				IL_01d0: stloc.1
+				IL_01d1: br IL_0295
+
+				IL_01d6: ldloc.2
+				IL_01d7: ldstr "--out"
+				IL_01dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01e1: stloc.3
+				IL_01e2: ldloc.3
+				IL_01e3: brfalse IL_0238
+
+				IL_01e8: ldarg.2
+				IL_01e9: ldloc.1
+				IL_01ea: ldc.r8 1
+				IL_01f3: add
+				IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01f9: stloc.s 4
+				IL_01fb: ldloc.s 4
+				IL_01fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0202: stloc.3
 				IL_0203: ldloc.3
-				IL_0204: ldstr "substring"
-				IL_0209: ldstr "--section="
-				IL_020e: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0213: conv.r8
-				IL_0214: box [System.Runtime]System.Double
-				IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_021e: stloc.s 10
-				IL_0220: ldloc.0
-				IL_0221: ldstr "section"
-				IL_0226: ldloc.s 10
-				IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_022d: pop
-				IL_022e: br IL_07db
+				IL_0204: brtrue IL_0215
 
-				IL_0233: ldloc.3
-				IL_0234: ldstr "--in"
-				IL_0239: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_023e: stloc.s 4
-				IL_0240: ldloc.s 4
-				IL_0242: box [System.Runtime]System.Boolean
-				IL_0247: stloc.s 5
-				IL_0249: ldloc.s 5
-				IL_024b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0250: stloc.s 4
-				IL_0252: ldloc.s 4
-				IL_0254: brtrue IL_0278
+				IL_0209: ldstr ""
+				IL_020e: stloc.s 9
+				IL_0210: br IL_0219
 
-				IL_0259: ldloc.3
-				IL_025a: ldstr "-i"
-				IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0264: stloc.s 4
-				IL_0266: ldloc.s 4
-				IL_0268: box [System.Runtime]System.Boolean
-				IL_026d: stloc.s 6
-				IL_026f: ldloc.s 6
-				IL_0271: stloc.s 12
-				IL_0273: br IL_027c
+				IL_0215: ldloc.s 4
+				IL_0217: stloc.s 9
 
-				IL_0278: ldloc.s 5
-				IL_027a: stloc.s 12
+				IL_0219: ldloc.0
+				IL_021a: ldstr "outFile"
+				IL_021f: ldloc.s 9
+				IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0226: pop
+				IL_0227: ldloc.1
+				IL_0228: ldc.r8 1
+				IL_0231: add
+				IL_0232: stloc.1
+				IL_0233: br IL_0295
 
-				IL_027c: ldloc.s 12
-				IL_027e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0283: stloc.s 4
-				IL_0285: ldloc.s 4
-				IL_0287: brfalse IL_02de
+				IL_0238: ldloc.2
+				IL_0239: ldstr "--id"
+				IL_023e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0243: stloc.3
+				IL_0244: ldloc.3
+				IL_0245: brfalse IL_0295
 
-				IL_028c: ldarg.2
-				IL_028d: ldloc.2
-				IL_028e: ldc.r8 1
-				IL_0297: add
-				IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_029d: stloc.s 10
-				IL_029f: ldloc.s 10
-				IL_02a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02a6: stloc.s 4
-				IL_02a8: ldloc.s 4
-				IL_02aa: brtrue IL_02bb
+				IL_024a: ldarg.2
+				IL_024b: ldloc.1
+				IL_024c: ldc.r8 1
+				IL_0255: add
+				IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_025b: stloc.s 4
+				IL_025d: ldloc.s 4
+				IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0264: stloc.3
+				IL_0265: ldloc.3
+				IL_0266: brtrue IL_0277
 
-				IL_02af: ldstr ""
-				IL_02b4: stloc.s 13
-				IL_02b6: br IL_02bf
+				IL_026b: ldstr ""
+				IL_0270: stloc.s 10
+				IL_0272: br IL_027b
 
-				IL_02bb: ldloc.s 10
-				IL_02bd: stloc.s 13
+				IL_0277: ldloc.s 4
+				IL_0279: stloc.s 10
 
-				IL_02bf: ldloc.0
-				IL_02c0: ldstr "inFile"
-				IL_02c5: ldloc.s 13
-				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_02cc: pop
-				IL_02cd: ldloc.2
-				IL_02ce: ldc.r8 1
-				IL_02d7: add
-				IL_02d8: stloc.2
-				IL_02d9: br IL_07db
+				IL_027b: ldloc.0
+				IL_027c: ldstr "id"
+				IL_0281: ldloc.s 10
+				IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0288: pop
+				IL_0289: ldloc.1
+				IL_028a: ldc.r8 1
+				IL_0293: add
+				IL_0294: stloc.1
 
-				IL_02de: ldloc.3
-				IL_02df: ldstr "startsWith"
-				IL_02e4: ldstr "--in="
-				IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02ee: stloc.s 10
-				IL_02f0: ldloc.s 10
-				IL_02f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02f7: stloc.s 4
-				IL_02f9: ldloc.s 4
-				IL_02fb: brfalse IL_0330
-
-				IL_0300: ldloc.3
-				IL_0301: ldstr "substring"
-				IL_0306: ldstr "--in="
-				IL_030b: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0310: conv.r8
-				IL_0311: box [System.Runtime]System.Double
-				IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_031b: stloc.s 10
-				IL_031d: ldloc.0
-				IL_031e: ldstr "inFile"
-				IL_0323: ldloc.s 10
-				IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_032a: pop
-				IL_032b: br IL_07db
-
-				IL_0330: ldloc.3
-				IL_0331: ldstr "--url"
-				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_033b: stloc.s 4
-				IL_033d: ldloc.s 4
-				IL_033f: box [System.Runtime]System.Boolean
-				IL_0344: stloc.s 5
-				IL_0346: ldloc.s 5
-				IL_0348: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_034d: stloc.s 4
-				IL_034f: ldloc.s 4
-				IL_0351: brtrue IL_0375
-
-				IL_0356: ldloc.3
-				IL_0357: ldstr "-u"
-				IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0361: stloc.s 4
-				IL_0363: ldloc.s 4
-				IL_0365: box [System.Runtime]System.Boolean
-				IL_036a: stloc.s 6
-				IL_036c: ldloc.s 6
-				IL_036e: stloc.s 14
-				IL_0370: br IL_0379
-
-				IL_0375: ldloc.s 5
-				IL_0377: stloc.s 14
-
-				IL_0379: ldloc.s 14
-				IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0380: stloc.s 4
-				IL_0382: ldloc.s 4
-				IL_0384: brfalse IL_03db
-
-				IL_0389: ldarg.2
-				IL_038a: ldloc.2
-				IL_038b: ldc.r8 1
-				IL_0394: add
-				IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_039a: stloc.s 10
-				IL_039c: ldloc.s 10
-				IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03a3: stloc.s 4
-				IL_03a5: ldloc.s 4
-				IL_03a7: brtrue IL_03b8
-
-				IL_03ac: ldstr ""
-				IL_03b1: stloc.s 15
-				IL_03b3: br IL_03bc
-
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 15
-
-				IL_03bc: ldloc.0
-				IL_03bd: ldstr "url"
-				IL_03c2: ldloc.s 15
-				IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_03c9: pop
-				IL_03ca: ldloc.2
-				IL_03cb: ldc.r8 1
-				IL_03d4: add
-				IL_03d5: stloc.2
-				IL_03d6: br IL_07db
-
-				IL_03db: ldloc.3
-				IL_03dc: ldstr "startsWith"
-				IL_03e1: ldstr "--url="
-				IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_03eb: stloc.s 10
-				IL_03ed: ldloc.s 10
-				IL_03ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03f4: stloc.s 4
-				IL_03f6: ldloc.s 4
-				IL_03f8: brfalse IL_042d
-
-				IL_03fd: ldloc.3
-				IL_03fe: ldstr "substring"
-				IL_0403: ldstr "--url="
-				IL_0408: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_040d: conv.r8
-				IL_040e: box [System.Runtime]System.Double
-				IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0418: stloc.s 10
-				IL_041a: ldloc.0
-				IL_041b: ldstr "url"
-				IL_0420: ldloc.s 10
-				IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0427: pop
-				IL_0428: br IL_07db
-
-				IL_042d: ldloc.3
-				IL_042e: ldstr "--auto"
-				IL_0433: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0438: stloc.s 4
-				IL_043a: ldloc.s 4
-				IL_043c: brfalse IL_0458
-
-				IL_0441: ldloc.0
-				IL_0442: ldstr "auto"
-				IL_0447: ldc.i4.1
-				IL_0448: box [System.Runtime]System.Boolean
-				IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0452: pop
-				IL_0453: br IL_07db
-
-				IL_0458: ldloc.3
-				IL_0459: ldstr "--index-url"
-				IL_045e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0463: stloc.s 4
-				IL_0465: ldloc.s 4
-				IL_0467: brfalse IL_04be
-
-				IL_046c: ldarg.2
-				IL_046d: ldloc.2
-				IL_046e: ldc.r8 1
-				IL_0477: add
-				IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_047d: stloc.s 10
-				IL_047f: ldloc.s 10
-				IL_0481: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0486: stloc.s 4
-				IL_0488: ldloc.s 4
-				IL_048a: brtrue IL_049b
-
-				IL_048f: ldstr ""
-				IL_0494: stloc.s 16
-				IL_0496: br IL_049f
-
-				IL_049b: ldloc.s 10
-				IL_049d: stloc.s 16
-
-				IL_049f: ldloc.0
-				IL_04a0: ldstr "indexUrl"
-				IL_04a5: ldloc.s 16
-				IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_04ac: pop
-				IL_04ad: ldloc.2
-				IL_04ae: ldc.r8 1
-				IL_04b7: add
-				IL_04b8: stloc.2
-				IL_04b9: br IL_07db
-
-				IL_04be: ldloc.3
-				IL_04bf: ldstr "startsWith"
-				IL_04c4: ldstr "--index-url="
-				IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_04ce: stloc.s 10
-				IL_04d0: ldloc.s 10
-				IL_04d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_04d7: stloc.s 4
-				IL_04d9: ldloc.s 4
-				IL_04db: brfalse IL_0510
-
-				IL_04e0: ldloc.3
-				IL_04e1: ldstr "substring"
-				IL_04e6: ldstr "--index-url="
-				IL_04eb: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_04f0: conv.r8
-				IL_04f1: box [System.Runtime]System.Double
-				IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_04fb: stloc.s 10
-				IL_04fd: ldloc.0
-				IL_04fe: ldstr "indexUrl"
-				IL_0503: ldloc.s 10
-				IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_050a: pop
-				IL_050b: br IL_07db
-
-				IL_0510: ldloc.3
-				IL_0511: ldstr "--out"
-				IL_0516: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_051b: stloc.s 4
-				IL_051d: ldloc.s 4
-				IL_051f: box [System.Runtime]System.Boolean
-				IL_0524: stloc.s 5
-				IL_0526: ldloc.s 5
-				IL_0528: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_052d: stloc.s 4
-				IL_052f: ldloc.s 4
-				IL_0531: brtrue IL_0555
-
-				IL_0536: ldloc.3
-				IL_0537: ldstr "-o"
-				IL_053c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0541: stloc.s 4
-				IL_0543: ldloc.s 4
-				IL_0545: box [System.Runtime]System.Boolean
-				IL_054a: stloc.s 6
-				IL_054c: ldloc.s 6
-				IL_054e: stloc.s 17
-				IL_0550: br IL_0559
-
-				IL_0555: ldloc.s 5
-				IL_0557: stloc.s 17
-
-				IL_0559: ldloc.s 17
-				IL_055b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0560: stloc.s 4
-				IL_0562: ldloc.s 4
-				IL_0564: brfalse IL_05bb
-
-				IL_0569: ldarg.2
-				IL_056a: ldloc.2
-				IL_056b: ldc.r8 1
-				IL_0574: add
-				IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_057a: stloc.s 10
-				IL_057c: ldloc.s 10
-				IL_057e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0583: stloc.s 4
-				IL_0585: ldloc.s 4
-				IL_0587: brtrue IL_0598
-
-				IL_058c: ldstr ""
-				IL_0591: stloc.s 18
-				IL_0593: br IL_059c
-
-				IL_0598: ldloc.s 10
-				IL_059a: stloc.s 18
-
-				IL_059c: ldloc.0
-				IL_059d: ldstr "outFile"
-				IL_05a2: ldloc.s 18
-				IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_05a9: pop
-				IL_05aa: ldloc.2
-				IL_05ab: ldc.r8 1
-				IL_05b4: add
-				IL_05b5: stloc.2
-				IL_05b6: br IL_07db
-
-				IL_05bb: ldloc.3
-				IL_05bc: ldstr "startsWith"
-				IL_05c1: ldstr "--out="
-				IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_05cb: stloc.s 10
-				IL_05cd: ldloc.s 10
-				IL_05cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_05d4: stloc.s 4
-				IL_05d6: ldloc.s 4
-				IL_05d8: brfalse IL_060d
-
-				IL_05dd: ldloc.3
-				IL_05de: ldstr "substring"
-				IL_05e3: ldstr "--out="
-				IL_05e8: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_05ed: conv.r8
-				IL_05ee: box [System.Runtime]System.Double
-				IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_05f8: stloc.s 10
-				IL_05fa: ldloc.0
-				IL_05fb: ldstr "outFile"
-				IL_0600: ldloc.s 10
-				IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0607: pop
-				IL_0608: br IL_07db
-
-				IL_060d: ldloc.3
-				IL_060e: ldstr "--id"
-				IL_0613: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0618: stloc.s 4
-				IL_061a: ldloc.s 4
-				IL_061c: brfalse IL_0673
-
-				IL_0621: ldarg.2
-				IL_0622: ldloc.2
-				IL_0623: ldc.r8 1
-				IL_062c: add
-				IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0632: stloc.s 10
-				IL_0634: ldloc.s 10
-				IL_0636: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_063b: stloc.s 4
-				IL_063d: ldloc.s 4
-				IL_063f: brtrue IL_0650
-
-				IL_0644: ldstr ""
-				IL_0649: stloc.s 19
-				IL_064b: br IL_0654
-
-				IL_0650: ldloc.s 10
-				IL_0652: stloc.s 19
-
-				IL_0654: ldloc.0
-				IL_0655: ldstr "id"
-				IL_065a: ldloc.s 19
-				IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0661: pop
-				IL_0662: ldloc.2
-				IL_0663: ldc.r8 1
-				IL_066c: add
-				IL_066d: stloc.2
-				IL_066e: br IL_07db
-
-				IL_0673: ldloc.3
-				IL_0674: ldstr "startsWith"
-				IL_0679: ldstr "--id="
-				IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0683: stloc.s 10
-				IL_0685: ldloc.s 10
-				IL_0687: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_068c: stloc.s 4
-				IL_068e: ldloc.s 4
-				IL_0690: brfalse IL_06c5
-
-				IL_0695: ldloc.3
-				IL_0696: ldstr "substring"
-				IL_069b: ldstr "--id="
-				IL_06a0: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_06a5: conv.r8
-				IL_06a6: box [System.Runtime]System.Double
-				IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_06b0: stloc.s 10
-				IL_06b2: ldloc.0
-				IL_06b3: ldstr "id"
-				IL_06b8: ldloc.s 10
-				IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_06bf: pop
-				IL_06c0: br IL_07db
-
-				IL_06c5: ldloc.3
-				IL_06c6: ldstr "--wrap"
-				IL_06cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_06d0: stloc.s 4
-				IL_06d2: ldloc.s 4
-				IL_06d4: brfalse IL_06f0
-
-				IL_06d9: ldloc.0
-				IL_06da: ldstr "wrap"
-				IL_06df: ldc.i4.1
-				IL_06e0: box [System.Runtime]System.Boolean
-				IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_06ea: pop
-				IL_06eb: br IL_07db
-
-				IL_06f0: ldloc.3
-				IL_06f1: ldstr "--no-wrap"
-				IL_06f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_06fb: stloc.s 4
-				IL_06fd: ldloc.s 4
-				IL_06ff: brfalse IL_071b
-
-				IL_0704: ldloc.0
-				IL_0705: ldstr "wrap"
-				IL_070a: ldc.i4.0
-				IL_070b: box [System.Runtime]System.Boolean
-				IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0715: pop
-				IL_0716: br IL_07db
-
-				IL_071b: ldloc.3
-				IL_071c: ldstr "--base"
-				IL_0721: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0726: stloc.s 4
-				IL_0728: ldloc.s 4
-				IL_072a: brfalse IL_0781
-
-				IL_072f: ldarg.2
-				IL_0730: ldloc.2
-				IL_0731: ldc.r8 1
-				IL_073a: add
-				IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0740: stloc.s 10
-				IL_0742: ldloc.s 10
-				IL_0744: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0749: stloc.s 4
-				IL_074b: ldloc.s 4
-				IL_074d: brtrue IL_075e
-
-				IL_0752: ldstr ""
-				IL_0757: stloc.s 20
-				IL_0759: br IL_0762
-
-				IL_075e: ldloc.s 10
-				IL_0760: stloc.s 20
-
-				IL_0762: ldloc.0
-				IL_0763: ldstr "baseHref"
-				IL_0768: ldloc.s 20
-				IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_076f: pop
-				IL_0770: ldloc.2
-				IL_0771: ldc.r8 1
-				IL_077a: add
-				IL_077b: stloc.2
-				IL_077c: br IL_07db
-
-				IL_0781: ldloc.3
-				IL_0782: ldstr "startsWith"
-				IL_0787: ldstr "--base="
-				IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0791: stloc.s 10
-				IL_0793: ldloc.s 10
-				IL_0795: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_079a: stloc.s 4
-				IL_079c: ldloc.s 4
-				IL_079e: brfalse IL_07d3
-
-				IL_07a3: ldloc.3
-				IL_07a4: ldstr "substring"
-				IL_07a9: ldstr "--base="
-				IL_07ae: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_07b3: conv.r8
-				IL_07b4: box [System.Runtime]System.Double
-				IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_07be: stloc.s 10
-				IL_07c0: ldloc.0
-				IL_07c1: ldstr "baseHref"
-				IL_07c6: ldloc.s 10
-				IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_07cd: pop
-				IL_07ce: br IL_07db
-
-				IL_07d3: ldloc.1
-				IL_07d4: ldloc.3
-				IL_07d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_07da: pop
-
-				IL_07db: ldloc.2
-				IL_07dc: ldc.r8 1
-				IL_07e5: add
-				IL_07e6: stloc.2
-				IL_07e7: br IL_00ab
+				IL_0295: ldloc.1
+				IL_0296: ldc.r8 1
+				IL_029f: add
+				IL_02a0: stloc.1
+				IL_02a1: br IL_006c
 			// end loop
 
-			IL_07ec: ldloc.0
-			IL_07ed: ldstr "section"
-			IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_07fc: ldc.i4.0
-			IL_07fd: ceq
-			IL_07ff: stloc.s 4
-			IL_0801: ldloc.s 4
-			IL_0803: box [System.Runtime]System.Boolean
-			IL_0808: stloc.s 5
-			IL_080a: ldloc.s 5
-			IL_080c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0811: stloc.s 4
-			IL_0813: ldloc.s 4
-			IL_0815: brfalse IL_083b
-
-			IL_081a: ldloc.1
-			IL_081b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0820: conv.r8
-			IL_0821: ldc.r8 1
-			IL_082a: clt
-			IL_082c: ldc.i4.0
-			IL_082d: ceq
-			IL_082f: box [System.Runtime]System.Boolean
-			IL_0834: stloc.s 21
-			IL_0836: br IL_083f
-
-			IL_083b: ldloc.s 5
-			IL_083d: stloc.s 21
-
-			IL_083f: ldloc.s 21
-			IL_0841: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0846: stloc.s 4
-			IL_0848: ldloc.s 4
-			IL_084a: brfalse IL_086a
-
-			IL_084f: ldloc.0
-			IL_0850: ldstr "section"
-			IL_0855: ldloc.1
-			IL_0856: ldc.r8 0.0
-			IL_085f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-			IL_0869: pop
-
-			IL_086a: ldloc.0
-			IL_086b: ldstr "inFile"
-			IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0875: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_087a: ldc.i4.0
-			IL_087b: ceq
-			IL_087d: stloc.s 4
-			IL_087f: ldloc.s 4
-			IL_0881: box [System.Runtime]System.Boolean
-			IL_0886: stloc.s 5
-			IL_0888: ldloc.s 5
-			IL_088a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_088f: stloc.s 4
-			IL_0891: ldloc.s 4
-			IL_0893: brfalse IL_08bf
-
-			IL_0898: ldloc.0
-			IL_0899: ldstr "url"
-			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08a8: ldc.i4.0
-			IL_08a9: ceq
-			IL_08ab: stloc.s 4
-			IL_08ad: ldloc.s 4
-			IL_08af: box [System.Runtime]System.Boolean
-			IL_08b4: stloc.s 6
-			IL_08b6: ldloc.s 6
-			IL_08b8: stloc.s 22
-			IL_08ba: br IL_08c3
-
-			IL_08bf: ldloc.s 5
-			IL_08c1: stloc.s 22
-
-			IL_08c3: ldloc.s 22
-			IL_08c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_08ca: stloc.s 4
-			IL_08cc: ldloc.s 4
-			IL_08ce: brfalse IL_08f4
-
-			IL_08d3: ldloc.1
-			IL_08d4: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_08d9: conv.r8
-			IL_08da: ldc.r8 2
-			IL_08e3: clt
-			IL_08e5: ldc.i4.0
-			IL_08e6: ceq
-			IL_08e8: box [System.Runtime]System.Boolean
-			IL_08ed: stloc.s 22
-			IL_08ef: br IL_08f4
-
-			IL_08f4: ldloc.s 22
-			IL_08f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_08fb: stloc.s 4
-			IL_08fd: ldloc.s 4
-			IL_08ff: brfalse IL_091f
-
-			IL_0904: ldloc.0
-			IL_0905: ldstr "inFile"
-			IL_090a: ldloc.1
-			IL_090b: ldc.r8 1
-			IL_0914: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0919: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-			IL_091e: pop
-
-			IL_091f: ldloc.0
-			IL_0920: ldstr "outFile"
-			IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_092a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_092f: ldc.i4.0
-			IL_0930: ceq
-			IL_0932: stloc.s 4
-			IL_0934: ldloc.s 4
-			IL_0936: box [System.Runtime]System.Boolean
-			IL_093b: stloc.s 5
-			IL_093d: ldloc.s 5
-			IL_093f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0944: stloc.s 4
-			IL_0946: ldloc.s 4
-			IL_0948: brfalse IL_096e
-
-			IL_094d: ldloc.1
-			IL_094e: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0953: conv.r8
-			IL_0954: ldc.r8 3
-			IL_095d: clt
-			IL_095f: ldc.i4.0
-			IL_0960: ceq
-			IL_0962: box [System.Runtime]System.Boolean
-			IL_0967: stloc.s 24
-			IL_0969: br IL_0972
-
-			IL_096e: ldloc.s 5
-			IL_0970: stloc.s 24
-
-			IL_0972: ldloc.s 24
-			IL_0974: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0979: stloc.s 4
-			IL_097b: ldloc.s 4
-			IL_097d: brfalse IL_099d
-
-			IL_0982: ldloc.0
-			IL_0983: ldstr "outFile"
-			IL_0988: ldloc.1
-			IL_0989: ldc.r8 2
-			IL_0992: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0997: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-			IL_099c: pop
-
-			IL_099d: ldloc.0
-			IL_099e: ret
+			IL_02a6: ldloc.0
+			IL_02a7: ret
 		} // end of method parseArgs::__js_call__
 
 	} // end of class parseArgs
 
-	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithHttp
+	.class nested public auto ansi abstract sealed beforefieldinit fetchText
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5a1c
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object urlString,
-				object maxRedirects
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x329c
-			// Header size: 12
-			// Code size: 66 (0x42)
-			.maxstack 8
-			.locals init (
-				[0] object
-			)
-
-			IL_0000: ldarg.3
-			IL_0001: brtrue IL_0016
-
-			IL_0006: ldc.r8 5
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: starg.s maxRedirects
-
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: ldc.i4.0
-			IL_0021: ldelem.ref
-			IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0027: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
-			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0032: ldnull
-			IL_0033: ldstr "http"
-			IL_0038: ldarg.2
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_003f: stloc.0
-			IL_0040: ldloc.0
-			IL_0041: ret
-		} // end of method fetchTextWithHttp::__js_call__
-
-	} // end of class fetchTextWithHttp
-
-	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithHttps
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5a25
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object urlString,
-				object maxRedirects
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x32ec
-			// Header size: 12
-			// Code size: 66 (0x42)
-			.maxstack 8
-			.locals init (
-				[0] object
-			)
-
-			IL_0000: ldarg.3
-			IL_0001: brtrue IL_0016
-
-			IL_0006: ldc.r8 5
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: starg.s maxRedirects
-
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: ldc.i4.0
-			IL_0021: ldelem.ref
-			IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0027: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
-			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0032: ldnull
-			IL_0033: ldstr "https"
-			IL_0038: ldarg.2
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_003f: stloc.0
-			IL_0040: ldloc.0
-			IL_0041: ret
-		} // end of method fetchTextWithHttps::__js_call__
-
-	} // end of class fetchTextWithHttps
-
-	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithTransport
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L170C22
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L72C22
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L194C7
+			.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L91C7
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L219C24
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L116C24
 					extends [System.Runtime]System.Object
 				{
 					// Nested Types
@@ -2443,7 +1059,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5a7f
+							// Method begins at RVA 0x4151
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2468,7 +1084,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x5890
+						// Method begins at RVA 0x4004
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -2479,24 +1095,24 @@
 						IL_0000: ldarg.0
 						IL_0001: ldc.i4.3
 						IL_0002: ldelem.ref
-						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
-						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
 						IL_000d: ldarg.2
 						IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 						IL_0013: stloc.0
 						IL_0014: ldarg.0
 						IL_0015: ldc.i4.3
 						IL_0016: ldelem.ref
-						IL_0017: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
+						IL_0017: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
 						IL_001c: ldloc.0
-						IL_001d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_001d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
 						IL_0022: ldnull
 						IL_0023: ret
-					} // end of method ArrowFunction_L219C24::__js_call__
+					} // end of method ArrowFunction_L116C24::__js_call__
 
-				} // end of class ArrowFunction_L219C24
+				} // end of class ArrowFunction_L116C24
 
-				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L222C23
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L119C23
 					extends [System.Runtime]System.Object
 				{
 					// Nested Types
@@ -2507,7 +1123,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5a88
+							// Method begins at RVA 0x415a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2531,13 +1147,12 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x58c0
+						// Method begins at RVA 0x4034
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
 						.locals init (
-							[0] object[],
-							[1] object
+							[0] object[]
 						)
 
 						IL_0000: ldc.i4.4
@@ -2570,21 +1185,21 @@
 						IL_001f: ldarg.0
 						IL_0020: ldc.i4.2
 						IL_0021: ldelem.ref
-						IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-						IL_0027: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+						IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+						IL_0027: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
 						IL_002c: ldloc.0
 						IL_002d: ldarg.0
 						IL_002e: ldc.i4.3
 						IL_002f: ldelem.ref
-						IL_0030: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
-						IL_0035: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_0030: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+						IL_0035: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
 						IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-						IL_003f: stloc.1
-						IL_0040: ldloc.1
+						IL_003f: pop
+						IL_0040: ldnull
 						IL_0041: ret
-					} // end of method ArrowFunction_L222C23::__js_call__
+					} // end of method ArrowFunction_L119C23::__js_call__
 
-				} // end of class ArrowFunction_L222C23
+				} // end of class ArrowFunction_L119C23
 
 				.class nested private auto ansi beforefieldinit Scope
 					extends [System.Runtime]System.Object
@@ -2594,18 +1209,18 @@
 						73 7d 2c 20 64 61 74 61 3d 7b 64 61 74 61 7d 00 00
 					)
 					// Nested Types
-					.class nested private auto ansi beforefieldinit Block_L198C55
+					.class nested private auto ansi beforefieldinit Block_L95C55
 						extends [System.Runtime]System.Object
 					{
 						// Nested Types
-						.class nested private auto ansi beforefieldinit Block_L199C33
+						.class nested private auto ansi beforefieldinit Block_L96C33
 							extends [System.Runtime]System.Object
 						{
 							// Methods
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x5a6d
+								// Method begins at RVA 0x413f
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -2614,16 +1229,16 @@
 								IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 								IL_0006: nop
 								IL_0007: ret
-							} // end of method Block_L199C33::.ctor
+							} // end of method Block_L96C33::.ctor
 
-						} // end of class Block_L199C33
+						} // end of class Block_L96C33
 
 
 						// Methods
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5a64
+							// Method begins at RVA 0x4136
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2632,18 +1247,18 @@
 							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 							IL_0006: nop
 							IL_0007: ret
-						} // end of method Block_L198C55::.ctor
+						} // end of method Block_L95C55::.ctor
 
-					} // end of class Block_L198C55
+					} // end of class Block_L95C55
 
-					.class nested private auto ansi beforefieldinit Block_L211C43
+					.class nested private auto ansi beforefieldinit Block_L108C43
 						extends [System.Runtime]System.Object
 					{
 						// Methods
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5a76
+							// Method begins at RVA 0x4148
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2652,9 +1267,9 @@
 							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 							IL_0006: nop
 							IL_0007: ret
-						} // end of method Block_L211C43::.ctor
+						} // end of method Block_L108C43::.ctor
 
-					} // end of class Block_L211C43
+					} // end of class Block_L108C43
 
 
 					// Fields
@@ -2665,7 +1280,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5a5b
+						// Method begins at RVA 0x412d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2690,12 +1305,12 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x5498
+					// Method begins at RVA 0x3c04
 					// Header size: 12
-					// Code size: 1001 (0x3e9)
+					// Code size: 1009 (0x3f1)
 					.maxstack 8
 					.locals init (
-						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope,
+						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
 						[1] object,
 						[2] object,
 						[3] object,
@@ -2711,13 +1326,12 @@
 						[13] object[],
 						[14] string,
 						[15] object,
-						[16] class [System.Runtime]System.Delegate,
+						[16] object,
 						[17] object,
-						[18] object,
-						[19] string
+						[18] string
 					)
 
-					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::.ctor()
+					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
 					IL_0005: stloc.0
 					IL_0006: ldarg.2
 					IL_0007: ldstr "statusCode"
@@ -2794,13 +1408,13 @@
 					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d4: stloc.s 5
 					IL_00d6: ldloc.s 5
-					IL_00d8: brfalse IL_0239
+					IL_00d8: brfalse IL_0241
 
 					IL_00dd: ldarg.0
 					IL_00de: ldc.i4.1
 					IL_00df: ldelem.ref
-					IL_00e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_00e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
+					IL_00e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_00e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
 					IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 					IL_00ef: ldc.r8 0.0
 					IL_00f8: cgt
@@ -2815,8 +1429,8 @@
 					IL_010e: ldarg.0
 					IL_010f: ldc.i4.2
 					IL_0110: ldelem.ref
-					IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
 					IL_011b: stloc.s 4
 					IL_011d: ldc.i4.3
 					IL_011e: newarr [System.Runtime]System.Object
@@ -2842,8 +1456,8 @@
 					IL_0137: ldarg.0
 					IL_0138: ldc.i4.1
 					IL_0139: ldelem.ref
-					IL_013a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_013f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_013a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_013f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
 					IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 					IL_0149: stloc.s 14
 					IL_014b: ldstr "Too many redirects fetching "
@@ -2862,275 +1476,279 @@
 					IL_0173: ldnull
 					IL_0174: ret
 
-					IL_0175: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
-					IL_017a: stloc.s 16
-					IL_017c: ldc.i4.2
-					IL_017d: newarr [System.Runtime]System.Object
-					IL_0182: dup
-					IL_0183: ldc.i4.0
-					IL_0184: ldloc.2
-					IL_0185: stelem.ref
-					IL_0186: dup
-					IL_0187: ldc.i4.1
-					IL_0188: ldarg.0
-					IL_0189: ldc.i4.2
-					IL_018a: ldelem.ref
-					IL_018b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_0190: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
-					IL_0195: stelem.ref
-					IL_0196: stloc.s 13
-					IL_0198: ldloc.s 16
-					IL_019a: ldloc.s 13
-					IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_01a1: stloc.s 15
-					IL_01a3: ldloc.s 15
-					IL_01a5: ldstr "toString"
-					IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01af: stloc.s 15
-					IL_01b1: ldloc.s 15
-					IL_01b3: stloc.3
-					IL_01b4: ldarg.2
-					IL_01b5: ldstr "resume"
-					IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01bf: pop
-					IL_01c0: ldarg.0
-					IL_01c1: ldc.i4.1
-					IL_01c2: ldelem.ref
-					IL_01c3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_01c8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
-					IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01d2: ldc.r8 1
-					IL_01db: sub
-					IL_01dc: box [System.Runtime]System.Double
-					IL_01e1: stloc.s 17
-					IL_01e3: ldc.i4.1
-					IL_01e4: newarr [System.Runtime]System.Object
-					IL_01e9: dup
-					IL_01ea: ldc.i4.0
-					IL_01eb: ldarg.0
-					IL_01ec: ldc.i4.0
-					IL_01ed: ldelem.ref
-					IL_01ee: stelem.ref
-					IL_01ef: ldc.i4.0
-					IL_01f0: ldelem.ref
-					IL_01f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-					IL_01f6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-					IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-					IL_0201: ldnull
-					IL_0202: ldloc.3
-					IL_0203: ldloc.s 17
-					IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-					IL_020a: stloc.s 15
-					IL_020c: ldarg.0
-					IL_020d: ldc.i4.2
-					IL_020e: ldelem.ref
-					IL_020f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_0214: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
-					IL_0219: stloc.s 4
-					IL_021b: ldloc.s 15
-					IL_021d: ldstr "then"
-					IL_0222: ldloc.s 4
-					IL_0224: ldarg.0
-					IL_0225: ldc.i4.2
-					IL_0226: ldelem.ref
-					IL_0227: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_022c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-					IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0236: pop
-					IL_0237: ldnull
-					IL_0238: ret
+					IL_0175: ldarg.0
+					IL_0176: ldc.i4.0
+					IL_0177: ldelem.ref
+					IL_0178: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_017d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_0182: stloc.s 15
+					IL_0184: ldc.i4.2
+					IL_0185: newarr [System.Runtime]System.Object
+					IL_018a: dup
+					IL_018b: ldc.i4.0
+					IL_018c: ldloc.2
+					IL_018d: stelem.ref
+					IL_018e: dup
+					IL_018f: ldc.i4.1
+					IL_0190: ldarg.0
+					IL_0191: ldc.i4.2
+					IL_0192: ldelem.ref
+					IL_0193: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0198: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_019d: stelem.ref
+					IL_019e: stloc.s 13
+					IL_01a0: ldloc.s 15
+					IL_01a2: ldloc.s 13
+					IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01a9: stloc.s 15
+					IL_01ab: ldloc.s 15
+					IL_01ad: ldstr "toString"
+					IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01b7: stloc.s 15
+					IL_01b9: ldloc.s 15
+					IL_01bb: stloc.3
+					IL_01bc: ldarg.2
+					IL_01bd: ldstr "resume"
+					IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01c7: pop
+					IL_01c8: ldarg.0
+					IL_01c9: ldc.i4.1
+					IL_01ca: ldelem.ref
+					IL_01cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_01d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_01d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01da: ldc.r8 1
+					IL_01e3: sub
+					IL_01e4: box [System.Runtime]System.Double
+					IL_01e9: stloc.s 16
+					IL_01eb: ldc.i4.1
+					IL_01ec: newarr [System.Runtime]System.Object
+					IL_01f1: dup
+					IL_01f2: ldc.i4.0
+					IL_01f3: ldarg.0
+					IL_01f4: ldc.i4.0
+					IL_01f5: ldelem.ref
+					IL_01f6: stelem.ref
+					IL_01f7: ldc.i4.0
+					IL_01f8: ldelem.ref
+					IL_01f9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_01fe: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+					IL_0204: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+					IL_0209: ldnull
+					IL_020a: ldloc.3
+					IL_020b: ldloc.s 16
+					IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+					IL_0212: stloc.s 15
+					IL_0214: ldarg.0
+					IL_0215: ldc.i4.2
+					IL_0216: ldelem.ref
+					IL_0217: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_021c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0221: stloc.s 4
+					IL_0223: ldloc.s 15
+					IL_0225: ldstr "then"
+					IL_022a: ldloc.s 4
+					IL_022c: ldarg.0
+					IL_022d: ldc.i4.2
+					IL_022e: ldelem.ref
+					IL_022f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0234: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_023e: pop
+					IL_023f: ldnull
+					IL_0240: ret
 
-					IL_0239: ldloc.1
-					IL_023a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_023f: stloc.s 8
-					IL_0241: ldloc.s 8
-					IL_0243: ldc.r8 200
-					IL_024c: clt
-					IL_024e: stloc.s 5
-					IL_0250: ldloc.s 5
-					IL_0252: box [System.Runtime]System.Boolean
-					IL_0257: stloc.s 9
-					IL_0259: ldloc.s 9
-					IL_025b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0260: stloc.s 5
-					IL_0262: ldloc.s 5
-					IL_0264: brtrue IL_0295
+					IL_0241: ldloc.1
+					IL_0242: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0247: stloc.s 8
+					IL_0249: ldloc.s 8
+					IL_024b: ldc.r8 200
+					IL_0254: clt
+					IL_0256: stloc.s 5
+					IL_0258: ldloc.s 5
+					IL_025a: box [System.Runtime]System.Boolean
+					IL_025f: stloc.s 9
+					IL_0261: ldloc.s 9
+					IL_0263: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0268: stloc.s 5
+					IL_026a: ldloc.s 5
+					IL_026c: brtrue IL_029d
 
-					IL_0269: ldloc.1
-					IL_026a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_026f: stloc.s 8
-					IL_0271: ldloc.s 8
-					IL_0273: ldc.r8 300
-					IL_027c: clt
-					IL_027e: ldc.i4.0
-					IL_027f: ceq
-					IL_0281: stloc.s 5
-					IL_0283: ldloc.s 5
-					IL_0285: box [System.Runtime]System.Boolean
-					IL_028a: stloc.s 10
-					IL_028c: ldloc.s 10
-					IL_028e: stloc.s 18
-					IL_0290: br IL_0299
+					IL_0271: ldloc.1
+					IL_0272: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0277: stloc.s 8
+					IL_0279: ldloc.s 8
+					IL_027b: ldc.r8 300
+					IL_0284: clt
+					IL_0286: ldc.i4.0
+					IL_0287: ceq
+					IL_0289: stloc.s 5
+					IL_028b: ldloc.s 5
+					IL_028d: box [System.Runtime]System.Boolean
+					IL_0292: stloc.s 10
+					IL_0294: ldloc.s 10
+					IL_0296: stloc.s 17
+					IL_0298: br IL_02a1
 
-					IL_0295: ldloc.s 9
-					IL_0297: stloc.s 18
+					IL_029d: ldloc.s 9
+					IL_029f: stloc.s 17
 
-					IL_0299: ldloc.s 18
-					IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02a0: stloc.s 5
-					IL_02a2: ldloc.s 5
-					IL_02a4: brfalse IL_033d
+					IL_02a1: ldloc.s 17
+					IL_02a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a8: stloc.s 5
+					IL_02aa: ldloc.s 5
+					IL_02ac: brfalse IL_0345
 
-					IL_02a9: ldarg.2
-					IL_02aa: ldstr "resume"
-					IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02b4: pop
-					IL_02b5: ldarg.0
-					IL_02b6: ldc.i4.2
-					IL_02b7: ldelem.ref
-					IL_02b8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_02bd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-					IL_02c2: stloc.s 4
-					IL_02c4: ldc.i4.3
-					IL_02c5: newarr [System.Runtime]System.Object
-					IL_02ca: dup
-					IL_02cb: ldc.i4.0
-					IL_02cc: ldarg.0
-					IL_02cd: ldc.i4.0
-					IL_02ce: ldelem.ref
-					IL_02cf: stelem.ref
-					IL_02d0: dup
-					IL_02d1: ldc.i4.1
-					IL_02d2: ldarg.0
-					IL_02d3: ldc.i4.1
-					IL_02d4: ldelem.ref
-					IL_02d5: stelem.ref
-					IL_02d6: dup
-					IL_02d7: ldc.i4.2
-					IL_02d8: ldarg.0
-					IL_02d9: ldc.i4.2
-					IL_02da: ldelem.ref
-					IL_02db: stelem.ref
-					IL_02dc: stloc.s 13
-					IL_02de: ldloc.1
-					IL_02df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_02e4: stloc.s 14
-					IL_02e6: ldstr "HTTP "
-					IL_02eb: ldloc.s 14
-					IL_02ed: call string [System.Runtime]System.String::Concat(string, string)
-					IL_02f2: stloc.s 14
-					IL_02f4: ldloc.s 14
-					IL_02f6: ldstr " fetching "
-					IL_02fb: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0300: stloc.s 14
-					IL_0302: ldarg.0
-					IL_0303: ldc.i4.1
-					IL_0304: ldelem.ref
-					IL_0305: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_030a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-					IL_030f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0314: stloc.s 19
-					IL_0316: ldloc.s 14
-					IL_0318: ldloc.s 19
-					IL_031a: call string [System.Runtime]System.String::Concat(string, string)
-					IL_031f: stloc.s 19
-					IL_0321: ldloc.s 19
-					IL_0323: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0328: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_032d: stloc.s 15
-					IL_032f: ldloc.s 4
-					IL_0331: ldloc.s 13
-					IL_0333: ldloc.s 15
-					IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-					IL_033a: pop
-					IL_033b: ldnull
-					IL_033c: ret
+					IL_02b1: ldarg.2
+					IL_02b2: ldstr "resume"
+					IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02bc: pop
+					IL_02bd: ldarg.0
+					IL_02be: ldc.i4.2
+					IL_02bf: ldelem.ref
+					IL_02c0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02c5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_02ca: stloc.s 4
+					IL_02cc: ldc.i4.3
+					IL_02cd: newarr [System.Runtime]System.Object
+					IL_02d2: dup
+					IL_02d3: ldc.i4.0
+					IL_02d4: ldarg.0
+					IL_02d5: ldc.i4.0
+					IL_02d6: ldelem.ref
+					IL_02d7: stelem.ref
+					IL_02d8: dup
+					IL_02d9: ldc.i4.1
+					IL_02da: ldarg.0
+					IL_02db: ldc.i4.1
+					IL_02dc: ldelem.ref
+					IL_02dd: stelem.ref
+					IL_02de: dup
+					IL_02df: ldc.i4.2
+					IL_02e0: ldarg.0
+					IL_02e1: ldc.i4.2
+					IL_02e2: ldelem.ref
+					IL_02e3: stelem.ref
+					IL_02e4: stloc.s 13
+					IL_02e6: ldloc.1
+					IL_02e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_02ec: stloc.s 14
+					IL_02ee: ldstr "HTTP "
+					IL_02f3: ldloc.s 14
+					IL_02f5: call string [System.Runtime]System.String::Concat(string, string)
+					IL_02fa: stloc.s 14
+					IL_02fc: ldloc.s 14
+					IL_02fe: ldstr " fetching "
+					IL_0303: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0308: stloc.s 14
+					IL_030a: ldarg.0
+					IL_030b: ldc.i4.1
+					IL_030c: ldelem.ref
+					IL_030d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0312: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0317: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_031c: stloc.s 18
+					IL_031e: ldloc.s 14
+					IL_0320: ldloc.s 18
+					IL_0322: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0327: stloc.s 18
+					IL_0329: ldloc.s 18
+					IL_032b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0330: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0335: stloc.s 15
+					IL_0337: ldloc.s 4
+					IL_0339: ldloc.s 13
+					IL_033b: ldloc.s 15
+					IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_0342: pop
+					IL_0343: ldnull
+					IL_0344: ret
 
-					IL_033d: ldarg.2
-					IL_033e: ldstr "setEncoding"
-					IL_0343: ldstr "utf8"
-					IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_034d: pop
-					IL_034e: ldloc.0
-					IL_034f: ldstr ""
-					IL_0354: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
-					IL_0359: ldnull
-					IL_035a: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/ArrowFunction_L219C24::__js_call__(object[], object, object)
-					IL_0360: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_0365: ldc.i4.4
-					IL_0366: newarr [System.Runtime]System.Object
-					IL_036b: dup
-					IL_036c: ldc.i4.0
-					IL_036d: ldarg.0
-					IL_036e: ldc.i4.0
-					IL_036f: ldelem.ref
-					IL_0370: stelem.ref
-					IL_0371: dup
-					IL_0372: ldc.i4.1
-					IL_0373: ldarg.0
-					IL_0374: ldc.i4.1
-					IL_0375: ldelem.ref
-					IL_0376: stelem.ref
-					IL_0377: dup
-					IL_0378: ldc.i4.2
-					IL_0379: ldarg.0
-					IL_037a: ldc.i4.2
-					IL_037b: ldelem.ref
-					IL_037c: stelem.ref
-					IL_037d: dup
-					IL_037e: ldc.i4.3
-					IL_037f: ldloc.0
-					IL_0380: stelem.ref
-					IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_038b: stloc.s 15
-					IL_038d: ldarg.2
-					IL_038e: ldstr "on"
-					IL_0393: ldstr "data"
-					IL_0398: ldloc.s 15
-					IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_039f: pop
-					IL_03a0: ldnull
-					IL_03a1: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/ArrowFunction_L222C23::__js_call__(object[], object)
-					IL_03a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_03ac: ldc.i4.4
-					IL_03ad: newarr [System.Runtime]System.Object
-					IL_03b2: dup
-					IL_03b3: ldc.i4.0
-					IL_03b4: ldarg.0
-					IL_03b5: ldc.i4.0
-					IL_03b6: ldelem.ref
-					IL_03b7: stelem.ref
-					IL_03b8: dup
-					IL_03b9: ldc.i4.1
-					IL_03ba: ldarg.0
-					IL_03bb: ldc.i4.1
-					IL_03bc: ldelem.ref
-					IL_03bd: stelem.ref
-					IL_03be: dup
-					IL_03bf: ldc.i4.2
-					IL_03c0: ldarg.0
-					IL_03c1: ldc.i4.2
-					IL_03c2: ldelem.ref
-					IL_03c3: stelem.ref
-					IL_03c4: dup
-					IL_03c5: ldc.i4.3
-					IL_03c6: ldloc.0
-					IL_03c7: stelem.ref
-					IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03d2: stloc.s 15
-					IL_03d4: ldarg.2
-					IL_03d5: ldstr "on"
-					IL_03da: ldstr "end"
-					IL_03df: ldloc.s 15
-					IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_03e6: pop
-					IL_03e7: ldnull
-					IL_03e8: ret
-				} // end of method ArrowFunction_L194C7::__js_call__
+					IL_0345: ldarg.2
+					IL_0346: ldstr "setEncoding"
+					IL_034b: ldstr "utf8"
+					IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0355: pop
+					IL_0356: ldloc.0
+					IL_0357: ldstr ""
+					IL_035c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_0361: ldnull
+					IL_0362: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_0368: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_036d: ldc.i4.4
+					IL_036e: newarr [System.Runtime]System.Object
+					IL_0373: dup
+					IL_0374: ldc.i4.0
+					IL_0375: ldarg.0
+					IL_0376: ldc.i4.0
+					IL_0377: ldelem.ref
+					IL_0378: stelem.ref
+					IL_0379: dup
+					IL_037a: ldc.i4.1
+					IL_037b: ldarg.0
+					IL_037c: ldc.i4.1
+					IL_037d: ldelem.ref
+					IL_037e: stelem.ref
+					IL_037f: dup
+					IL_0380: ldc.i4.2
+					IL_0381: ldarg.0
+					IL_0382: ldc.i4.2
+					IL_0383: ldelem.ref
+					IL_0384: stelem.ref
+					IL_0385: dup
+					IL_0386: ldc.i4.3
+					IL_0387: ldloc.0
+					IL_0388: stelem.ref
+					IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0393: stloc.s 15
+					IL_0395: ldarg.2
+					IL_0396: ldstr "on"
+					IL_039b: ldstr "data"
+					IL_03a0: ldloc.s 15
+					IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03a7: pop
+					IL_03a8: ldnull
+					IL_03a9: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_03af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_03b4: ldc.i4.4
+					IL_03b5: newarr [System.Runtime]System.Object
+					IL_03ba: dup
+					IL_03bb: ldc.i4.0
+					IL_03bc: ldarg.0
+					IL_03bd: ldc.i4.0
+					IL_03be: ldelem.ref
+					IL_03bf: stelem.ref
+					IL_03c0: dup
+					IL_03c1: ldc.i4.1
+					IL_03c2: ldarg.0
+					IL_03c3: ldc.i4.1
+					IL_03c4: ldelem.ref
+					IL_03c5: stelem.ref
+					IL_03c6: dup
+					IL_03c7: ldc.i4.2
+					IL_03c8: ldarg.0
+					IL_03c9: ldc.i4.2
+					IL_03ca: ldelem.ref
+					IL_03cb: stelem.ref
+					IL_03cc: dup
+					IL_03cd: ldc.i4.3
+					IL_03ce: ldloc.0
+					IL_03cf: stelem.ref
+					IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03da: stloc.s 15
+					IL_03dc: ldarg.2
+					IL_03dd: ldstr "on"
+					IL_03e2: ldstr "end"
+					IL_03e7: ldloc.s 15
+					IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03ee: pop
+					IL_03ef: ldnull
+					IL_03f0: ret
+				} // end of method ArrowFunction_L91C7::__js_call__
 
-			} // end of class ArrowFunction_L194C7
+			} // end of class ArrowFunction_L91C7
 
 			.class nested private auto ansi beforefieldinit Scope
 				extends [System.Runtime]System.Object
@@ -3142,14 +1760,14 @@
 					4f 62 6a 3d 7b 75 72 6c 4f 62 6a 7d 00 00
 				)
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L172C8
+				.class nested private auto ansi beforefieldinit Block_L74C8
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5a40
+						// Method begins at RVA 0x411b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3158,18 +1776,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L172C8::.ctor
+					} // end of method Block_L74C8::.ctor
 
-				} // end of class Block_L172C8
+				} // end of class Block_L74C8
 
-				.class nested private auto ansi beforefieldinit Block_L174C12
+				.class nested private auto ansi beforefieldinit Block_L76C12
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5a49
+						// Method begins at RVA 0x4124
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3178,29 +1796,9 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L174C12::.ctor
+					} // end of method Block_L76C12::.ctor
 
-				} // end of class Block_L174C12
-
-				.class nested private auto ansi beforefieldinit Block_L179C44
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a52
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L179C44::.ctor
-
-				} // end of class Block_L179C44
+				} // end of class Block_L76C12
 
 
 				// Fields
@@ -3212,7 +1810,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5a37
+					// Method begins at RVA 0x4112
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3238,312 +1836,221 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x5148
+				// Method begins at RVA 0x3a28
 				// Header size: 12
-				// Code size: 674 (0x2a2)
+				// Code size: 448 (0x1c0)
 				.maxstack 8
 				.locals init (
-					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope,
+					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
 					[1] class [System.Runtime]System.Exception,
 					[2] object,
 					[3] object,
 					[4] object,
-					[5] class [System.Runtime]System.Delegate,
+					[5] object,
 					[6] object,
 					[7] object[],
 					[8] string,
 					[9] object,
-					[10] object,
-					[11] bool,
-					[12] string,
-					[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[10] bool,
+					[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
-				IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::.ctor()
+				IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::.ctor()
 				IL_0005: stloc.0
 				IL_0006: ldloc.0
 				IL_0007: ldarg.2
-				IL_0008: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+				IL_0008: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
 				IL_000d: ldloc.0
 				IL_000e: ldarg.3
-				IL_000f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+				IL_000f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
 				IL_0014: ldloc.0
 				IL_0015: ldnull
-				IL_0016: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+				IL_0016: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
 				.try
 				{
-					IL_001b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
-					IL_0020: stloc.s 5
-					IL_0022: ldloc.s 5
-					IL_0024: ldc.i4.1
-					IL_0025: newarr [System.Runtime]System.Object
-					IL_002a: dup
-					IL_002b: ldc.i4.0
-					IL_002c: ldarg.0
-					IL_002d: ldc.i4.1
-					IL_002e: ldelem.ref
-					IL_002f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_0034: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-					IL_0039: stelem.ref
-					IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_003f: stloc.s 6
-					IL_0041: ldloc.0
-					IL_0042: ldloc.s 6
-					IL_0044: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
-					IL_0049: leave IL_00b5
+					IL_001b: ldarg.0
+					IL_001c: ldc.i4.0
+					IL_001d: ldelem.ref
+					IL_001e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_0023: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_0028: stloc.s 6
+					IL_002a: ldloc.s 6
+					IL_002c: ldc.i4.1
+					IL_002d: newarr [System.Runtime]System.Object
+					IL_0032: dup
+					IL_0033: ldc.i4.0
+					IL_0034: ldarg.0
+					IL_0035: ldc.i4.1
+					IL_0036: ldelem.ref
+					IL_0037: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_003c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0041: stelem.ref
+					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_0047: stloc.s 6
+					IL_0049: ldloc.0
+					IL_004a: ldloc.s 6
+					IL_004c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_0051: leave IL_00bd
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
-					IL_004e: stloc.1
-					IL_004f: ldloc.0
-					IL_0050: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-					IL_0055: stloc.s 6
-					IL_0057: ldc.i4.2
-					IL_0058: newarr [System.Runtime]System.Object
-					IL_005d: dup
-					IL_005e: ldc.i4.0
-					IL_005f: ldarg.0
-					IL_0060: ldc.i4.0
-					IL_0061: ldelem.ref
-					IL_0062: stelem.ref
-					IL_0063: dup
-					IL_0064: ldc.i4.1
-					IL_0065: ldarg.0
-					IL_0066: ldc.i4.1
-					IL_0067: ldelem.ref
-					IL_0068: stelem.ref
-					IL_0069: stloc.s 7
-					IL_006b: ldarg.0
+					IL_0056: stloc.1
+					IL_0057: ldloc.0
+					IL_0058: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_005d: stloc.s 6
+					IL_005f: ldc.i4.2
+					IL_0060: newarr [System.Runtime]System.Object
+					IL_0065: dup
+					IL_0066: ldc.i4.0
+					IL_0067: ldarg.0
+					IL_0068: ldc.i4.0
+					IL_0069: ldelem.ref
+					IL_006a: stelem.ref
+					IL_006b: dup
 					IL_006c: ldc.i4.1
-					IL_006d: ldelem.ref
-					IL_006e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_0073: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-					IL_0078: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_007d: stloc.s 8
-					IL_007f: ldstr "Invalid URL: "
-					IL_0084: ldloc.s 8
-					IL_0086: call string [System.Runtime]System.String::Concat(string, string)
-					IL_008b: stloc.s 8
-					IL_008d: ldloc.s 8
-					IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0099: stloc.s 9
-					IL_009b: ldloc.s 6
-					IL_009d: ldloc.s 7
-					IL_009f: ldloc.s 9
-					IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-					IL_00a6: pop
-					IL_00a7: ldnull
-					IL_00a8: stloc.2
-					IL_00a9: ldnull
-					IL_00aa: stloc.2
-					IL_00ab: leave IL_02a0
+					IL_006d: ldarg.0
+					IL_006e: ldc.i4.1
+					IL_006f: ldelem.ref
+					IL_0070: stelem.ref
+					IL_0071: stloc.s 7
+					IL_0073: ldarg.0
+					IL_0074: ldc.i4.1
+					IL_0075: ldelem.ref
+					IL_0076: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_007b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0080: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0085: stloc.s 8
+					IL_0087: ldstr "Invalid URL: "
+					IL_008c: ldloc.s 8
+					IL_008e: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0093: stloc.s 8
+					IL_0095: ldloc.s 8
+					IL_0097: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_009c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00a1: stloc.s 9
+					IL_00a3: ldloc.s 6
+					IL_00a5: ldloc.s 7
+					IL_00a7: ldloc.s 9
+					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_00ae: pop
+					IL_00af: ldnull
+					IL_00b0: stloc.2
+					IL_00b1: ldnull
+					IL_00b2: stloc.2
+					IL_00b3: leave IL_01be
 
-					IL_00b0: leave IL_00b5
+					IL_00b8: leave IL_00bd
 				} // end handler
 
-				IL_00b5: ldloc.0
-				IL_00b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
-				IL_00bb: ldstr "protocol"
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00c5: stloc.s 9
-				IL_00c7: ldarg.0
-				IL_00c8: ldc.i4.1
-				IL_00c9: ldelem.ref
-				IL_00ca: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_00cf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-				IL_00d4: ldstr ":"
-				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00de: stloc.s 10
-				IL_00e0: ldloc.s 9
-				IL_00e2: ldloc.s 10
-				IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_00e9: stloc.s 11
-				IL_00eb: ldloc.s 11
-				IL_00ed: brfalse IL_01a6
+				IL_00bd: ldloc.0
+				IL_00be: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_00c3: ldstr "protocol"
+				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00cd: ldstr "https:"
+				IL_00d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00d7: stloc.s 10
+				IL_00d9: ldloc.s 10
+				IL_00db: brfalse IL_00f3
 
-				IL_00f2: ldloc.0
-				IL_00f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-				IL_00f8: stloc.s 9
-				IL_00fa: ldc.i4.2
-				IL_00fb: newarr [System.Runtime]System.Object
-				IL_0100: dup
-				IL_0101: ldc.i4.0
-				IL_0102: ldarg.0
-				IL_0103: ldc.i4.0
-				IL_0104: ldelem.ref
-				IL_0105: stelem.ref
-				IL_0106: dup
-				IL_0107: ldc.i4.1
-				IL_0108: ldarg.0
-				IL_0109: ldc.i4.1
-				IL_010a: ldelem.ref
-				IL_010b: stelem.ref
-				IL_010c: stloc.s 7
-				IL_010e: ldarg.0
-				IL_010f: ldc.i4.1
-				IL_0110: ldelem.ref
-				IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-				IL_011b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0120: stloc.s 8
-				IL_0122: ldstr "Only "
-				IL_0127: ldloc.s 8
-				IL_0129: call string [System.Runtime]System.String::Concat(string, string)
-				IL_012e: stloc.s 8
-				IL_0130: ldloc.s 8
-				IL_0132: ldstr ":// URLs are supported by the "
-				IL_0137: call string [System.Runtime]System.String::Concat(string, string)
-				IL_013c: stloc.s 8
-				IL_013e: ldarg.0
-				IL_013f: ldc.i4.1
-				IL_0140: ldelem.ref
-				IL_0141: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_0146: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-				IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0150: stloc.s 12
-				IL_0152: ldloc.s 8
-				IL_0154: ldloc.s 12
-				IL_0156: call string [System.Runtime]System.String::Concat(string, string)
-				IL_015b: stloc.s 12
-				IL_015d: ldloc.s 12
-				IL_015f: ldstr " fallback. Got: "
-				IL_0164: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0169: stloc.s 12
-				IL_016b: ldarg.0
+				IL_00e0: ldarg.0
+				IL_00e1: ldc.i4.0
+				IL_00e2: ldelem.ref
+				IL_00e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00ed: stloc.3
+				IL_00ee: br IL_0101
+
+				IL_00f3: ldarg.0
+				IL_00f4: ldc.i4.0
+				IL_00f5: ldelem.ref
+				IL_00f6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00fb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_0100: stloc.3
+
+				IL_0101: ldloc.3
+				IL_0102: stloc.s 4
+				IL_0104: ldloc.0
+				IL_0105: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_010a: stloc.s 9
+				IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0111: dup
+				IL_0112: ldstr "method"
+				IL_0117: ldstr "GET"
+				IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0121: dup
+				IL_0122: ldstr "headers"
+				IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_012c: dup
+				IL_012d: ldstr "Accept-Encoding"
+				IL_0132: ldstr "identity"
+				IL_0137: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_013c: dup
+				IL_013d: ldstr "User-Agent"
+				IL_0142: ldstr "js2il-docs-script"
+				IL_0147: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_014c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0151: stloc.s 11
+				IL_0153: ldnull
+				IL_0154: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_015f: ldc.i4.3
+				IL_0160: newarr [System.Runtime]System.Object
+				IL_0165: dup
+				IL_0166: ldc.i4.0
+				IL_0167: ldarg.0
+				IL_0168: ldc.i4.0
+				IL_0169: ldelem.ref
+				IL_016a: stelem.ref
+				IL_016b: dup
 				IL_016c: ldc.i4.1
-				IL_016d: ldelem.ref
-				IL_016e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_0173: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-				IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_017d: stloc.s 8
-				IL_017f: ldloc.s 12
-				IL_0181: ldloc.s 8
-				IL_0183: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0188: stloc.s 8
-				IL_018a: ldloc.s 8
-				IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0196: stloc.s 6
-				IL_0198: ldloc.s 9
-				IL_019a: ldloc.s 7
-				IL_019c: ldloc.s 6
-				IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-				IL_01a3: pop
-				IL_01a4: ldnull
-				IL_01a5: ret
+				IL_016d: ldarg.0
+				IL_016e: ldc.i4.1
+				IL_016f: ldelem.ref
+				IL_0170: stelem.ref
+				IL_0171: dup
+				IL_0172: ldc.i4.2
+				IL_0173: ldloc.0
+				IL_0174: stelem.ref
+				IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_017f: stloc.s 6
+				IL_0181: ldloc.s 4
+				IL_0183: ldstr "request"
+				IL_0188: ldloc.s 9
+				IL_018a: ldloc.s 11
+				IL_018c: ldloc.s 6
+				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0193: stloc.s 6
+				IL_0195: ldloc.s 6
+				IL_0197: stloc.s 5
+				IL_0199: ldloc.s 5
+				IL_019b: ldstr "on"
+				IL_01a0: ldstr "error"
+				IL_01a5: ldloc.0
+				IL_01a6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01b0: pop
+				IL_01b1: ldloc.s 5
+				IL_01b3: ldstr "end"
+				IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_01bd: pop
 
-				IL_01a6: ldarg.0
-				IL_01a7: ldc.i4.1
-				IL_01a8: ldelem.ref
-				IL_01a9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_01ae: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-				IL_01b3: ldstr "http"
-				IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01bd: stloc.s 11
-				IL_01bf: ldloc.s 11
-				IL_01c1: brfalse IL_01d9
+				IL_01be: ldloc.2
+				IL_01bf: ret
+			} // end of method ArrowFunction_L72C22::__js_call__
 
-				IL_01c6: ldarg.0
-				IL_01c7: ldc.i4.0
-				IL_01c8: ldelem.ref
-				IL_01c9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-				IL_01ce: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::http
-				IL_01d3: stloc.3
-				IL_01d4: br IL_01e7
-
-				IL_01d9: ldarg.0
-				IL_01da: ldc.i4.0
-				IL_01db: ldelem.ref
-				IL_01dc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-				IL_01e1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::https
-				IL_01e6: stloc.3
-
-				IL_01e7: ldloc.0
-				IL_01e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
-				IL_01ed: stloc.s 6
-				IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_01f4: dup
-				IL_01f5: ldstr "method"
-				IL_01fa: ldstr "GET"
-				IL_01ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0204: dup
-				IL_0205: ldstr "headers"
-				IL_020a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_020f: dup
-				IL_0210: ldstr "Accept-Encoding"
-				IL_0215: ldstr "identity"
-				IL_021a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_021f: dup
-				IL_0220: ldstr "User-Agent"
-				IL_0225: ldstr "js2il-docs-script"
-				IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0234: stloc.s 13
-				IL_0236: ldnull
-				IL_0237: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7::__js_call__(object[], object, object)
-				IL_023d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_0242: ldc.i4.3
-				IL_0243: newarr [System.Runtime]System.Object
-				IL_0248: dup
-				IL_0249: ldc.i4.0
-				IL_024a: ldarg.0
-				IL_024b: ldc.i4.0
-				IL_024c: ldelem.ref
-				IL_024d: stelem.ref
-				IL_024e: dup
-				IL_024f: ldc.i4.1
-				IL_0250: ldarg.0
-				IL_0251: ldc.i4.1
-				IL_0252: ldelem.ref
-				IL_0253: stelem.ref
-				IL_0254: dup
-				IL_0255: ldc.i4.2
-				IL_0256: ldloc.0
-				IL_0257: stelem.ref
-				IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_0262: stloc.s 9
-				IL_0264: ldloc.3
-				IL_0265: ldstr "request"
-				IL_026a: ldloc.s 6
-				IL_026c: ldloc.s 13
-				IL_026e: ldloc.s 9
-				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_0275: stloc.s 9
-				IL_0277: ldloc.s 9
-				IL_0279: stloc.s 4
-				IL_027b: ldloc.s 4
-				IL_027d: ldstr "on"
-				IL_0282: ldstr "error"
-				IL_0287: ldloc.0
-				IL_0288: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-				IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0292: pop
-				IL_0293: ldloc.s 4
-				IL_0295: ldstr "end"
-				IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_029f: pop
-
-				IL_02a0: ldloc.2
-				IL_02a1: ret
-			} // end of method ArrowFunction_L170C22::__js_call__
-
-		} // end of class ArrowFunction_L170C22
+		} // end of class ArrowFunction_L72C22
 
 		.class nested private auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
 			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 4d 53 63 6f 70 65 20 70 72 6f 74 6f 63 6f
-				6c 3d 7b 70 72 6f 74 6f 63 6f 6c 7d 2c 20 75 72
-				6c 53 74 72 69 6e 67 3d 7b 75 72 6c 53 74 72 69
-				6e 67 7d 2c 20 6d 61 78 52 65 64 69 72 65 63 74
-				73 3d 7b 6d 61 78 52 65 64 69 72 65 63 74 73 7d
-				00 00
+				01 00 38 53 63 6f 70 65 20 75 72 6c 53 74 72 69
+				6e 67 3d 7b 75 72 6c 53 74 72 69 6e 67 7d 2c 20
+				6d 61 78 52 65 64 69 72 65 63 74 73 3d 7b 6d 61
+				78 52 65 64 69 72 65 63 74 73 7d 00 00
 			)
 			// Fields
-			.field public object protocol
 			.field public object urlString
 			.field public object maxRedirects
 
@@ -3551,7 +2058,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5a2e
+				// Method begins at RVA 0x4109
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3568,9 +2075,8 @@
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
-				object protocol,
 				object urlString,
 				object maxRedirects
 			) cil managed 
@@ -3578,463 +2084,57 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x333c
+			// Method begins at RVA 0x27fc
 			// Header size: 12
-			// Code size: 97 (0x61)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope,
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise
 			)
 
-			IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::.ctor()
+			IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldarg.s maxRedirects
-			IL_0008: brtrue IL_001d
+			IL_0006: ldarg.3
+			IL_0007: brtrue IL_001c
 
-			IL_000d: ldc.r8 5
-			IL_0016: box [System.Runtime]System.Double
-			IL_001b: starg.s maxRedirects
+			IL_000c: ldc.r8 5
+			IL_0015: box [System.Runtime]System.Double
+			IL_001a: starg.s maxRedirects
 
-			IL_001d: ldloc.0
-			IL_001e: ldarg.2
-			IL_001f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-			IL_0024: ldloc.0
-			IL_0025: ldarg.3
-			IL_0026: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-			IL_002b: ldloc.0
-			IL_002c: ldarg.s maxRedirects
-			IL_002e: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
-			IL_0033: ldnull
-			IL_0034: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22::__js_call__(object[], object, object, object)
-			IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
-			IL_003f: ldc.i4.2
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldloc.0
-			IL_004c: stelem.ref
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0057: stloc.1
-			IL_0058: ldloc.1
-			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
-			IL_005e: stloc.2
-			IL_005f: ldloc.2
-			IL_0060: ret
-		} // end of method fetchTextWithTransport::__js_call__
-
-	} // end of class fetchTextWithTransport
-
-	.class nested public auto ansi abstract sealed beforefieldinit fetchText
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5a91
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object urlString
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x33ac
-			// Header size: 12
-			// Code size: 39 (0x27)
-			.maxstack 8
-			.locals init (
-				[0] object
-			)
-
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0011: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_001c: ldnull
+			IL_001c: ldloc.0
 			IL_001d: ldarg.2
-			IL_001e: ldnull
-			IL_001f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0024: stloc.0
-			IL_0025: ldloc.0
-			IL_0026: ret
+			IL_001e: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+			IL_0023: ldloc.0
+			IL_0024: ldarg.3
+			IL_0025: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+			IL_002a: ldnull
+			IL_002b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22::__js_call__(object[], object, object, object)
+			IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+			IL_0036: ldc.i4.2
+			IL_0037: newarr [System.Runtime]System.Object
+			IL_003c: dup
+			IL_003d: ldc.i4.0
+			IL_003e: ldarg.0
+			IL_003f: stelem.ref
+			IL_0040: dup
+			IL_0041: ldc.i4.1
+			IL_0042: ldloc.0
+			IL_0043: stelem.ref
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_004e: stloc.1
+			IL_004f: ldloc.1
+			IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+			IL_0055: stloc.2
+			IL_0056: ldloc.2
+			IL_0057: ret
 		} // end of method fetchText::__js_call__
 
 	} // end of class fetchText
-
-	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithNodeRequest
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L237C6
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5aa3
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L237C6::.ctor
-
-			} // end of class Block_L237C6
-
-			.class nested private auto ansi beforefieldinit Block_L239C10
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5aac
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L239C10::.ctor
-
-			} // end of class Block_L239C10
-
-			.class nested private auto ansi beforefieldinit Block_L243C35
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5ab5
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L243C35::.ctor
-
-			} // end of class Block_L243C35
-
-			.class nested private auto ansi beforefieldinit Block_L247C36
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5abe
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L247C36::.ctor
-
-			} // end of class Block_L247C36
-
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5a9a
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object urlString,
-				object maxRedirects
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x33e0
-			// Header size: 12
-			// Code size: 309 (0x135)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] class [System.Runtime]System.Exception,
-				[2] object,
-				[3] class [System.Runtime]System.Delegate,
-				[4] object,
-				[5] string,
-				[6] bool
-			)
-
-			IL_0000: ldarg.3
-			IL_0001: brtrue IL_0016
-
-			IL_0006: ldc.r8 5
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: starg.s maxRedirects
-
-			IL_0016: ldnull
-			IL_0017: stloc.0
-			.try
-			{
-				IL_0018: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
-				IL_001d: stloc.3
-				IL_001e: ldloc.3
-				IL_001f: ldc.i4.1
-				IL_0020: newarr [System.Runtime]System.Object
-				IL_0025: dup
-				IL_0026: ldc.i4.0
-				IL_0027: ldarg.2
-				IL_0028: stelem.ref
-				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-				IL_002e: stloc.s 4
-				IL_0030: ldloc.s 4
-				IL_0032: stloc.0
-				IL_0033: leave IL_0075
-			} // end .try
-			catch [System.Runtime]System.Exception
-			{
-				IL_0038: stloc.1
-				IL_0039: ldarg.2
-				IL_003a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_003f: stloc.s 5
-				IL_0041: ldstr "Invalid URL: "
-				IL_0046: ldloc.s 5
-				IL_0048: call string [System.Runtime]System.String::Concat(string, string)
-				IL_004d: stloc.s 5
-				IL_004f: ldloc.s 5
-				IL_0051: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0056: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_005b: stloc.s 4
-				IL_005d: ldloc.s 4
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-				IL_0064: stloc.s 4
-				IL_0066: ldnull
-				IL_0067: stloc.2
-				IL_0068: ldloc.s 4
-				IL_006a: stloc.2
-				IL_006b: leave IL_0133
-
-				IL_0070: leave IL_0075
-			} // end handler
-
-			IL_0075: ldloc.0
-			IL_0076: ldstr "protocol"
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0080: ldstr "http:"
-			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_008a: stloc.s 6
-			IL_008c: ldloc.s 6
-			IL_008e: brfalse IL_00bc
-
-			IL_0093: ldc.i4.1
-			IL_0094: newarr [System.Runtime]System.Object
-			IL_0099: dup
-			IL_009a: ldc.i4.0
-			IL_009b: ldarg.0
-			IL_009c: stelem.ref
-			IL_009d: ldc.i4.0
-			IL_009e: ldelem.ref
-			IL_009f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_00a4: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttp::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_00af: ldnull
-			IL_00b0: ldarg.2
-			IL_00b1: ldarg.3
-			IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_00b7: stloc.s 4
-			IL_00b9: ldloc.s 4
-			IL_00bb: ret
-
-			IL_00bc: ldloc.0
-			IL_00bd: ldstr "protocol"
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c7: ldstr "https:"
-			IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00d1: stloc.s 6
-			IL_00d3: ldloc.s 6
-			IL_00d5: brfalse IL_0103
-
-			IL_00da: ldc.i4.1
-			IL_00db: newarr [System.Runtime]System.Object
-			IL_00e0: dup
-			IL_00e1: ldc.i4.0
-			IL_00e2: ldarg.0
-			IL_00e3: stelem.ref
-			IL_00e4: ldc.i4.0
-			IL_00e5: ldelem.ref
-			IL_00e6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_00eb: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttps::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_00f6: ldnull
-			IL_00f7: ldarg.2
-			IL_00f8: ldarg.3
-			IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_00fe: stloc.s 4
-			IL_0100: ldloc.s 4
-			IL_0102: ret
-
-			IL_0103: ldarg.2
-			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0109: stloc.s 5
-			IL_010b: ldstr "Only http:// and https:// URLs are supported by the request fallback. Got: "
-			IL_0110: ldloc.s 5
-			IL_0112: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0117: stloc.s 5
-			IL_0119: ldloc.s 5
-			IL_011b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0125: stloc.s 4
-			IL_0127: ldloc.s 4
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-			IL_012e: stloc.s 4
-			IL_0130: ldloc.s 4
-			IL_0132: ret
-
-			IL_0133: ldloc.2
-			IL_0134: ret
-		} // end of method fetchTextWithNodeRequest::__js_call__
-
-	} // end of class fetchTextWithNodeRequest
-
-	.class nested public auto ansi abstract sealed beforefieldinit detectEol
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5ac7
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object text
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x3534
-			// Header size: 12
-			// Code size: 49 (0x31)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] bool
-			)
-
-			IL_0000: ldarg.1
-			IL_0001: ldstr "includes"
-			IL_0006: ldstr "\r\n"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0017: stloc.2
-			IL_0018: ldloc.2
-			IL_0019: brfalse IL_0029
-
-			IL_001e: ldstr "\r\n"
-			IL_0023: stloc.0
-			IL_0024: br IL_002f
-
-			IL_0029: ldstr "\n"
-			IL_002e: stloc.0
-
-			IL_002f: ldloc.0
-			IL_0030: ret
-		} // end of method detectEol::__js_call__
-
-	} // end of class detectEol
 
 	.class nested public auto ansi abstract sealed beforefieldinit escapeRegExp
 		extends [System.Runtime]System.Object
@@ -4047,7 +2147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ad0
+				// Method begins at RVA 0x4163
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4071,7 +2171,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3574
+			// Method begins at RVA 0x2860
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -4096,220 +2196,6 @@
 
 	} // end of class escapeRegExp
 
-	.class nested public auto ansi abstract sealed beforefieldinit writeTextPreserveEol
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L266C31
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5ae2
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L266C31::.ctor
-
-			} // end of class Block_L266C31
-
-			.class nested private auto ansi beforefieldinit Block_L274C60
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5aeb
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L274C60::.ctor
-
-			} // end of class Block_L274C60
-
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5ad9
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object filePath,
-				object text
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x35a4
-			// Header size: 12
-			// Code size: 286 (0x11e)
-			.maxstack 8
-			.locals init (
-				[0] string,
-				[1] object,
-				[2] object,
-				[3] object,
-				[4] bool,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[6] object,
-				[7] object,
-				[8] object,
-				[9] object,
-				[10] object
-			)
-
-			IL_0000: ldstr "\n"
-			IL_0005: stloc.0
-			IL_0006: ldc.i4.0
-			IL_0007: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_000c: stloc.1
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_0013: ldstr "existsSync"
-			IL_0018: ldarg.2
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001e: stloc.3
-			IL_001f: ldloc.3
-			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0025: stloc.s 4
-			IL_0027: ldloc.s 4
-			IL_0029: brfalse IL_0051
-
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_0034: ldstr "readFileSync"
-			IL_0039: ldarg.2
-			IL_003a: ldstr "utf8"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0044: stloc.3
-			IL_0045: ldloc.3
-			IL_0046: stloc.1
-			IL_0047: ldnull
-			IL_0048: ldloc.1
-			IL_0049: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/detectEol::__js_call__(object, object)
-			IL_004e: stloc.3
-			IL_004f: ldloc.3
-			IL_0050: stloc.0
-
-			IL_0051: ldstr "\\r\\n|\\n"
-			IL_0056: ldstr "g"
-			IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0060: stloc.s 5
-			IL_0062: ldarg.3
-			IL_0063: ldstr "replace"
-			IL_0068: ldloc.s 5
-			IL_006a: ldloc.0
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0070: stloc.3
-			IL_0071: ldloc.3
-			IL_0072: stloc.2
-			IL_0073: ldloc.1
-			IL_0074: ldc.i4.0
-			IL_0075: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_007f: stloc.s 4
-			IL_0081: ldloc.s 4
-			IL_0083: box [System.Runtime]System.Boolean
-			IL_0088: stloc.s 6
-			IL_008a: ldloc.s 6
-			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0091: stloc.s 4
-			IL_0093: ldloc.s 4
-			IL_0095: brfalse IL_00b5
-
-			IL_009a: ldloc.1
-			IL_009b: ldloc.2
-			IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00a1: stloc.s 4
-			IL_00a3: ldloc.s 4
-			IL_00a5: box [System.Runtime]System.Boolean
-			IL_00aa: stloc.s 7
-			IL_00ac: ldloc.s 7
-			IL_00ae: stloc.s 9
-			IL_00b0: br IL_00b9
-
-			IL_00b5: ldloc.s 6
-			IL_00b7: stloc.s 9
-
-			IL_00b9: ldloc.s 9
-			IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00c0: stloc.s 4
-			IL_00c2: ldloc.s 4
-			IL_00c4: brfalse IL_00cb
-
-			IL_00c9: ldnull
-			IL_00ca: ret
-
-			IL_00cb: ldarg.0
-			IL_00cc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_00d1: stloc.3
-			IL_00d2: ldarg.0
-			IL_00d3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
-			IL_00d8: ldstr "dirname"
-			IL_00dd: ldarg.2
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00e3: stloc.s 10
-			IL_00e5: ldloc.3
-			IL_00e6: ldstr "mkdirSync"
-			IL_00eb: ldloc.s 10
-			IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00f2: dup
-			IL_00f3: ldstr "recursive"
-			IL_00f8: ldc.i4.1
-			IL_00f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0103: pop
-			IL_0104: ldarg.0
-			IL_0105: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_010a: ldstr "writeFileSync"
-			IL_010f: ldarg.2
-			IL_0110: ldloc.2
-			IL_0111: ldstr "utf8"
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_011b: pop
-			IL_011c: ldnull
-			IL_011d: ret
-		} // end of method writeTextPreserveEol::__js_call__
-
-	} // end of class writeTextPreserveEol
-
 	.class nested public auto ansi abstract sealed beforefieldinit findTagNameAt
 		extends [System.Runtime]System.Object
 	{
@@ -4318,36 +2204,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L290C26
+			.class nested private auto ansi beforefieldinit Block_L135C46
 				extends [System.Runtime]System.Object
 			{
-				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L292C93
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5b06
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L292C93::.ctor
-
-				} // end of class Block_L292C93
-
-
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5afd
+					// Method begins at RVA 0x4175
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4356,16 +2220,58 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L290C26::.ctor
+				} // end of method Block_L135C46::.ctor
 
-			} // end of class Block_L290C26
+			} // end of class Block_L135C46
+
+			.class nested private auto ansi beforefieldinit Block_L140C30
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L142C93
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4187
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L142C93::.ctor
+
+				} // end of class Block_L142C93
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x417e
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L140C30::.ctor
+
+			} // end of class Block_L140C30
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5af4
+				// Method begins at RVA 0x416c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4382,7 +2288,7 @@
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
 				object html,
 				object tagStart
@@ -4391,249 +2297,223 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x36d0
+			// Method begins at RVA 0x2890
 			// Header size: 12
-			// Code size: 584 (0x248)
+			// Code size: 507 (0x1fb)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] bool,
-				[2] object,
+				[1] object,
+				[2] float64,
 				[3] object,
-				[4] object,
+				[4] bool,
 				[5] object,
-				[6] float64,
+				[6] object,
 				[7] object,
-				[8] bool,
+				[8] object,
 				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] object,
-				[16] object,
-				[17] object,
-				[18] object
+				[14] object
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: stloc.s 6
-			IL_0008: ldloc.s 6
-			IL_000a: ldc.r8 0.0
-			IL_0013: clt
-			IL_0015: box [System.Runtime]System.Boolean
-			IL_001a: stloc.s 7
-			IL_001c: ldloc.s 7
-			IL_001e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0023: stloc.s 8
-			IL_0025: ldloc.s 8
-			IL_0027: brtrue IL_0052
+			IL_0006: stloc.2
+			IL_0007: ldloc.2
+			IL_0008: ldc.r8 0.0
+			IL_0011: clt
+			IL_0013: box [System.Runtime]System.Boolean
+			IL_0018: stloc.3
+			IL_0019: ldloc.3
+			IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_001f: stloc.s 4
+			IL_0021: ldloc.s 4
+			IL_0023: brtrue IL_004d
 
-			IL_002c: ldarg.2
-			IL_002d: ldloc.s 6
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0034: ldstr "<"
-			IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_003e: stloc.s 8
-			IL_0040: ldloc.s 8
-			IL_0042: box [System.Runtime]System.Boolean
-			IL_0047: stloc.s 9
-			IL_0049: ldloc.s 9
-			IL_004b: stloc.s 11
-			IL_004d: br IL_0056
+			IL_0028: ldarg.2
+			IL_0029: ldloc.2
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_002f: ldstr "<"
+			IL_0034: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0039: stloc.s 4
+			IL_003b: ldloc.s 4
+			IL_003d: box [System.Runtime]System.Boolean
+			IL_0042: stloc.s 5
+			IL_0044: ldloc.s 5
+			IL_0046: stloc.s 7
+			IL_0048: br IL_0050
 
-			IL_0052: ldloc.s 7
-			IL_0054: stloc.s 11
+			IL_004d: ldloc.3
+			IL_004e: stloc.s 7
 
-			IL_0056: ldloc.s 11
-			IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005d: stloc.s 8
-			IL_005f: ldloc.s 8
-			IL_0061: brfalse IL_006c
+			IL_0050: ldloc.s 7
+			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0057: stloc.s 4
+			IL_0059: ldloc.s 4
+			IL_005b: brfalse IL_0066
 
-			IL_0066: ldstr ""
-			IL_006b: ret
+			IL_0060: ldstr ""
+			IL_0065: ret
 
-			IL_006c: ldarg.3
-			IL_006d: ldc.r8 1
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_007b: stloc.s 11
-			IL_007d: ldloc.s 11
-			IL_007f: stloc.0
-			IL_0080: ldarg.2
-			IL_0081: ldloc.0
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0087: ldstr "/"
-			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
-			IL_0095: stloc.1
-			IL_0096: ldloc.1
-			IL_0097: brfalse IL_00b5
+			IL_0066: ldarg.3
+			IL_0067: ldc.r8 1
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0075: stloc.s 7
+			IL_0077: ldloc.s 7
+			IL_0079: stloc.0
+			// loop start (head: IL_007a)
+				IL_007a: ldarg.2
+				IL_007b: ldstr "length"
+				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0085: stloc.s 8
+				IL_0087: ldloc.0
+				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_008d: stloc.2
+				IL_008e: ldloc.2
+				IL_008f: ldloc.s 8
+				IL_0091: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0096: clt
+				IL_0098: brfalse IL_01d7
 
-			IL_009c: ldloc.0
-			IL_009d: ldc.r8 1
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00ab: stloc.s 11
-			IL_00ad: ldloc.s 11
-			IL_00af: stloc.2
-			IL_00b0: br IL_00b7
+				IL_009d: ldarg.2
+				IL_009e: ldloc.0
+				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_00a4: stloc.1
+				IL_00a5: ldloc.1
+				IL_00a6: ldstr " "
+				IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00b0: stloc.s 4
+				IL_00b2: ldloc.s 4
+				IL_00b4: box [System.Runtime]System.Boolean
+				IL_00b9: stloc.3
+				IL_00ba: ldloc.3
+				IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00c0: stloc.s 4
+				IL_00c2: ldloc.s 4
+				IL_00c4: brtrue IL_00e8
 
-			IL_00b5: ldloc.0
-			IL_00b6: stloc.2
+				IL_00c9: ldloc.1
+				IL_00ca: ldstr "\t"
+				IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00d4: stloc.s 4
+				IL_00d6: ldloc.s 4
+				IL_00d8: box [System.Runtime]System.Boolean
+				IL_00dd: stloc.s 5
+				IL_00df: ldloc.s 5
+				IL_00e1: stloc.s 9
+				IL_00e3: br IL_00eb
 
-			IL_00b7: ldloc.2
-			IL_00b8: stloc.3
-			IL_00b9: ldloc.3
-			IL_00ba: stloc.s 4
-			// loop start (head: IL_00bc)
-				IL_00bc: ldarg.2
-				IL_00bd: ldstr "length"
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00c7: stloc.s 12
-				IL_00c9: ldloc.s 4
-				IL_00cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00d0: stloc.s 6
-				IL_00d2: ldloc.s 6
-				IL_00d4: ldloc.s 12
-				IL_00d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00db: clt
-				IL_00dd: brfalse IL_0235
+				IL_00e8: ldloc.3
+				IL_00e9: stloc.s 9
 
-				IL_00e2: ldarg.2
-				IL_00e3: ldloc.s 4
-				IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00ea: stloc.s 5
-				IL_00ec: ldloc.s 5
-				IL_00ee: ldstr " "
-				IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00f8: stloc.s 8
-				IL_00fa: ldloc.s 8
-				IL_00fc: box [System.Runtime]System.Boolean
-				IL_0101: stloc.s 7
-				IL_0103: ldloc.s 7
-				IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_010a: stloc.s 8
-				IL_010c: ldloc.s 8
-				IL_010e: brtrue IL_0133
+				IL_00eb: ldloc.s 9
+				IL_00ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00f2: stloc.s 4
+				IL_00f4: ldloc.s 4
+				IL_00f6: brtrue IL_0118
 
-				IL_0113: ldloc.s 5
-				IL_0115: ldstr "\t"
-				IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_011f: stloc.s 8
-				IL_0121: ldloc.s 8
-				IL_0123: box [System.Runtime]System.Boolean
-				IL_0128: stloc.s 9
-				IL_012a: ldloc.s 9
-				IL_012c: stloc.s 13
-				IL_012e: br IL_0137
+				IL_00fb: ldloc.1
+				IL_00fc: ldstr "\r"
+				IL_0101: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0106: stloc.s 4
+				IL_0108: ldloc.s 4
+				IL_010a: box [System.Runtime]System.Boolean
+				IL_010f: stloc.3
+				IL_0110: ldloc.3
+				IL_0111: stloc.s 9
+				IL_0113: br IL_0118
 
-				IL_0133: ldloc.s 7
-				IL_0135: stloc.s 13
+				IL_0118: ldloc.s 9
+				IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_011f: stloc.s 4
+				IL_0121: ldloc.s 4
+				IL_0123: brtrue IL_0145
 
-				IL_0137: ldloc.s 13
-				IL_0139: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013e: stloc.s 8
-				IL_0140: ldloc.s 8
-				IL_0142: brtrue IL_0167
+				IL_0128: ldloc.1
+				IL_0129: ldstr "\n"
+				IL_012e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0133: stloc.s 4
+				IL_0135: ldloc.s 4
+				IL_0137: box [System.Runtime]System.Boolean
+				IL_013c: stloc.3
+				IL_013d: ldloc.3
+				IL_013e: stloc.s 9
+				IL_0140: br IL_0145
 
-				IL_0147: ldloc.s 5
-				IL_0149: ldstr "\r"
-				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0153: stloc.s 8
-				IL_0155: ldloc.s 8
-				IL_0157: box [System.Runtime]System.Boolean
-				IL_015c: stloc.s 7
-				IL_015e: ldloc.s 7
-				IL_0160: stloc.s 13
-				IL_0162: br IL_0167
+				IL_0145: ldloc.s 9
+				IL_0147: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_014c: stloc.s 4
+				IL_014e: ldloc.s 4
+				IL_0150: brtrue IL_0172
 
-				IL_0167: ldloc.s 13
-				IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_016e: stloc.s 8
-				IL_0170: ldloc.s 8
-				IL_0172: brtrue IL_0197
+				IL_0155: ldloc.1
+				IL_0156: ldstr ">"
+				IL_015b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0160: stloc.s 4
+				IL_0162: ldloc.s 4
+				IL_0164: box [System.Runtime]System.Boolean
+				IL_0169: stloc.3
+				IL_016a: ldloc.3
+				IL_016b: stloc.s 9
+				IL_016d: br IL_0172
 
-				IL_0177: ldloc.s 5
-				IL_0179: ldstr "\n"
-				IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0183: stloc.s 8
-				IL_0185: ldloc.s 8
-				IL_0187: box [System.Runtime]System.Boolean
-				IL_018c: stloc.s 7
-				IL_018e: ldloc.s 7
-				IL_0190: stloc.s 13
-				IL_0192: br IL_0197
+				IL_0172: ldloc.s 9
+				IL_0174: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0179: stloc.s 4
+				IL_017b: ldloc.s 4
+				IL_017d: brtrue IL_019f
 
-				IL_0197: ldloc.s 13
-				IL_0199: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_019e: stloc.s 8
-				IL_01a0: ldloc.s 8
-				IL_01a2: brtrue IL_01c7
+				IL_0182: ldloc.1
+				IL_0183: ldstr "/"
+				IL_0188: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_018d: stloc.s 4
+				IL_018f: ldloc.s 4
+				IL_0191: box [System.Runtime]System.Boolean
+				IL_0196: stloc.3
+				IL_0197: ldloc.3
+				IL_0198: stloc.s 9
+				IL_019a: br IL_019f
 
-				IL_01a7: ldloc.s 5
-				IL_01a9: ldstr ">"
-				IL_01ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01b3: stloc.s 8
-				IL_01b5: ldloc.s 8
-				IL_01b7: box [System.Runtime]System.Boolean
-				IL_01bc: stloc.s 7
-				IL_01be: ldloc.s 7
-				IL_01c0: stloc.s 13
-				IL_01c2: br IL_01c7
+				IL_019f: ldloc.s 9
+				IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01a6: stloc.s 4
+				IL_01a8: ldloc.s 4
+				IL_01aa: brfalse IL_01b4
 
-				IL_01c7: ldloc.s 13
-				IL_01c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01ce: stloc.s 8
-				IL_01d0: ldloc.s 8
-				IL_01d2: brtrue IL_01f7
+				IL_01af: br IL_01d7
 
-				IL_01d7: ldloc.s 5
-				IL_01d9: ldstr "/"
-				IL_01de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01e3: stloc.s 8
-				IL_01e5: ldloc.s 8
-				IL_01e7: box [System.Runtime]System.Boolean
-				IL_01ec: stloc.s 7
-				IL_01ee: ldloc.s 7
-				IL_01f0: stloc.s 13
-				IL_01f2: br IL_01f7
-
-				IL_01f7: ldloc.s 13
-				IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01fe: stloc.s 8
-				IL_0200: ldloc.s 8
-				IL_0202: brfalse IL_020c
-
-				IL_0207: br IL_0235
-
-				IL_020c: ldloc.s 4
-				IL_020e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0213: stloc.s 6
-				IL_0215: ldloc.s 6
-				IL_0217: ldc.r8 1
-				IL_0220: add
-				IL_0221: stloc.s 6
-				IL_0223: ldloc.s 6
-				IL_0225: box [System.Runtime]System.Double
-				IL_022a: stloc.s 18
-				IL_022c: ldloc.s 18
-				IL_022e: stloc.s 4
-				IL_0230: br IL_00bc
+				IL_01b4: ldloc.0
+				IL_01b5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01ba: stloc.2
+				IL_01bb: ldloc.2
+				IL_01bc: ldc.r8 1
+				IL_01c5: add
+				IL_01c6: stloc.2
+				IL_01c7: ldloc.2
+				IL_01c8: box [System.Runtime]System.Double
+				IL_01cd: stloc.s 14
+				IL_01cf: ldloc.s 14
+				IL_01d1: stloc.0
+				IL_01d2: br IL_007a
 			// end loop
 
-			IL_0235: ldarg.2
-			IL_0236: ldstr "substring"
-			IL_023b: ldloc.3
-			IL_023c: ldloc.s 4
-			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0243: stloc.s 12
-			IL_0245: ldloc.s 12
-			IL_0247: ret
+			IL_01d7: ldarg.3
+			IL_01d8: ldc.r8 1
+			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01e6: stloc.s 9
+			IL_01e8: ldarg.2
+			IL_01e9: ldstr "substring"
+			IL_01ee: ldloc.s 9
+			IL_01f0: ldloc.0
+			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01f6: stloc.s 8
+			IL_01f8: ldloc.s 8
+			IL_01fa: ret
 		} // end of method findTagNameAt::__js_call__
 
 	} // end of class findTagNameAt
@@ -4646,14 +2526,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L307C19
+			.class nested private auto ansi beforefieldinit Block_L156C19
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b18
+					// Method begins at RVA 0x4199
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4662,18 +2542,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L307C19::.ctor
+				} // end of method Block_L156C19::.ctor
 
-			} // end of class Block_L307C19
+			} // end of class Block_L156C19
 
-			.class nested private auto ansi beforefieldinit Block_L312C20
+			.class nested private auto ansi beforefieldinit Block_L160C19
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b21
+					// Method begins at RVA 0x41a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4682,18 +2562,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L312C20::.ctor
+				} // end of method Block_L160C19::.ctor
 
-			} // end of class Block_L312C20
+			} // end of class Block_L160C19
 
-			.class nested private auto ansi beforefieldinit Block_L317C16
+			.class nested private auto ansi beforefieldinit Block_L165C20
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b2a
+					// Method begins at RVA 0x41ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4702,22 +2582,42 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L317C16::.ctor
+				} // end of method Block_L165C20::.ctor
 
-			} // end of class Block_L317C16
+			} // end of class Block_L165C20
 
-			.class nested private auto ansi beforefieldinit Block_L328C15
+			.class nested private auto ansi beforefieldinit Block_L170C16
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x41b4
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L170C16::.ctor
+
+			} // end of class Block_L170C16
+
+			.class nested private auto ansi beforefieldinit Block_L180C15
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L334C24
+				.class nested private auto ansi beforefieldinit Block_L182C16
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5b3c
+						// Method begins at RVA 0x41c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4726,22 +2626,42 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L334C24::.ctor
+					} // end of method Block_L182C16::.ctor
 
-				} // end of class Block_L334C24
+				} // end of class Block_L182C16
 
-				.class nested private auto ansi beforefieldinit Block_L339C17
+				.class nested private auto ansi beforefieldinit Block_L187C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x41cf
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L187C24::.ctor
+
+				} // end of class Block_L187C24
+
+				.class nested private auto ansi beforefieldinit Block_L191C32
 					extends [System.Runtime]System.Object
 				{
 					// Nested Types
-					.class nested private auto ansi beforefieldinit Block_L341C23
+					.class nested private auto ansi beforefieldinit Block_L193C23
 						extends [System.Runtime]System.Object
 					{
 						// Methods
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5b4e
+							// Method begins at RVA 0x41e1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -4750,16 +2670,16 @@
 							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 							IL_0006: nop
 							IL_0007: ret
-						} // end of method Block_L341C23::.ctor
+						} // end of method Block_L193C23::.ctor
 
-					} // end of class Block_L341C23
+					} // end of class Block_L193C23
 
 
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5b45
+						// Method begins at RVA 0x41d8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4768,18 +2688,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L339C17::.ctor
+					} // end of method Block_L191C32::.ctor
 
-				} // end of class Block_L339C17
+				} // end of class Block_L191C32
 
-				.class nested private auto ansi beforefieldinit Block_L348C11
+				.class nested private auto ansi beforefieldinit Block_L199C11
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5b57
+						// Method begins at RVA 0x41ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4788,16 +2708,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L348C11::.ctor
+					} // end of method Block_L199C11::.ctor
 
-				} // end of class Block_L348C11
+				} // end of class Block_L199C11
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b33
+					// Method begins at RVA 0x41bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4806,16 +2726,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L328C15::.ctor
+				} // end of method Block_L180C15::.ctor
 
-			} // end of class Block_L328C15
+			} // end of class Block_L180C15
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b0f
+				// Method begins at RVA 0x4190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4832,7 +2752,7 @@
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
 				object html,
 				object elementId
@@ -4841,11 +2761,11 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3924
+			// Method begins at RVA 0x2a98
 			// Header size: 12
-			// Code size: 966 (0x3c6)
+			// Code size: 958 (0x3be)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4858,54 +2778,52 @@
 				[7] object,
 				[8] object,
 				[9] object,
-				[10] object,
+				[10] string,
 				[11] object,
-				[12] string,
-				[13] object,
-				[14] float64,
-				[15] bool,
-				[16] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[18] string
+				[12] float64,
+				[13] bool,
+				[14] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[16] string
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0006: stloc.s 12
+			IL_0006: stloc.s 10
 			IL_0008: ldstr "id=\""
-			IL_000d: ldloc.s 12
+			IL_000d: ldloc.s 10
 			IL_000f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0014: stloc.s 12
-			IL_0016: ldloc.s 12
+			IL_0014: stloc.s 10
+			IL_0016: ldloc.s 10
 			IL_0018: ldstr "\""
 			IL_001d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0022: stloc.s 12
-			IL_0024: ldloc.s 12
+			IL_0022: stloc.s 10
+			IL_0024: ldloc.s 10
 			IL_0026: stloc.0
 			IL_0027: ldarg.3
 			IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002d: stloc.s 12
+			IL_002d: stloc.s 10
 			IL_002f: ldstr "id='"
-			IL_0034: ldloc.s 12
+			IL_0034: ldloc.s 10
 			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.s 12
-			IL_003d: ldloc.s 12
+			IL_003b: stloc.s 10
+			IL_003d: ldloc.s 10
 			IL_003f: ldstr "'"
 			IL_0044: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0049: stloc.s 12
-			IL_004b: ldloc.s 12
+			IL_0049: stloc.s 10
+			IL_004b: ldloc.s 10
 			IL_004d: stloc.1
 			IL_004e: ldarg.2
 			IL_004f: ldstr "indexOf"
 			IL_0054: ldloc.0
 			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005a: stloc.s 13
-			IL_005c: ldloc.s 13
+			IL_005a: stloc.s 11
+			IL_005c: ldloc.s 11
 			IL_005e: stloc.2
 			IL_005f: ldloc.2
 			IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0065: stloc.s 14
-			IL_0067: ldloc.s 14
+			IL_0065: stloc.s 12
+			IL_0067: ldloc.s 12
 			IL_0069: ldc.r8 0.0
 			IL_0072: clt
 			IL_0074: brfalse IL_008a
@@ -4914,30 +2832,30 @@
 			IL_007a: ldstr "indexOf"
 			IL_007f: ldloc.1
 			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0085: stloc.s 13
-			IL_0087: ldloc.s 13
+			IL_0085: stloc.s 11
+			IL_0087: ldloc.s 11
 			IL_0089: stloc.2
 
 			IL_008a: ldloc.2
 			IL_008b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0090: stloc.s 14
-			IL_0092: ldloc.s 14
+			IL_0090: stloc.s 12
+			IL_0092: ldloc.s 12
 			IL_0094: ldc.r8 0.0
 			IL_009d: clt
 			IL_009f: brfalse IL_00e9
 
 			IL_00a4: ldarg.3
 			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00aa: stloc.s 12
+			IL_00aa: stloc.s 10
 			IL_00ac: ldstr "Could not find id '"
-			IL_00b1: ldloc.s 12
+			IL_00b1: ldloc.s 10
 			IL_00b3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b8: stloc.s 12
-			IL_00ba: ldloc.s 12
+			IL_00b8: stloc.s 10
+			IL_00ba: ldloc.s 10
 			IL_00bc: ldstr "' in input HTML."
 			IL_00c1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c6: stloc.s 12
-			IL_00c8: ldloc.s 12
+			IL_00c6: stloc.s 10
+			IL_00c8: ldloc.s 10
 			IL_00ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 			IL_00d4: dup
@@ -4957,29 +2875,29 @@
 			IL_00ef: ldstr "<"
 			IL_00f4: ldloc.2
 			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fa: stloc.s 13
-			IL_00fc: ldloc.s 13
+			IL_00fa: stloc.s 11
+			IL_00fc: ldloc.s 11
 			IL_00fe: stloc.3
 			IL_00ff: ldloc.3
 			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0105: stloc.s 14
-			IL_0107: ldloc.s 14
+			IL_0105: stloc.s 12
+			IL_0107: ldloc.s 12
 			IL_0109: ldc.r8 0.0
 			IL_0112: clt
 			IL_0114: brfalse IL_015e
 
 			IL_0119: ldarg.3
 			IL_011a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_011f: stloc.s 12
+			IL_011f: stloc.s 10
 			IL_0121: ldstr "Could not locate tag start for id '"
-			IL_0126: ldloc.s 12
+			IL_0126: ldloc.s 10
 			IL_0128: call string [System.Runtime]System.String::Concat(string, string)
-			IL_012d: stloc.s 12
-			IL_012f: ldloc.s 12
+			IL_012d: stloc.s 10
+			IL_012f: ldloc.s 10
 			IL_0131: ldstr "'."
 			IL_0136: call string [System.Runtime]System.String::Concat(string, string)
-			IL_013b: stloc.s 12
-			IL_013d: ldloc.s 12
+			IL_013b: stloc.s 10
+			IL_013d: ldloc.s 10
 			IL_013f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 			IL_0149: dup
@@ -5002,36 +2920,36 @@
 			IL_0167: stelem.ref
 			IL_0168: ldc.i4.0
 			IL_0169: ldelem.ref
-			IL_016a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_016f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_016a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_016f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 			IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
 			IL_017a: ldnull
 			IL_017b: ldarg.2
 			IL_017c: ldloc.3
 			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0182: stloc.s 13
-			IL_0184: ldloc.s 13
+			IL_0182: stloc.s 11
+			IL_0184: ldloc.s 11
 			IL_0186: stloc.s 4
 			IL_0188: ldloc.s 4
 			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_018f: ldc.i4.0
 			IL_0190: ceq
-			IL_0192: stloc.s 15
-			IL_0194: ldloc.s 15
+			IL_0192: stloc.s 13
+			IL_0194: ldloc.s 13
 			IL_0196: brfalse IL_01e0
 
 			IL_019b: ldarg.3
 			IL_019c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a1: stloc.s 12
+			IL_01a1: stloc.s 10
 			IL_01a3: ldstr "Could not determine tag name for id '"
-			IL_01a8: ldloc.s 12
+			IL_01a8: ldloc.s 10
 			IL_01aa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01af: stloc.s 12
-			IL_01b1: ldloc.s 12
+			IL_01af: stloc.s 10
+			IL_01b1: ldloc.s 10
 			IL_01b3: ldstr "'."
 			IL_01b8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01bd: stloc.s 12
-			IL_01bf: ldloc.s 12
+			IL_01bd: stloc.s 10
+			IL_01bf: ldloc.s 10
 			IL_01c1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_01c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 			IL_01cb: dup
@@ -5048,24 +2966,24 @@
 
 			IL_01e0: ldnull
 			IL_01e1: ldloc.s 4
-			IL_01e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
-			IL_01e8: stloc.s 13
-			IL_01ea: ldloc.s 13
+			IL_01e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+			IL_01e8: stloc.s 11
+			IL_01ea: ldloc.s 11
 			IL_01ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01f1: stloc.s 12
+			IL_01f1: stloc.s 10
 			IL_01f3: ldstr "<\\/?"
-			IL_01f8: ldloc.s 12
+			IL_01f8: ldloc.s 10
 			IL_01fa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ff: stloc.s 12
-			IL_0201: ldloc.s 12
+			IL_01ff: stloc.s 10
+			IL_0201: ldloc.s 10
 			IL_0203: ldstr "\\b[^>]*>"
 			IL_0208: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020d: stloc.s 12
-			IL_020f: ldloc.s 12
+			IL_020d: stloc.s 10
+			IL_020f: ldloc.s 10
 			IL_0211: ldstr "gi"
 			IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_021b: stloc.s 16
-			IL_021d: ldloc.s 16
+			IL_021b: stloc.s 14
+			IL_021d: ldloc.s 14
 			IL_021f: stloc.s 5
 			IL_0221: ldloc.s 5
 			IL_0223: ldstr "lastIndex"
@@ -5080,24 +2998,24 @@
 			IL_0249: stloc.s 7
 			// loop start (head: IL_024b)
 				IL_024b: ldc.i4.1
-				IL_024c: brfalse IL_035d
+				IL_024c: brfalse IL_0355
 
 				IL_0251: ldloc.s 5
 				IL_0253: ldstr "exec"
 				IL_0258: ldarg.2
 				IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_025e: stloc.s 13
-				IL_0260: ldloc.s 13
+				IL_025e: stloc.s 11
+				IL_0260: ldloc.s 11
 				IL_0262: stloc.s 8
 				IL_0264: ldloc.s 8
 				IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_026b: ldc.i4.0
 				IL_026c: ceq
-				IL_026e: stloc.s 15
-				IL_0270: ldloc.s 15
+				IL_026e: stloc.s 13
+				IL_0270: ldloc.s 13
 				IL_0272: brfalse IL_027c
 
-				IL_0277: br IL_035d
+				IL_0277: br IL_0355
 
 				IL_027c: ldloc.s 8
 				IL_027e: ldc.r8 0.0
@@ -5105,8 +3023,8 @@
 				IL_028c: stloc.s 9
 				IL_028e: ldloc.s 7
 				IL_0290: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0295: stloc.s 14
-				IL_0297: ldloc.s 14
+				IL_0295: stloc.s 12
+				IL_0297: ldloc.s 12
 				IL_0299: ldc.r8 0.0
 				IL_02a2: clt
 				IL_02a4: brfalse IL_02bb
@@ -5114,104 +3032,100 @@
 				IL_02a9: ldloc.s 8
 				IL_02ab: ldstr "index"
 				IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02b5: stloc.s 13
-				IL_02b7: ldloc.s 13
+				IL_02b5: stloc.s 11
+				IL_02b7: ldloc.s 11
 				IL_02b9: stloc.s 7
 
 				IL_02bb: ldloc.s 9
 				IL_02bd: ldstr "startsWith"
 				IL_02c2: ldstr "</"
 				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02cc: stloc.s 13
-				IL_02ce: ldloc.s 13
-				IL_02d0: stloc.s 10
-				IL_02d2: ldloc.s 10
-				IL_02d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02d9: stloc.s 15
-				IL_02db: ldloc.s 15
-				IL_02dd: brfalse IL_034a
+				IL_02cc: stloc.s 11
+				IL_02ce: ldloc.s 11
+				IL_02d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d5: stloc.s 13
+				IL_02d7: ldloc.s 13
+				IL_02d9: brfalse IL_0342
 
-				IL_02e2: ldloc.s 6
-				IL_02e4: ldc.r8 1
-				IL_02ed: sub
-				IL_02ee: stloc.s 6
-				IL_02f0: ldloc.s 6
-				IL_02f2: ldc.r8 0.0
-				IL_02fb: ceq
-				IL_02fd: brfalse IL_0345
+				IL_02de: ldloc.s 6
+				IL_02e0: ldc.r8 1
+				IL_02e9: sub
+				IL_02ea: stloc.s 6
+				IL_02ec: ldloc.s 6
+				IL_02ee: ldc.r8 0.0
+				IL_02f7: ceq
+				IL_02f9: brfalse IL_033d
 
-				IL_0302: ldloc.s 5
-				IL_0304: ldstr "lastIndex"
-				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_030e: stloc.s 11
-				IL_0310: ldarg.2
-				IL_0311: ldstr "substring"
-				IL_0316: ldloc.s 7
-				IL_0318: ldloc.s 11
-				IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_031f: stloc.s 13
-				IL_0321: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0326: dup
-				IL_0327: ldstr "tagName"
-				IL_032c: ldloc.s 4
-				IL_032e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0333: dup
-				IL_0334: ldstr "html"
-				IL_0339: ldloc.s 13
-				IL_033b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0340: stloc.s 17
-				IL_0342: ldloc.s 17
-				IL_0344: ret
+				IL_02fe: ldarg.2
+				IL_02ff: ldstr "substring"
+				IL_0304: ldloc.s 7
+				IL_0306: ldloc.s 5
+				IL_0308: ldstr "lastIndex"
+				IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0317: stloc.s 11
+				IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_031e: dup
+				IL_031f: ldstr "tagName"
+				IL_0324: ldloc.s 4
+				IL_0326: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_032b: dup
+				IL_032c: ldstr "html"
+				IL_0331: ldloc.s 11
+				IL_0333: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0338: stloc.s 15
+				IL_033a: ldloc.s 15
+				IL_033c: ret
 
-				IL_0345: br IL_0358
+				IL_033d: br IL_0350
 
-				IL_034a: ldloc.s 6
-				IL_034c: ldc.r8 1
-				IL_0355: add
-				IL_0356: stloc.s 6
+				IL_0342: ldloc.s 6
+				IL_0344: ldc.r8 1
+				IL_034d: add
+				IL_034e: stloc.s 6
 
-				IL_0358: br IL_024b
+				IL_0350: br IL_024b
 			// end loop
 
-			IL_035d: ldloc.s 4
-			IL_035f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0364: stloc.s 12
-			IL_0366: ldstr "Could not find a matching closing </"
-			IL_036b: ldloc.s 12
-			IL_036d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0372: stloc.s 12
-			IL_0374: ldloc.s 12
-			IL_0376: ldstr "> for id '"
-			IL_037b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0380: stloc.s 12
-			IL_0382: ldarg.3
-			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0388: stloc.s 18
-			IL_038a: ldloc.s 12
-			IL_038c: ldloc.s 18
-			IL_038e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0393: stloc.s 18
-			IL_0395: ldloc.s 18
-			IL_0397: ldstr "'."
-			IL_039c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03a1: stloc.s 18
-			IL_03a3: ldloc.s 18
-			IL_03a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03af: dup
-			IL_03b0: isinst [System.Runtime]System.Exception
-			IL_03b5: dup
-			IL_03b6: brtrue IL_03c2
+			IL_0355: ldloc.s 4
+			IL_0357: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_035c: stloc.s 10
+			IL_035e: ldstr "Could not find a matching closing </"
+			IL_0363: ldloc.s 10
+			IL_0365: call string [System.Runtime]System.String::Concat(string, string)
+			IL_036a: stloc.s 10
+			IL_036c: ldloc.s 10
+			IL_036e: ldstr "> for id '"
+			IL_0373: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0378: stloc.s 10
+			IL_037a: ldarg.3
+			IL_037b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0380: stloc.s 16
+			IL_0382: ldloc.s 10
+			IL_0384: ldloc.s 16
+			IL_0386: call string [System.Runtime]System.String::Concat(string, string)
+			IL_038b: stloc.s 16
+			IL_038d: ldloc.s 16
+			IL_038f: ldstr "'."
+			IL_0394: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0399: stloc.s 16
+			IL_039b: ldloc.s 16
+			IL_039d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03a7: dup
+			IL_03a8: isinst [System.Runtime]System.Exception
+			IL_03ad: dup
+			IL_03ae: brtrue IL_03ba
 
-			IL_03bb: pop
-			IL_03bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03c1: throw
+			IL_03b3: pop
+			IL_03b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03b9: throw
 
-			IL_03c2: pop
-			IL_03c3: throw
+			IL_03ba: pop
+			IL_03bb: throw
 
-			IL_03c4: ldnull
-			IL_03c5: ret
+			IL_03bc: ldnull
+			IL_03bd: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -5223,11 +3137,33 @@
 		.class nested private auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L215C13
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x41fc
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L215C13::.ctor
+
+			} // end of class Block_L215C13
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b60
+				// Method begins at RVA 0x41f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5244,7 +3180,7 @@
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
 				object indexHtml,
 				object section
@@ -5253,11 +3189,11 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3cf8
+			// Method begins at RVA 0x2e64
 			// Header size: 12
-			// Code size: 452 (0x1c4)
+			// Code size: 444 (0x1bc)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5268,300 +3204,6 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] object,
-				[10] string,
-				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[12] bool,
-				[13] object,
-				[14] object,
-				[15] object,
-				[16] object,
-				[17] float64,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
-			)
-
-			IL_0000: ldnull
-			IL_0001: ldarg.3
-			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
-			IL_0007: stloc.s 9
-			IL_0009: ldloc.s 9
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0012: stloc.s 10
-			IL_0014: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_0019: ldloc.s 10
-			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0020: stloc.s 10
-			IL_0022: ldloc.s 10
-			IL_0024: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
-			IL_0029: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002e: stloc.s 10
-			IL_0030: ldloc.s 10
-			IL_0032: ldstr "i"
-			IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_003c: stloc.s 11
-			IL_003e: ldloc.s 11
-			IL_0040: stloc.1
-			IL_0041: ldloc.1
-			IL_0042: ldstr "exec"
-			IL_0047: ldarg.2
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_004d: stloc.s 9
-			IL_004f: ldloc.s 9
-			IL_0051: stloc.2
-			IL_0052: ldloc.2
-			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0058: stloc.s 12
-			IL_005a: ldloc.s 12
-			IL_005c: brfalse IL_00a5
-
-			IL_0061: ldloc.2
-			IL_0062: ldc.r8 1
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0070: stloc.s 9
-			IL_0072: ldloc.s 9
-			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0079: stloc.s 12
-			IL_007b: ldloc.s 12
-			IL_007d: brtrue IL_0098
-
-			IL_0082: ldloc.2
-			IL_0083: ldc.r8 2
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0091: stloc.s 14
-			IL_0093: br IL_009c
-
-			IL_0098: ldloc.s 9
-			IL_009a: stloc.s 14
-
-			IL_009c: ldloc.s 14
-			IL_009e: stloc.s 15
-			IL_00a0: br IL_00a8
-
-			IL_00a5: ldloc.2
-			IL_00a6: stloc.s 15
-
-			IL_00a8: ldloc.s 15
-			IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00af: stloc.s 12
-			IL_00b1: ldloc.s 12
-			IL_00b3: brtrue IL_00c4
-
-			IL_00b8: ldstr ""
-			IL_00bd: stloc.s 15
-			IL_00bf: br IL_00c4
-
-			IL_00c4: ldloc.s 15
-			IL_00c6: stloc.3
-			IL_00c7: ldloc.3
-			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00cd: ldc.i4.0
-			IL_00ce: ceq
-			IL_00d0: stloc.s 12
-			IL_00d2: ldloc.s 12
-			IL_00d4: brfalse IL_00e0
-
-			IL_00d9: ldc.i4.0
-			IL_00da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00df: ret
-
-			IL_00e0: ldloc.3
-			IL_00e1: ldstr "indexOf"
-			IL_00e6: ldstr "#"
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f0: stloc.s 9
-			IL_00f2: ldloc.s 9
-			IL_00f4: stloc.s 4
-			IL_00f6: ldloc.s 4
-			IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00fd: stloc.s 17
-			IL_00ff: ldloc.s 17
-			IL_0101: ldc.r8 0.0
-			IL_010a: clt
-			IL_010c: ldc.i4.0
-			IL_010d: ceq
-			IL_010f: brfalse IL_013a
-
-			IL_0114: ldloc.3
-			IL_0115: castclass [System.Runtime]System.String
-			IL_011a: ldc.r8 0.0
-			IL_0123: box [System.Runtime]System.Double
-			IL_0128: ldloc.s 4
-			IL_012a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_012f: stloc.s 10
-			IL_0131: ldloc.s 10
-			IL_0133: stloc.s 5
-			IL_0135: br IL_013d
-
-			IL_013a: ldloc.3
-			IL_013b: stloc.s 5
-
-			IL_013d: ldloc.s 5
-			IL_013f: stloc.s 6
-			IL_0141: ldloc.s 4
-			IL_0143: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0148: stloc.s 17
-			IL_014a: ldloc.s 17
-			IL_014c: ldc.r8 0.0
-			IL_0155: clt
-			IL_0157: ldc.i4.0
-			IL_0158: ceq
-			IL_015a: brfalse IL_0189
-
-			IL_015f: ldloc.s 4
-			IL_0161: ldc.r8 1
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_016f: stloc.s 15
-			IL_0171: ldloc.3
-			IL_0172: castclass [System.Runtime]System.String
-			IL_0177: ldloc.s 15
-			IL_0179: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_017e: stloc.s 10
-			IL_0180: ldloc.s 10
-			IL_0182: stloc.s 7
-			IL_0184: br IL_0190
-
-			IL_0189: ldstr ""
-			IL_018e: stloc.s 7
-
-			IL_0190: ldloc.s 7
-			IL_0192: stloc.s 8
-			IL_0194: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0199: dup
-			IL_019a: ldstr "href"
-			IL_019f: ldloc.3
-			IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01a5: dup
-			IL_01a6: ldstr "filePart"
-			IL_01ab: ldloc.s 6
-			IL_01ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01b2: dup
-			IL_01b3: ldstr "fragment"
-			IL_01b8: ldloc.s 8
-			IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01bf: stloc.s 18
-			IL_01c1: ldloc.s 18
-			IL_01c3: ret
-		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
-
-	} // end of class resolveSectionLinkFromMultipageIndexHtml
-
-	.class nested public auto ansi abstract sealed beforefieldinit resolveSectionIdFromHtml
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L387C2
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5b72
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L387C2::.ctor
-
-			} // end of class Block_L387C2
-
-			.class nested private auto ansi beforefieldinit Block_L398C2
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5b7b
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L398C2::.ctor
-
-			} // end of class Block_L398C2
-
-			.class nested private auto ansi beforefieldinit Block_L408C2
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5b84
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L408C2::.ctor
-
-			} // end of class Block_L408C2
-
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5b69
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object html,
-				object section
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x3ec8
-			// Header size: 12
-			// Code size: 586 (0x24a)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[4] object,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[6] object,
-				[7] object,
 				[8] string,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[10] bool,
@@ -5569,22 +3211,20 @@
 				[12] object,
 				[13] object,
 				[14] object,
-				[15] object,
-				[16] string,
-				[17] object,
-				[18] object
+				[15] float64,
+				[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldnull
 			IL_0001: ldarg.3
-			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
 			IL_0007: stloc.s 7
 			IL_0009: ldloc.s 7
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0012: stloc.s 8
-			IL_0014: ldstr "<a\\b[^>]*href=(?:\"[^\"]*#([^\"#]+)\"|'[^']*#([^'#]+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_0014: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
 			IL_0019: ldloc.s 8
 			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0020: stloc.s 8
@@ -5609,7 +3249,7 @@
 			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0058: stloc.s 10
 			IL_005a: ldloc.s 10
-			IL_005c: brfalse IL_00bb
+			IL_005c: brfalse IL_00a5
 
 			IL_0061: ldloc.2
 			IL_0062: ldc.r8 1
@@ -5631,158 +3271,112 @@
 			IL_009a: stloc.s 12
 
 			IL_009c: ldloc.s 12
-			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a3: stloc.s 10
-			IL_00a5: ldloc.s 10
-			IL_00a7: brtrue IL_00b8
+			IL_009e: stloc.s 13
+			IL_00a0: br IL_00a8
 
-			IL_00ac: ldstr ""
-			IL_00b1: stloc.s 12
-			IL_00b3: br IL_00b8
+			IL_00a5: ldloc.2
+			IL_00a6: stloc.s 13
 
-			IL_00b8: ldloc.s 12
-			IL_00ba: ret
+			IL_00a8: ldloc.s 13
+			IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00af: stloc.s 10
+			IL_00b1: ldloc.s 10
+			IL_00b3: brtrue IL_00c4
 
-			IL_00bb: ldloc.0
-			IL_00bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c1: stloc.s 8
-			IL_00c3: ldstr "<emu-clause\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,8000}?<h[1-6]\\b[^>]*>[\\s\\S]{0,1200}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_00c8: ldloc.s 8
-			IL_00ca: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00cf: stloc.s 8
-			IL_00d1: ldloc.s 8
-			IL_00d3: ldstr "\\s*<\\/span>[\\s\\S]{0,1200}?<\\/h[1-6]>"
-			IL_00d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00dd: stloc.s 8
-			IL_00df: ldloc.s 8
-			IL_00e1: ldstr "i"
-			IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00eb: stloc.s 9
-			IL_00ed: ldloc.s 9
-			IL_00ef: stloc.3
-			IL_00f0: ldloc.3
-			IL_00f1: ldstr "exec"
-			IL_00f6: ldarg.2
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00fc: stloc.s 7
-			IL_00fe: ldloc.s 7
-			IL_0100: stloc.s 4
-			IL_0102: ldloc.s 4
-			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0109: stloc.s 10
-			IL_010b: ldloc.s 10
-			IL_010d: brfalse IL_016e
+			IL_00b8: ldstr ""
+			IL_00bd: stloc.s 13
+			IL_00bf: br IL_00c4
 
-			IL_0112: ldloc.s 4
-			IL_0114: ldc.r8 1
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0122: stloc.s 7
-			IL_0124: ldloc.s 7
-			IL_0126: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012b: stloc.s 10
-			IL_012d: ldloc.s 10
-			IL_012f: brtrue IL_014b
+			IL_00c4: ldloc.s 13
+			IL_00c6: stloc.3
+			IL_00c7: ldloc.3
+			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00cd: ldc.i4.0
+			IL_00ce: ceq
+			IL_00d0: stloc.s 10
+			IL_00d2: ldloc.s 10
+			IL_00d4: brfalse IL_00e0
 
-			IL_0134: ldloc.s 4
-			IL_0136: ldc.r8 2
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0144: stloc.s 14
-			IL_0146: br IL_014f
+			IL_00d9: ldc.i4.0
+			IL_00da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00df: ret
 
-			IL_014b: ldloc.s 7
-			IL_014d: stloc.s 14
+			IL_00e0: ldloc.3
+			IL_00e1: ldstr "indexOf"
+			IL_00e6: ldstr "#"
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f0: stloc.s 7
+			IL_00f2: ldloc.s 7
+			IL_00f4: stloc.s 4
+			IL_00f6: ldloc.s 4
+			IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00fd: stloc.s 15
+			IL_00ff: ldloc.s 15
+			IL_0101: ldc.r8 0.0
+			IL_010a: clt
+			IL_010c: ldc.i4.0
+			IL_010d: ceq
+			IL_010f: brfalse IL_013a
 
-			IL_014f: ldloc.s 14
-			IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0156: stloc.s 10
-			IL_0158: ldloc.s 10
-			IL_015a: brtrue IL_016b
+			IL_0114: ldloc.3
+			IL_0115: castclass [System.Runtime]System.String
+			IL_011a: ldc.r8 0.0
+			IL_0123: box [System.Runtime]System.Double
+			IL_0128: ldloc.s 4
+			IL_012a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_012f: stloc.s 8
+			IL_0131: ldloc.s 8
+			IL_0133: stloc.s 5
+			IL_0135: br IL_013d
 
-			IL_015f: ldstr ""
-			IL_0164: stloc.s 14
-			IL_0166: br IL_016b
+			IL_013a: ldloc.3
+			IL_013b: stloc.s 5
 
-			IL_016b: ldloc.s 14
-			IL_016d: ret
+			IL_013d: ldloc.s 4
+			IL_013f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0144: stloc.s 15
+			IL_0146: ldloc.s 15
+			IL_0148: ldc.r8 0.0
+			IL_0151: clt
+			IL_0153: ldc.i4.0
+			IL_0154: ceq
+			IL_0156: brfalse IL_0185
 
-			IL_016e: ldloc.0
-			IL_016f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0174: stloc.s 8
-			IL_0176: ldstr "<h[1-6]\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,1200}?(?:\\s*"
-			IL_017b: ldloc.s 8
-			IL_017d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0182: stloc.s 8
-			IL_0184: ldloc.s 8
-			IL_0186: ldstr "\\b|<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_018b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0190: stloc.s 8
-			IL_0192: ldloc.0
-			IL_0193: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0198: stloc.s 16
-			IL_019a: ldloc.s 8
-			IL_019c: ldloc.s 16
-			IL_019e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a3: stloc.s 16
-			IL_01a5: ldloc.s 16
-			IL_01a7: ldstr "\\s*<\\/span>)"
-			IL_01ac: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b1: stloc.s 16
-			IL_01b3: ldloc.s 16
-			IL_01b5: ldstr "i"
-			IL_01ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_01bf: stloc.s 9
-			IL_01c1: ldloc.s 9
-			IL_01c3: stloc.s 5
-			IL_01c5: ldloc.s 5
-			IL_01c7: ldstr "exec"
-			IL_01cc: ldarg.2
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01d2: stloc.s 7
-			IL_01d4: ldloc.s 7
-			IL_01d6: stloc.s 6
-			IL_01d8: ldloc.s 6
-			IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01df: stloc.s 10
-			IL_01e1: ldloc.s 10
-			IL_01e3: brfalse IL_0244
+			IL_015b: ldloc.s 4
+			IL_015d: ldc.r8 1
+			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_016b: stloc.s 13
+			IL_016d: ldloc.3
+			IL_016e: castclass [System.Runtime]System.String
+			IL_0173: ldloc.s 13
+			IL_0175: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_017a: stloc.s 8
+			IL_017c: ldloc.s 8
+			IL_017e: stloc.s 6
+			IL_0180: br IL_018c
 
-			IL_01e8: ldloc.s 6
-			IL_01ea: ldc.r8 1
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01f8: stloc.s 7
-			IL_01fa: ldloc.s 7
-			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0201: stloc.s 10
-			IL_0203: ldloc.s 10
-			IL_0205: brtrue IL_0221
+			IL_0185: ldstr ""
+			IL_018a: stloc.s 6
 
-			IL_020a: ldloc.s 6
-			IL_020c: ldc.r8 2
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_021a: stloc.s 17
-			IL_021c: br IL_0225
+			IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0191: dup
+			IL_0192: ldstr "href"
+			IL_0197: ldloc.3
+			IL_0198: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_019d: dup
+			IL_019e: ldstr "filePart"
+			IL_01a3: ldloc.s 5
+			IL_01a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01aa: dup
+			IL_01ab: ldstr "fragment"
+			IL_01b0: ldloc.s 6
+			IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01b7: stloc.s 16
+			IL_01b9: ldloc.s 16
+			IL_01bb: ret
+		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
-			IL_0221: ldloc.s 7
-			IL_0223: stloc.s 17
-
-			IL_0225: ldloc.s 17
-			IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022c: stloc.s 10
-			IL_022e: ldloc.s 10
-			IL_0230: brtrue IL_0241
-
-			IL_0235: ldstr ""
-			IL_023a: stloc.s 17
-			IL_023c: br IL_0241
-
-			IL_0241: ldloc.s 17
-			IL_0243: ret
-
-			IL_0244: ldstr ""
-			IL_0249: ret
-		} // end of method resolveSectionIdFromHtml::__js_call__
-
-	} // end of class resolveSectionIdFromHtml
+	} // end of class resolveSectionLinkFromMultipageIndexHtml
 
 	.class nested public auto ansi abstract sealed beforefieldinit wrapAsStandaloneHtml
 		extends [System.Runtime]System.Object
@@ -5795,7 +3389,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b8d
+				// Method begins at RVA 0x4205
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5814,334 +3408,94 @@
 			object __js_call__ (
 				object newTarget,
 				object extractedHtml,
-				object options
+				object title,
+				object baseHref
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4120
+			// Method begins at RVA 0x302c
 			// Header size: 12
-			// Code size: 295 (0x127)
+			// Code size: 152 (0x98)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] object,
-				[3] object,
-				[4] string,
-				[5] object,
-				[6] bool,
-				[7] object,
-				[8] object,
-				[9] object,
-				[10] string,
-				[11] string
+				[2] bool,
+				[3] string,
+				[4] string
 			)
 
-			IL_0000: ldarg.2
-			IL_0001: ldstr "title"
-			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_000b: stloc.s 5
-			IL_000d: ldloc.s 5
-			IL_000f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0014: stloc.s 6
-			IL_0016: ldloc.s 6
-			IL_0018: brtrue IL_0029
+			IL_0000: ldarg.3
+			IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0006: stloc.2
+			IL_0007: ldloc.2
+			IL_0008: brfalse IL_0033
 
-			IL_001d: ldstr "ECMA-262 Section Extract"
-			IL_0022: stloc.s 8
-			IL_0024: br IL_002d
+			IL_000d: ldarg.3
+			IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0013: stloc.3
+			IL_0014: ldstr "  <base href=\""
+			IL_0019: ldloc.3
+			IL_001a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_001f: stloc.3
+			IL_0020: ldloc.3
+			IL_0021: ldstr "\">\n"
+			IL_0026: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002b: stloc.3
+			IL_002c: ldloc.3
+			IL_002d: stloc.0
+			IL_002e: br IL_0039
 
-			IL_0029: ldloc.s 5
-			IL_002b: stloc.s 8
+			IL_0033: ldstr ""
+			IL_0038: stloc.0
 
-			IL_002d: ldloc.s 8
-			IL_002f: stloc.0
-			IL_0030: ldarg.2
-			IL_0031: ldstr "baseHref"
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003b: stloc.s 5
-			IL_003d: ldloc.s 5
-			IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0044: stloc.s 6
-			IL_0046: ldloc.s 6
-			IL_0048: brtrue IL_0059
-
-			IL_004d: ldstr ""
-			IL_0052: stloc.s 9
-			IL_0054: br IL_005d
-
-			IL_0059: ldloc.s 5
-			IL_005b: stloc.s 9
-
-			IL_005d: ldloc.s 9
-			IL_005f: stloc.1
-			IL_0060: ldloc.1
-			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0066: stloc.s 6
-			IL_0068: ldloc.s 6
-			IL_006a: brfalse IL_009b
-
-			IL_006f: ldloc.1
-			IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0075: stloc.s 10
-			IL_0077: ldstr "  <base href=\""
-			IL_007c: ldloc.s 10
-			IL_007e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0083: stloc.s 10
-			IL_0085: ldloc.s 10
-			IL_0087: ldstr "\">\n"
-			IL_008c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0091: stloc.s 10
-			IL_0093: ldloc.s 10
-			IL_0095: stloc.2
-			IL_0096: br IL_00a1
-
-			IL_009b: ldstr ""
-			IL_00a0: stloc.2
-
-			IL_00a1: ldloc.2
-			IL_00a2: stloc.3
-			IL_00a3: ldstr "  <style>\n    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }\n    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }\n    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }\n    table { border-collapse: collapse; }\n    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }\n    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }\n    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }\n  </style>\n"
-			IL_00a8: stloc.s 4
-			IL_00aa: ldloc.3
-			IL_00ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00b0: stloc.s 10
-			IL_00b2: ldstr "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
-			IL_00b7: ldloc.s 10
-			IL_00b9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00be: stloc.s 10
-			IL_00c0: ldloc.s 4
-			IL_00c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c7: stloc.s 11
-			IL_00c9: ldloc.s 10
-			IL_00cb: ldloc.s 11
-			IL_00cd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d2: stloc.s 11
-			IL_00d4: ldloc.s 11
-			IL_00d6: ldstr "  <title>"
-			IL_00db: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00e0: stloc.s 11
-			IL_00e2: ldloc.0
-			IL_00e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00e8: stloc.s 10
-			IL_00ea: ldloc.s 11
-			IL_00ec: ldloc.s 10
-			IL_00ee: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00f3: stloc.s 10
-			IL_00f5: ldloc.s 10
-			IL_00f7: ldstr "</title>\n</head>\n<body>\n"
-			IL_00fc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0101: stloc.s 10
-			IL_0103: ldarg.1
-			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0109: stloc.s 11
-			IL_010b: ldloc.s 10
-			IL_010d: ldloc.s 11
-			IL_010f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0114: stloc.s 11
-			IL_0116: ldloc.s 11
-			IL_0118: ldstr "\n</body>\n</html>\n"
-			IL_011d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0122: stloc.s 11
-			IL_0124: ldloc.s 11
-			IL_0126: ret
+			IL_0039: ldloc.0
+			IL_003a: stloc.1
+			IL_003b: ldloc.1
+			IL_003c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0041: stloc.3
+			IL_0042: ldstr "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+			IL_0047: ldloc.3
+			IL_0048: call string [System.Runtime]System.String::Concat(string, string)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: ldstr "  <style>\n    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }\n    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }\n    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }\n    table { border-collapse: collapse; }\n    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }\n    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }\n    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }\n  </style>\n  <title>"
+			IL_0054: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0059: stloc.3
+			IL_005a: ldarg.2
+			IL_005b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0060: stloc.s 4
+			IL_0062: ldloc.3
+			IL_0063: ldloc.s 4
+			IL_0065: call string [System.Runtime]System.String::Concat(string, string)
+			IL_006a: stloc.s 4
+			IL_006c: ldloc.s 4
+			IL_006e: ldstr "</title>\n</head>\n<body>\n"
+			IL_0073: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0078: stloc.s 4
+			IL_007a: ldarg.1
+			IL_007b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0080: stloc.3
+			IL_0081: ldloc.s 4
+			IL_0083: ldloc.3
+			IL_0084: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0089: stloc.3
+			IL_008a: ldloc.3
+			IL_008b: ldstr "\n</body>\n</html>\n"
+			IL_0090: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0095: stloc.3
+			IL_0096: ldloc.3
+			IL_0097: ret
 		} // end of method wrapAsStandaloneHtml::__js_call__
 
 	} // end of class wrapAsStandaloneHtml
 
-	.class nested public auto ansi abstract sealed beforefieldinit printHelp
+	.class nested public auto ansi abstract sealed beforefieldinit runHarnessCli
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5b96
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x4254
-			// Header size: 12
-			// Code size: 322 (0x142)
-			.maxstack 8
-
-			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0005: ldstr "Extract a section's HTML from a locally saved ECMA-262 multipage HTML file."
-			IL_000a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_000f: pop
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0015: ldstr "You can also fetch the input HTML from the web using Node's built-in fetch/https."
-			IL_001a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_001f: pop
-			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0025: ldstr ""
-			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_002f: pop
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldstr "Usage:"
-			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003f: pop
-			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0045: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --in <input.html> --out <output.html>"
-			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_004f: pop
-			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0055: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --url <https://...> --out <output.html>"
-			IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_005f: pop
-			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0065: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --auto --out <output.html>"
-			IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_006f: pop
-			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0075: ldstr ""
-			IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_007f: pop
-			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0085: ldstr "Options:"
-			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_008f: pop
-			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0095: ldstr "  --section, -s   Section number to extract (e.g. 27.3)"
-			IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_009f: pop
-			IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00a5: ldstr "  --in, -i        Input HTML file path"
-			IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00af: pop
-			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00b5: ldstr "  --url, -u       Fetch input HTML from URL instead of --in"
-			IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bf: pop
-			IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00c5: ldstr "  --auto          Auto-discover the correct multipage URL from the multipage index"
-			IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00cf: pop
-			IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00d5: ldstr "  --index-url     Multipage index URL used by --auto (default: https://tc39.es/ecma262/multipage/)"
-			IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00df: pop
-			IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00e5: ldstr "  --out, -o       Output file path"
-			IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00ef: pop
-			IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00f5: ldstr "  --id            Explicit element id to extract (e.g. sec-generatorfunction-objects)"
-			IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00ff: pop
-			IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0105: ldstr "  --wrap          Wrap output as standalone HTML (default)"
-			IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_010f: pop
-			IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0115: ldstr "  --no-wrap       Output only the extracted element HTML"
-			IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_011f: pop
-			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0125: ldstr "  --base          Optional <base href=\"...\"> to inject when wrapping"
-			IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_012f: pop
-			IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0135: ldstr "  --help, -h      Show help"
-			IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_013f: pop
-			IL_0140: ldnull
-			IL_0141: ret
-		} // end of method printHelp::__js_call__
-
-	} // end of class printHelp
-
-	.class nested public auto ansi abstract sealed beforefieldinit main
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L492C92
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-					01 00 12 53 63 6f 70 65 20 61 3d 7b 61 7d 2c 20
-					62 3d 7b 62 7d 00 00
-				)
-				// Fields
-				.field public object a
-				.field public object b
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5bc3
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object newTarget,
-					object a,
-					object b
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-					01 00 00 00 00 00 00 00
-				)
-				// Method begins at RVA 0x5408
-				// Header size: 12
-				// Code size: 10 (0xa)
-				.maxstack 8
-				.locals init (
-					[0] object
-				)
-
-				IL_0000: ldarg.1
-				IL_0001: ldarg.2
-				IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0007: stloc.0
-				IL_0008: ldloc.0
-				IL_0009: ret
-			} // end of method ArrowFunction_L492C92::__js_call__
-
-		} // end of class ArrowFunction_L492C92
-
 		.class nested private auto ansi beforefieldinit Scope
 			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
 		{
@@ -6161,14 +3515,14 @@
 				2c 20 e2 80 a6 00 00
 			)
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L478C17
+			.class nested private auto ansi beforefieldinit Block_L254C21
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ba8
+					// Method begins at RVA 0x4217
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6177,18 +3531,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L478C17::.ctor
+				} // end of method Block_L254C21::.ctor
 
-			} // end of class Block_L478C17
+			} // end of class Block_L254C21
 
-			.class nested private auto ansi beforefieldinit Block_L483C21
+			.class nested private auto ansi beforefieldinit Block_L258C21
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5bb1
+					// Method begins at RVA 0x4220
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6197,18 +3551,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L483C21::.ctor
+				} // end of method Block_L258C21::.ctor
 
-			} // end of class Block_L483C21
+			} // end of class Block_L258C21
 
-			.class nested private auto ansi beforefieldinit Block_L488C33
+			.class nested private auto ansi beforefieldinit Block_L263C28
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5bba
+					// Method begins at RVA 0x4229
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6217,62 +3571,22 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L488C33::.ctor
+				} // end of method Block_L263C28::.ctor
 
-			} // end of class Block_L488C33
+			} // end of class Block_L263C28
 
-			.class nested private auto ansi beforefieldinit Block_L493C28
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5bcc
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L493C28::.ctor
-
-			} // end of class Block_L493C28
-
-			.class nested private auto ansi beforefieldinit Block_L497C21
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5bd5
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L497C21::.ctor
-
-			} // end of class Block_L497C21
-
-			.class nested private auto ansi beforefieldinit Block_L507C17
+			.class nested private auto ansi beforefieldinit Block_L271C17
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L509C19
+				.class nested private auto ansi beforefieldinit Block_L275C15
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5be7
+						// Method begins at RVA 0x423b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6281,18 +3595,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L509C19::.ctor
+					} // end of method Block_L275C15::.ctor
 
-				} // end of class Block_L509C19
+				} // end of class Block_L275C15
 
-				.class nested private auto ansi beforefieldinit Block_L515C15
+				.class nested private auto ansi beforefieldinit Block_L282C20
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5bf0
+						// Method begins at RVA 0x4244
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6301,16 +3615,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L515C15::.ctor
+					} // end of method Block_L282C20::.ctor
 
-				} // end of class Block_L515C15
+				} // end of class Block_L282C20
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5bde
+					// Method begins at RVA 0x4232
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6319,18 +3633,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L507C17::.ctor
+				} // end of method Block_L271C17::.ctor
 
-			} // end of class Block_L507C17
+			} // end of class Block_L271C17
 
-			.class nested private auto ansi beforefieldinit Block_L524C23
+			.class nested private auto ansi beforefieldinit Block_L285C9
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5bf9
+					// Method begins at RVA 0x424d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6339,60 +3653,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L524C23::.ctor
+				} // end of method Block_L285C9::.ctor
 
-			} // end of class Block_L524C23
+			} // end of class Block_L285C9
 
-			.class nested private auto ansi beforefieldinit Block_L528C9
-				extends [System.Runtime]System.Object
-			{
-				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L530C35
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5c0b
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L530C35::.ctor
-
-				} // end of class Block_L530C35
-
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c02
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L528C9::.ctor
-
-			} // end of class Block_L528C9
-
-			.class nested private auto ansi beforefieldinit Block_L537C48
+			.class nested private auto ansi beforefieldinit Block_L291C18
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5c14
+					// Method begins at RVA 0x4256
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6401,69 +3673,9 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L537C48::.ctor
+				} // end of method Block_L291C18::.ctor
 
-			} // end of class Block_L537C48
-
-			.class nested private auto ansi beforefieldinit Block_L541C18
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c1d
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L541C18::.ctor
-
-			} // end of class Block_L541C18
-
-			.class nested private auto ansi beforefieldinit Block_L545C18
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c26
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L545C18::.ctor
-
-			} // end of class Block_L545C18
-
-			.class nested private auto ansi beforefieldinit Block_L554C17
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c2f
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L554C17::.ctor
-
-			} // end of class Block_L554C17
+			} // end of class Block_L291C18
 
 
 			// Fields
@@ -6487,20 +3699,12 @@
 			.field public object _awaited18
 			.field public object _awaited19
 			.field public object _awaited20
-			.field public object _awaited21
-			.field public object _awaited22
-			.field public object _awaited23
-			.field public object _awaited24
-			.field public object _awaited25
-			.field public object _awaited26
-			.field public object _awaited27
-			.field public object _awaited28
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b9f
+				// Method begins at RVA 0x420e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6518,29 +3722,27 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object[] scopes,
-				object newTarget,
-				object argv,
-				object logger
+				object newTarget
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x43a4
+			// Method begins at RVA 0x30d0
 			// Header size: 12
-			// Code size: 3479 (0xd97)
+			// Code size: 2378 (0x94a)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope,
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
 				[1] object,
 				[2] object,
 				[3] object,
 				[4] object,
 				[5] object,
 				[6] object,
-				[7] object,
-				[8] string,
-				[9] string,
+				[7] string,
+				[8] object,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -6548,40 +3750,26 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
+				[17] bool,
 				[18] object,
 				[19] object,
-				[20] object,
-				[21] bool,
+				[20] string,
+				[21] string,
 				[22] object,
 				[23] object,
-				[24] object,
-				[25] object,
-				[26] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[27] object,
-				[28] object,
-				[29] string,
-				[30] string,
-				[31] class [System.Runtime]System.Delegate,
-				[32] object,
-				[33] object[],
-				[34] object,
-				[35] object,
-				[36] object,
-				[37] object,
-				[38] object,
-				[39] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[24] object[],
+				[25] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.0
 			IL_0002: ldelem.ref
-			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope
+			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope
 			IL_0008: dup
-			IL_0009: brtrue IL_0049
+			IL_0009: brtrue IL_003b
 
 			IL_000e: pop
-			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::.ctor()
+			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::.ctor()
 			IL_0014: stloc.0
 			IL_0015: ldloc.0
 			IL_0016: ldarg.0
@@ -6589,1602 +3777,1022 @@
 			IL_001c: starg.s scopes
 			IL_001e: ldloc.0
 			IL_001f: ldnull
-			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
-			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldc.i4.2
-			IL_002d: newarr [System.Runtime]System.Object
-			IL_0032: dup
-			IL_0033: ldc.i4.0
-			IL_0034: ldarg.2
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.1
-			IL_0038: ldarg.3
-			IL_0039: stelem.ref
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindMoveNext(object, object[], object[])
-			IL_003f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0044: br IL_004a
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+			IL_0031: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0036: br IL_003c
 
-			IL_0049: stloc.0
+			IL_003b: stloc.0
 
-			IL_004a: ldloc.0
-			IL_004b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0050: brtrue IL_0062
+			IL_003c: ldloc.0
+			IL_003d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0042: brtrue IL_0054
 
-			IL_0055: ldloc.0
-			IL_0056: ldc.i4.s 19
-			IL_0058: newarr [System.Runtime]System.Object
-			IL_005d: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0047: ldloc.0
+			IL_0048: ldc.i4.s 15
+			IL_004a: newarr [System.Runtime]System.Object
+			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
-			IL_0062: ldloc.0
-			IL_0063: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0068: ldc.i4.0
-			IL_0069: ble.s IL_00e2
+			IL_0054: ldloc.0
+			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_005a: ldc.i4.0
+			IL_005b: ble.s IL_00b7
 
-			IL_006b: ldloc.0
-			IL_006c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0071: dup
-			IL_0072: ldc.i4.0
-			IL_0073: ldelem.ref
-			IL_0074: stloc.1
-			IL_0075: dup
-			IL_0076: ldc.i4.1
-			IL_0077: ldelem.ref
-			IL_0078: stloc.2
+			IL_005d: ldloc.0
+			IL_005e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0063: dup
+			IL_0064: ldc.i4.0
+			IL_0065: ldelem.ref
+			IL_0066: stloc.1
+			IL_0067: dup
+			IL_0068: ldc.i4.1
+			IL_0069: ldelem.ref
+			IL_006a: stloc.2
+			IL_006b: dup
+			IL_006c: ldc.i4.2
+			IL_006d: ldelem.ref
+			IL_006e: stloc.3
+			IL_006f: dup
+			IL_0070: ldc.i4.3
+			IL_0071: ldelem.ref
+			IL_0072: stloc.s 4
+			IL_0074: dup
+			IL_0075: ldc.i4.4
+			IL_0076: ldelem.ref
+			IL_0077: stloc.s 5
 			IL_0079: dup
-			IL_007a: ldc.i4.2
+			IL_007a: ldc.i4.5
 			IL_007b: ldelem.ref
-			IL_007c: stloc.3
-			IL_007d: dup
-			IL_007e: ldc.i4.3
-			IL_007f: ldelem.ref
-			IL_0080: stloc.s 4
-			IL_0082: dup
-			IL_0083: ldc.i4.4
-			IL_0084: ldelem.ref
-			IL_0085: stloc.s 5
-			IL_0087: dup
-			IL_0088: ldc.i4.5
-			IL_0089: ldelem.ref
-			IL_008a: stloc.s 6
-			IL_008c: dup
-			IL_008d: ldc.i4.6
-			IL_008e: ldelem.ref
-			IL_008f: stloc.s 7
-			IL_0091: dup
-			IL_0092: ldc.i4.7
-			IL_0093: ldelem.ref
-			IL_0094: castclass [System.Runtime]System.String
-			IL_0099: stloc.s 8
-			IL_009b: dup
-			IL_009c: ldc.i4.8
-			IL_009d: ldelem.ref
-			IL_009e: castclass [System.Runtime]System.String
-			IL_00a3: stloc.s 9
-			IL_00a5: dup
-			IL_00a6: ldc.i4.s 9
-			IL_00a8: ldelem.ref
-			IL_00a9: stloc.s 10
-			IL_00ab: dup
-			IL_00ac: ldc.i4.s 10
-			IL_00ae: ldelem.ref
-			IL_00af: stloc.s 11
-			IL_00b1: dup
-			IL_00b2: ldc.i4.s 11
-			IL_00b4: ldelem.ref
-			IL_00b5: stloc.s 12
-			IL_00b7: dup
-			IL_00b8: ldc.i4.s 12
-			IL_00ba: ldelem.ref
-			IL_00bb: stloc.s 13
-			IL_00bd: dup
-			IL_00be: ldc.i4.s 13
-			IL_00c0: ldelem.ref
-			IL_00c1: stloc.s 14
-			IL_00c3: dup
-			IL_00c4: ldc.i4.s 14
-			IL_00c6: ldelem.ref
-			IL_00c7: stloc.s 15
-			IL_00c9: dup
-			IL_00ca: ldc.i4.s 15
-			IL_00cc: ldelem.ref
-			IL_00cd: stloc.s 16
-			IL_00cf: dup
-			IL_00d0: ldc.i4.s 16
-			IL_00d2: ldelem.ref
-			IL_00d3: stloc.s 17
-			IL_00d5: dup
-			IL_00d6: ldc.i4.s 17
-			IL_00d8: ldelem.ref
-			IL_00d9: stloc.s 18
-			IL_00db: dup
-			IL_00dc: ldc.i4.s 18
-			IL_00de: ldelem.ref
-			IL_00df: stloc.s 19
-			IL_00e1: pop
+			IL_007c: stloc.s 6
+			IL_007e: dup
+			IL_007f: ldc.i4.6
+			IL_0080: ldelem.ref
+			IL_0081: castclass [System.Runtime]System.String
+			IL_0086: stloc.s 7
+			IL_0088: dup
+			IL_0089: ldc.i4.7
+			IL_008a: ldelem.ref
+			IL_008b: stloc.s 8
+			IL_008d: dup
+			IL_008e: ldc.i4.8
+			IL_008f: ldelem.ref
+			IL_0090: stloc.s 9
+			IL_0092: dup
+			IL_0093: ldc.i4.s 9
+			IL_0095: ldelem.ref
+			IL_0096: stloc.s 10
+			IL_0098: dup
+			IL_0099: ldc.i4.s 10
+			IL_009b: ldelem.ref
+			IL_009c: stloc.s 11
+			IL_009e: dup
+			IL_009f: ldc.i4.s 11
+			IL_00a1: ldelem.ref
+			IL_00a2: stloc.s 12
+			IL_00a4: dup
+			IL_00a5: ldc.i4.s 12
+			IL_00a7: ldelem.ref
+			IL_00a8: stloc.s 13
+			IL_00aa: dup
+			IL_00ab: ldc.i4.s 13
+			IL_00ad: ldelem.ref
+			IL_00ae: stloc.s 14
+			IL_00b0: dup
+			IL_00b1: ldc.i4.s 14
+			IL_00b3: ldelem.ref
+			IL_00b4: stloc.s 15
+			IL_00b6: pop
 
-			IL_00e2: ldloc.0
-			IL_00e3: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e8: switch (IL_00fd, IL_060d, IL_0846, IL_094b)
+			IL_00b7: ldloc.0
+			IL_00b8: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00bd: switch (IL_00d2, IL_03ca, IL_05c2, IL_06dc)
 
-			IL_00fd: ldarg.2
-			IL_00fe: brtrue IL_0114
+			IL_00d2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00d7: ldstr "argv"
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e1: stloc.s 16
+			IL_00e3: ldc.i4.1
+			IL_00e4: newarr [System.Runtime]System.Object
+			IL_00e9: dup
+			IL_00ea: ldc.i4.0
+			IL_00eb: ldarg.0
+			IL_00ec: ldc.i4.1
+			IL_00ed: ldelem.ref
+			IL_00ee: stelem.ref
+			IL_00ef: ldc.i4.0
+			IL_00f0: ldelem.ref
+			IL_00f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_00f6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+			IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0101: ldnull
+			IL_0102: ldloc.s 16
+			IL_0104: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0109: stloc.s 16
+			IL_010b: ldloc.s 16
+			IL_010d: stloc.1
+			IL_010e: ldloc.1
+			IL_010f: ldstr "section"
+			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_011e: ldc.i4.0
+			IL_011f: ceq
+			IL_0121: stloc.s 17
+			IL_0123: ldloc.s 17
+			IL_0125: brfalse IL_016b
 
-			IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0108: ldstr "argv"
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0112: starg.s argv
+			IL_012a: ldstr "Missing required --section (e.g. 27.3)."
+			IL_012f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0134: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0139: stloc.s 16
+			IL_013b: ldloc.0
+			IL_013c: ldc.i4.m1
+			IL_013d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0142: ldloc.0
+			IL_0143: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_014d: ldarg.0
+			IL_014e: ldc.i4.1
+			IL_014f: newarr [System.Runtime]System.Object
+			IL_0154: dup
+			IL_0155: ldc.i4.0
+			IL_0156: ldloc.s 16
+			IL_0158: stelem.ref
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_015e: pop
+			IL_015f: ldloc.0
+			IL_0160: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0165: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_016a: ret
 
-			IL_0114: ldarg.3
-			IL_0115: brtrue IL_012b
+			IL_016b: ldloc.1
+			IL_016c: ldstr "outFile"
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_017b: ldc.i4.0
+			IL_017c: ceq
+			IL_017e: stloc.s 17
+			IL_0180: ldloc.s 17
+			IL_0182: brfalse IL_01c8
 
-			IL_011a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_011f: ldstr "log"
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0129: starg.s logger
-
-			IL_012b: ldc.i4.1
-			IL_012c: newarr [System.Runtime]System.Object
-			IL_0131: dup
-			IL_0132: ldc.i4.0
-			IL_0133: ldarg.0
-			IL_0134: ldc.i4.1
-			IL_0135: ldelem.ref
-			IL_0136: stelem.ref
-			IL_0137: ldc.i4.0
-			IL_0138: ldelem.ref
-			IL_0139: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_013e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0149: ldnull
-			IL_014a: ldarg.2
-			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0150: stloc.s 20
-			IL_0152: ldloc.s 20
-			IL_0154: stloc.1
-			IL_0155: ldloc.1
-			IL_0156: ldstr "help"
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0165: stloc.s 21
-			IL_0167: ldloc.s 21
-			IL_0169: brfalse IL_01a4
-
-			IL_016e: ldnull
-			IL_016f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/printHelp::__js_call__(object)
-			IL_0174: pop
-			IL_0175: ldloc.0
-			IL_0176: ldc.i4.m1
-			IL_0177: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_017c: ldloc.0
-			IL_017d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0187: ldarg.0
-			IL_0188: ldc.i4.1
-			IL_0189: newarr [System.Runtime]System.Object
-			IL_018e: dup
-			IL_018f: ldc.i4.0
-			IL_0190: ldnull
-			IL_0191: stelem.ref
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0197: pop
+			IL_0187: ldstr "Missing required --out <output.html>."
+			IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0196: stloc.s 16
 			IL_0198: ldloc.0
-			IL_0199: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_019e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01a3: ret
+			IL_0199: ldc.i4.m1
+			IL_019a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_019f: ldloc.0
+			IL_01a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01aa: ldarg.0
+			IL_01ab: ldc.i4.1
+			IL_01ac: newarr [System.Runtime]System.Object
+			IL_01b1: dup
+			IL_01b2: ldc.i4.0
+			IL_01b3: ldloc.s 16
+			IL_01b5: stelem.ref
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01bb: pop
+			IL_01bc: ldloc.0
+			IL_01bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01c7: ret
 
-			IL_01a4: ldloc.1
-			IL_01a5: ldstr "section"
-			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01b4: ldc.i4.0
-			IL_01b5: ceq
-			IL_01b7: stloc.s 21
-			IL_01b9: ldloc.s 21
-			IL_01bb: brfalse IL_0201
+			IL_01c8: ldloc.1
+			IL_01c9: ldstr "url"
+			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01d8: stloc.s 17
+			IL_01da: ldloc.s 17
+			IL_01dc: brfalse IL_01f5
 
-			IL_01c0: ldstr "Missing required --section (e.g. 27.3)."
-			IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01cf: stloc.s 20
-			IL_01d1: ldloc.0
-			IL_01d2: ldc.i4.m1
-			IL_01d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d8: ldloc.0
-			IL_01d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01e3: ldarg.0
-			IL_01e4: ldc.i4.1
-			IL_01e5: newarr [System.Runtime]System.Object
-			IL_01ea: dup
-			IL_01eb: ldc.i4.0
-			IL_01ec: ldloc.s 20
-			IL_01ee: stelem.ref
-			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01f4: pop
-			IL_01f5: ldloc.0
-			IL_01f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0200: ret
+			IL_01e1: ldc.r8 1
+			IL_01ea: box [System.Runtime]System.Double
+			IL_01ef: stloc.2
+			IL_01f0: br IL_0204
 
-			IL_0201: ldloc.1
-			IL_0202: ldstr "inFile"
-			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_020c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0211: ldc.i4.0
-			IL_0212: ceq
-			IL_0214: stloc.s 21
-			IL_0216: ldloc.s 21
-			IL_0218: box [System.Runtime]System.Boolean
-			IL_021d: stloc.s 22
-			IL_021f: ldloc.s 22
-			IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0226: stloc.s 21
-			IL_0228: ldloc.s 21
-			IL_022a: brfalse IL_0256
+			IL_01f5: ldc.r8 0.0
+			IL_01fe: box [System.Runtime]System.Double
+			IL_0203: stloc.2
 
-			IL_022f: ldloc.1
-			IL_0230: ldstr "url"
-			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_023f: ldc.i4.0
-			IL_0240: ceq
-			IL_0242: stloc.s 21
-			IL_0244: ldloc.s 21
-			IL_0246: box [System.Runtime]System.Boolean
-			IL_024b: stloc.s 23
-			IL_024d: ldloc.s 23
-			IL_024f: stloc.s 25
-			IL_0251: br IL_025a
+			IL_0204: ldloc.1
+			IL_0205: ldstr "auto"
+			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0214: stloc.s 17
+			IL_0216: ldloc.s 17
+			IL_0218: brfalse IL_0231
 
-			IL_0256: ldloc.s 22
-			IL_0258: stloc.s 25
+			IL_021d: ldc.r8 1
+			IL_0226: box [System.Runtime]System.Double
+			IL_022b: stloc.3
+			IL_022c: br IL_0240
 
-			IL_025a: ldloc.s 25
-			IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0261: stloc.s 21
-			IL_0263: ldloc.s 21
-			IL_0265: brfalse IL_027c
+			IL_0231: ldc.r8 0.0
+			IL_023a: box [System.Runtime]System.Double
+			IL_023f: stloc.3
 
-			IL_026a: ldloc.1
-			IL_026b: ldstr "auto"
-			IL_0270: ldc.i4.1
-			IL_0271: box [System.Runtime]System.Boolean
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-			IL_027b: pop
+			IL_0240: ldloc.2
+			IL_0241: ldloc.3
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0247: stloc.s 18
+			IL_0249: ldloc.s 18
+			IL_024b: stloc.s 4
+			IL_024d: ldloc.s 4
+			IL_024f: ldc.r8 1
+			IL_0258: box [System.Runtime]System.Double
+			IL_025d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0262: stloc.s 17
+			IL_0264: ldloc.s 17
+			IL_0266: brfalse IL_02ac
 
-			IL_027c: ldloc.1
-			IL_027d: ldstr "inFile"
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_028c: stloc.s 21
-			IL_028e: ldloc.s 21
-			IL_0290: brfalse IL_02a9
+			IL_026b: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_0270: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0275: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_027a: stloc.s 16
+			IL_027c: ldloc.0
+			IL_027d: ldc.i4.m1
+			IL_027e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0283: ldloc.0
+			IL_0284: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0289: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_028e: ldarg.0
+			IL_028f: ldc.i4.1
+			IL_0290: newarr [System.Runtime]System.Object
+			IL_0295: dup
+			IL_0296: ldc.i4.0
+			IL_0297: ldloc.s 16
+			IL_0299: stelem.ref
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_029f: pop
+			IL_02a0: ldloc.0
+			IL_02a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02a6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02ab: ret
 
-			IL_0295: ldc.r8 1
-			IL_029e: box [System.Runtime]System.Double
-			IL_02a3: stloc.2
-			IL_02a4: br IL_02b8
+			IL_02ac: ldnull
+			IL_02ad: stloc.s 5
+			IL_02af: ldloc.1
+			IL_02b0: ldstr "id"
+			IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ba: stloc.s 16
+			IL_02bc: ldloc.s 16
+			IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02c3: stloc.s 17
+			IL_02c5: ldloc.s 17
+			IL_02c7: brtrue IL_02d8
 
-			IL_02a9: ldc.r8 0.0
-			IL_02b2: box [System.Runtime]System.Double
-			IL_02b7: stloc.2
+			IL_02cc: ldstr ""
+			IL_02d1: stloc.s 19
+			IL_02d3: br IL_02dc
 
-			IL_02b8: ldloc.1
-			IL_02b9: ldstr "url"
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02c8: stloc.s 21
-			IL_02ca: ldloc.s 21
-			IL_02cc: brfalse IL_02e5
+			IL_02d8: ldloc.s 16
+			IL_02da: stloc.s 19
 
-			IL_02d1: ldc.r8 1
-			IL_02da: box [System.Runtime]System.Double
-			IL_02df: stloc.3
-			IL_02e0: br IL_02f4
+			IL_02dc: ldloc.s 19
+			IL_02de: castclass [System.Runtime]System.String
+			IL_02e3: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_02e8: stloc.s 20
+			IL_02ea: ldloc.s 20
+			IL_02ec: stloc.s 6
+			IL_02ee: ldstr ""
+			IL_02f3: stloc.s 7
+			IL_02f5: ldloc.1
+			IL_02f6: ldstr "auto"
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0300: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0305: stloc.s 17
+			IL_0307: ldloc.s 17
+			IL_0309: brfalse IL_0620
 
-			IL_02e5: ldc.r8 0.0
-			IL_02ee: box [System.Runtime]System.Double
-			IL_02f3: stloc.3
+			IL_030e: ldloc.1
+			IL_030f: ldstr "indexUrl"
+			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0319: ldstr "trim"
+			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0323: stloc.s 16
+			IL_0325: ldloc.s 16
+			IL_0327: stloc.s 8
+			IL_0329: ldc.i4.1
+			IL_032a: newarr [System.Runtime]System.Object
+			IL_032f: dup
+			IL_0330: ldc.i4.0
+			IL_0331: ldarg.0
+			IL_0332: ldc.i4.1
+			IL_0333: ldelem.ref
+			IL_0334: stelem.ref
+			IL_0335: ldc.i4.0
+			IL_0336: ldelem.ref
+			IL_0337: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_033c: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0342: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0347: ldnull
+			IL_0348: ldloc.s 8
+			IL_034a: ldnull
+			IL_034b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0350: stloc.s 16
+			IL_0352: ldloc.0
+			IL_0353: ldc.i4.1
+			IL_0354: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0359: ldloc.0
+			IL_035a: ldloc.s 16
+			IL_035c: ldarg.0
+			IL_035d: ldc.i4.1
+			IL_035e: ldloc.0
+			IL_035f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0369: ldloc.0
+			IL_036a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_036f: dup
+			IL_0370: ldc.i4.0
+			IL_0371: ldloc.1
+			IL_0372: stelem.ref
+			IL_0373: dup
+			IL_0374: ldc.i4.1
+			IL_0375: ldloc.2
+			IL_0376: stelem.ref
+			IL_0377: dup
+			IL_0378: ldc.i4.2
+			IL_0379: ldloc.3
+			IL_037a: stelem.ref
+			IL_037b: dup
+			IL_037c: ldc.i4.3
+			IL_037d: ldloc.s 4
+			IL_037f: stelem.ref
+			IL_0380: dup
+			IL_0381: ldc.i4.4
+			IL_0382: ldloc.s 5
+			IL_0384: stelem.ref
+			IL_0385: dup
+			IL_0386: ldc.i4.5
+			IL_0387: ldloc.s 6
+			IL_0389: stelem.ref
+			IL_038a: dup
+			IL_038b: ldc.i4.6
+			IL_038c: ldloc.s 7
+			IL_038e: stelem.ref
+			IL_038f: dup
+			IL_0390: ldc.i4.7
+			IL_0391: ldloc.s 8
+			IL_0393: stelem.ref
+			IL_0394: dup
+			IL_0395: ldc.i4.8
+			IL_0396: ldloc.s 9
+			IL_0398: stelem.ref
+			IL_0399: dup
+			IL_039a: ldc.i4.s 9
+			IL_039c: ldloc.s 10
+			IL_039e: stelem.ref
+			IL_039f: dup
+			IL_03a0: ldc.i4.s 10
+			IL_03a2: ldloc.s 11
+			IL_03a4: stelem.ref
+			IL_03a5: dup
+			IL_03a6: ldc.i4.s 11
+			IL_03a8: ldloc.s 12
+			IL_03aa: stelem.ref
+			IL_03ab: dup
+			IL_03ac: ldc.i4.s 12
+			IL_03ae: ldloc.s 13
+			IL_03b0: stelem.ref
+			IL_03b1: dup
+			IL_03b2: ldc.i4.s 13
+			IL_03b4: ldloc.s 14
+			IL_03b6: stelem.ref
+			IL_03b7: dup
+			IL_03b8: ldc.i4.s 14
+			IL_03ba: ldloc.s 15
+			IL_03bc: stelem.ref
+			IL_03bd: pop
+			IL_03be: ldloc.0
+			IL_03bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03c4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03c9: ret
 
-			IL_02f4: ldloc.1
-			IL_02f5: ldstr "auto"
-			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0304: stloc.s 21
-			IL_0306: ldloc.s 21
-			IL_0308: brfalse IL_0322
+			IL_03ca: ldloc.0
+			IL_03cb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_03d0: stloc.s 16
+			IL_03d2: ldloc.s 16
+			IL_03d4: stloc.s 9
+			IL_03d6: ldloc.1
+			IL_03d7: ldstr "section"
+			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e1: ldstr "trim"
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03eb: stloc.s 16
+			IL_03ed: ldc.i4.1
+			IL_03ee: newarr [System.Runtime]System.Object
+			IL_03f3: dup
+			IL_03f4: ldc.i4.0
+			IL_03f5: ldarg.0
+			IL_03f6: ldc.i4.1
+			IL_03f7: ldelem.ref
+			IL_03f8: stelem.ref
+			IL_03f9: ldc.i4.0
+			IL_03fa: ldelem.ref
+			IL_03fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0400: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0406: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_040b: ldnull
+			IL_040c: ldloc.s 9
+			IL_040e: ldloc.s 16
+			IL_0410: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0415: stloc.s 16
+			IL_0417: ldloc.s 16
+			IL_0419: stloc.s 10
+			IL_041b: ldloc.s 10
+			IL_041d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0422: ldc.i4.0
+			IL_0423: ceq
+			IL_0425: stloc.s 17
+			IL_0427: ldloc.s 17
+			IL_0429: brfalse IL_04ae
 
-			IL_030d: ldc.r8 1
-			IL_0316: box [System.Runtime]System.Double
-			IL_031b: stloc.s 4
-			IL_031d: br IL_0332
+			IL_042e: ldloc.1
+			IL_042f: ldstr "section"
+			IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0439: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_043e: stloc.s 20
+			IL_0440: ldstr "Could not find section '"
+			IL_0445: ldloc.s 20
+			IL_0447: call string [System.Runtime]System.String::Concat(string, string)
+			IL_044c: stloc.s 20
+			IL_044e: ldloc.s 20
+			IL_0450: ldstr "' in multipage index: "
+			IL_0455: call string [System.Runtime]System.String::Concat(string, string)
+			IL_045a: stloc.s 20
+			IL_045c: ldloc.s 8
+			IL_045e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0463: stloc.s 21
+			IL_0465: ldloc.s 20
+			IL_0467: ldloc.s 21
+			IL_0469: call string [System.Runtime]System.String::Concat(string, string)
+			IL_046e: stloc.s 21
+			IL_0470: ldloc.s 21
+			IL_0472: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0477: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_047c: stloc.s 16
+			IL_047e: ldloc.0
+			IL_047f: ldc.i4.m1
+			IL_0480: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0485: ldloc.0
+			IL_0486: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_048b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0490: ldarg.0
+			IL_0491: ldc.i4.1
+			IL_0492: newarr [System.Runtime]System.Object
+			IL_0497: dup
+			IL_0498: ldc.i4.0
+			IL_0499: ldloc.s 16
+			IL_049b: stelem.ref
+			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04a1: pop
+			IL_04a2: ldloc.0
+			IL_04a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04ad: ret
 
-			IL_0322: ldc.r8 0.0
-			IL_032b: box [System.Runtime]System.Double
-			IL_0330: stloc.s 4
+			IL_04ae: ldarg.0
+			IL_04af: ldc.i4.1
+			IL_04b0: ldelem.ref
+			IL_04b1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_04bb: stloc.s 16
+			IL_04bd: ldloc.s 10
+			IL_04bf: ldstr "filePart"
+			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04c9: stloc.s 22
+			IL_04cb: ldloc.s 22
+			IL_04cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04d2: stloc.s 17
+			IL_04d4: ldloc.s 17
+			IL_04d6: brtrue IL_04ee
 
-			IL_0332: ldc.i4.3
-			IL_0333: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0338: dup
-			IL_0339: ldloc.2
-			IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_033f: dup
-			IL_0340: ldloc.3
-			IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0346: dup
-			IL_0347: ldloc.s 4
-			IL_0349: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_034e: stloc.s 26
-			IL_0350: ldnull
-			IL_0351: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/ArrowFunction_L492C92::__js_call__(object, object, object)
-			IL_0357: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_035c: ldc.i4.1
-			IL_035d: newarr [System.Runtime]System.Object
-			IL_0362: dup
-			IL_0363: ldc.i4.0
-			IL_0364: ldarg.0
-			IL_0365: ldc.i4.1
-			IL_0366: ldelem.ref
-			IL_0367: stelem.ref
-			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0372: stloc.s 20
-			IL_0374: ldloc.s 26
-			IL_0376: ldc.i4.2
-			IL_0377: newarr [System.Runtime]System.Object
-			IL_037c: dup
-			IL_037d: ldc.i4.0
-			IL_037e: ldloc.s 20
-			IL_0380: stelem.ref
-			IL_0381: dup
-			IL_0382: ldc.i4.1
-			IL_0383: ldc.r8 0.0
-			IL_038c: box [System.Runtime]System.Double
-			IL_0391: stelem.ref
-			IL_0392: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::reduce(object[])
-			IL_0397: stloc.s 20
-			IL_0399: ldloc.s 20
-			IL_039b: stloc.s 5
-			IL_039d: ldloc.s 5
-			IL_039f: ldc.r8 1
-			IL_03a8: box [System.Runtime]System.Double
-			IL_03ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03b2: stloc.s 21
-			IL_03b4: ldloc.s 21
-			IL_03b6: brfalse IL_03fc
+			IL_04db: ldloc.s 10
+			IL_04dd: ldstr "href"
+			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04e7: stloc.s 23
+			IL_04e9: br IL_04f2
 
-			IL_03bb: ldstr "Provide exactly one input mode: --in, --url, or --auto."
-			IL_03c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03ca: stloc.s 20
-			IL_03cc: ldloc.0
-			IL_03cd: ldc.i4.m1
-			IL_03ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03d3: ldloc.0
-			IL_03d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_03de: ldarg.0
-			IL_03df: ldc.i4.1
-			IL_03e0: newarr [System.Runtime]System.Object
-			IL_03e5: dup
-			IL_03e6: ldc.i4.0
-			IL_03e7: ldloc.s 20
-			IL_03e9: stelem.ref
-			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03ef: pop
-			IL_03f0: ldloc.0
-			IL_03f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03fb: ret
+			IL_04ee: ldloc.s 22
+			IL_04f0: stloc.s 23
 
-			IL_03fc: ldloc.1
-			IL_03fd: ldstr "outFile"
-			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0407: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_040c: ldc.i4.0
-			IL_040d: ceq
-			IL_040f: stloc.s 21
-			IL_0411: ldloc.s 21
-			IL_0413: brfalse IL_0459
-
-			IL_0418: ldstr "Missing required --out <output.html>."
-			IL_041d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0422: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0427: stloc.s 20
-			IL_0429: ldloc.0
-			IL_042a: ldc.i4.m1
-			IL_042b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0430: ldloc.0
-			IL_0431: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0436: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_043b: ldarg.0
-			IL_043c: ldc.i4.1
-			IL_043d: newarr [System.Runtime]System.Object
-			IL_0442: dup
-			IL_0443: ldc.i4.0
-			IL_0444: ldloc.s 20
-			IL_0446: stelem.ref
-			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_044c: pop
-			IL_044d: ldloc.0
-			IL_044e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0453: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0458: ret
-
-			IL_0459: ldarg.0
-			IL_045a: ldc.i4.1
-			IL_045b: ldelem.ref
-			IL_045c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0461: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
-			IL_0466: stloc.s 20
-			IL_0468: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_046d: ldstr "cwd"
-			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0477: stloc.s 27
-			IL_0479: ldloc.s 20
-			IL_047b: ldstr "resolve"
-			IL_0480: ldloc.s 27
-			IL_0482: ldloc.1
-			IL_0483: ldstr "outFile"
-			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0492: stloc.s 27
-			IL_0494: ldloc.s 27
-			IL_0496: stloc.s 6
-			IL_0498: ldnull
-			IL_0499: stloc.s 7
-			IL_049b: ldstr ""
-			IL_04a0: stloc.s 8
-			IL_04a2: ldstr ""
-			IL_04a7: stloc.s 9
-			IL_04a9: ldloc.1
-			IL_04aa: ldstr "auto"
-			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04b9: stloc.s 21
-			IL_04bb: ldloc.s 21
-			IL_04bd: brfalse IL_085f
-
-			IL_04c2: ldloc.1
-			IL_04c3: ldstr "indexUrl"
-			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04cd: stloc.s 27
-			IL_04cf: ldloc.s 27
-			IL_04d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04d6: stloc.s 21
-			IL_04d8: ldloc.s 21
-			IL_04da: brtrue IL_04eb
-
-			IL_04df: ldstr "https://tc39.es/ecma262/multipage/"
-			IL_04e4: stloc.s 28
-			IL_04e6: br IL_04ef
-
-			IL_04eb: ldloc.s 27
-			IL_04ed: stloc.s 28
-
-			IL_04ef: ldloc.s 28
-			IL_04f1: castclass [System.Runtime]System.String
-			IL_04f6: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_04fb: stloc.s 29
-			IL_04fd: ldloc.s 29
-			IL_04ff: stloc.s 10
-			IL_0501: ldloc.s 10
-			IL_0503: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0508: ldc.i4.0
-			IL_0509: ceq
-			IL_050b: stloc.s 21
-			IL_050d: ldloc.s 21
-			IL_050f: brfalse IL_0555
-
-			IL_0514: ldstr "Missing --index-url value."
-			IL_0519: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_051e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0523: stloc.s 27
-			IL_0525: ldloc.0
-			IL_0526: ldc.i4.m1
-			IL_0527: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_052c: ldloc.0
-			IL_052d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0532: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0537: ldarg.0
-			IL_0538: ldc.i4.1
-			IL_0539: newarr [System.Runtime]System.Object
-			IL_053e: dup
-			IL_053f: ldc.i4.0
-			IL_0540: ldloc.s 27
-			IL_0542: stelem.ref
-			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0548: pop
-			IL_0549: ldloc.0
-			IL_054a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_054f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0554: ret
-
-			IL_0555: ldc.i4.1
-			IL_0556: newarr [System.Runtime]System.Object
-			IL_055b: dup
-			IL_055c: ldc.i4.0
-			IL_055d: ldarg.0
-			IL_055e: ldc.i4.1
-			IL_055f: ldelem.ref
-			IL_0560: stelem.ref
-			IL_0561: ldc.i4.0
-			IL_0562: ldelem.ref
-			IL_0563: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0568: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-			IL_056e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0573: ldnull
-			IL_0574: ldloc.s 10
-			IL_0576: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_057b: stloc.s 27
-			IL_057d: ldloc.0
-			IL_057e: ldc.i4.1
-			IL_057f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0584: ldloc.0
-			IL_0585: ldloc.s 27
-			IL_0587: ldarg.0
-			IL_0588: ldc.i4.1
-			IL_0589: ldloc.0
-			IL_058a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_058f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0594: ldloc.0
-			IL_0595: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_059a: dup
-			IL_059b: ldc.i4.0
-			IL_059c: ldloc.1
-			IL_059d: stelem.ref
-			IL_059e: dup
-			IL_059f: ldc.i4.1
-			IL_05a0: ldloc.2
-			IL_05a1: stelem.ref
-			IL_05a2: dup
-			IL_05a3: ldc.i4.2
-			IL_05a4: ldloc.3
-			IL_05a5: stelem.ref
-			IL_05a6: dup
-			IL_05a7: ldc.i4.3
-			IL_05a8: ldloc.s 4
-			IL_05aa: stelem.ref
-			IL_05ab: dup
-			IL_05ac: ldc.i4.4
-			IL_05ad: ldloc.s 5
-			IL_05af: stelem.ref
-			IL_05b0: dup
-			IL_05b1: ldc.i4.5
-			IL_05b2: ldloc.s 6
+			IL_04f2: ldc.i4.2
+			IL_04f3: newarr [System.Runtime]System.Object
+			IL_04f8: dup
+			IL_04f9: ldc.i4.0
+			IL_04fa: ldloc.s 23
+			IL_04fc: stelem.ref
+			IL_04fd: dup
+			IL_04fe: ldc.i4.1
+			IL_04ff: ldloc.s 8
+			IL_0501: stelem.ref
+			IL_0502: stloc.s 24
+			IL_0504: ldloc.s 16
+			IL_0506: ldloc.s 24
+			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_050d: stloc.s 16
+			IL_050f: ldloc.s 16
+			IL_0511: ldstr "toString"
+			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_051b: stloc.s 16
+			IL_051d: ldloc.s 16
+			IL_051f: stloc.s 11
+			IL_0521: ldc.i4.1
+			IL_0522: newarr [System.Runtime]System.Object
+			IL_0527: dup
+			IL_0528: ldc.i4.0
+			IL_0529: ldarg.0
+			IL_052a: ldc.i4.1
+			IL_052b: ldelem.ref
+			IL_052c: stelem.ref
+			IL_052d: ldc.i4.0
+			IL_052e: ldelem.ref
+			IL_052f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0534: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_053a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_053f: ldnull
+			IL_0540: ldloc.s 11
+			IL_0542: ldnull
+			IL_0543: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0548: stloc.s 16
+			IL_054a: ldloc.0
+			IL_054b: ldc.i4.2
+			IL_054c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0551: ldloc.0
+			IL_0552: ldloc.s 16
+			IL_0554: ldarg.0
+			IL_0555: ldc.i4.2
+			IL_0556: ldloc.0
+			IL_0557: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_055c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0561: ldloc.0
+			IL_0562: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0567: dup
+			IL_0568: ldc.i4.0
+			IL_0569: ldloc.1
+			IL_056a: stelem.ref
+			IL_056b: dup
+			IL_056c: ldc.i4.1
+			IL_056d: ldloc.2
+			IL_056e: stelem.ref
+			IL_056f: dup
+			IL_0570: ldc.i4.2
+			IL_0571: ldloc.3
+			IL_0572: stelem.ref
+			IL_0573: dup
+			IL_0574: ldc.i4.3
+			IL_0575: ldloc.s 4
+			IL_0577: stelem.ref
+			IL_0578: dup
+			IL_0579: ldc.i4.4
+			IL_057a: ldloc.s 5
+			IL_057c: stelem.ref
+			IL_057d: dup
+			IL_057e: ldc.i4.5
+			IL_057f: ldloc.s 6
+			IL_0581: stelem.ref
+			IL_0582: dup
+			IL_0583: ldc.i4.6
+			IL_0584: ldloc.s 7
+			IL_0586: stelem.ref
+			IL_0587: dup
+			IL_0588: ldc.i4.7
+			IL_0589: ldloc.s 8
+			IL_058b: stelem.ref
+			IL_058c: dup
+			IL_058d: ldc.i4.8
+			IL_058e: ldloc.s 9
+			IL_0590: stelem.ref
+			IL_0591: dup
+			IL_0592: ldc.i4.s 9
+			IL_0594: ldloc.s 10
+			IL_0596: stelem.ref
+			IL_0597: dup
+			IL_0598: ldc.i4.s 10
+			IL_059a: ldloc.s 11
+			IL_059c: stelem.ref
+			IL_059d: dup
+			IL_059e: ldc.i4.s 11
+			IL_05a0: ldloc.s 12
+			IL_05a2: stelem.ref
+			IL_05a3: dup
+			IL_05a4: ldc.i4.s 12
+			IL_05a6: ldloc.s 13
+			IL_05a8: stelem.ref
+			IL_05a9: dup
+			IL_05aa: ldc.i4.s 13
+			IL_05ac: ldloc.s 14
+			IL_05ae: stelem.ref
+			IL_05af: dup
+			IL_05b0: ldc.i4.s 14
+			IL_05b2: ldloc.s 15
 			IL_05b4: stelem.ref
-			IL_05b5: dup
-			IL_05b6: ldc.i4.6
-			IL_05b7: ldloc.s 7
-			IL_05b9: stelem.ref
-			IL_05ba: dup
-			IL_05bb: ldc.i4.7
-			IL_05bc: ldloc.s 8
-			IL_05be: stelem.ref
-			IL_05bf: dup
-			IL_05c0: ldc.i4.8
-			IL_05c1: ldloc.s 9
-			IL_05c3: stelem.ref
-			IL_05c4: dup
-			IL_05c5: ldc.i4.s 9
-			IL_05c7: ldloc.s 10
-			IL_05c9: stelem.ref
-			IL_05ca: dup
-			IL_05cb: ldc.i4.s 10
-			IL_05cd: ldloc.s 11
-			IL_05cf: stelem.ref
-			IL_05d0: dup
-			IL_05d1: ldc.i4.s 11
-			IL_05d3: ldloc.s 12
-			IL_05d5: stelem.ref
-			IL_05d6: dup
-			IL_05d7: ldc.i4.s 12
-			IL_05d9: ldloc.s 13
-			IL_05db: stelem.ref
-			IL_05dc: dup
-			IL_05dd: ldc.i4.s 13
-			IL_05df: ldloc.s 14
-			IL_05e1: stelem.ref
-			IL_05e2: dup
-			IL_05e3: ldc.i4.s 14
-			IL_05e5: ldloc.s 15
-			IL_05e7: stelem.ref
-			IL_05e8: dup
-			IL_05e9: ldc.i4.s 15
-			IL_05eb: ldloc.s 16
-			IL_05ed: stelem.ref
-			IL_05ee: dup
-			IL_05ef: ldc.i4.s 16
-			IL_05f1: ldloc.s 17
-			IL_05f3: stelem.ref
-			IL_05f4: dup
-			IL_05f5: ldc.i4.s 17
-			IL_05f7: ldloc.s 18
-			IL_05f9: stelem.ref
-			IL_05fa: dup
-			IL_05fb: ldc.i4.s 18
-			IL_05fd: ldloc.s 19
-			IL_05ff: stelem.ref
-			IL_0600: pop
-			IL_0601: ldloc.0
-			IL_0602: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0607: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_060c: ret
+			IL_05b5: pop
+			IL_05b6: ldloc.0
+			IL_05b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05bc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05c1: ret
 
-			IL_060d: ldloc.0
-			IL_060e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited1
-			IL_0613: stloc.s 27
-			IL_0615: ldloc.s 27
-			IL_0617: stloc.s 11
-			IL_0619: ldloc.1
-			IL_061a: ldstr "section"
-			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0624: ldstr "trim"
-			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_062e: stloc.s 27
-			IL_0630: ldc.i4.1
-			IL_0631: newarr [System.Runtime]System.Object
-			IL_0636: dup
-			IL_0637: ldc.i4.0
-			IL_0638: ldarg.0
-			IL_0639: ldc.i4.1
-			IL_063a: ldelem.ref
-			IL_063b: stelem.ref
-			IL_063c: ldc.i4.0
-			IL_063d: ldelem.ref
-			IL_063e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0643: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0649: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_064e: ldnull
-			IL_064f: ldloc.s 11
-			IL_0651: ldloc.s 27
-			IL_0653: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0658: stloc.s 27
-			IL_065a: ldloc.s 27
-			IL_065c: stloc.s 12
-			IL_065e: ldloc.s 12
-			IL_0660: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0665: ldc.i4.0
-			IL_0666: ceq
-			IL_0668: stloc.s 21
-			IL_066a: ldloc.s 21
-			IL_066c: brfalse IL_06f1
+			IL_05c2: ldloc.0
+			IL_05c3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_05c8: stloc.s 16
+			IL_05ca: ldloc.s 16
+			IL_05cc: stloc.s 5
+			IL_05ce: ldloc.s 11
+			IL_05d0: stloc.s 16
+			IL_05d2: ldloc.s 16
+			IL_05d4: stloc.s 7
+			IL_05d6: ldloc.s 6
+			IL_05d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05dd: ldc.i4.0
+			IL_05de: ceq
+			IL_05e0: stloc.s 17
+			IL_05e2: ldloc.s 17
+			IL_05e4: brfalse IL_061b
 
-			IL_0671: ldloc.1
-			IL_0672: ldstr "section"
-			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_067c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0681: stloc.s 29
-			IL_0683: ldstr "Could not find section '"
-			IL_0688: ldloc.s 29
-			IL_068a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_068f: stloc.s 29
-			IL_0691: ldloc.s 29
-			IL_0693: ldstr "' in multipage index: "
-			IL_0698: call string [System.Runtime]System.String::Concat(string, string)
-			IL_069d: stloc.s 29
-			IL_069f: ldloc.s 10
-			IL_06a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06a6: stloc.s 30
-			IL_06a8: ldloc.s 29
-			IL_06aa: ldloc.s 30
-			IL_06ac: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06b1: stloc.s 30
-			IL_06b3: ldloc.s 30
-			IL_06b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_06bf: stloc.s 27
-			IL_06c1: ldloc.0
-			IL_06c2: ldc.i4.m1
-			IL_06c3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06c8: ldloc.0
-			IL_06c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_06d3: ldarg.0
-			IL_06d4: ldc.i4.1
-			IL_06d5: newarr [System.Runtime]System.Object
-			IL_06da: dup
-			IL_06db: ldc.i4.0
-			IL_06dc: ldloc.s 27
-			IL_06de: stelem.ref
-			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06e4: pop
-			IL_06e5: ldloc.0
-			IL_06e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06f0: ret
+			IL_05e9: ldloc.s 10
+			IL_05eb: ldstr "fragment"
+			IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f5: stloc.s 16
+			IL_05f7: ldloc.s 16
+			IL_05f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05fe: stloc.s 17
+			IL_0600: ldloc.s 17
+			IL_0602: brtrue IL_0613
 
-			IL_06f1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
-			IL_06f6: stloc.s 31
-			IL_06f8: ldloc.s 12
-			IL_06fa: ldstr "filePart"
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0704: stloc.s 27
-			IL_0706: ldloc.s 27
-			IL_0708: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_070d: stloc.s 21
-			IL_070f: ldloc.s 21
-			IL_0711: brtrue IL_0729
+			IL_0607: ldstr ""
+			IL_060c: stloc.s 25
+			IL_060e: br IL_0617
 
-			IL_0716: ldloc.s 12
-			IL_0718: ldstr "href"
-			IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0722: stloc.s 32
-			IL_0724: br IL_072d
+			IL_0613: ldloc.s 16
+			IL_0615: stloc.s 25
 
-			IL_0729: ldloc.s 27
-			IL_072b: stloc.s 32
+			IL_0617: ldloc.s 25
+			IL_0619: stloc.s 6
 
-			IL_072d: ldc.i4.2
-			IL_072e: newarr [System.Runtime]System.Object
-			IL_0733: dup
-			IL_0734: ldc.i4.0
-			IL_0735: ldloc.s 32
-			IL_0737: stelem.ref
-			IL_0738: dup
-			IL_0739: ldc.i4.1
-			IL_073a: ldloc.s 10
-			IL_073c: stelem.ref
-			IL_073d: stloc.s 33
-			IL_073f: ldloc.s 31
-			IL_0741: ldloc.s 33
-			IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0748: stloc.s 27
-			IL_074a: ldloc.s 27
-			IL_074c: ldstr "toString"
-			IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0756: stloc.s 27
-			IL_0758: ldloc.s 27
-			IL_075a: stloc.s 13
-			IL_075c: ldloc.s 12
-			IL_075e: ldstr "fragment"
-			IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0768: stloc.s 27
-			IL_076a: ldloc.s 27
-			IL_076c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0771: stloc.s 21
-			IL_0773: ldloc.s 21
-			IL_0775: brtrue IL_0786
+			IL_061b: br IL_06f0
 
-			IL_077a: ldstr ""
-			IL_077f: stloc.s 34
-			IL_0781: br IL_078a
+			IL_0620: ldloc.1
+			IL_0621: ldstr "url"
+			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_062b: ldstr "trim"
+			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0635: stloc.s 16
+			IL_0637: ldloc.s 16
+			IL_0639: stloc.s 12
+			IL_063b: ldc.i4.1
+			IL_063c: newarr [System.Runtime]System.Object
+			IL_0641: dup
+			IL_0642: ldc.i4.0
+			IL_0643: ldarg.0
+			IL_0644: ldc.i4.1
+			IL_0645: ldelem.ref
+			IL_0646: stelem.ref
+			IL_0647: ldc.i4.0
+			IL_0648: ldelem.ref
+			IL_0649: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_064e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0654: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0659: ldnull
+			IL_065a: ldloc.s 12
+			IL_065c: ldnull
+			IL_065d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0662: stloc.s 16
+			IL_0664: ldloc.0
+			IL_0665: ldc.i4.3
+			IL_0666: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_066b: ldloc.0
+			IL_066c: ldloc.s 16
+			IL_066e: ldarg.0
+			IL_066f: ldc.i4.3
+			IL_0670: ldloc.0
+			IL_0671: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0676: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_067b: ldloc.0
+			IL_067c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0681: dup
+			IL_0682: ldc.i4.0
+			IL_0683: ldloc.1
+			IL_0684: stelem.ref
+			IL_0685: dup
+			IL_0686: ldc.i4.1
+			IL_0687: ldloc.2
+			IL_0688: stelem.ref
+			IL_0689: dup
+			IL_068a: ldc.i4.2
+			IL_068b: ldloc.3
+			IL_068c: stelem.ref
+			IL_068d: dup
+			IL_068e: ldc.i4.3
+			IL_068f: ldloc.s 4
+			IL_0691: stelem.ref
+			IL_0692: dup
+			IL_0693: ldc.i4.4
+			IL_0694: ldloc.s 5
+			IL_0696: stelem.ref
+			IL_0697: dup
+			IL_0698: ldc.i4.5
+			IL_0699: ldloc.s 6
+			IL_069b: stelem.ref
+			IL_069c: dup
+			IL_069d: ldc.i4.6
+			IL_069e: ldloc.s 7
+			IL_06a0: stelem.ref
+			IL_06a1: dup
+			IL_06a2: ldc.i4.7
+			IL_06a3: ldloc.s 8
+			IL_06a5: stelem.ref
+			IL_06a6: dup
+			IL_06a7: ldc.i4.8
+			IL_06a8: ldloc.s 9
+			IL_06aa: stelem.ref
+			IL_06ab: dup
+			IL_06ac: ldc.i4.s 9
+			IL_06ae: ldloc.s 10
+			IL_06b0: stelem.ref
+			IL_06b1: dup
+			IL_06b2: ldc.i4.s 10
+			IL_06b4: ldloc.s 11
+			IL_06b6: stelem.ref
+			IL_06b7: dup
+			IL_06b8: ldc.i4.s 11
+			IL_06ba: ldloc.s 12
+			IL_06bc: stelem.ref
+			IL_06bd: dup
+			IL_06be: ldc.i4.s 12
+			IL_06c0: ldloc.s 13
+			IL_06c2: stelem.ref
+			IL_06c3: dup
+			IL_06c4: ldc.i4.s 13
+			IL_06c6: ldloc.s 14
+			IL_06c8: stelem.ref
+			IL_06c9: dup
+			IL_06ca: ldc.i4.s 14
+			IL_06cc: ldloc.s 15
+			IL_06ce: stelem.ref
+			IL_06cf: pop
+			IL_06d0: ldloc.0
+			IL_06d1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06d6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06db: ret
 
-			IL_0786: ldloc.s 27
-			IL_0788: stloc.s 34
+			IL_06dc: ldloc.0
+			IL_06dd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_06e2: stloc.s 16
+			IL_06e4: ldloc.s 16
+			IL_06e6: stloc.s 5
+			IL_06e8: ldloc.s 12
+			IL_06ea: stloc.s 16
+			IL_06ec: ldloc.s 16
+			IL_06ee: stloc.s 7
 
-			IL_078a: ldloc.s 34
-			IL_078c: stloc.s 9
-			IL_078e: ldc.i4.1
-			IL_078f: newarr [System.Runtime]System.Object
-			IL_0794: dup
-			IL_0795: ldc.i4.0
-			IL_0796: ldarg.0
-			IL_0797: ldc.i4.1
-			IL_0798: ldelem.ref
-			IL_0799: stelem.ref
-			IL_079a: ldc.i4.0
-			IL_079b: ldelem.ref
-			IL_079c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_07a1: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-			IL_07a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_07ac: ldnull
-			IL_07ad: ldloc.s 13
-			IL_07af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_07b4: stloc.s 27
-			IL_07b6: ldloc.0
-			IL_07b7: ldc.i4.2
-			IL_07b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07bd: ldloc.0
-			IL_07be: ldloc.s 27
-			IL_07c0: ldarg.0
-			IL_07c1: ldc.i4.2
-			IL_07c2: ldloc.0
-			IL_07c3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_07cd: ldloc.0
-			IL_07ce: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_07d3: dup
-			IL_07d4: ldc.i4.0
-			IL_07d5: ldloc.1
-			IL_07d6: stelem.ref
-			IL_07d7: dup
-			IL_07d8: ldc.i4.1
-			IL_07d9: ldloc.2
-			IL_07da: stelem.ref
-			IL_07db: dup
-			IL_07dc: ldc.i4.2
-			IL_07dd: ldloc.3
-			IL_07de: stelem.ref
-			IL_07df: dup
-			IL_07e0: ldc.i4.3
-			IL_07e1: ldloc.s 4
-			IL_07e3: stelem.ref
-			IL_07e4: dup
-			IL_07e5: ldc.i4.4
-			IL_07e6: ldloc.s 5
-			IL_07e8: stelem.ref
-			IL_07e9: dup
-			IL_07ea: ldc.i4.5
-			IL_07eb: ldloc.s 6
-			IL_07ed: stelem.ref
-			IL_07ee: dup
-			IL_07ef: ldc.i4.6
-			IL_07f0: ldloc.s 7
-			IL_07f2: stelem.ref
-			IL_07f3: dup
-			IL_07f4: ldc.i4.7
-			IL_07f5: ldloc.s 8
-			IL_07f7: stelem.ref
-			IL_07f8: dup
-			IL_07f9: ldc.i4.8
-			IL_07fa: ldloc.s 9
-			IL_07fc: stelem.ref
-			IL_07fd: dup
-			IL_07fe: ldc.i4.s 9
-			IL_0800: ldloc.s 10
-			IL_0802: stelem.ref
-			IL_0803: dup
-			IL_0804: ldc.i4.s 10
-			IL_0806: ldloc.s 11
-			IL_0808: stelem.ref
-			IL_0809: dup
-			IL_080a: ldc.i4.s 11
-			IL_080c: ldloc.s 12
-			IL_080e: stelem.ref
-			IL_080f: dup
-			IL_0810: ldc.i4.s 12
-			IL_0812: ldloc.s 13
-			IL_0814: stelem.ref
-			IL_0815: dup
-			IL_0816: ldc.i4.s 13
-			IL_0818: ldloc.s 14
-			IL_081a: stelem.ref
-			IL_081b: dup
-			IL_081c: ldc.i4.s 14
-			IL_081e: ldloc.s 15
-			IL_0820: stelem.ref
-			IL_0821: dup
-			IL_0822: ldc.i4.s 15
-			IL_0824: ldloc.s 16
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.s 16
-			IL_082a: ldloc.s 17
-			IL_082c: stelem.ref
-			IL_082d: dup
-			IL_082e: ldc.i4.s 17
-			IL_0830: ldloc.s 18
-			IL_0832: stelem.ref
-			IL_0833: dup
-			IL_0834: ldc.i4.s 18
-			IL_0836: ldloc.s 19
-			IL_0838: stelem.ref
-			IL_0839: pop
-			IL_083a: ldloc.0
-			IL_083b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0840: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0845: ret
+			IL_06f0: ldloc.s 6
+			IL_06f2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06f7: ldc.i4.0
+			IL_06f8: ceq
+			IL_06fa: stloc.s 17
+			IL_06fc: ldloc.s 17
+			IL_06fe: brfalse IL_076f
 
-			IL_0846: ldloc.0
-			IL_0847: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited2
-			IL_084c: stloc.s 27
-			IL_084e: ldloc.s 27
-			IL_0850: stloc.s 7
-			IL_0852: ldloc.s 13
-			IL_0854: stloc.s 27
-			IL_0856: ldloc.s 27
-			IL_0858: stloc.s 8
-			IL_085a: br IL_0a4a
+			IL_0703: ldloc.1
+			IL_0704: ldstr "section"
+			IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_070e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0713: stloc.s 21
+			IL_0715: ldstr "Could not infer an element id for section '"
+			IL_071a: ldloc.s 21
+			IL_071c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0721: stloc.s 21
+			IL_0723: ldloc.s 21
+			IL_0725: ldstr "'. Try passing --id sec-... explicitly."
+			IL_072a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_072f: stloc.s 21
+			IL_0731: ldloc.s 21
+			IL_0733: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0738: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_073d: stloc.s 16
+			IL_073f: ldloc.0
+			IL_0740: ldc.i4.m1
+			IL_0741: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0746: ldloc.0
+			IL_0747: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_074c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0751: ldarg.0
+			IL_0752: ldc.i4.1
+			IL_0753: newarr [System.Runtime]System.Object
+			IL_0758: dup
+			IL_0759: ldc.i4.0
+			IL_075a: ldloc.s 16
+			IL_075c: stelem.ref
+			IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0762: pop
+			IL_0763: ldloc.0
+			IL_0764: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0769: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_076e: ret
 
-			IL_085f: ldloc.1
-			IL_0860: ldstr "url"
-			IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_086a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_086f: stloc.s 21
-			IL_0871: ldloc.s 21
-			IL_0873: brfalse IL_0964
+			IL_076f: ldc.i4.1
+			IL_0770: newarr [System.Runtime]System.Object
+			IL_0775: dup
+			IL_0776: ldc.i4.0
+			IL_0777: ldarg.0
+			IL_0778: ldc.i4.1
+			IL_0779: ldelem.ref
+			IL_077a: stelem.ref
+			IL_077b: ldc.i4.0
+			IL_077c: ldelem.ref
+			IL_077d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0782: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0788: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_078d: ldnull
+			IL_078e: ldloc.s 5
+			IL_0790: ldloc.s 6
+			IL_0792: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0797: stloc.s 16
+			IL_0799: ldloc.s 16
+			IL_079b: stloc.s 13
+			IL_079d: ldarg.0
+			IL_079e: ldc.i4.1
+			IL_079f: ldelem.ref
+			IL_07a0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07a5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_07aa: stloc.s 16
+			IL_07ac: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_07b1: ldstr "cwd"
+			IL_07b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_07bb: stloc.s 22
+			IL_07bd: ldloc.s 16
+			IL_07bf: ldstr "join"
+			IL_07c4: ldloc.s 22
+			IL_07c6: ldloc.1
+			IL_07c7: ldstr "outFile"
+			IL_07cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_07d6: stloc.s 22
+			IL_07d8: ldloc.s 22
+			IL_07da: stloc.s 14
+			IL_07dc: ldloc.s 13
+			IL_07de: ldstr "html"
+			IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07e8: stloc.s 22
+			IL_07ea: ldloc.1
+			IL_07eb: ldstr "section"
+			IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07fa: stloc.s 21
+			IL_07fc: ldstr "ECMA-262 "
+			IL_0801: ldloc.s 21
+			IL_0803: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0808: stloc.s 21
+			IL_080a: ldnull
+			IL_080b: ldloc.s 22
+			IL_080d: ldloc.s 21
+			IL_080f: ldloc.s 7
+			IL_0811: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+			IL_0816: stloc.s 22
+			IL_0818: ldloc.s 22
+			IL_081a: stloc.s 15
+			IL_081c: ldarg.0
+			IL_081d: ldc.i4.1
+			IL_081e: ldelem.ref
+			IL_081f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0824: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0829: ldstr "writeFileSync"
+			IL_082e: ldloc.s 14
+			IL_0830: ldloc.s 15
+			IL_0832: ldstr "utf8"
+			IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_083c: pop
+			IL_083d: ldloc.1
+			IL_083e: ldstr "section"
+			IL_0843: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0848: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_084d: stloc.s 21
+			IL_084f: ldstr "Extracted section "
+			IL_0854: ldloc.s 21
+			IL_0856: call string [System.Runtime]System.String::Concat(string, string)
+			IL_085b: stloc.s 21
+			IL_085d: ldloc.s 21
+			IL_085f: ldstr " (id="
+			IL_0864: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0869: stloc.s 21
+			IL_086b: ldloc.s 6
+			IL_086d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0872: stloc.s 20
+			IL_0874: ldloc.s 21
+			IL_0876: ldloc.s 20
+			IL_0878: call string [System.Runtime]System.String::Concat(string, string)
+			IL_087d: stloc.s 20
+			IL_087f: ldloc.s 20
+			IL_0881: ldstr ", tag="
+			IL_0886: call string [System.Runtime]System.String::Concat(string, string)
+			IL_088b: stloc.s 20
+			IL_088d: ldloc.s 13
+			IL_088f: ldstr "tagName"
+			IL_0894: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0899: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_089e: stloc.s 21
+			IL_08a0: ldloc.s 20
+			IL_08a2: ldloc.s 21
+			IL_08a4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08a9: stloc.s 21
+			IL_08ab: ldloc.s 21
+			IL_08ad: ldstr ") -> "
+			IL_08b2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08b7: stloc.s 21
+			IL_08b9: ldloc.s 14
+			IL_08bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08c0: stloc.s 20
+			IL_08c2: ldloc.s 21
+			IL_08c4: ldloc.s 20
+			IL_08c6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08cb: stloc.s 20
+			IL_08cd: ldnull
+			IL_08ce: ldloc.s 20
+			IL_08d0: ldloc.s 14
+			IL_08d2: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_08d7: stloc.s 22
+			IL_08d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08de: ldloc.s 22
+			IL_08e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08e5: pop
+			IL_08e6: ldarg.0
+			IL_08e7: ldc.i4.1
+			IL_08e8: ldelem.ref
+			IL_08e9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08ee: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_08f3: ldstr "readFileSync"
+			IL_08f8: ldloc.s 14
+			IL_08fa: ldstr "utf8"
+			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0904: stloc.s 22
+			IL_0906: ldnull
+			IL_0907: ldloc.s 22
+			IL_0909: ldloc.s 14
+			IL_090b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0910: stloc.s 22
+			IL_0912: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0917: ldloc.s 22
+			IL_0919: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_091e: pop
+			IL_091f: ldloc.0
+			IL_0920: ldc.i4.m1
+			IL_0921: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0926: ldloc.0
+			IL_0927: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_092c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0931: ldarg.0
+			IL_0932: ldc.i4.1
+			IL_0933: newarr [System.Runtime]System.Object
+			IL_0938: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_093d: pop
+			IL_093e: ldloc.0
+			IL_093f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0944: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0949: ret
+		} // end of method runHarnessCli::__js_call__
 
-			IL_0878: ldloc.1
-			IL_0879: ldstr "url"
-			IL_087e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0883: ldstr "trim"
-			IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_088d: stloc.s 27
-			IL_088f: ldloc.s 27
-			IL_0891: stloc.s 14
-			IL_0893: ldc.i4.1
-			IL_0894: newarr [System.Runtime]System.Object
-			IL_0899: dup
-			IL_089a: ldc.i4.0
-			IL_089b: ldarg.0
-			IL_089c: ldc.i4.1
-			IL_089d: ldelem.ref
-			IL_089e: stelem.ref
-			IL_089f: ldc.i4.0
-			IL_08a0: ldelem.ref
-			IL_08a1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_08a6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-			IL_08ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_08b1: ldnull
-			IL_08b2: ldloc.s 14
-			IL_08b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_08b9: stloc.s 27
-			IL_08bb: ldloc.0
-			IL_08bc: ldc.i4.3
-			IL_08bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08c2: ldloc.0
-			IL_08c3: ldloc.s 27
-			IL_08c5: ldarg.0
-			IL_08c6: ldc.i4.3
-			IL_08c7: ldloc.0
-			IL_08c8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_08cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_08d2: ldloc.0
-			IL_08d3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_08d8: dup
-			IL_08d9: ldc.i4.0
-			IL_08da: ldloc.1
-			IL_08db: stelem.ref
-			IL_08dc: dup
-			IL_08dd: ldc.i4.1
-			IL_08de: ldloc.2
-			IL_08df: stelem.ref
-			IL_08e0: dup
-			IL_08e1: ldc.i4.2
-			IL_08e2: ldloc.3
-			IL_08e3: stelem.ref
-			IL_08e4: dup
-			IL_08e5: ldc.i4.3
-			IL_08e6: ldloc.s 4
-			IL_08e8: stelem.ref
-			IL_08e9: dup
-			IL_08ea: ldc.i4.4
-			IL_08eb: ldloc.s 5
-			IL_08ed: stelem.ref
-			IL_08ee: dup
-			IL_08ef: ldc.i4.5
-			IL_08f0: ldloc.s 6
-			IL_08f2: stelem.ref
-			IL_08f3: dup
-			IL_08f4: ldc.i4.6
-			IL_08f5: ldloc.s 7
-			IL_08f7: stelem.ref
-			IL_08f8: dup
-			IL_08f9: ldc.i4.7
-			IL_08fa: ldloc.s 8
-			IL_08fc: stelem.ref
-			IL_08fd: dup
-			IL_08fe: ldc.i4.8
-			IL_08ff: ldloc.s 9
-			IL_0901: stelem.ref
-			IL_0902: dup
-			IL_0903: ldc.i4.s 9
-			IL_0905: ldloc.s 10
-			IL_0907: stelem.ref
-			IL_0908: dup
-			IL_0909: ldc.i4.s 10
-			IL_090b: ldloc.s 11
-			IL_090d: stelem.ref
-			IL_090e: dup
-			IL_090f: ldc.i4.s 11
-			IL_0911: ldloc.s 12
-			IL_0913: stelem.ref
-			IL_0914: dup
-			IL_0915: ldc.i4.s 12
-			IL_0917: ldloc.s 13
-			IL_0919: stelem.ref
-			IL_091a: dup
-			IL_091b: ldc.i4.s 13
-			IL_091d: ldloc.s 14
-			IL_091f: stelem.ref
-			IL_0920: dup
-			IL_0921: ldc.i4.s 14
-			IL_0923: ldloc.s 15
-			IL_0925: stelem.ref
-			IL_0926: dup
-			IL_0927: ldc.i4.s 15
-			IL_0929: ldloc.s 16
-			IL_092b: stelem.ref
-			IL_092c: dup
-			IL_092d: ldc.i4.s 16
-			IL_092f: ldloc.s 17
-			IL_0931: stelem.ref
-			IL_0932: dup
-			IL_0933: ldc.i4.s 17
-			IL_0935: ldloc.s 18
-			IL_0937: stelem.ref
-			IL_0938: dup
-			IL_0939: ldc.i4.s 18
-			IL_093b: ldloc.s 19
-			IL_093d: stelem.ref
-			IL_093e: pop
-			IL_093f: ldloc.0
-			IL_0940: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0945: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_094a: ret
-
-			IL_094b: ldloc.0
-			IL_094c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited3
-			IL_0951: stloc.s 27
-			IL_0953: ldloc.s 27
-			IL_0955: stloc.s 7
-			IL_0957: ldloc.s 14
-			IL_0959: stloc.s 27
-			IL_095b: ldloc.s 27
-			IL_095d: stloc.s 8
-			IL_095f: br IL_0a4a
-
-			IL_0964: ldarg.0
-			IL_0965: ldc.i4.1
-			IL_0966: ldelem.ref
-			IL_0967: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_096c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
-			IL_0971: stloc.s 27
-			IL_0973: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0978: ldstr "cwd"
-			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0982: stloc.s 20
-			IL_0984: ldloc.s 27
-			IL_0986: ldstr "resolve"
-			IL_098b: ldloc.s 20
-			IL_098d: ldloc.1
-			IL_098e: ldstr "inFile"
-			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_099d: stloc.s 20
-			IL_099f: ldloc.s 20
-			IL_09a1: stloc.s 15
-			IL_09a3: ldarg.0
-			IL_09a4: ldc.i4.1
-			IL_09a5: ldelem.ref
-			IL_09a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_09ab: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_09b0: ldstr "existsSync"
-			IL_09b5: ldloc.s 15
-			IL_09b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_09bc: stloc.s 20
-			IL_09be: ldloc.s 20
-			IL_09c0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_09c5: ldc.i4.0
-			IL_09c6: ceq
-			IL_09c8: stloc.s 21
-			IL_09ca: ldloc.s 21
-			IL_09cc: brfalse IL_0a26
-
-			IL_09d1: ldloc.s 15
-			IL_09d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09d8: stloc.s 30
-			IL_09da: ldstr "Input file not found: "
-			IL_09df: ldloc.s 30
-			IL_09e1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09e6: stloc.s 30
-			IL_09e8: ldloc.s 30
-			IL_09ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_09f4: stloc.s 20
-			IL_09f6: ldloc.0
-			IL_09f7: ldc.i4.m1
-			IL_09f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_09fd: ldloc.0
-			IL_09fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a03: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0a08: ldarg.0
-			IL_0a09: ldc.i4.1
-			IL_0a0a: newarr [System.Runtime]System.Object
-			IL_0a0f: dup
-			IL_0a10: ldc.i4.0
-			IL_0a11: ldloc.s 20
-			IL_0a13: stelem.ref
-			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0a19: pop
-			IL_0a1a: ldloc.0
-			IL_0a1b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a20: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a25: ret
-
-			IL_0a26: ldarg.0
-			IL_0a27: ldc.i4.1
-			IL_0a28: ldelem.ref
-			IL_0a29: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0a2e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_0a33: ldstr "readFileSync"
-			IL_0a38: ldloc.s 15
-			IL_0a3a: ldstr "utf8"
-			IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a44: stloc.s 20
-			IL_0a46: ldloc.s 20
-			IL_0a48: stloc.s 7
-
-			IL_0a4a: ldloc.1
-			IL_0a4b: ldstr "id"
-			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a55: stloc.s 20
-			IL_0a57: ldloc.s 20
-			IL_0a59: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0a5e: stloc.s 21
-			IL_0a60: ldloc.s 21
-			IL_0a62: brtrue IL_0a73
-
-			IL_0a67: ldstr ""
-			IL_0a6c: stloc.s 35
-			IL_0a6e: br IL_0a77
-
-			IL_0a73: ldloc.s 20
-			IL_0a75: stloc.s 35
-
-			IL_0a77: ldloc.s 35
-			IL_0a79: castclass [System.Runtime]System.String
-			IL_0a7e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0a83: stloc.s 30
-			IL_0a85: ldloc.s 30
-			IL_0a87: stloc.s 16
-			IL_0a89: ldloc.s 16
-			IL_0a8b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a90: ldc.i4.0
-			IL_0a91: ceq
-			IL_0a93: stloc.s 21
-			IL_0a95: ldloc.s 21
-			IL_0a97: box [System.Runtime]System.Boolean
-			IL_0a9c: stloc.s 22
-			IL_0a9e: ldloc.s 22
-			IL_0aa0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0aa5: stloc.s 21
-			IL_0aa7: ldloc.s 21
-			IL_0aa9: brfalse IL_0ab7
-
-			IL_0aae: ldloc.s 9
-			IL_0ab0: stloc.s 36
-			IL_0ab2: br IL_0abb
-
-			IL_0ab7: ldloc.s 22
-			IL_0ab9: stloc.s 36
-
-			IL_0abb: ldloc.s 36
-			IL_0abd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0ac2: stloc.s 21
-			IL_0ac4: ldloc.s 21
-			IL_0ac6: brfalse IL_0ad3
-
-			IL_0acb: ldloc.s 9
-			IL_0acd: stloc.s 36
-			IL_0acf: ldloc.s 36
-			IL_0ad1: stloc.s 16
-
-			IL_0ad3: ldloc.s 16
-			IL_0ad5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0ada: ldc.i4.0
-			IL_0adb: ceq
-			IL_0add: stloc.s 21
-			IL_0adf: ldloc.s 21
-			IL_0ae1: brfalse IL_0b2b
-
-			IL_0ae6: ldloc.1
-			IL_0ae7: ldstr "section"
-			IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0af1: ldstr "trim"
-			IL_0af6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0afb: stloc.s 20
-			IL_0afd: ldc.i4.1
-			IL_0afe: newarr [System.Runtime]System.Object
-			IL_0b03: dup
-			IL_0b04: ldc.i4.0
-			IL_0b05: ldarg.0
-			IL_0b06: ldc.i4.1
-			IL_0b07: ldelem.ref
-			IL_0b08: stelem.ref
-			IL_0b09: ldc.i4.0
-			IL_0b0a: ldelem.ref
-			IL_0b0b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0b10: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionIdFromHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0b16: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0b1b: ldnull
-			IL_0b1c: ldloc.s 7
-			IL_0b1e: ldloc.s 20
-			IL_0b20: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0b25: stloc.s 20
-			IL_0b27: ldloc.s 20
-			IL_0b29: stloc.s 16
-
-			IL_0b2b: ldloc.s 16
-			IL_0b2d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0b32: ldc.i4.0
-			IL_0b33: ceq
-			IL_0b35: stloc.s 21
-			IL_0b37: ldloc.s 21
-			IL_0b39: brfalse IL_0baa
-
-			IL_0b3e: ldloc.1
-			IL_0b3f: ldstr "section"
-			IL_0b44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b49: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b4e: stloc.s 30
-			IL_0b50: ldstr "Could not infer an element id for section '"
-			IL_0b55: ldloc.s 30
-			IL_0b57: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b5c: stloc.s 30
-			IL_0b5e: ldloc.s 30
-			IL_0b60: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0b65: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b6a: stloc.s 30
-			IL_0b6c: ldloc.s 30
-			IL_0b6e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b73: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0b78: stloc.s 20
-			IL_0b7a: ldloc.0
-			IL_0b7b: ldc.i4.m1
-			IL_0b7c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b81: ldloc.0
-			IL_0b82: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0b87: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0b8c: ldarg.0
-			IL_0b8d: ldc.i4.1
-			IL_0b8e: newarr [System.Runtime]System.Object
-			IL_0b93: dup
-			IL_0b94: ldc.i4.0
-			IL_0b95: ldloc.s 20
-			IL_0b97: stelem.ref
-			IL_0b98: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0b9d: pop
-			IL_0b9e: ldloc.0
-			IL_0b9f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ba4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ba9: ret
-
-			IL_0baa: ldc.i4.1
-			IL_0bab: newarr [System.Runtime]System.Object
-			IL_0bb0: dup
-			IL_0bb1: ldc.i4.0
-			IL_0bb2: ldarg.0
-			IL_0bb3: ldc.i4.1
-			IL_0bb4: ldelem.ref
-			IL_0bb5: stelem.ref
-			IL_0bb6: ldc.i4.0
-			IL_0bb7: ldelem.ref
-			IL_0bb8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0bbd: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0bc3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0bc8: ldnull
-			IL_0bc9: ldloc.s 7
-			IL_0bcb: ldloc.s 16
-			IL_0bcd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0bd2: stloc.s 20
-			IL_0bd4: ldloc.s 20
-			IL_0bd6: stloc.s 17
-			IL_0bd8: ldloc.s 17
-			IL_0bda: ldstr "html"
-			IL_0bdf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0be4: stloc.s 18
-			IL_0be6: ldloc.1
-			IL_0be7: ldstr "wrap"
-			IL_0bec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bf1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0bf6: stloc.s 21
-			IL_0bf8: ldloc.s 21
-			IL_0bfa: brfalse IL_0c9a
-
-			IL_0bff: ldloc.1
-			IL_0c00: ldstr "baseHref"
-			IL_0c05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c0a: stloc.s 20
-			IL_0c0c: ldloc.s 20
-			IL_0c0e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0c13: stloc.s 21
-			IL_0c15: ldloc.s 21
-			IL_0c17: brtrue IL_0c25
-
-			IL_0c1c: ldloc.s 8
-			IL_0c1e: stloc.s 37
-			IL_0c20: br IL_0c29
-
-			IL_0c25: ldloc.s 20
-			IL_0c27: stloc.s 37
-
-			IL_0c29: ldloc.s 37
-			IL_0c2b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0c30: stloc.s 21
-			IL_0c32: ldloc.s 21
-			IL_0c34: brtrue IL_0c45
-
-			IL_0c39: ldstr ""
-			IL_0c3e: stloc.s 37
-			IL_0c40: br IL_0c45
-
-			IL_0c45: ldloc.s 37
-			IL_0c47: stloc.s 19
-			IL_0c49: ldloc.1
-			IL_0c4a: ldstr "section"
-			IL_0c4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c54: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0c59: stloc.s 30
-			IL_0c5b: ldstr "ECMA-262 "
-			IL_0c60: ldloc.s 30
-			IL_0c62: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c67: stloc.s 30
-			IL_0c69: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0c6e: dup
-			IL_0c6f: ldstr "title"
-			IL_0c74: ldloc.s 30
-			IL_0c76: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0c7b: dup
-			IL_0c7c: ldstr "baseHref"
-			IL_0c81: ldloc.s 19
-			IL_0c83: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0c88: stloc.s 39
-			IL_0c8a: ldnull
-			IL_0c8b: ldloc.s 18
-			IL_0c8d: ldloc.s 39
-			IL_0c8f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/wrapAsStandaloneHtml::__js_call__(object, object, object)
-			IL_0c94: stloc.s 20
-			IL_0c96: ldloc.s 20
-			IL_0c98: stloc.s 18
-
-			IL_0c9a: ldc.i4.1
-			IL_0c9b: newarr [System.Runtime]System.Object
-			IL_0ca0: dup
-			IL_0ca1: ldc.i4.0
-			IL_0ca2: ldarg.0
-			IL_0ca3: ldc.i4.1
-			IL_0ca4: ldelem.ref
-			IL_0ca5: stelem.ref
-			IL_0ca6: ldc.i4.0
-			IL_0ca7: ldelem.ref
-			IL_0ca8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0cad: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/writeTextPreserveEol::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0cb3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0cb8: ldnull
-			IL_0cb9: ldloc.s 6
-			IL_0cbb: ldloc.s 18
-			IL_0cbd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0cc2: pop
-			IL_0cc3: ldc.i4.1
-			IL_0cc4: newarr [System.Runtime]System.Object
-			IL_0cc9: dup
-			IL_0cca: ldc.i4.0
-			IL_0ccb: ldarg.0
-			IL_0ccc: ldc.i4.1
-			IL_0ccd: ldelem.ref
-			IL_0cce: stelem.ref
-			IL_0ccf: stloc.s 33
-			IL_0cd1: ldloc.1
-			IL_0cd2: ldstr "section"
-			IL_0cd7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cdc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ce1: stloc.s 30
-			IL_0ce3: ldstr "Extracted section "
-			IL_0ce8: ldloc.s 30
-			IL_0cea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cef: stloc.s 30
-			IL_0cf1: ldloc.s 30
-			IL_0cf3: ldstr " (id="
-			IL_0cf8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cfd: stloc.s 30
-			IL_0cff: ldloc.s 16
-			IL_0d01: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0d06: stloc.s 29
-			IL_0d08: ldloc.s 30
-			IL_0d0a: ldloc.s 29
-			IL_0d0c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d11: stloc.s 29
-			IL_0d13: ldloc.s 29
-			IL_0d15: ldstr ", tag="
-			IL_0d1a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d1f: stloc.s 29
-			IL_0d21: ldloc.s 17
-			IL_0d23: ldstr "tagName"
-			IL_0d28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0d32: stloc.s 30
-			IL_0d34: ldloc.s 29
-			IL_0d36: ldloc.s 30
-			IL_0d38: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d3d: stloc.s 30
-			IL_0d3f: ldloc.s 30
-			IL_0d41: ldstr ") -> "
-			IL_0d46: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d4b: stloc.s 30
-			IL_0d4d: ldloc.s 6
-			IL_0d4f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0d54: stloc.s 29
-			IL_0d56: ldloc.s 30
-			IL_0d58: ldloc.s 29
-			IL_0d5a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d5f: stloc.s 29
-			IL_0d61: ldarg.3
-			IL_0d62: ldloc.s 33
-			IL_0d64: ldloc.s 29
-			IL_0d66: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-			IL_0d6b: pop
-			IL_0d6c: ldloc.0
-			IL_0d6d: ldc.i4.m1
-			IL_0d6e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0d73: ldloc.0
-			IL_0d74: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0d79: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0d7e: ldarg.0
-			IL_0d7f: ldc.i4.1
-			IL_0d80: newarr [System.Runtime]System.Object
-			IL_0d85: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0d8a: pop
-			IL_0d8b: ldloc.0
-			IL_0d8c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0d91: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0d96: ret
-		} // end of method main::__js_call__
-
-	} // end of class main
-
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L573C16
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
-				72 7d 00 00
-			)
-			// Fields
-			.field public object err
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c41
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object err
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x5420
-			// Header size: 12
-			// Code size: 108 (0x6c)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[2] bool,
-				[3] object,
-				[4] object
-			)
-
-			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0005: stloc.1
-			IL_0006: ldarg.1
-			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_000c: stloc.2
-			IL_000d: ldloc.2
-			IL_000e: brfalse IL_0025
-
-			IL_0013: ldarg.1
-			IL_0014: ldstr "message"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.s 4
-			IL_0020: br IL_0028
-
-			IL_0025: ldarg.1
-			IL_0026: stloc.s 4
-
-			IL_0028: ldloc.s 4
-			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002f: stloc.2
-			IL_0030: ldloc.2
-			IL_0031: brfalse IL_0047
-
-			IL_0036: ldarg.1
-			IL_0037: ldstr "message"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.0
-			IL_0042: br IL_0049
-
-			IL_0047: ldarg.1
-			IL_0048: stloc.0
-
-			IL_0049: ldloc.1
-			IL_004a: ldloc.0
-			IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0050: pop
-			IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0056: ldstr "exitCode"
-			IL_005b: ldc.r8 1
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
-			IL_0069: pop
-			IL_006a: ldnull
-			IL_006b: ret
-		} // end of method ArrowFunction_L573C16::__js_call__
-
-	} // end of class ArrowFunction_L573C16
+	} // end of class runHarnessCli
 
 	.class nested private auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
 		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 80 d3 53 63 6f 70 65 20 66 73 3d 7b 66 73
+			01 00 80 93 53 63 6f 70 65 20 66 73 3d 7b 66 73
 			7d 2c 20 68 74 74 70 3d 7b 68 74 74 70 7d 2c 20
-			70 61 74 68 3d 7b 70 61 74 68 7d 2c 20 68 74 74
-			70 73 3d 7b 68 74 74 70 73 7d 2c 20 70 61 72 73
-			65 41 72 67 73 3d 7b 70 61 72 73 65 41 72 67 73
-			7d 2c 20 66 65 74 63 68 54 65 78 74 57 69 74 68
-			48 74 74 70 3d 7b 66 65 74 63 68 54 65 78 74 57
-			69 74 68 48 74 74 70 7d 2c 20 66 65 74 63 68 54
-			65 78 74 57 69 74 68 48 74 74 70 73 3d 7b 66 65
-			74 63 68 54 65 78 74 57 69 74 68 48 74 74 70 73
-			7d 2c 20 66 65 74 63 68 54 65 78 74 57 69 74 68
-			54 72 61 6e 73 70 6f 72 74 3d 7b 66 65 74 63 68
-			54 65 78 74 57 69 74 68 54 72 61 6e 73 70 6f 72
+			68 74 74 70 73 3d 7b 68 74 74 70 73 7d 2c 20 70
+			61 74 68 3d 7b 70 61 74 68 7d 2c 20 4e 6f 64 65
+			55 72 6c 3d 7b 4e 6f 64 65 55 72 6c 7d 2c 20 6e
+			6f 72 6d 61 6c 69 7a 65 3d 7b 6e 6f 72 6d 61 6c
+			69 7a 65 7d 2c 20 70 61 72 73 65 41 72 67 73 3d
+			7b 70 61 72 73 65 41 72 67 73 7d 2c 20 66 65 74
+			63 68 54 65 78 74 3d 7b 66 65 74 63 68 54 65 78
 			74 7d 2c 20 e2 80 a6 00 00
 		)
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Block_L572C29
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c38
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L572C29::.ctor
-
-		} // end of class Block_L572C29
-
-
 		// Fields
 		.field public object fs
 		.field public object http
-		.field public object path
 		.field public object https
+		.field public object path
+		.field public object NodeUrl
+		.field public object normalize
 		.field public object parseArgs
-		.field public object fetchTextWithHttp
-		.field public object fetchTextWithHttps
-		.field public object fetchTextWithTransport
 		.field public object fetchText
-		.field public object fetchTextWithNodeRequest
-		.field public object detectEol
 		.field public object escapeRegExp
-		.field public object writeTextPreserveEol
 		.field public object findTagNameAt
 		.field public object extractElementById
 		.field public object resolveSectionLinkFromMultipageIndexHtml
-		.field public object resolveSectionIdFromHtml
 		.field public object wrapAsStandaloneHtml
-		.field public object printHelp
-		.field public object main
+		.field public object runHarnessCli
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5956
+			// Method begins at RVA 0x409d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8208,306 +4816,185 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2108
+		// Method begins at RVA 0x20c4
 		// Header size: 12
-		// Code size: 704 (0x2c0)
+		// Code size: 424 (0x1a8)
 		.maxstack 8
 		.locals init (
-			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope,
+			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope,
 			[1] object,
-			[2] object,
-			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] bool,
-			[6] object
+			[2] object
 		)
 
-		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::.ctor()
+		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldloc.0
-		IL_000f: stelem.ref
-		IL_0010: ldc.i4.0
-		IL_0011: ldelem.ref
-		IL_0012: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_0017: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0022: stloc.3
-		IL_0023: ldloc.0
-		IL_0024: ldloc.3
-		IL_0025: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::parseArgs
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
-		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.i4.0
-		IL_0035: ldelem.ref
-		IL_0036: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_003b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttp::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0046: stloc.3
-		IL_0047: ldloc.0
-		IL_0048: ldloc.3
-		IL_0049: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithHttp
-		IL_004e: ldc.i4.1
-		IL_004f: newarr [System.Runtime]System.Object
-		IL_0054: dup
-		IL_0055: ldc.i4.0
-		IL_0056: ldloc.0
-		IL_0057: stelem.ref
-		IL_0058: ldc.i4.0
-		IL_0059: ldelem.ref
-		IL_005a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_005f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttps::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_006a: stloc.3
-		IL_006b: ldloc.0
-		IL_006c: ldloc.3
-		IL_006d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithHttps
-		IL_0072: ldc.i4.1
-		IL_0073: newarr [System.Runtime]System.Object
-		IL_0078: dup
-		IL_0079: ldc.i4.0
-		IL_007a: ldloc.0
-		IL_007b: stelem.ref
-		IL_007c: ldc.i4.0
-		IL_007d: ldelem.ref
-		IL_007e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_0083: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
-		IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-		IL_008e: stloc.3
-		IL_008f: ldloc.0
-		IL_0090: ldloc.3
-		IL_0091: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithTransport
-		IL_0096: ldc.i4.1
-		IL_0097: newarr [System.Runtime]System.Object
-		IL_009c: dup
-		IL_009d: ldc.i4.0
-		IL_009e: ldloc.0
-		IL_009f: stelem.ref
-		IL_00a0: ldc.i4.0
-		IL_00a1: ldelem.ref
-		IL_00a2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_00a7: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00b2: stloc.3
-		IL_00b3: ldloc.3
-		IL_00b4: stloc.1
-		IL_00b5: ldc.i4.1
-		IL_00b6: newarr [System.Runtime]System.Object
-		IL_00bb: dup
-		IL_00bc: ldc.i4.0
-		IL_00bd: ldloc.0
-		IL_00be: stelem.ref
-		IL_00bf: ldc.i4.0
-		IL_00c0: ldelem.ref
-		IL_00c1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_00c6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00d1: stloc.3
-		IL_00d2: ldloc.0
-		IL_00d3: ldloc.3
-		IL_00d4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithNodeRequest
-		IL_00d9: ldnull
-		IL_00da: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/detectEol::__js_call__(object, object)
-		IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00e5: stloc.3
-		IL_00e6: ldloc.0
-		IL_00e7: ldloc.3
-		IL_00e8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::detectEol
-		IL_00ed: ldnull
-		IL_00ee: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
-		IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00f9: stloc.3
-		IL_00fa: ldloc.0
-		IL_00fb: ldloc.3
-		IL_00fc: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::escapeRegExp
-		IL_0101: ldc.i4.1
-		IL_0102: newarr [System.Runtime]System.Object
-		IL_0107: dup
-		IL_0108: ldc.i4.0
-		IL_0109: ldloc.0
-		IL_010a: stelem.ref
-		IL_010b: ldc.i4.0
-		IL_010c: ldelem.ref
-		IL_010d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_0112: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/writeTextPreserveEol::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_011d: stloc.3
-		IL_011e: ldloc.0
-		IL_011f: ldloc.3
-		IL_0120: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::writeTextPreserveEol
-		IL_0125: ldc.i4.1
-		IL_0126: newarr [System.Runtime]System.Object
-		IL_012b: dup
-		IL_012c: ldc.i4.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0012: stloc.2
+		IL_0013: ldloc.0
+		IL_0014: ldloc.2
+		IL_0015: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+		IL_001a: ldc.i4.1
+		IL_001b: newarr [System.Runtime]System.Object
+		IL_0020: dup
+		IL_0021: ldc.i4.0
+		IL_0022: ldloc.0
+		IL_0023: stelem.ref
+		IL_0024: ldc.i4.0
+		IL_0025: ldelem.ref
+		IL_0026: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_002b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0036: stloc.2
+		IL_0037: ldloc.0
+		IL_0038: ldloc.2
+		IL_0039: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
+		IL_003e: ldc.i4.1
+		IL_003f: newarr [System.Runtime]System.Object
+		IL_0044: dup
+		IL_0045: ldc.i4.0
+		IL_0046: ldloc.0
+		IL_0047: stelem.ref
+		IL_0048: ldc.i4.0
+		IL_0049: ldelem.ref
+		IL_004a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_004f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_005a: stloc.2
+		IL_005b: ldloc.0
+		IL_005c: ldloc.2
+		IL_005d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+		IL_0062: ldnull
+		IL_0063: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+		IL_0069: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_006e: stloc.2
+		IL_006f: ldloc.0
+		IL_0070: ldloc.2
+		IL_0071: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: ldc.i4.0
+		IL_0081: ldelem.ref
+		IL_0082: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_0087: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+		IL_008d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0092: stloc.2
+		IL_0093: ldloc.0
+		IL_0094: ldloc.2
+		IL_0095: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+		IL_009a: ldc.i4.1
+		IL_009b: newarr [System.Runtime]System.Object
+		IL_00a0: dup
+		IL_00a1: ldc.i4.0
+		IL_00a2: ldloc.0
+		IL_00a3: stelem.ref
+		IL_00a4: ldc.i4.0
+		IL_00a5: ldelem.ref
+		IL_00a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_00ab: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+		IL_00b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00b6: stloc.2
+		IL_00b7: ldloc.0
+		IL_00b8: ldloc.2
+		IL_00b9: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+		IL_00be: ldc.i4.1
+		IL_00bf: newarr [System.Runtime]System.Object
+		IL_00c4: dup
+		IL_00c5: ldc.i4.0
+		IL_00c6: ldloc.0
+		IL_00c7: stelem.ref
+		IL_00c8: ldc.i4.0
+		IL_00c9: ldelem.ref
+		IL_00ca: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_00cf: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+		IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00da: stloc.2
+		IL_00db: ldloc.0
+		IL_00dc: ldloc.2
+		IL_00dd: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+		IL_00e2: ldnull
+		IL_00e3: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+		IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_00ee: stloc.2
+		IL_00ef: ldloc.0
+		IL_00f0: ldloc.2
+		IL_00f1: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+		IL_00f6: ldc.i4.1
+		IL_00f7: newarr [System.Runtime]System.Object
+		IL_00fc: dup
+		IL_00fd: ldc.i4.0
+		IL_00fe: ldloc.0
+		IL_00ff: stelem.ref
+		IL_0100: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
+		IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_010b: stloc.2
+		IL_010c: ldloc.2
+		IL_010d: stloc.1
+		IL_010e: ldarg.1
+		IL_010f: ldstr "fs"
+		IL_0114: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0119: stloc.2
+		IL_011a: ldloc.0
+		IL_011b: ldloc.2
+		IL_011c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+		IL_0121: ldarg.1
+		IL_0122: ldstr "node:http"
+		IL_0127: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_012c: stloc.2
 		IL_012d: ldloc.0
-		IL_012e: stelem.ref
-		IL_012f: ldc.i4.0
-		IL_0130: ldelem.ref
-		IL_0131: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_0136: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_013c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0141: stloc.3
-		IL_0142: ldloc.0
-		IL_0143: ldloc.3
-		IL_0144: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::findTagNameAt
-		IL_0149: ldc.i4.1
-		IL_014a: newarr [System.Runtime]System.Object
-		IL_014f: dup
-		IL_0150: ldc.i4.0
-		IL_0151: ldloc.0
-		IL_0152: stelem.ref
-		IL_0153: ldc.i4.0
-		IL_0154: ldelem.ref
-		IL_0155: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_015a: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0165: stloc.3
-		IL_0166: ldloc.0
-		IL_0167: ldloc.3
-		IL_0168: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::extractElementById
-		IL_016d: ldc.i4.1
-		IL_016e: newarr [System.Runtime]System.Object
-		IL_0173: dup
-		IL_0174: ldc.i4.0
-		IL_0175: ldloc.0
-		IL_0176: stelem.ref
-		IL_0177: ldc.i4.0
-		IL_0178: ldelem.ref
-		IL_0179: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_017e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0189: stloc.3
-		IL_018a: ldloc.0
-		IL_018b: ldloc.3
-		IL_018c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::resolveSectionLinkFromMultipageIndexHtml
-		IL_0191: ldc.i4.1
-		IL_0192: newarr [System.Runtime]System.Object
-		IL_0197: dup
-		IL_0198: ldc.i4.0
-		IL_0199: ldloc.0
-		IL_019a: stelem.ref
-		IL_019b: ldc.i4.0
-		IL_019c: ldelem.ref
-		IL_019d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_01a2: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionIdFromHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01ad: stloc.3
-		IL_01ae: ldloc.0
-		IL_01af: ldloc.3
-		IL_01b0: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::resolveSectionIdFromHtml
-		IL_01b5: ldnull
-		IL_01b6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/wrapAsStandaloneHtml::__js_call__(object, object, object)
-		IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01c1: stloc.3
-		IL_01c2: ldloc.0
-		IL_01c3: ldloc.3
-		IL_01c4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::wrapAsStandaloneHtml
-		IL_01c9: ldnull
-		IL_01ca: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/printHelp::__js_call__(object)
-		IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01d5: stloc.3
-		IL_01d6: ldloc.0
-		IL_01d7: ldloc.3
-		IL_01d8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::printHelp
-		IL_01dd: ldc.i4.1
-		IL_01de: newarr [System.Runtime]System.Object
-		IL_01e3: dup
-		IL_01e4: ldc.i4.0
-		IL_01e5: ldloc.0
-		IL_01e6: stelem.ref
-		IL_01e7: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
-		IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01f2: stloc.3
-		IL_01f3: ldloc.3
-		IL_01f4: stloc.2
-		IL_01f5: ldarg.1
-		IL_01f6: ldstr "fs"
-		IL_01fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0200: stloc.3
-		IL_0201: ldloc.0
-		IL_0202: ldloc.3
-		IL_0203: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-		IL_0208: ldarg.1
-		IL_0209: ldstr "http"
-		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0213: stloc.3
-		IL_0214: ldloc.0
-		IL_0215: ldloc.3
-		IL_0216: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::http
-		IL_021b: ldarg.1
-		IL_021c: ldstr "path"
-		IL_0221: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0226: stloc.3
-		IL_0227: ldloc.0
-		IL_0228: ldloc.3
-		IL_0229: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
-		IL_022e: ldarg.1
-		IL_022f: ldstr "https"
-		IL_0234: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0239: stloc.3
-		IL_023a: ldloc.0
-		IL_023b: ldloc.3
-		IL_023c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::https
-		IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0246: dup
-		IL_0247: ldstr "main"
-		IL_024c: ldloc.2
-		IL_024d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0252: stloc.s 4
-		IL_0254: ldarg.2
-		IL_0255: ldstr "exports"
-		IL_025a: ldloc.s 4
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-		IL_0261: pop
-		IL_0262: ldarg.1
-		IL_0263: ldstr "main"
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026d: ldarg.2
-		IL_026e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0273: stloc.s 5
-		IL_0275: ldloc.s 5
-		IL_0277: brfalse IL_02bf
+		IL_012e: ldloc.2
+		IL_012f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+		IL_0134: ldarg.1
+		IL_0135: ldstr "node:https"
+		IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_013f: stloc.2
+		IL_0140: ldloc.0
+		IL_0141: ldloc.2
+		IL_0142: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+		IL_0147: ldarg.1
+		IL_0148: ldstr "path"
+		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0152: stloc.2
+		IL_0153: ldloc.0
+		IL_0154: ldloc.2
+		IL_0155: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+		IL_015a: ldarg.1
+		IL_015b: ldstr "node:url"
+		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0165: stloc.2
+		IL_0166: ldloc.2
+		IL_0167: brfalse IL_0177
 
-		IL_027c: ldc.i4.1
-		IL_027d: newarr [System.Runtime]System.Object
-		IL_0282: dup
-		IL_0283: ldc.i4.0
-		IL_0284: ldloc.0
-		IL_0285: stelem.ref
-		IL_0286: ldnull
-		IL_0287: ldnull
-		IL_0288: ldnull
-		IL_0289: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
-		IL_028e: stloc.3
-		IL_028f: ldnull
-		IL_0290: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/ArrowFunction_L573C16::__js_call__(object, object)
-		IL_0296: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_029b: ldc.i4.1
-		IL_029c: newarr [System.Runtime]System.Object
-		IL_02a1: dup
-		IL_02a2: ldc.i4.0
-		IL_02a3: ldloc.0
-		IL_02a4: stelem.ref
-		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02af: stloc.s 6
-		IL_02b1: ldloc.3
-		IL_02b2: ldstr "catch"
-		IL_02b7: ldloc.s 6
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02be: pop
+		IL_016c: ldloc.2
+		IL_016d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0172: brfalse IL_0187
 
-		IL_02bf: ret
-	} // end of method Compile_Scripts_ExtractEcma262SectionHtml::__js_module_init__
+		IL_0177: ldloc.2
+		IL_0178: ldstr ""
+		IL_017d: ldstr "URL"
+		IL_0182: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml
+		IL_0187: ldloc.2
+		IL_0188: ldstr "URL"
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0192: stloc.2
+		IL_0193: ldloc.0
+		IL_0194: ldloc.2
+		IL_0195: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+		IL_019a: ldarg.0
+		IL_019b: ldstr "runHarnessCli"
+		IL_01a0: ldloc.1
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_01a6: pop
+		IL_01a7: ret
+	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_TestHarness::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object
@@ -8516,7 +5003,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5c4a
+		// Method begins at RVA 0x425f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8
@@ -8531,23 +5018,4 @@
 	} // end of method Program::Main
 
 } // end of class Program
-
-.class interface public auto ansi abstract Js2IL.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.ICompileScriptsExtractEcma262SectionHtmlExports
-	implements [System.Runtime]System.IDisposable
-{
-	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
-		01 00 29 43 6f 6d 70 69 6c 65 5f 53 63 72 69 70
-		74 73 5f 45 78 74 72 61 63 74 45 63 6d 61 32 36
-		32 53 65 63 74 69 6f 6e 48 74 6d 6c 00 00
-	)
-	// Methods
-	.method public hidebysig newslot abstract virtual 
-		instance class [System.Runtime]System.Threading.Tasks.Task Main (
-			object arg1,
-			object arg2
-		) cil managed 
-	{
-	} // end of method ICompileScriptsExtractEcma262SectionHtmlExports::Main
-
-} // end of class Js2IL.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.ICompileScriptsExtractEcma262SectionHtmlExports
 

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -1,0 +1,8553 @@
+﻿// IL code: Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit normalize
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L7C29
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5920
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L7C29::.ctor
+
+			} // end of class Block_L7C29
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5917
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object text,
+				object outFile
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x23d4
+			// Header size: 12
+			// Code size: 249 (0xf9)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] bool,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: ldstr "includes"
+			IL_0006: ldstr " -> "
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: brfalse IL_0073
+
+			IL_001e: ldarg.1
+			IL_001f: ldstr "indexOf"
+			IL_0024: ldstr " -> "
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002e: stloc.0
+			IL_002f: ldloc.0
+			IL_0030: ldc.r8 4
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_003e: stloc.2
+			IL_003f: ldarg.1
+			IL_0040: ldstr "substring"
+			IL_0045: ldc.r8 0.0
+			IL_004e: box [System.Runtime]System.Double
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0059: stloc.0
+			IL_005a: ldloc.0
+			IL_005b: ldstr "<outFile>"
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0065: pop
+			IL_0066: ldloc.0
+			IL_0067: ldstr "<outFile>"
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0071: starg.s text
+
+			IL_0073: ldstr "[.*+?^${}()|[\\]\\\\]"
+			IL_0078: ldstr "g"
+			IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0082: stloc.3
+			IL_0083: ldarg.2
+			IL_0084: ldstr "replace"
+			IL_0089: ldloc.3
+			IL_008a: ldstr "\\$&"
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0094: stloc.0
+			IL_0095: ldloc.0
+			IL_0096: ldstr "g"
+			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00a0: stloc.3
+			IL_00a1: ldarg.1
+			IL_00a2: ldstr "replace"
+			IL_00a7: ldloc.3
+			IL_00a8: ldstr "<outFile>"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00b2: stloc.0
+			IL_00b3: ldstr "127\\.0\\.0\\.1:\\d+"
+			IL_00b8: ldstr "g"
+			IL_00bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00c2: stloc.3
+			IL_00c3: ldloc.0
+			IL_00c4: ldstr "replace"
+			IL_00c9: ldloc.3
+			IL_00ca: ldstr "127.0.0.1:<port>"
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d4: stloc.0
+			IL_00d5: ldstr "\\r\\n"
+			IL_00da: ldstr "g"
+			IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00e4: stloc.3
+			IL_00e5: ldloc.0
+			IL_00e6: ldstr "replace"
+			IL_00eb: ldloc.3
+			IL_00ec: ldstr "\n"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f6: stloc.0
+			IL_00f7: ldloc.0
+			IL_00f8: ret
+		} // end of method normalize::__js_call__
+
+	} // end of class normalize
+
+	.class nested public auto ansi abstract sealed beforefieldinit run
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L22C19
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+					01 00 13 53 63 6f 70 65 20 76 61 6c 75 65 3d 7b
+					76 61 6c 75 65 7d 00 00
+				)
+				// Fields
+				.field public object 'value'
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5932
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget,
+					object 'value'
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x28c4
+				// Header size: 12
+				// Code size: 29 (0x1d)
+				.maxstack 8
+				.locals init (
+					[0] string
+				)
+
+				IL_0000: ldarg.2
+				IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0006: stloc.0
+				IL_0007: ldarg.0
+				IL_0008: ldc.i4.1
+				IL_0009: ldelem.ref
+				IL_000a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope
+				IL_000f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::lines
+				IL_0014: ldloc.0
+				IL_0015: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_001a: pop
+				IL_001b: ldnull
+				IL_001c: ret
+			} // end of method ArrowFunction_L22C19::__js_call__
+
+		} // end of class ArrowFunction_L22C19
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 13 53 63 6f 70 65 20 6c 69 6e 65 73 3d 7b
+				6c 69 6e 65 73 7d 00 00
+			)
+			// Fields
+			.field public class [JavaScriptRuntime]JavaScriptRuntime.Array lines
+			.field public object _awaited1
+			.field public object _awaited2
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5929
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L38C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L38C28
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5944
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L38C28::.ctor
+
+			} // end of class Block_L38C28
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x593b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L38C7::.ctor
+
+		} // end of class Scope_ForOf_L38C7
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x24dc
+			// Header size: 12
+			// Code size: 782 (0x30e)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[6] bool,
+				[7] bool,
+				[8] object,
+				[9] object,
+				[10] object,
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[12] bool
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope
+			IL_0008: dup
+			IL_0009: brtrue IL_003b
+
+			IL_000e: pop
+			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::.ctor()
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: ldarg.0
+			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
+			IL_001c: starg.s scopes
+			IL_001e: ldloc.0
+			IL_001f: ldnull
+			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_002b: ldarg.0
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+			IL_0031: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0036: br IL_003c
+
+			IL_003b: stloc.0
+
+			IL_003c: ldloc.0
+			IL_003d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0042: brtrue IL_0053
+
+			IL_0047: ldloc.0
+			IL_0048: ldc.i4.8
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+
+			IL_0053: ldloc.0
+			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0059: ldc.i4.0
+			IL_005a: ble.s IL_0097
+
+			IL_005c: ldloc.0
+			IL_005d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0062: dup
+			IL_0063: ldc.i4.0
+			IL_0064: ldelem.ref
+			IL_0065: stloc.1
+			IL_0066: dup
+			IL_0067: ldc.i4.1
+			IL_0068: ldelem.ref
+			IL_0069: stloc.2
+			IL_006a: dup
+			IL_006b: ldc.i4.2
+			IL_006c: ldelem.ref
+			IL_006d: stloc.3
+			IL_006e: dup
+			IL_006f: ldc.i4.3
+			IL_0070: ldelem.ref
+			IL_0071: stloc.s 4
+			IL_0073: dup
+			IL_0074: ldc.i4.4
+			IL_0075: ldelem.ref
+			IL_0076: castclass [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator
+			IL_007b: stloc.s 5
+			IL_007d: dup
+			IL_007e: ldc.i4.5
+			IL_007f: ldelem.ref
+			IL_0080: unbox.any [System.Runtime]System.Boolean
+			IL_0085: stloc.s 6
+			IL_0087: dup
+			IL_0088: ldc.i4.6
+			IL_0089: ldelem.ref
+			IL_008a: unbox.any [System.Runtime]System.Boolean
+			IL_008f: stloc.s 7
+			IL_0091: dup
+			IL_0092: ldc.i4.7
+			IL_0093: ldelem.ref
+			IL_0094: stloc.s 8
+			IL_0096: pop
+
+			IL_0097: ldloc.0
+			IL_0098: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_009d: switch (IL_00aa, IL_0222)
+
+			IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00af: ldstr "argv"
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b9: ldc.r8 2
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00c7: stloc.1
+			IL_00c8: ldarg.0
+			IL_00c9: ldc.i4.1
+			IL_00ca: ldelem.ref
+			IL_00cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
+			IL_00d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::path
+			IL_00d5: stloc.s 9
+			IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00dc: ldstr "cwd"
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00e6: stloc.s 10
+			IL_00e8: ldloc.s 9
+			IL_00ea: ldstr "join"
+			IL_00ef: ldloc.s 10
+			IL_00f1: ldstr "section-auto.html"
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00fb: stloc.s 10
+			IL_00fd: ldloc.s 10
+			IL_00ff: stloc.2
+			IL_0100: ldarg.0
+			IL_0101: ldc.i4.1
+			IL_0102: ldelem.ref
+			IL_0103: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
+			IL_0108: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
+			IL_010d: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml"
+			IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0117: stloc.s 10
+			IL_0119: ldloc.s 10
+			IL_011b: stloc.3
+			IL_011c: ldloc.0
+			IL_011d: ldc.i4.0
+			IL_011e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0123: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::lines
+			IL_0128: ldnull
+			IL_0129: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/ArrowFunction_L22C19::__js_call__(object[], object, object)
+			IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0134: ldc.i4.2
+			IL_0135: newarr [System.Runtime]System.Object
+			IL_013a: dup
+			IL_013b: ldc.i4.0
+			IL_013c: ldarg.0
+			IL_013d: ldc.i4.1
+			IL_013e: ldelem.ref
+			IL_013f: stelem.ref
+			IL_0140: dup
+			IL_0141: ldc.i4.1
+			IL_0142: ldloc.0
+			IL_0143: stelem.ref
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_014e: stloc.s 10
+			IL_0150: ldloc.s 10
+			IL_0152: stloc.s 4
+			IL_0154: ldc.i4.s 9
+			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_015b: dup
+			IL_015c: ldstr "dotnet"
+			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0166: dup
+			IL_0167: ldstr "extractEcma262SectionHtml.js"
+			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0171: dup
+			IL_0172: ldstr "--section"
+			IL_0177: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_017c: dup
+			IL_017d: ldstr "27.3"
+			IL_0182: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0187: dup
+			IL_0188: ldstr "--auto"
+			IL_018d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0192: dup
+			IL_0193: ldstr "--index-url"
+			IL_0198: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_019d: dup
+			IL_019e: ldloc.1
+			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a4: dup
+			IL_01a5: ldstr "--out"
+			IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01af: dup
+			IL_01b0: ldloc.2
+			IL_01b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b6: stloc.s 11
+			IL_01b8: ldloc.3
+			IL_01b9: ldstr "main"
+			IL_01be: ldloc.s 11
+			IL_01c0: ldloc.s 4
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01c7: stloc.s 10
+			IL_01c9: ldloc.0
+			IL_01ca: ldc.i4.1
+			IL_01cb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01d0: ldloc.0
+			IL_01d1: ldloc.s 10
+			IL_01d3: ldarg.0
+			IL_01d4: ldc.i4.1
+			IL_01d5: ldloc.0
+			IL_01d6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01e0: ldloc.0
+			IL_01e1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01e6: dup
+			IL_01e7: ldc.i4.0
+			IL_01e8: ldloc.1
+			IL_01e9: stelem.ref
+			IL_01ea: dup
+			IL_01eb: ldc.i4.1
+			IL_01ec: ldloc.2
+			IL_01ed: stelem.ref
+			IL_01ee: dup
+			IL_01ef: ldc.i4.2
+			IL_01f0: ldloc.3
+			IL_01f1: stelem.ref
+			IL_01f2: dup
+			IL_01f3: ldc.i4.3
+			IL_01f4: ldloc.s 4
+			IL_01f6: stelem.ref
+			IL_01f7: dup
+			IL_01f8: ldc.i4.4
+			IL_01f9: ldloc.s 5
+			IL_01fb: stelem.ref
+			IL_01fc: dup
+			IL_01fd: ldc.i4.5
+			IL_01fe: ldloc.s 6
+			IL_0200: box [System.Runtime]System.Boolean
+			IL_0205: stelem.ref
+			IL_0206: dup
+			IL_0207: ldc.i4.6
+			IL_0208: ldloc.s 7
+			IL_020a: box [System.Runtime]System.Boolean
+			IL_020f: stelem.ref
+			IL_0210: dup
+			IL_0211: ldc.i4.7
+			IL_0212: ldloc.s 8
+			IL_0214: stelem.ref
+			IL_0215: pop
+			IL_0216: ldloc.0
+			IL_0217: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_021c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0221: ret
+
+			IL_0222: ldloc.0
+			IL_0223: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::_awaited1
+			IL_0228: pop
+			IL_0229: ldloc.0
+			IL_022a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::lines
+			IL_022f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0234: stloc.s 5
+			IL_0236: ldc.i4.0
+			IL_0237: stloc.s 6
+			IL_0239: ldc.i4.0
+			IL_023a: stloc.s 7
+			.try
+			{
+				// loop start (head: IL_023c)
+					IL_023c: ldloc.s 5
+					IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_0243: stloc.s 10
+					IL_0245: ldloc.s 10
+					IL_0247: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_024c: stloc.s 12
+					IL_024e: ldloc.s 12
+					IL_0250: brtrue IL_028e
+
+					IL_0255: ldloc.s 10
+					IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_025c: stloc.s 10
+					IL_025e: ldloc.s 10
+					IL_0260: stloc.s 8
+					IL_0262: ldnull
+					IL_0263: ldloc.s 8
+					IL_0265: ldloc.2
+					IL_0266: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/normalize::__js_call__(object, object, object)
+					IL_026b: stloc.s 10
+					IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+					IL_0272: ldloc.s 10
+					IL_0274: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+					IL_0279: pop
+					IL_027a: br IL_023c
+				// end loop
+				IL_027f: ldloc.s 5
+				IL_0281: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0286: ldc.i4.1
+				IL_0287: stloc.s 7
+				IL_0289: leave IL_02ac
+
+				IL_028e: ldc.i4.1
+				IL_028f: stloc.s 6
+				IL_0291: leave IL_02ac
+			} // end .try
+			finally
+			{
+				IL_0296: ldloc.s 6
+				IL_0298: brtrue IL_02ab
+
+				IL_029d: ldloc.s 7
+				IL_029f: brtrue IL_02ab
+
+				IL_02a4: ldloc.s 5
+				IL_02a6: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+
+				IL_02ab: endfinally
+			} // end handler
+
+			IL_02ac: ldarg.0
+			IL_02ad: ldc.i4.1
+			IL_02ae: ldelem.ref
+			IL_02af: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
+			IL_02b4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::fs
+			IL_02b9: ldstr "readFileSync"
+			IL_02be: ldloc.2
+			IL_02bf: ldstr "utf8"
+			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02c9: stloc.s 10
+			IL_02cb: ldnull
+			IL_02cc: ldloc.s 10
+			IL_02ce: ldloc.2
+			IL_02cf: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/normalize::__js_call__(object, object, object)
+			IL_02d4: stloc.s 10
+			IL_02d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02db: ldloc.s 10
+			IL_02dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02e2: pop
+			IL_02e3: ldloc.0
+			IL_02e4: ldc.i4.m1
+			IL_02e5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02ea: ldloc.0
+			IL_02eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02f5: ldarg.0
+			IL_02f6: ldc.i4.1
+			IL_02f7: newarr [System.Runtime]System.Object
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0301: pop
+			IL_0302: ldloc.0
+			IL_0303: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0308: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_030d: ret
+		} // end of method run::__js_call__
+
+	} // end of class run
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L45C13
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
+				72 7d 00 00
+			)
+			// Fields
+			.field public object err
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x594d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object err
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2808
+			// Header size: 12
+			// Code size: 175 (0xaf)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[3] bool,
+				[4] object,
+				[5] object,
+				[6] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: stloc.2
+			IL_0006: ldarg.1
+			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_000c: stloc.3
+			IL_000d: ldloc.3
+			IL_000e: brfalse IL_0025
+
+			IL_0013: ldarg.1
+			IL_0014: ldstr "stack"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001e: stloc.s 5
+			IL_0020: br IL_0028
+
+			IL_0025: ldarg.1
+			IL_0026: stloc.s 5
+
+			IL_0028: ldloc.s 5
+			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002f: stloc.3
+			IL_0030: ldloc.3
+			IL_0031: brfalse IL_0047
+
+			IL_0036: ldarg.1
+			IL_0037: ldstr "stack"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0041: stloc.0
+			IL_0042: br IL_008c
+
+			IL_0047: ldarg.1
+			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: brfalse IL_0066
+
+			IL_0054: ldarg.1
+			IL_0055: ldstr "message"
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005f: stloc.s 6
+			IL_0061: br IL_0069
+
+			IL_0066: ldarg.1
+			IL_0067: stloc.s 6
+
+			IL_0069: ldloc.s 6
+			IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: brfalse IL_0088
+
+			IL_0077: ldarg.1
+			IL_0078: ldstr "message"
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0082: stloc.1
+			IL_0083: br IL_008a
+
+			IL_0088: ldarg.1
+			IL_0089: stloc.1
+
+			IL_008a: ldloc.1
+			IL_008b: stloc.0
+
+			IL_008c: ldloc.2
+			IL_008d: ldloc.0
+			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0093: pop
+			IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0099: ldstr "exitCode"
+			IL_009e: ldc.r8 1
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_00ac: pop
+			IL_00ad: ldnull
+			IL_00ae: ret
+		} // end of method ArrowFunction_L45C13::__js_call__
+
+	} // end of class ArrowFunction_L45C13
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 4f 53 63 6f 70 65 20 72 65 71 75 69 72 65
+			3d 7b 72 65 71 75 69 72 65 7d 2c 20 66 73 3d 7b
+			66 73 7d 2c 20 70 61 74 68 3d 7b 70 61 74 68 7d
+			2c 20 6e 6f 72 6d 61 6c 69 7a 65 3d 7b 6e 6f 72
+			6d 61 6c 69 7a 65 7d 2c 20 72 75 6e 3d 7b 72 75
+			6e 7d 00 00
+		)
+		// Fields
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
+		.field public object fs
+		.field public object path
+		.field public object normalize
+		.field public object run
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x590e
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 169 (0xa9)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope,
+			[1] object,
+			[2] object,
+			[3] object
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
+		IL_000d: ldnull
+		IL_000e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/normalize::__js_call__(object, object, object)
+		IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0019: stloc.2
+		IL_001a: ldloc.0
+		IL_001b: ldloc.2
+		IL_001c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::normalize
+		IL_0021: ldc.i4.1
+		IL_0022: newarr [System.Runtime]System.Object
+		IL_0027: dup
+		IL_0028: ldc.i4.0
+		IL_0029: ldloc.0
+		IL_002a: stelem.ref
+		IL_002b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
+		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0036: stloc.2
+		IL_0037: ldloc.2
+		IL_0038: stloc.1
+		IL_0039: ldloc.0
+		IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
+		IL_003f: ldstr "fs"
+		IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0049: stloc.2
+		IL_004a: ldloc.0
+		IL_004b: ldloc.2
+		IL_004c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::fs
+		IL_0051: ldloc.0
+		IL_0052: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
+		IL_0057: ldstr "path"
+		IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0061: stloc.2
+		IL_0062: ldloc.0
+		IL_0063: ldloc.2
+		IL_0064: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::path
+		IL_0069: ldc.i4.1
+		IL_006a: newarr [System.Runtime]System.Object
+		IL_006f: dup
+		IL_0070: ldc.i4.0
+		IL_0071: ldloc.0
+		IL_0072: stelem.ref
+		IL_0073: ldnull
+		IL_0074: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
+		IL_0079: stloc.2
+		IL_007a: ldnull
+		IL_007b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/ArrowFunction_L45C13::__js_call__(object, object)
+		IL_0081: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0086: ldc.i4.1
+		IL_0087: newarr [System.Runtime]System.Object
+		IL_008c: dup
+		IL_008d: ldc.i4.0
+		IL_008e: ldloc.0
+		IL_008f: stelem.ref
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_009a: stloc.3
+		IL_009b: ldloc.2
+		IL_009c: ldstr "catch"
+		IL_00a1: ldloc.3
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00a7: pop
+		IL_00a8: ret
+	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_AutoMode::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
+
+.class private auto ansi beforefieldinit Modules.Compile_Scripts_ExtractEcma262SectionHtml
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit parseArgs
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x595f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_For_L49C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L49C40
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L52C38
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x597a
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L52C38::.ctor
+
+				} // end of class Block_L52C38
+
+				.class nested private auto ansi beforefieldinit Block_L57C41
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5983
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L57C41::.ctor
+
+				} // end of class Block_L57C41
+
+				.class nested private auto ansi beforefieldinit Block_L63C36
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x598c
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L63C36::.ctor
+
+				} // end of class Block_L63C36
+
+				.class nested private auto ansi beforefieldinit Block_L68C36
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5995
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L68C36::.ctor
+
+				} // end of class Block_L68C36
+
+				.class nested private auto ansi beforefieldinit Block_L74C31
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x599e
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L74C31::.ctor
+
+				} // end of class Block_L74C31
+
+				.class nested private auto ansi beforefieldinit Block_L79C37
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59a7
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L79C37::.ctor
+
+				} // end of class Block_L79C37
+
+				.class nested private auto ansi beforefieldinit Block_L85C32
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59b0
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L85C32::.ctor
+
+				} // end of class Block_L85C32
+
+				.class nested private auto ansi beforefieldinit Block_L90C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59b9
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L90C24::.ctor
+
+				} // end of class Block_L90C24
+
+				.class nested private auto ansi beforefieldinit Block_L95C29
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59c2
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L95C29::.ctor
+
+				} // end of class Block_L95C29
+
+				.class nested private auto ansi beforefieldinit Block_L101C38
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59cb
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L101C38::.ctor
+
+				} // end of class Block_L101C38
+
+				.class nested private auto ansi beforefieldinit Block_L106C37
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59d4
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L106C37::.ctor
+
+				} // end of class Block_L106C37
+
+				.class nested private auto ansi beforefieldinit Block_L112C32
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59dd
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L112C32::.ctor
+
+				} // end of class Block_L112C32
+
+				.class nested private auto ansi beforefieldinit Block_L117C22
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59e6
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L117C22::.ctor
+
+				} // end of class Block_L117C22
+
+				.class nested private auto ansi beforefieldinit Block_L123C31
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59ef
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L123C31::.ctor
+
+				} // end of class Block_L123C31
+
+				.class nested private auto ansi beforefieldinit Block_L128C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59f8
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L128C24::.ctor
+
+				} // end of class Block_L128C24
+
+				.class nested private auto ansi beforefieldinit Block_L133C27
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a01
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L133C27::.ctor
+
+				} // end of class Block_L133C27
+
+				.class nested private auto ansi beforefieldinit Block_L138C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a0a
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L138C24::.ctor
+
+				} // end of class Block_L138C24
+
+				.class nested private auto ansi beforefieldinit Block_L144C33
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a13
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L144C33::.ctor
+
+				} // end of class Block_L144C33
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5971
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L49C40::.ctor
+
+			} // end of class Block_L49C40
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5968
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_For_L49C7::.ctor
+
+		} // end of class Scope_For_L49C7
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object argv
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x28f0
+			// Header size: 12
+			// Code size: 2463 (0x99f)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[2] float64,
+				[3] object,
+				[4] bool,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] object,
+				[11] object,
+				[12] object,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] object,
+				[18] object,
+				[19] object,
+				[20] object,
+				[21] object,
+				[22] object,
+				[23] object,
+				[24] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0005: dup
+			IL_0006: ldstr "section"
+			IL_000b: ldstr ""
+			IL_0010: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0015: dup
+			IL_0016: ldstr "inFile"
+			IL_001b: ldstr ""
+			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0025: dup
+			IL_0026: ldstr "url"
+			IL_002b: ldstr ""
+			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0035: dup
+			IL_0036: ldstr "auto"
+			IL_003b: ldc.i4.0
+			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0041: dup
+			IL_0042: ldstr "indexUrl"
+			IL_0047: ldstr "https://tc39.es/ecma262/multipage/"
+			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0051: dup
+			IL_0052: ldstr "outFile"
+			IL_0057: ldstr ""
+			IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0061: dup
+			IL_0062: ldstr "id"
+			IL_0067: ldstr ""
+			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0071: dup
+			IL_0072: ldstr "wrap"
+			IL_0077: ldc.i4.1
+			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_007d: dup
+			IL_007e: ldstr "baseHref"
+			IL_0083: ldstr ""
+			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_008d: dup
+			IL_008e: ldstr "help"
+			IL_0093: ldc.i4.0
+			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0099: stloc.0
+			IL_009a: ldc.i4.0
+			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00a0: stloc.1
+			IL_00a1: ldc.r8 2
+			IL_00aa: stloc.2
+			// loop start (head: IL_00ab)
+				IL_00ab: ldloc.2
+				IL_00ac: ldarg.2
+				IL_00ad: ldstr "length"
+				IL_00b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00b7: clt
+				IL_00b9: brfalse IL_07ec
+
+				IL_00be: ldarg.2
+				IL_00bf: ldloc.2
+				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00c5: stloc.3
+				IL_00c6: ldloc.3
+				IL_00c7: ldstr "--help"
+				IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00d1: stloc.s 4
+				IL_00d3: ldloc.s 4
+				IL_00d5: box [System.Runtime]System.Boolean
+				IL_00da: stloc.s 5
+				IL_00dc: ldloc.s 5
+				IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00e3: stloc.s 4
+				IL_00e5: ldloc.s 4
+				IL_00e7: brtrue IL_010b
+
+				IL_00ec: ldloc.3
+				IL_00ed: ldstr "-h"
+				IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00f7: stloc.s 4
+				IL_00f9: ldloc.s 4
+				IL_00fb: box [System.Runtime]System.Boolean
+				IL_0100: stloc.s 6
+				IL_0102: ldloc.s 6
+				IL_0104: stloc.s 8
+				IL_0106: br IL_010f
+
+				IL_010b: ldloc.s 5
+				IL_010d: stloc.s 8
+
+				IL_010f: ldloc.s 8
+				IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0116: stloc.s 4
+				IL_0118: ldloc.s 4
+				IL_011a: brfalse IL_0136
+
+				IL_011f: ldloc.0
+				IL_0120: ldstr "help"
+				IL_0125: ldc.i4.1
+				IL_0126: box [System.Runtime]System.Boolean
+				IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0130: pop
+				IL_0131: br IL_07db
+
+				IL_0136: ldloc.3
+				IL_0137: ldstr "--section"
+				IL_013c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0141: stloc.s 4
+				IL_0143: ldloc.s 4
+				IL_0145: box [System.Runtime]System.Boolean
+				IL_014a: stloc.s 5
+				IL_014c: ldloc.s 5
+				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0153: stloc.s 4
+				IL_0155: ldloc.s 4
+				IL_0157: brtrue IL_017b
+
+				IL_015c: ldloc.3
+				IL_015d: ldstr "-s"
+				IL_0162: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0167: stloc.s 4
+				IL_0169: ldloc.s 4
+				IL_016b: box [System.Runtime]System.Boolean
+				IL_0170: stloc.s 6
+				IL_0172: ldloc.s 6
+				IL_0174: stloc.s 9
+				IL_0176: br IL_017f
+
+				IL_017b: ldloc.s 5
+				IL_017d: stloc.s 9
+
+				IL_017f: ldloc.s 9
+				IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0186: stloc.s 4
+				IL_0188: ldloc.s 4
+				IL_018a: brfalse IL_01e1
+
+				IL_018f: ldarg.2
+				IL_0190: ldloc.2
+				IL_0191: ldc.r8 1
+				IL_019a: add
+				IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01a0: stloc.s 10
+				IL_01a2: ldloc.s 10
+				IL_01a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01a9: stloc.s 4
+				IL_01ab: ldloc.s 4
+				IL_01ad: brtrue IL_01be
+
+				IL_01b2: ldstr ""
+				IL_01b7: stloc.s 11
+				IL_01b9: br IL_01c2
+
+				IL_01be: ldloc.s 10
+				IL_01c0: stloc.s 11
+
+				IL_01c2: ldloc.0
+				IL_01c3: ldstr "section"
+				IL_01c8: ldloc.s 11
+				IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_01cf: pop
+				IL_01d0: ldloc.2
+				IL_01d1: ldc.r8 1
+				IL_01da: add
+				IL_01db: stloc.2
+				IL_01dc: br IL_07db
+
+				IL_01e1: ldloc.3
+				IL_01e2: ldstr "startsWith"
+				IL_01e7: ldstr "--section="
+				IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01f1: stloc.s 10
+				IL_01f3: ldloc.s 10
+				IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01fa: stloc.s 4
+				IL_01fc: ldloc.s 4
+				IL_01fe: brfalse IL_0233
+
+				IL_0203: ldloc.3
+				IL_0204: ldstr "substring"
+				IL_0209: ldstr "--section="
+				IL_020e: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_0213: conv.r8
+				IL_0214: box [System.Runtime]System.Double
+				IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_021e: stloc.s 10
+				IL_0220: ldloc.0
+				IL_0221: ldstr "section"
+				IL_0226: ldloc.s 10
+				IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_022d: pop
+				IL_022e: br IL_07db
+
+				IL_0233: ldloc.3
+				IL_0234: ldstr "--in"
+				IL_0239: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_023e: stloc.s 4
+				IL_0240: ldloc.s 4
+				IL_0242: box [System.Runtime]System.Boolean
+				IL_0247: stloc.s 5
+				IL_0249: ldloc.s 5
+				IL_024b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0250: stloc.s 4
+				IL_0252: ldloc.s 4
+				IL_0254: brtrue IL_0278
+
+				IL_0259: ldloc.3
+				IL_025a: ldstr "-i"
+				IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0264: stloc.s 4
+				IL_0266: ldloc.s 4
+				IL_0268: box [System.Runtime]System.Boolean
+				IL_026d: stloc.s 6
+				IL_026f: ldloc.s 6
+				IL_0271: stloc.s 12
+				IL_0273: br IL_027c
+
+				IL_0278: ldloc.s 5
+				IL_027a: stloc.s 12
+
+				IL_027c: ldloc.s 12
+				IL_027e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0283: stloc.s 4
+				IL_0285: ldloc.s 4
+				IL_0287: brfalse IL_02de
+
+				IL_028c: ldarg.2
+				IL_028d: ldloc.2
+				IL_028e: ldc.r8 1
+				IL_0297: add
+				IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_029d: stloc.s 10
+				IL_029f: ldloc.s 10
+				IL_02a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02a6: stloc.s 4
+				IL_02a8: ldloc.s 4
+				IL_02aa: brtrue IL_02bb
+
+				IL_02af: ldstr ""
+				IL_02b4: stloc.s 13
+				IL_02b6: br IL_02bf
+
+				IL_02bb: ldloc.s 10
+				IL_02bd: stloc.s 13
+
+				IL_02bf: ldloc.0
+				IL_02c0: ldstr "inFile"
+				IL_02c5: ldloc.s 13
+				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_02cc: pop
+				IL_02cd: ldloc.2
+				IL_02ce: ldc.r8 1
+				IL_02d7: add
+				IL_02d8: stloc.2
+				IL_02d9: br IL_07db
+
+				IL_02de: ldloc.3
+				IL_02df: ldstr "startsWith"
+				IL_02e4: ldstr "--in="
+				IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02ee: stloc.s 10
+				IL_02f0: ldloc.s 10
+				IL_02f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02f7: stloc.s 4
+				IL_02f9: ldloc.s 4
+				IL_02fb: brfalse IL_0330
+
+				IL_0300: ldloc.3
+				IL_0301: ldstr "substring"
+				IL_0306: ldstr "--in="
+				IL_030b: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_0310: conv.r8
+				IL_0311: box [System.Runtime]System.Double
+				IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_031b: stloc.s 10
+				IL_031d: ldloc.0
+				IL_031e: ldstr "inFile"
+				IL_0323: ldloc.s 10
+				IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_032a: pop
+				IL_032b: br IL_07db
+
+				IL_0330: ldloc.3
+				IL_0331: ldstr "--url"
+				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_033b: stloc.s 4
+				IL_033d: ldloc.s 4
+				IL_033f: box [System.Runtime]System.Boolean
+				IL_0344: stloc.s 5
+				IL_0346: ldloc.s 5
+				IL_0348: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_034d: stloc.s 4
+				IL_034f: ldloc.s 4
+				IL_0351: brtrue IL_0375
+
+				IL_0356: ldloc.3
+				IL_0357: ldstr "-u"
+				IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0361: stloc.s 4
+				IL_0363: ldloc.s 4
+				IL_0365: box [System.Runtime]System.Boolean
+				IL_036a: stloc.s 6
+				IL_036c: ldloc.s 6
+				IL_036e: stloc.s 14
+				IL_0370: br IL_0379
+
+				IL_0375: ldloc.s 5
+				IL_0377: stloc.s 14
+
+				IL_0379: ldloc.s 14
+				IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0380: stloc.s 4
+				IL_0382: ldloc.s 4
+				IL_0384: brfalse IL_03db
+
+				IL_0389: ldarg.2
+				IL_038a: ldloc.2
+				IL_038b: ldc.r8 1
+				IL_0394: add
+				IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_039a: stloc.s 10
+				IL_039c: ldloc.s 10
+				IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_03a3: stloc.s 4
+				IL_03a5: ldloc.s 4
+				IL_03a7: brtrue IL_03b8
+
+				IL_03ac: ldstr ""
+				IL_03b1: stloc.s 15
+				IL_03b3: br IL_03bc
+
+				IL_03b8: ldloc.s 10
+				IL_03ba: stloc.s 15
+
+				IL_03bc: ldloc.0
+				IL_03bd: ldstr "url"
+				IL_03c2: ldloc.s 15
+				IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_03c9: pop
+				IL_03ca: ldloc.2
+				IL_03cb: ldc.r8 1
+				IL_03d4: add
+				IL_03d5: stloc.2
+				IL_03d6: br IL_07db
+
+				IL_03db: ldloc.3
+				IL_03dc: ldstr "startsWith"
+				IL_03e1: ldstr "--url="
+				IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_03eb: stloc.s 10
+				IL_03ed: ldloc.s 10
+				IL_03ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_03f4: stloc.s 4
+				IL_03f6: ldloc.s 4
+				IL_03f8: brfalse IL_042d
+
+				IL_03fd: ldloc.3
+				IL_03fe: ldstr "substring"
+				IL_0403: ldstr "--url="
+				IL_0408: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_040d: conv.r8
+				IL_040e: box [System.Runtime]System.Double
+				IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0418: stloc.s 10
+				IL_041a: ldloc.0
+				IL_041b: ldstr "url"
+				IL_0420: ldloc.s 10
+				IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0427: pop
+				IL_0428: br IL_07db
+
+				IL_042d: ldloc.3
+				IL_042e: ldstr "--auto"
+				IL_0433: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0438: stloc.s 4
+				IL_043a: ldloc.s 4
+				IL_043c: brfalse IL_0458
+
+				IL_0441: ldloc.0
+				IL_0442: ldstr "auto"
+				IL_0447: ldc.i4.1
+				IL_0448: box [System.Runtime]System.Boolean
+				IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0452: pop
+				IL_0453: br IL_07db
+
+				IL_0458: ldloc.3
+				IL_0459: ldstr "--index-url"
+				IL_045e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0463: stloc.s 4
+				IL_0465: ldloc.s 4
+				IL_0467: brfalse IL_04be
+
+				IL_046c: ldarg.2
+				IL_046d: ldloc.2
+				IL_046e: ldc.r8 1
+				IL_0477: add
+				IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_047d: stloc.s 10
+				IL_047f: ldloc.s 10
+				IL_0481: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0486: stloc.s 4
+				IL_0488: ldloc.s 4
+				IL_048a: brtrue IL_049b
+
+				IL_048f: ldstr ""
+				IL_0494: stloc.s 16
+				IL_0496: br IL_049f
+
+				IL_049b: ldloc.s 10
+				IL_049d: stloc.s 16
+
+				IL_049f: ldloc.0
+				IL_04a0: ldstr "indexUrl"
+				IL_04a5: ldloc.s 16
+				IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_04ac: pop
+				IL_04ad: ldloc.2
+				IL_04ae: ldc.r8 1
+				IL_04b7: add
+				IL_04b8: stloc.2
+				IL_04b9: br IL_07db
+
+				IL_04be: ldloc.3
+				IL_04bf: ldstr "startsWith"
+				IL_04c4: ldstr "--index-url="
+				IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_04ce: stloc.s 10
+				IL_04d0: ldloc.s 10
+				IL_04d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_04d7: stloc.s 4
+				IL_04d9: ldloc.s 4
+				IL_04db: brfalse IL_0510
+
+				IL_04e0: ldloc.3
+				IL_04e1: ldstr "substring"
+				IL_04e6: ldstr "--index-url="
+				IL_04eb: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_04f0: conv.r8
+				IL_04f1: box [System.Runtime]System.Double
+				IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_04fb: stloc.s 10
+				IL_04fd: ldloc.0
+				IL_04fe: ldstr "indexUrl"
+				IL_0503: ldloc.s 10
+				IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_050a: pop
+				IL_050b: br IL_07db
+
+				IL_0510: ldloc.3
+				IL_0511: ldstr "--out"
+				IL_0516: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_051b: stloc.s 4
+				IL_051d: ldloc.s 4
+				IL_051f: box [System.Runtime]System.Boolean
+				IL_0524: stloc.s 5
+				IL_0526: ldloc.s 5
+				IL_0528: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_052d: stloc.s 4
+				IL_052f: ldloc.s 4
+				IL_0531: brtrue IL_0555
+
+				IL_0536: ldloc.3
+				IL_0537: ldstr "-o"
+				IL_053c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0541: stloc.s 4
+				IL_0543: ldloc.s 4
+				IL_0545: box [System.Runtime]System.Boolean
+				IL_054a: stloc.s 6
+				IL_054c: ldloc.s 6
+				IL_054e: stloc.s 17
+				IL_0550: br IL_0559
+
+				IL_0555: ldloc.s 5
+				IL_0557: stloc.s 17
+
+				IL_0559: ldloc.s 17
+				IL_055b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0560: stloc.s 4
+				IL_0562: ldloc.s 4
+				IL_0564: brfalse IL_05bb
+
+				IL_0569: ldarg.2
+				IL_056a: ldloc.2
+				IL_056b: ldc.r8 1
+				IL_0574: add
+				IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_057a: stloc.s 10
+				IL_057c: ldloc.s 10
+				IL_057e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0583: stloc.s 4
+				IL_0585: ldloc.s 4
+				IL_0587: brtrue IL_0598
+
+				IL_058c: ldstr ""
+				IL_0591: stloc.s 18
+				IL_0593: br IL_059c
+
+				IL_0598: ldloc.s 10
+				IL_059a: stloc.s 18
+
+				IL_059c: ldloc.0
+				IL_059d: ldstr "outFile"
+				IL_05a2: ldloc.s 18
+				IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_05a9: pop
+				IL_05aa: ldloc.2
+				IL_05ab: ldc.r8 1
+				IL_05b4: add
+				IL_05b5: stloc.2
+				IL_05b6: br IL_07db
+
+				IL_05bb: ldloc.3
+				IL_05bc: ldstr "startsWith"
+				IL_05c1: ldstr "--out="
+				IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_05cb: stloc.s 10
+				IL_05cd: ldloc.s 10
+				IL_05cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_05d4: stloc.s 4
+				IL_05d6: ldloc.s 4
+				IL_05d8: brfalse IL_060d
+
+				IL_05dd: ldloc.3
+				IL_05de: ldstr "substring"
+				IL_05e3: ldstr "--out="
+				IL_05e8: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_05ed: conv.r8
+				IL_05ee: box [System.Runtime]System.Double
+				IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_05f8: stloc.s 10
+				IL_05fa: ldloc.0
+				IL_05fb: ldstr "outFile"
+				IL_0600: ldloc.s 10
+				IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0607: pop
+				IL_0608: br IL_07db
+
+				IL_060d: ldloc.3
+				IL_060e: ldstr "--id"
+				IL_0613: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0618: stloc.s 4
+				IL_061a: ldloc.s 4
+				IL_061c: brfalse IL_0673
+
+				IL_0621: ldarg.2
+				IL_0622: ldloc.2
+				IL_0623: ldc.r8 1
+				IL_062c: add
+				IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0632: stloc.s 10
+				IL_0634: ldloc.s 10
+				IL_0636: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_063b: stloc.s 4
+				IL_063d: ldloc.s 4
+				IL_063f: brtrue IL_0650
+
+				IL_0644: ldstr ""
+				IL_0649: stloc.s 19
+				IL_064b: br IL_0654
+
+				IL_0650: ldloc.s 10
+				IL_0652: stloc.s 19
+
+				IL_0654: ldloc.0
+				IL_0655: ldstr "id"
+				IL_065a: ldloc.s 19
+				IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0661: pop
+				IL_0662: ldloc.2
+				IL_0663: ldc.r8 1
+				IL_066c: add
+				IL_066d: stloc.2
+				IL_066e: br IL_07db
+
+				IL_0673: ldloc.3
+				IL_0674: ldstr "startsWith"
+				IL_0679: ldstr "--id="
+				IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0683: stloc.s 10
+				IL_0685: ldloc.s 10
+				IL_0687: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_068c: stloc.s 4
+				IL_068e: ldloc.s 4
+				IL_0690: brfalse IL_06c5
+
+				IL_0695: ldloc.3
+				IL_0696: ldstr "substring"
+				IL_069b: ldstr "--id="
+				IL_06a0: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_06a5: conv.r8
+				IL_06a6: box [System.Runtime]System.Double
+				IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_06b0: stloc.s 10
+				IL_06b2: ldloc.0
+				IL_06b3: ldstr "id"
+				IL_06b8: ldloc.s 10
+				IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_06bf: pop
+				IL_06c0: br IL_07db
+
+				IL_06c5: ldloc.3
+				IL_06c6: ldstr "--wrap"
+				IL_06cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_06d0: stloc.s 4
+				IL_06d2: ldloc.s 4
+				IL_06d4: brfalse IL_06f0
+
+				IL_06d9: ldloc.0
+				IL_06da: ldstr "wrap"
+				IL_06df: ldc.i4.1
+				IL_06e0: box [System.Runtime]System.Boolean
+				IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_06ea: pop
+				IL_06eb: br IL_07db
+
+				IL_06f0: ldloc.3
+				IL_06f1: ldstr "--no-wrap"
+				IL_06f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_06fb: stloc.s 4
+				IL_06fd: ldloc.s 4
+				IL_06ff: brfalse IL_071b
+
+				IL_0704: ldloc.0
+				IL_0705: ldstr "wrap"
+				IL_070a: ldc.i4.0
+				IL_070b: box [System.Runtime]System.Boolean
+				IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0715: pop
+				IL_0716: br IL_07db
+
+				IL_071b: ldloc.3
+				IL_071c: ldstr "--base"
+				IL_0721: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0726: stloc.s 4
+				IL_0728: ldloc.s 4
+				IL_072a: brfalse IL_0781
+
+				IL_072f: ldarg.2
+				IL_0730: ldloc.2
+				IL_0731: ldc.r8 1
+				IL_073a: add
+				IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0740: stloc.s 10
+				IL_0742: ldloc.s 10
+				IL_0744: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0749: stloc.s 4
+				IL_074b: ldloc.s 4
+				IL_074d: brtrue IL_075e
+
+				IL_0752: ldstr ""
+				IL_0757: stloc.s 20
+				IL_0759: br IL_0762
+
+				IL_075e: ldloc.s 10
+				IL_0760: stloc.s 20
+
+				IL_0762: ldloc.0
+				IL_0763: ldstr "baseHref"
+				IL_0768: ldloc.s 20
+				IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_076f: pop
+				IL_0770: ldloc.2
+				IL_0771: ldc.r8 1
+				IL_077a: add
+				IL_077b: stloc.2
+				IL_077c: br IL_07db
+
+				IL_0781: ldloc.3
+				IL_0782: ldstr "startsWith"
+				IL_0787: ldstr "--base="
+				IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0791: stloc.s 10
+				IL_0793: ldloc.s 10
+				IL_0795: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_079a: stloc.s 4
+				IL_079c: ldloc.s 4
+				IL_079e: brfalse IL_07d3
+
+				IL_07a3: ldloc.3
+				IL_07a4: ldstr "substring"
+				IL_07a9: ldstr "--base="
+				IL_07ae: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_07b3: conv.r8
+				IL_07b4: box [System.Runtime]System.Double
+				IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_07be: stloc.s 10
+				IL_07c0: ldloc.0
+				IL_07c1: ldstr "baseHref"
+				IL_07c6: ldloc.s 10
+				IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_07cd: pop
+				IL_07ce: br IL_07db
+
+				IL_07d3: ldloc.1
+				IL_07d4: ldloc.3
+				IL_07d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_07da: pop
+
+				IL_07db: ldloc.2
+				IL_07dc: ldc.r8 1
+				IL_07e5: add
+				IL_07e6: stloc.2
+				IL_07e7: br IL_00ab
+			// end loop
+
+			IL_07ec: ldloc.0
+			IL_07ed: ldstr "section"
+			IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_07fc: ldc.i4.0
+			IL_07fd: ceq
+			IL_07ff: stloc.s 4
+			IL_0801: ldloc.s 4
+			IL_0803: box [System.Runtime]System.Boolean
+			IL_0808: stloc.s 5
+			IL_080a: ldloc.s 5
+			IL_080c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0811: stloc.s 4
+			IL_0813: ldloc.s 4
+			IL_0815: brfalse IL_083b
+
+			IL_081a: ldloc.1
+			IL_081b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0820: conv.r8
+			IL_0821: ldc.r8 1
+			IL_082a: clt
+			IL_082c: ldc.i4.0
+			IL_082d: ceq
+			IL_082f: box [System.Runtime]System.Boolean
+			IL_0834: stloc.s 21
+			IL_0836: br IL_083f
+
+			IL_083b: ldloc.s 5
+			IL_083d: stloc.s 21
+
+			IL_083f: ldloc.s 21
+			IL_0841: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0846: stloc.s 4
+			IL_0848: ldloc.s 4
+			IL_084a: brfalse IL_086a
+
+			IL_084f: ldloc.0
+			IL_0850: ldstr "section"
+			IL_0855: ldloc.1
+			IL_0856: ldc.r8 0.0
+			IL_085f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_0869: pop
+
+			IL_086a: ldloc.0
+			IL_086b: ldstr "inFile"
+			IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0875: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_087a: ldc.i4.0
+			IL_087b: ceq
+			IL_087d: stloc.s 4
+			IL_087f: ldloc.s 4
+			IL_0881: box [System.Runtime]System.Boolean
+			IL_0886: stloc.s 5
+			IL_0888: ldloc.s 5
+			IL_088a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_088f: stloc.s 4
+			IL_0891: ldloc.s 4
+			IL_0893: brfalse IL_08bf
+
+			IL_0898: ldloc.0
+			IL_0899: ldstr "url"
+			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08a3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08a8: ldc.i4.0
+			IL_08a9: ceq
+			IL_08ab: stloc.s 4
+			IL_08ad: ldloc.s 4
+			IL_08af: box [System.Runtime]System.Boolean
+			IL_08b4: stloc.s 6
+			IL_08b6: ldloc.s 6
+			IL_08b8: stloc.s 22
+			IL_08ba: br IL_08c3
+
+			IL_08bf: ldloc.s 5
+			IL_08c1: stloc.s 22
+
+			IL_08c3: ldloc.s 22
+			IL_08c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_08ca: stloc.s 4
+			IL_08cc: ldloc.s 4
+			IL_08ce: brfalse IL_08f4
+
+			IL_08d3: ldloc.1
+			IL_08d4: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_08d9: conv.r8
+			IL_08da: ldc.r8 2
+			IL_08e3: clt
+			IL_08e5: ldc.i4.0
+			IL_08e6: ceq
+			IL_08e8: box [System.Runtime]System.Boolean
+			IL_08ed: stloc.s 22
+			IL_08ef: br IL_08f4
+
+			IL_08f4: ldloc.s 22
+			IL_08f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_08fb: stloc.s 4
+			IL_08fd: ldloc.s 4
+			IL_08ff: brfalse IL_091f
+
+			IL_0904: ldloc.0
+			IL_0905: ldstr "inFile"
+			IL_090a: ldloc.1
+			IL_090b: ldc.r8 1
+			IL_0914: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0919: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_091e: pop
+
+			IL_091f: ldloc.0
+			IL_0920: ldstr "outFile"
+			IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_092a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_092f: ldc.i4.0
+			IL_0930: ceq
+			IL_0932: stloc.s 4
+			IL_0934: ldloc.s 4
+			IL_0936: box [System.Runtime]System.Boolean
+			IL_093b: stloc.s 5
+			IL_093d: ldloc.s 5
+			IL_093f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0944: stloc.s 4
+			IL_0946: ldloc.s 4
+			IL_0948: brfalse IL_096e
+
+			IL_094d: ldloc.1
+			IL_094e: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0953: conv.r8
+			IL_0954: ldc.r8 3
+			IL_095d: clt
+			IL_095f: ldc.i4.0
+			IL_0960: ceq
+			IL_0962: box [System.Runtime]System.Boolean
+			IL_0967: stloc.s 24
+			IL_0969: br IL_0972
+
+			IL_096e: ldloc.s 5
+			IL_0970: stloc.s 24
+
+			IL_0972: ldloc.s 24
+			IL_0974: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0979: stloc.s 4
+			IL_097b: ldloc.s 4
+			IL_097d: brfalse IL_099d
+
+			IL_0982: ldloc.0
+			IL_0983: ldstr "outFile"
+			IL_0988: ldloc.1
+			IL_0989: ldc.r8 2
+			IL_0992: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0997: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_099c: pop
+
+			IL_099d: ldloc.0
+			IL_099e: ret
+		} // end of method parseArgs::__js_call__
+
+	} // end of class parseArgs
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithHttp
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a1c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object urlString,
+				object maxRedirects
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x329c
+			// Header size: 12
+			// Code size: 66 (0x42)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: brtrue IL_0016
+
+			IL_0006: ldc.r8 5
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: starg.s maxRedirects
+
+			IL_0016: ldc.i4.1
+			IL_0017: newarr [System.Runtime]System.Object
+			IL_001c: dup
+			IL_001d: ldc.i4.0
+			IL_001e: ldarg.0
+			IL_001f: stelem.ref
+			IL_0020: ldc.i4.0
+			IL_0021: ldelem.ref
+			IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0027: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
+			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0032: ldnull
+			IL_0033: ldstr "http"
+			IL_0038: ldarg.2
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_003f: stloc.0
+			IL_0040: ldloc.0
+			IL_0041: ret
+		} // end of method fetchTextWithHttp::__js_call__
+
+	} // end of class fetchTextWithHttp
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithHttps
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a25
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object urlString,
+				object maxRedirects
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x32ec
+			// Header size: 12
+			// Code size: 66 (0x42)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: brtrue IL_0016
+
+			IL_0006: ldc.r8 5
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: starg.s maxRedirects
+
+			IL_0016: ldc.i4.1
+			IL_0017: newarr [System.Runtime]System.Object
+			IL_001c: dup
+			IL_001d: ldc.i4.0
+			IL_001e: ldarg.0
+			IL_001f: stelem.ref
+			IL_0020: ldc.i4.0
+			IL_0021: ldelem.ref
+			IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0027: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
+			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0032: ldnull
+			IL_0033: ldstr "https"
+			IL_0038: ldarg.2
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_003f: stloc.0
+			IL_0040: ldloc.0
+			IL_0041: ret
+		} // end of method fetchTextWithHttps::__js_call__
+
+	} // end of class fetchTextWithHttps
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithTransport
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L170C22
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L194C7
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L219C24
+					extends [System.Runtime]System.Object
+				{
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Scope
+						extends [System.Runtime]System.Object
+					{
+						.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+							01 00 13 53 63 6f 70 65 20 63 68 75 6e 6b 3d 7b
+							63 68 75 6e 6b 7d 00 00
+						)
+						// Fields
+						.field public object chunk
+
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5a7f
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Scope::.ctor
+
+					} // end of class Scope
+
+
+					// Methods
+					.method public hidebysig static 
+						object __js_call__ (
+							object[] scopes,
+							object newTarget,
+							object chunk
+						) cil managed 
+					{
+						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+							01 00 02 00 00 00 00 00
+						)
+						// Method begins at RVA 0x5890
+						// Header size: 12
+						// Code size: 36 (0x24)
+						.maxstack 8
+						.locals init (
+							[0] object
+						)
+
+						IL_0000: ldarg.0
+						IL_0001: ldc.i4.3
+						IL_0002: ldelem.ref
+						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
+						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_000d: ldarg.2
+						IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+						IL_0013: stloc.0
+						IL_0014: ldarg.0
+						IL_0015: ldc.i4.3
+						IL_0016: ldelem.ref
+						IL_0017: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
+						IL_001c: ldloc.0
+						IL_001d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_0022: ldnull
+						IL_0023: ret
+					} // end of method ArrowFunction_L219C24::__js_call__
+
+				} // end of class ArrowFunction_L219C24
+
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L222C23
+					extends [System.Runtime]System.Object
+				{
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Scope
+						extends [System.Runtime]System.Object
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5a88
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Scope::.ctor
+
+					} // end of class Scope
+
+
+					// Methods
+					.method public hidebysig static 
+						object __js_call__ (
+							object[] scopes,
+							object newTarget
+						) cil managed 
+					{
+						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+							01 00 02 00 00 00 00 00
+						)
+						// Method begins at RVA 0x58c0
+						// Header size: 12
+						// Code size: 66 (0x42)
+						.maxstack 8
+						.locals init (
+							[0] object[],
+							[1] object
+						)
+
+						IL_0000: ldc.i4.4
+						IL_0001: newarr [System.Runtime]System.Object
+						IL_0006: dup
+						IL_0007: ldc.i4.0
+						IL_0008: ldarg.0
+						IL_0009: ldc.i4.0
+						IL_000a: ldelem.ref
+						IL_000b: stelem.ref
+						IL_000c: dup
+						IL_000d: ldc.i4.1
+						IL_000e: ldarg.0
+						IL_000f: ldc.i4.1
+						IL_0010: ldelem.ref
+						IL_0011: stelem.ref
+						IL_0012: dup
+						IL_0013: ldc.i4.2
+						IL_0014: ldarg.0
+						IL_0015: ldc.i4.2
+						IL_0016: ldelem.ref
+						IL_0017: stelem.ref
+						IL_0018: dup
+						IL_0019: ldc.i4.3
+						IL_001a: ldarg.0
+						IL_001b: ldc.i4.3
+						IL_001c: ldelem.ref
+						IL_001d: stelem.ref
+						IL_001e: stloc.0
+						IL_001f: ldarg.0
+						IL_0020: ldc.i4.2
+						IL_0021: ldelem.ref
+						IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+						IL_0027: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+						IL_002c: ldloc.0
+						IL_002d: ldarg.0
+						IL_002e: ldc.i4.3
+						IL_002f: ldelem.ref
+						IL_0030: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
+						IL_0035: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+						IL_003f: stloc.1
+						IL_0040: ldloc.1
+						IL_0041: ret
+					} // end of method ArrowFunction_L222C23::__js_call__
+
+				} // end of class ArrowFunction_L222C23
+
+				.class nested private auto ansi beforefieldinit Scope
+					extends [System.Runtime]System.Object
+				{
+					.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+						01 00 1c 53 63 6f 70 65 20 72 65 73 3d 7b 72 65
+						73 7d 2c 20 64 61 74 61 3d 7b 64 61 74 61 7d 00 00
+					)
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Block_L198C55
+						extends [System.Runtime]System.Object
+					{
+						// Nested Types
+						.class nested private auto ansi beforefieldinit Block_L199C33
+							extends [System.Runtime]System.Object
+						{
+							// Methods
+							.method public hidebysig specialname rtspecialname 
+								instance void .ctor () cil managed 
+							{
+								// Method begins at RVA 0x5a6d
+								// Header size: 1
+								// Code size: 8 (0x8)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+								IL_0006: nop
+								IL_0007: ret
+							} // end of method Block_L199C33::.ctor
+
+						} // end of class Block_L199C33
+
+
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5a64
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Block_L198C55::.ctor
+
+					} // end of class Block_L198C55
+
+					.class nested private auto ansi beforefieldinit Block_L211C43
+						extends [System.Runtime]System.Object
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5a76
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Block_L211C43::.ctor
+
+					} // end of class Block_L211C43
+
+
+					// Fields
+					.field public object res
+					.field public object data
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a5b
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Scope::.ctor
+
+				} // end of class Scope
+
+
+				// Methods
+				.method public hidebysig static 
+					object __js_call__ (
+						object[] scopes,
+						object newTarget,
+						object res
+					) cil managed 
+				{
+					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+						01 00 02 00 00 00 00 00
+					)
+					// Method begins at RVA 0x5498
+					// Header size: 12
+					// Code size: 1001 (0x3e9)
+					.maxstack 8
+					.locals init (
+						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope,
+						[1] object,
+						[2] object,
+						[3] object,
+						[4] object,
+						[5] bool,
+						[6] object,
+						[7] object,
+						[8] float64,
+						[9] object,
+						[10] object,
+						[11] object,
+						[12] object,
+						[13] object[],
+						[14] string,
+						[15] object,
+						[16] class [System.Runtime]System.Delegate,
+						[17] object,
+						[18] object,
+						[19] string
+					)
+
+					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::.ctor()
+					IL_0005: stloc.0
+					IL_0006: ldarg.2
+					IL_0007: ldstr "statusCode"
+					IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0011: stloc.s 4
+					IL_0013: ldloc.s 4
+					IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_001a: stloc.s 5
+					IL_001c: ldloc.s 5
+					IL_001e: brtrue IL_0038
+
+					IL_0023: ldc.r8 0.0
+					IL_002c: box [System.Runtime]System.Double
+					IL_0031: stloc.s 7
+					IL_0033: br IL_003c
+
+					IL_0038: ldloc.s 4
+					IL_003a: stloc.s 7
+
+					IL_003c: ldloc.s 7
+					IL_003e: stloc.1
+					IL_003f: ldarg.2
+					IL_0040: ldstr "headers"
+					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_004a: ldstr "location"
+					IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0054: stloc.2
+					IL_0055: ldloc.1
+					IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_005b: stloc.s 8
+					IL_005d: ldloc.s 8
+					IL_005f: ldc.r8 300
+					IL_0068: clt
+					IL_006a: ldc.i4.0
+					IL_006b: ceq
+					IL_006d: stloc.s 5
+					IL_006f: ldloc.s 5
+					IL_0071: box [System.Runtime]System.Boolean
+					IL_0076: stloc.s 9
+					IL_0078: ldloc.s 9
+					IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_007f: stloc.s 5
+					IL_0081: ldloc.s 5
+					IL_0083: brfalse IL_00b1
+
+					IL_0088: ldloc.1
+					IL_0089: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_008e: stloc.s 8
+					IL_0090: ldloc.s 8
+					IL_0092: ldc.r8 400
+					IL_009b: clt
+					IL_009d: stloc.s 5
+					IL_009f: ldloc.s 5
+					IL_00a1: box [System.Runtime]System.Boolean
+					IL_00a6: stloc.s 10
+					IL_00a8: ldloc.s 10
+					IL_00aa: stloc.s 11
+					IL_00ac: br IL_00b5
+
+					IL_00b1: ldloc.s 9
+					IL_00b3: stloc.s 11
+
+					IL_00b5: ldloc.s 11
+					IL_00b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00bc: stloc.s 5
+					IL_00be: ldloc.s 5
+					IL_00c0: brfalse IL_00cd
+
+					IL_00c5: ldloc.2
+					IL_00c6: stloc.s 11
+					IL_00c8: br IL_00cd
+
+					IL_00cd: ldloc.s 11
+					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00d4: stloc.s 5
+					IL_00d6: ldloc.s 5
+					IL_00d8: brfalse IL_0239
+
+					IL_00dd: ldarg.0
+					IL_00de: ldc.i4.1
+					IL_00df: ldelem.ref
+					IL_00e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_00e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
+					IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00ef: ldc.r8 0.0
+					IL_00f8: cgt
+					IL_00fa: ldc.i4.0
+					IL_00fb: ceq
+					IL_00fd: brfalse IL_0175
+
+					IL_0102: ldarg.2
+					IL_0103: ldstr "resume"
+					IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_010d: pop
+					IL_010e: ldarg.0
+					IL_010f: ldc.i4.2
+					IL_0110: ldelem.ref
+					IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_011b: stloc.s 4
+					IL_011d: ldc.i4.3
+					IL_011e: newarr [System.Runtime]System.Object
+					IL_0123: dup
+					IL_0124: ldc.i4.0
+					IL_0125: ldarg.0
+					IL_0126: ldc.i4.0
+					IL_0127: ldelem.ref
+					IL_0128: stelem.ref
+					IL_0129: dup
+					IL_012a: ldc.i4.1
+					IL_012b: ldarg.0
+					IL_012c: ldc.i4.1
+					IL_012d: ldelem.ref
+					IL_012e: stelem.ref
+					IL_012f: dup
+					IL_0130: ldc.i4.2
+					IL_0131: ldarg.0
+					IL_0132: ldc.i4.2
+					IL_0133: ldelem.ref
+					IL_0134: stelem.ref
+					IL_0135: stloc.s 13
+					IL_0137: ldarg.0
+					IL_0138: ldc.i4.1
+					IL_0139: ldelem.ref
+					IL_013a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_013f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0149: stloc.s 14
+					IL_014b: ldstr "Too many redirects fetching "
+					IL_0150: ldloc.s 14
+					IL_0152: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0157: stloc.s 14
+					IL_0159: ldloc.s 14
+					IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0165: stloc.s 15
+					IL_0167: ldloc.s 4
+					IL_0169: ldloc.s 13
+					IL_016b: ldloc.s 15
+					IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_0172: pop
+					IL_0173: ldnull
+					IL_0174: ret
+
+					IL_0175: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
+					IL_017a: stloc.s 16
+					IL_017c: ldc.i4.2
+					IL_017d: newarr [System.Runtime]System.Object
+					IL_0182: dup
+					IL_0183: ldc.i4.0
+					IL_0184: ldloc.2
+					IL_0185: stelem.ref
+					IL_0186: dup
+					IL_0187: ldc.i4.1
+					IL_0188: ldarg.0
+					IL_0189: ldc.i4.2
+					IL_018a: ldelem.ref
+					IL_018b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_0190: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+					IL_0195: stelem.ref
+					IL_0196: stloc.s 13
+					IL_0198: ldloc.s 16
+					IL_019a: ldloc.s 13
+					IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01a1: stloc.s 15
+					IL_01a3: ldloc.s 15
+					IL_01a5: ldstr "toString"
+					IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01af: stloc.s 15
+					IL_01b1: ldloc.s 15
+					IL_01b3: stloc.3
+					IL_01b4: ldarg.2
+					IL_01b5: ldstr "resume"
+					IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01bf: pop
+					IL_01c0: ldarg.0
+					IL_01c1: ldc.i4.1
+					IL_01c2: ldelem.ref
+					IL_01c3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_01c8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
+					IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01d2: ldc.r8 1
+					IL_01db: sub
+					IL_01dc: box [System.Runtime]System.Double
+					IL_01e1: stloc.s 17
+					IL_01e3: ldc.i4.1
+					IL_01e4: newarr [System.Runtime]System.Object
+					IL_01e9: dup
+					IL_01ea: ldc.i4.0
+					IL_01eb: ldarg.0
+					IL_01ec: ldc.i4.0
+					IL_01ed: ldelem.ref
+					IL_01ee: stelem.ref
+					IL_01ef: ldc.i4.0
+					IL_01f0: ldelem.ref
+					IL_01f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+					IL_01f6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+					IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+					IL_0201: ldnull
+					IL_0202: ldloc.3
+					IL_0203: ldloc.s 17
+					IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+					IL_020a: stloc.s 15
+					IL_020c: ldarg.0
+					IL_020d: ldc.i4.2
+					IL_020e: ldelem.ref
+					IL_020f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_0214: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+					IL_0219: stloc.s 4
+					IL_021b: ldloc.s 15
+					IL_021d: ldstr "then"
+					IL_0222: ldloc.s 4
+					IL_0224: ldarg.0
+					IL_0225: ldc.i4.2
+					IL_0226: ldelem.ref
+					IL_0227: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_022c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0236: pop
+					IL_0237: ldnull
+					IL_0238: ret
+
+					IL_0239: ldloc.1
+					IL_023a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_023f: stloc.s 8
+					IL_0241: ldloc.s 8
+					IL_0243: ldc.r8 200
+					IL_024c: clt
+					IL_024e: stloc.s 5
+					IL_0250: ldloc.s 5
+					IL_0252: box [System.Runtime]System.Boolean
+					IL_0257: stloc.s 9
+					IL_0259: ldloc.s 9
+					IL_025b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0260: stloc.s 5
+					IL_0262: ldloc.s 5
+					IL_0264: brtrue IL_0295
+
+					IL_0269: ldloc.1
+					IL_026a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_026f: stloc.s 8
+					IL_0271: ldloc.s 8
+					IL_0273: ldc.r8 300
+					IL_027c: clt
+					IL_027e: ldc.i4.0
+					IL_027f: ceq
+					IL_0281: stloc.s 5
+					IL_0283: ldloc.s 5
+					IL_0285: box [System.Runtime]System.Boolean
+					IL_028a: stloc.s 10
+					IL_028c: ldloc.s 10
+					IL_028e: stloc.s 18
+					IL_0290: br IL_0299
+
+					IL_0295: ldloc.s 9
+					IL_0297: stloc.s 18
+
+					IL_0299: ldloc.s 18
+					IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a0: stloc.s 5
+					IL_02a2: ldloc.s 5
+					IL_02a4: brfalse IL_033d
+
+					IL_02a9: ldarg.2
+					IL_02aa: ldstr "resume"
+					IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02b4: pop
+					IL_02b5: ldarg.0
+					IL_02b6: ldc.i4.2
+					IL_02b7: ldelem.ref
+					IL_02b8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_02bd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_02c2: stloc.s 4
+					IL_02c4: ldc.i4.3
+					IL_02c5: newarr [System.Runtime]System.Object
+					IL_02ca: dup
+					IL_02cb: ldc.i4.0
+					IL_02cc: ldarg.0
+					IL_02cd: ldc.i4.0
+					IL_02ce: ldelem.ref
+					IL_02cf: stelem.ref
+					IL_02d0: dup
+					IL_02d1: ldc.i4.1
+					IL_02d2: ldarg.0
+					IL_02d3: ldc.i4.1
+					IL_02d4: ldelem.ref
+					IL_02d5: stelem.ref
+					IL_02d6: dup
+					IL_02d7: ldc.i4.2
+					IL_02d8: ldarg.0
+					IL_02d9: ldc.i4.2
+					IL_02da: ldelem.ref
+					IL_02db: stelem.ref
+					IL_02dc: stloc.s 13
+					IL_02de: ldloc.1
+					IL_02df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_02e4: stloc.s 14
+					IL_02e6: ldstr "HTTP "
+					IL_02eb: ldloc.s 14
+					IL_02ed: call string [System.Runtime]System.String::Concat(string, string)
+					IL_02f2: stloc.s 14
+					IL_02f4: ldloc.s 14
+					IL_02f6: ldstr " fetching "
+					IL_02fb: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0300: stloc.s 14
+					IL_0302: ldarg.0
+					IL_0303: ldc.i4.1
+					IL_0304: ldelem.ref
+					IL_0305: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_030a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_030f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0314: stloc.s 19
+					IL_0316: ldloc.s 14
+					IL_0318: ldloc.s 19
+					IL_031a: call string [System.Runtime]System.String::Concat(string, string)
+					IL_031f: stloc.s 19
+					IL_0321: ldloc.s 19
+					IL_0323: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0328: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_032d: stloc.s 15
+					IL_032f: ldloc.s 4
+					IL_0331: ldloc.s 13
+					IL_0333: ldloc.s 15
+					IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_033a: pop
+					IL_033b: ldnull
+					IL_033c: ret
+
+					IL_033d: ldarg.2
+					IL_033e: ldstr "setEncoding"
+					IL_0343: ldstr "utf8"
+					IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_034d: pop
+					IL_034e: ldloc.0
+					IL_034f: ldstr ""
+					IL_0354: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+					IL_0359: ldnull
+					IL_035a: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/ArrowFunction_L219C24::__js_call__(object[], object, object)
+					IL_0360: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_0365: ldc.i4.4
+					IL_0366: newarr [System.Runtime]System.Object
+					IL_036b: dup
+					IL_036c: ldc.i4.0
+					IL_036d: ldarg.0
+					IL_036e: ldc.i4.0
+					IL_036f: ldelem.ref
+					IL_0370: stelem.ref
+					IL_0371: dup
+					IL_0372: ldc.i4.1
+					IL_0373: ldarg.0
+					IL_0374: ldc.i4.1
+					IL_0375: ldelem.ref
+					IL_0376: stelem.ref
+					IL_0377: dup
+					IL_0378: ldc.i4.2
+					IL_0379: ldarg.0
+					IL_037a: ldc.i4.2
+					IL_037b: ldelem.ref
+					IL_037c: stelem.ref
+					IL_037d: dup
+					IL_037e: ldc.i4.3
+					IL_037f: ldloc.0
+					IL_0380: stelem.ref
+					IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_038b: stloc.s 15
+					IL_038d: ldarg.2
+					IL_038e: ldstr "on"
+					IL_0393: ldstr "data"
+					IL_0398: ldloc.s 15
+					IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_039f: pop
+					IL_03a0: ldnull
+					IL_03a1: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/ArrowFunction_L222C23::__js_call__(object[], object)
+					IL_03a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_03ac: ldc.i4.4
+					IL_03ad: newarr [System.Runtime]System.Object
+					IL_03b2: dup
+					IL_03b3: ldc.i4.0
+					IL_03b4: ldarg.0
+					IL_03b5: ldc.i4.0
+					IL_03b6: ldelem.ref
+					IL_03b7: stelem.ref
+					IL_03b8: dup
+					IL_03b9: ldc.i4.1
+					IL_03ba: ldarg.0
+					IL_03bb: ldc.i4.1
+					IL_03bc: ldelem.ref
+					IL_03bd: stelem.ref
+					IL_03be: dup
+					IL_03bf: ldc.i4.2
+					IL_03c0: ldarg.0
+					IL_03c1: ldc.i4.2
+					IL_03c2: ldelem.ref
+					IL_03c3: stelem.ref
+					IL_03c4: dup
+					IL_03c5: ldc.i4.3
+					IL_03c6: ldloc.0
+					IL_03c7: stelem.ref
+					IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03d2: stloc.s 15
+					IL_03d4: ldarg.2
+					IL_03d5: ldstr "on"
+					IL_03da: ldstr "end"
+					IL_03df: ldloc.s 15
+					IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03e6: pop
+					IL_03e7: ldnull
+					IL_03e8: ret
+				} // end of method ArrowFunction_L194C7::__js_call__
+
+			} // end of class ArrowFunction_L194C7
+
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+					01 00 39 53 63 6f 70 65 20 72 65 73 6f 6c 76 65
+					3d 7b 72 65 73 6f 6c 76 65 7d 2c 20 72 65 6a 65
+					63 74 3d 7b 72 65 6a 65 63 74 7d 2c 20 75 72 6c
+					4f 62 6a 3d 7b 75 72 6c 4f 62 6a 7d 00 00
+				)
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L172C8
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a40
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L172C8::.ctor
+
+				} // end of class Block_L172C8
+
+				.class nested private auto ansi beforefieldinit Block_L174C12
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a49
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L174C12::.ctor
+
+				} // end of class Block_L174C12
+
+				.class nested private auto ansi beforefieldinit Block_L179C44
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a52
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L179C44::.ctor
+
+				} // end of class Block_L179C44
+
+
+				// Fields
+				.field public object resolve
+				.field public object reject
+				.field public object urlObj
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5a37
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget,
+					object resolve,
+					object reject
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x5148
+				// Header size: 12
+				// Code size: 674 (0x2a2)
+				.maxstack 8
+				.locals init (
+					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope,
+					[1] class [System.Runtime]System.Exception,
+					[2] object,
+					[3] object,
+					[4] object,
+					[5] class [System.Runtime]System.Delegate,
+					[6] object,
+					[7] object[],
+					[8] string,
+					[9] object,
+					[10] object,
+					[11] bool,
+					[12] string,
+					[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				)
+
+				IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::.ctor()
+				IL_0005: stloc.0
+				IL_0006: ldloc.0
+				IL_0007: ldarg.2
+				IL_0008: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+				IL_000d: ldloc.0
+				IL_000e: ldarg.3
+				IL_000f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+				IL_0014: ldloc.0
+				IL_0015: ldnull
+				IL_0016: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+				.try
+				{
+					IL_001b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
+					IL_0020: stloc.s 5
+					IL_0022: ldloc.s 5
+					IL_0024: ldc.i4.1
+					IL_0025: newarr [System.Runtime]System.Object
+					IL_002a: dup
+					IL_002b: ldc.i4.0
+					IL_002c: ldarg.0
+					IL_002d: ldc.i4.1
+					IL_002e: ldelem.ref
+					IL_002f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_0034: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_0039: stelem.ref
+					IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_003f: stloc.s 6
+					IL_0041: ldloc.0
+					IL_0042: ldloc.s 6
+					IL_0044: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+					IL_0049: leave IL_00b5
+				} // end .try
+				catch [System.Runtime]System.Exception
+				{
+					IL_004e: stloc.1
+					IL_004f: ldloc.0
+					IL_0050: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_0055: stloc.s 6
+					IL_0057: ldc.i4.2
+					IL_0058: newarr [System.Runtime]System.Object
+					IL_005d: dup
+					IL_005e: ldc.i4.0
+					IL_005f: ldarg.0
+					IL_0060: ldc.i4.0
+					IL_0061: ldelem.ref
+					IL_0062: stelem.ref
+					IL_0063: dup
+					IL_0064: ldc.i4.1
+					IL_0065: ldarg.0
+					IL_0066: ldc.i4.1
+					IL_0067: ldelem.ref
+					IL_0068: stelem.ref
+					IL_0069: stloc.s 7
+					IL_006b: ldarg.0
+					IL_006c: ldc.i4.1
+					IL_006d: ldelem.ref
+					IL_006e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_0073: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_0078: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_007d: stloc.s 8
+					IL_007f: ldstr "Invalid URL: "
+					IL_0084: ldloc.s 8
+					IL_0086: call string [System.Runtime]System.String::Concat(string, string)
+					IL_008b: stloc.s 8
+					IL_008d: ldloc.s 8
+					IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0099: stloc.s 9
+					IL_009b: ldloc.s 6
+					IL_009d: ldloc.s 7
+					IL_009f: ldloc.s 9
+					IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_00a6: pop
+					IL_00a7: ldnull
+					IL_00a8: stloc.2
+					IL_00a9: ldnull
+					IL_00aa: stloc.2
+					IL_00ab: leave IL_02a0
+
+					IL_00b0: leave IL_00b5
+				} // end handler
+
+				IL_00b5: ldloc.0
+				IL_00b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+				IL_00bb: ldstr "protocol"
+				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00c5: stloc.s 9
+				IL_00c7: ldarg.0
+				IL_00c8: ldc.i4.1
+				IL_00c9: ldelem.ref
+				IL_00ca: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_00cf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+				IL_00d4: ldstr ":"
+				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00de: stloc.s 10
+				IL_00e0: ldloc.s 9
+				IL_00e2: ldloc.s 10
+				IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_00e9: stloc.s 11
+				IL_00eb: ldloc.s 11
+				IL_00ed: brfalse IL_01a6
+
+				IL_00f2: ldloc.0
+				IL_00f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+				IL_00f8: stloc.s 9
+				IL_00fa: ldc.i4.2
+				IL_00fb: newarr [System.Runtime]System.Object
+				IL_0100: dup
+				IL_0101: ldc.i4.0
+				IL_0102: ldarg.0
+				IL_0103: ldc.i4.0
+				IL_0104: ldelem.ref
+				IL_0105: stelem.ref
+				IL_0106: dup
+				IL_0107: ldc.i4.1
+				IL_0108: ldarg.0
+				IL_0109: ldc.i4.1
+				IL_010a: ldelem.ref
+				IL_010b: stelem.ref
+				IL_010c: stloc.s 7
+				IL_010e: ldarg.0
+				IL_010f: ldc.i4.1
+				IL_0110: ldelem.ref
+				IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+				IL_011b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0120: stloc.s 8
+				IL_0122: ldstr "Only "
+				IL_0127: ldloc.s 8
+				IL_0129: call string [System.Runtime]System.String::Concat(string, string)
+				IL_012e: stloc.s 8
+				IL_0130: ldloc.s 8
+				IL_0132: ldstr ":// URLs are supported by the "
+				IL_0137: call string [System.Runtime]System.String::Concat(string, string)
+				IL_013c: stloc.s 8
+				IL_013e: ldarg.0
+				IL_013f: ldc.i4.1
+				IL_0140: ldelem.ref
+				IL_0141: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_0146: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+				IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0150: stloc.s 12
+				IL_0152: ldloc.s 8
+				IL_0154: ldloc.s 12
+				IL_0156: call string [System.Runtime]System.String::Concat(string, string)
+				IL_015b: stloc.s 12
+				IL_015d: ldloc.s 12
+				IL_015f: ldstr " fallback. Got: "
+				IL_0164: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0169: stloc.s 12
+				IL_016b: ldarg.0
+				IL_016c: ldc.i4.1
+				IL_016d: ldelem.ref
+				IL_016e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_0173: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+				IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_017d: stloc.s 8
+				IL_017f: ldloc.s 12
+				IL_0181: ldloc.s 8
+				IL_0183: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0188: stloc.s 8
+				IL_018a: ldloc.s 8
+				IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0196: stloc.s 6
+				IL_0198: ldloc.s 9
+				IL_019a: ldloc.s 7
+				IL_019c: ldloc.s 6
+				IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+				IL_01a3: pop
+				IL_01a4: ldnull
+				IL_01a5: ret
+
+				IL_01a6: ldarg.0
+				IL_01a7: ldc.i4.1
+				IL_01a8: ldelem.ref
+				IL_01a9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_01ae: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+				IL_01b3: ldstr "http"
+				IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01bd: stloc.s 11
+				IL_01bf: ldloc.s 11
+				IL_01c1: brfalse IL_01d9
+
+				IL_01c6: ldarg.0
+				IL_01c7: ldc.i4.0
+				IL_01c8: ldelem.ref
+				IL_01c9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+				IL_01ce: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::http
+				IL_01d3: stloc.3
+				IL_01d4: br IL_01e7
+
+				IL_01d9: ldarg.0
+				IL_01da: ldc.i4.0
+				IL_01db: ldelem.ref
+				IL_01dc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+				IL_01e1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::https
+				IL_01e6: stloc.3
+
+				IL_01e7: ldloc.0
+				IL_01e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+				IL_01ed: stloc.s 6
+				IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_01f4: dup
+				IL_01f5: ldstr "method"
+				IL_01fa: ldstr "GET"
+				IL_01ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0204: dup
+				IL_0205: ldstr "headers"
+				IL_020a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_020f: dup
+				IL_0210: ldstr "Accept-Encoding"
+				IL_0215: ldstr "identity"
+				IL_021a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_021f: dup
+				IL_0220: ldstr "User-Agent"
+				IL_0225: ldstr "js2il-docs-script"
+				IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0234: stloc.s 13
+				IL_0236: ldnull
+				IL_0237: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7::__js_call__(object[], object, object)
+				IL_023d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0242: ldc.i4.3
+				IL_0243: newarr [System.Runtime]System.Object
+				IL_0248: dup
+				IL_0249: ldc.i4.0
+				IL_024a: ldarg.0
+				IL_024b: ldc.i4.0
+				IL_024c: ldelem.ref
+				IL_024d: stelem.ref
+				IL_024e: dup
+				IL_024f: ldc.i4.1
+				IL_0250: ldarg.0
+				IL_0251: ldc.i4.1
+				IL_0252: ldelem.ref
+				IL_0253: stelem.ref
+				IL_0254: dup
+				IL_0255: ldc.i4.2
+				IL_0256: ldloc.0
+				IL_0257: stelem.ref
+				IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0262: stloc.s 9
+				IL_0264: ldloc.3
+				IL_0265: ldstr "request"
+				IL_026a: ldloc.s 6
+				IL_026c: ldloc.s 13
+				IL_026e: ldloc.s 9
+				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0275: stloc.s 9
+				IL_0277: ldloc.s 9
+				IL_0279: stloc.s 4
+				IL_027b: ldloc.s 4
+				IL_027d: ldstr "on"
+				IL_0282: ldstr "error"
+				IL_0287: ldloc.0
+				IL_0288: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+				IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0292: pop
+				IL_0293: ldloc.s 4
+				IL_0295: ldstr "end"
+				IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_029f: pop
+
+				IL_02a0: ldloc.2
+				IL_02a1: ret
+			} // end of method ArrowFunction_L170C22::__js_call__
+
+		} // end of class ArrowFunction_L170C22
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 4d 53 63 6f 70 65 20 70 72 6f 74 6f 63 6f
+				6c 3d 7b 70 72 6f 74 6f 63 6f 6c 7d 2c 20 75 72
+				6c 53 74 72 69 6e 67 3d 7b 75 72 6c 53 74 72 69
+				6e 67 7d 2c 20 6d 61 78 52 65 64 69 72 65 63 74
+				73 3d 7b 6d 61 78 52 65 64 69 72 65 63 74 73 7d
+				00 00
+			)
+			// Fields
+			.field public object protocol
+			.field public object urlString
+			.field public object maxRedirects
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a2e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object protocol,
+				object urlString,
+				object maxRedirects
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x333c
+			// Header size: 12
+			// Code size: 97 (0x61)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope,
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise
+			)
+
+			IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldarg.s maxRedirects
+			IL_0008: brtrue IL_001d
+
+			IL_000d: ldc.r8 5
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: starg.s maxRedirects
+
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+			IL_0024: ldloc.0
+			IL_0025: ldarg.3
+			IL_0026: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+			IL_002b: ldloc.0
+			IL_002c: ldarg.s maxRedirects
+			IL_002e: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
+			IL_0033: ldnull
+			IL_0034: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22::__js_call__(object[], object, object, object)
+			IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+			IL_003f: ldc.i4.2
+			IL_0040: newarr [System.Runtime]System.Object
+			IL_0045: dup
+			IL_0046: ldc.i4.0
+			IL_0047: ldarg.0
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.1
+			IL_004b: ldloc.0
+			IL_004c: stelem.ref
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0057: stloc.1
+			IL_0058: ldloc.1
+			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+			IL_005e: stloc.2
+			IL_005f: ldloc.2
+			IL_0060: ret
+		} // end of method fetchTextWithTransport::__js_call__
+
+	} // end of class fetchTextWithTransport
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchText
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a91
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object urlString
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x33ac
+			// Header size: 12
+			// Code size: 39 (0x27)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: ldc.i4.0
+			IL_000b: ldelem.ref
+			IL_000c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0011: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_001c: ldnull
+			IL_001d: ldarg.2
+			IL_001e: ldnull
+			IL_001f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0024: stloc.0
+			IL_0025: ldloc.0
+			IL_0026: ret
+		} // end of method fetchText::__js_call__
+
+	} // end of class fetchText
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithNodeRequest
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L237C6
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5aa3
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L237C6::.ctor
+
+			} // end of class Block_L237C6
+
+			.class nested private auto ansi beforefieldinit Block_L239C10
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5aac
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L239C10::.ctor
+
+			} // end of class Block_L239C10
+
+			.class nested private auto ansi beforefieldinit Block_L243C35
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5ab5
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L243C35::.ctor
+
+			} // end of class Block_L243C35
+
+			.class nested private auto ansi beforefieldinit Block_L247C36
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5abe
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L247C36::.ctor
+
+			} // end of class Block_L247C36
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a9a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object urlString,
+				object maxRedirects
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x33e0
+			// Header size: 12
+			// Code size: 309 (0x135)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [System.Runtime]System.Exception,
+				[2] object,
+				[3] class [System.Runtime]System.Delegate,
+				[4] object,
+				[5] string,
+				[6] bool
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: brtrue IL_0016
+
+			IL_0006: ldc.r8 5
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: starg.s maxRedirects
+
+			IL_0016: ldnull
+			IL_0017: stloc.0
+			.try
+			{
+				IL_0018: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
+				IL_001d: stloc.3
+				IL_001e: ldloc.3
+				IL_001f: ldc.i4.1
+				IL_0020: newarr [System.Runtime]System.Object
+				IL_0025: dup
+				IL_0026: ldc.i4.0
+				IL_0027: ldarg.2
+				IL_0028: stelem.ref
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+				IL_002e: stloc.s 4
+				IL_0030: ldloc.s 4
+				IL_0032: stloc.0
+				IL_0033: leave IL_0075
+			} // end .try
+			catch [System.Runtime]System.Exception
+			{
+				IL_0038: stloc.1
+				IL_0039: ldarg.2
+				IL_003a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_003f: stloc.s 5
+				IL_0041: ldstr "Invalid URL: "
+				IL_0046: ldloc.s 5
+				IL_0048: call string [System.Runtime]System.String::Concat(string, string)
+				IL_004d: stloc.s 5
+				IL_004f: ldloc.s 5
+				IL_0051: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0056: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_005b: stloc.s 4
+				IL_005d: ldloc.s 4
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+				IL_0064: stloc.s 4
+				IL_0066: ldnull
+				IL_0067: stloc.2
+				IL_0068: ldloc.s 4
+				IL_006a: stloc.2
+				IL_006b: leave IL_0133
+
+				IL_0070: leave IL_0075
+			} // end handler
+
+			IL_0075: ldloc.0
+			IL_0076: ldstr "protocol"
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0080: ldstr "http:"
+			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_008a: stloc.s 6
+			IL_008c: ldloc.s 6
+			IL_008e: brfalse IL_00bc
+
+			IL_0093: ldc.i4.1
+			IL_0094: newarr [System.Runtime]System.Object
+			IL_0099: dup
+			IL_009a: ldc.i4.0
+			IL_009b: ldarg.0
+			IL_009c: stelem.ref
+			IL_009d: ldc.i4.0
+			IL_009e: ldelem.ref
+			IL_009f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_00a4: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttp::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_00af: ldnull
+			IL_00b0: ldarg.2
+			IL_00b1: ldarg.3
+			IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_00b7: stloc.s 4
+			IL_00b9: ldloc.s 4
+			IL_00bb: ret
+
+			IL_00bc: ldloc.0
+			IL_00bd: ldstr "protocol"
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c7: ldstr "https:"
+			IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00d1: stloc.s 6
+			IL_00d3: ldloc.s 6
+			IL_00d5: brfalse IL_0103
+
+			IL_00da: ldc.i4.1
+			IL_00db: newarr [System.Runtime]System.Object
+			IL_00e0: dup
+			IL_00e1: ldc.i4.0
+			IL_00e2: ldarg.0
+			IL_00e3: stelem.ref
+			IL_00e4: ldc.i4.0
+			IL_00e5: ldelem.ref
+			IL_00e6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_00eb: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttps::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_00f6: ldnull
+			IL_00f7: ldarg.2
+			IL_00f8: ldarg.3
+			IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_00fe: stloc.s 4
+			IL_0100: ldloc.s 4
+			IL_0102: ret
+
+			IL_0103: ldarg.2
+			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0109: stloc.s 5
+			IL_010b: ldstr "Only http:// and https:// URLs are supported by the request fallback. Got: "
+			IL_0110: ldloc.s 5
+			IL_0112: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0117: stloc.s 5
+			IL_0119: ldloc.s 5
+			IL_011b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0125: stloc.s 4
+			IL_0127: ldloc.s 4
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+			IL_012e: stloc.s 4
+			IL_0130: ldloc.s 4
+			IL_0132: ret
+
+			IL_0133: ldloc.2
+			IL_0134: ret
+		} // end of method fetchTextWithNodeRequest::__js_call__
+
+	} // end of class fetchTextWithNodeRequest
+
+	.class nested public auto ansi abstract sealed beforefieldinit detectEol
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5ac7
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object text
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x3534
+			// Header size: 12
+			// Code size: 49 (0x31)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] bool
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: ldstr "includes"
+			IL_0006: ldstr "\r\n"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0010: stloc.1
+			IL_0011: ldloc.1
+			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0017: stloc.2
+			IL_0018: ldloc.2
+			IL_0019: brfalse IL_0029
+
+			IL_001e: ldstr "\r\n"
+			IL_0023: stloc.0
+			IL_0024: br IL_002f
+
+			IL_0029: ldstr "\n"
+			IL_002e: stloc.0
+
+			IL_002f: ldloc.0
+			IL_0030: ret
+		} // end of method detectEol::__js_call__
+
+	} // end of class detectEol
+
+	.class nested public auto ansi abstract sealed beforefieldinit escapeRegExp
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5ad0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object text
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x3574
+			// Header size: 12
+			// Code size: 36 (0x24)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[1] object
+			)
+
+			IL_0000: ldstr "[.*+?^${}()|[\\]\\\\]"
+			IL_0005: ldstr "g"
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.1
+			IL_0011: ldstr "replace"
+			IL_0016: ldloc.0
+			IL_0017: ldstr "\\$&"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: ret
+		} // end of method escapeRegExp::__js_call__
+
+	} // end of class escapeRegExp
+
+	.class nested public auto ansi abstract sealed beforefieldinit writeTextPreserveEol
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L266C31
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5ae2
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L266C31::.ctor
+
+			} // end of class Block_L266C31
+
+			.class nested private auto ansi beforefieldinit Block_L274C60
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5aeb
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L274C60::.ctor
+
+			} // end of class Block_L274C60
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5ad9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object filePath,
+				object text
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x35a4
+			// Header size: 12
+			// Code size: 286 (0x11e)
+			.maxstack 8
+			.locals init (
+				[0] string,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] bool,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] object
+			)
+
+			IL_0000: ldstr "\n"
+			IL_0005: stloc.0
+			IL_0006: ldc.i4.0
+			IL_0007: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_000c: stloc.1
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_0013: ldstr "existsSync"
+			IL_0018: ldarg.2
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001e: stloc.3
+			IL_001f: ldloc.3
+			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0025: stloc.s 4
+			IL_0027: ldloc.s 4
+			IL_0029: brfalse IL_0051
+
+			IL_002e: ldarg.0
+			IL_002f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_0034: ldstr "readFileSync"
+			IL_0039: ldarg.2
+			IL_003a: ldstr "utf8"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0044: stloc.3
+			IL_0045: ldloc.3
+			IL_0046: stloc.1
+			IL_0047: ldnull
+			IL_0048: ldloc.1
+			IL_0049: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/detectEol::__js_call__(object, object)
+			IL_004e: stloc.3
+			IL_004f: ldloc.3
+			IL_0050: stloc.0
+
+			IL_0051: ldstr "\\r\\n|\\n"
+			IL_0056: ldstr "g"
+			IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0060: stloc.s 5
+			IL_0062: ldarg.3
+			IL_0063: ldstr "replace"
+			IL_0068: ldloc.s 5
+			IL_006a: ldloc.0
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: stloc.2
+			IL_0073: ldloc.1
+			IL_0074: ldc.i4.0
+			IL_0075: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_007f: stloc.s 4
+			IL_0081: ldloc.s 4
+			IL_0083: box [System.Runtime]System.Boolean
+			IL_0088: stloc.s 6
+			IL_008a: ldloc.s 6
+			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0091: stloc.s 4
+			IL_0093: ldloc.s 4
+			IL_0095: brfalse IL_00b5
+
+			IL_009a: ldloc.1
+			IL_009b: ldloc.2
+			IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00a1: stloc.s 4
+			IL_00a3: ldloc.s 4
+			IL_00a5: box [System.Runtime]System.Boolean
+			IL_00aa: stloc.s 7
+			IL_00ac: ldloc.s 7
+			IL_00ae: stloc.s 9
+			IL_00b0: br IL_00b9
+
+			IL_00b5: ldloc.s 6
+			IL_00b7: stloc.s 9
+
+			IL_00b9: ldloc.s 9
+			IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00c0: stloc.s 4
+			IL_00c2: ldloc.s 4
+			IL_00c4: brfalse IL_00cb
+
+			IL_00c9: ldnull
+			IL_00ca: ret
+
+			IL_00cb: ldarg.0
+			IL_00cc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_00d1: stloc.3
+			IL_00d2: ldarg.0
+			IL_00d3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
+			IL_00d8: ldstr "dirname"
+			IL_00dd: ldarg.2
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e3: stloc.s 10
+			IL_00e5: ldloc.3
+			IL_00e6: ldstr "mkdirSync"
+			IL_00eb: ldloc.s 10
+			IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00f2: dup
+			IL_00f3: ldstr "recursive"
+			IL_00f8: ldc.i4.1
+			IL_00f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0103: pop
+			IL_0104: ldarg.0
+			IL_0105: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_010a: ldstr "writeFileSync"
+			IL_010f: ldarg.2
+			IL_0110: ldloc.2
+			IL_0111: ldstr "utf8"
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_011b: pop
+			IL_011c: ldnull
+			IL_011d: ret
+		} // end of method writeTextPreserveEol::__js_call__
+
+	} // end of class writeTextPreserveEol
+
+	.class nested public auto ansi abstract sealed beforefieldinit findTagNameAt
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L290C26
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L292C93
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5b06
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L292C93::.ctor
+
+				} // end of class Block_L292C93
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5afd
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L290C26::.ctor
+
+			} // end of class Block_L290C26
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5af4
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object html,
+				object tagStart
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x36d0
+			// Header size: 12
+			// Code size: 584 (0x248)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] bool,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] float64,
+				[7] object,
+				[8] bool,
+				[9] object,
+				[10] object,
+				[11] object,
+				[12] object,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] object,
+				[18] object
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: stloc.s 6
+			IL_0008: ldloc.s 6
+			IL_000a: ldc.r8 0.0
+			IL_0013: clt
+			IL_0015: box [System.Runtime]System.Boolean
+			IL_001a: stloc.s 7
+			IL_001c: ldloc.s 7
+			IL_001e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0023: stloc.s 8
+			IL_0025: ldloc.s 8
+			IL_0027: brtrue IL_0052
+
+			IL_002c: ldarg.2
+			IL_002d: ldloc.s 6
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0034: ldstr "<"
+			IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_003e: stloc.s 8
+			IL_0040: ldloc.s 8
+			IL_0042: box [System.Runtime]System.Boolean
+			IL_0047: stloc.s 9
+			IL_0049: ldloc.s 9
+			IL_004b: stloc.s 11
+			IL_004d: br IL_0056
+
+			IL_0052: ldloc.s 7
+			IL_0054: stloc.s 11
+
+			IL_0056: ldloc.s 11
+			IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005d: stloc.s 8
+			IL_005f: ldloc.s 8
+			IL_0061: brfalse IL_006c
+
+			IL_0066: ldstr ""
+			IL_006b: ret
+
+			IL_006c: ldarg.3
+			IL_006d: ldc.r8 1
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_007b: stloc.s 11
+			IL_007d: ldloc.s 11
+			IL_007f: stloc.0
+			IL_0080: ldarg.2
+			IL_0081: ldloc.0
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0087: ldstr "/"
+			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0091: stloc.s 8
+			IL_0093: ldloc.s 8
+			IL_0095: stloc.1
+			IL_0096: ldloc.1
+			IL_0097: brfalse IL_00b5
+
+			IL_009c: ldloc.0
+			IL_009d: ldc.r8 1
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00ab: stloc.s 11
+			IL_00ad: ldloc.s 11
+			IL_00af: stloc.2
+			IL_00b0: br IL_00b7
+
+			IL_00b5: ldloc.0
+			IL_00b6: stloc.2
+
+			IL_00b7: ldloc.2
+			IL_00b8: stloc.3
+			IL_00b9: ldloc.3
+			IL_00ba: stloc.s 4
+			// loop start (head: IL_00bc)
+				IL_00bc: ldarg.2
+				IL_00bd: ldstr "length"
+				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00c7: stloc.s 12
+				IL_00c9: ldloc.s 4
+				IL_00cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d0: stloc.s 6
+				IL_00d2: ldloc.s 6
+				IL_00d4: ldloc.s 12
+				IL_00d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00db: clt
+				IL_00dd: brfalse IL_0235
+
+				IL_00e2: ldarg.2
+				IL_00e3: ldloc.s 4
+				IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_00ea: stloc.s 5
+				IL_00ec: ldloc.s 5
+				IL_00ee: ldstr " "
+				IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00f8: stloc.s 8
+				IL_00fa: ldloc.s 8
+				IL_00fc: box [System.Runtime]System.Boolean
+				IL_0101: stloc.s 7
+				IL_0103: ldloc.s 7
+				IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_010a: stloc.s 8
+				IL_010c: ldloc.s 8
+				IL_010e: brtrue IL_0133
+
+				IL_0113: ldloc.s 5
+				IL_0115: ldstr "\t"
+				IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_011f: stloc.s 8
+				IL_0121: ldloc.s 8
+				IL_0123: box [System.Runtime]System.Boolean
+				IL_0128: stloc.s 9
+				IL_012a: ldloc.s 9
+				IL_012c: stloc.s 13
+				IL_012e: br IL_0137
+
+				IL_0133: ldloc.s 7
+				IL_0135: stloc.s 13
+
+				IL_0137: ldloc.s 13
+				IL_0139: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_013e: stloc.s 8
+				IL_0140: ldloc.s 8
+				IL_0142: brtrue IL_0167
+
+				IL_0147: ldloc.s 5
+				IL_0149: ldstr "\r"
+				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0153: stloc.s 8
+				IL_0155: ldloc.s 8
+				IL_0157: box [System.Runtime]System.Boolean
+				IL_015c: stloc.s 7
+				IL_015e: ldloc.s 7
+				IL_0160: stloc.s 13
+				IL_0162: br IL_0167
+
+				IL_0167: ldloc.s 13
+				IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_016e: stloc.s 8
+				IL_0170: ldloc.s 8
+				IL_0172: brtrue IL_0197
+
+				IL_0177: ldloc.s 5
+				IL_0179: ldstr "\n"
+				IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0183: stloc.s 8
+				IL_0185: ldloc.s 8
+				IL_0187: box [System.Runtime]System.Boolean
+				IL_018c: stloc.s 7
+				IL_018e: ldloc.s 7
+				IL_0190: stloc.s 13
+				IL_0192: br IL_0197
+
+				IL_0197: ldloc.s 13
+				IL_0199: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_019e: stloc.s 8
+				IL_01a0: ldloc.s 8
+				IL_01a2: brtrue IL_01c7
+
+				IL_01a7: ldloc.s 5
+				IL_01a9: ldstr ">"
+				IL_01ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01b3: stloc.s 8
+				IL_01b5: ldloc.s 8
+				IL_01b7: box [System.Runtime]System.Boolean
+				IL_01bc: stloc.s 7
+				IL_01be: ldloc.s 7
+				IL_01c0: stloc.s 13
+				IL_01c2: br IL_01c7
+
+				IL_01c7: ldloc.s 13
+				IL_01c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01ce: stloc.s 8
+				IL_01d0: ldloc.s 8
+				IL_01d2: brtrue IL_01f7
+
+				IL_01d7: ldloc.s 5
+				IL_01d9: ldstr "/"
+				IL_01de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01e3: stloc.s 8
+				IL_01e5: ldloc.s 8
+				IL_01e7: box [System.Runtime]System.Boolean
+				IL_01ec: stloc.s 7
+				IL_01ee: ldloc.s 7
+				IL_01f0: stloc.s 13
+				IL_01f2: br IL_01f7
+
+				IL_01f7: ldloc.s 13
+				IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01fe: stloc.s 8
+				IL_0200: ldloc.s 8
+				IL_0202: brfalse IL_020c
+
+				IL_0207: br IL_0235
+
+				IL_020c: ldloc.s 4
+				IL_020e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0213: stloc.s 6
+				IL_0215: ldloc.s 6
+				IL_0217: ldc.r8 1
+				IL_0220: add
+				IL_0221: stloc.s 6
+				IL_0223: ldloc.s 6
+				IL_0225: box [System.Runtime]System.Double
+				IL_022a: stloc.s 18
+				IL_022c: ldloc.s 18
+				IL_022e: stloc.s 4
+				IL_0230: br IL_00bc
+			// end loop
+
+			IL_0235: ldarg.2
+			IL_0236: ldstr "substring"
+			IL_023b: ldloc.3
+			IL_023c: ldloc.s 4
+			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0243: stloc.s 12
+			IL_0245: ldloc.s 12
+			IL_0247: ret
+		} // end of method findTagNameAt::__js_call__
+
+	} // end of class findTagNameAt
+
+	.class nested public auto ansi abstract sealed beforefieldinit extractElementById
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L307C19
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b18
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L307C19::.ctor
+
+			} // end of class Block_L307C19
+
+			.class nested private auto ansi beforefieldinit Block_L312C20
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b21
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L312C20::.ctor
+
+			} // end of class Block_L312C20
+
+			.class nested private auto ansi beforefieldinit Block_L317C16
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b2a
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L317C16::.ctor
+
+			} // end of class Block_L317C16
+
+			.class nested private auto ansi beforefieldinit Block_L328C15
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L334C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5b3c
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L334C24::.ctor
+
+				} // end of class Block_L334C24
+
+				.class nested private auto ansi beforefieldinit Block_L339C17
+					extends [System.Runtime]System.Object
+				{
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Block_L341C23
+						extends [System.Runtime]System.Object
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5b4e
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Block_L341C23::.ctor
+
+					} // end of class Block_L341C23
+
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5b45
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L339C17::.ctor
+
+				} // end of class Block_L339C17
+
+				.class nested private auto ansi beforefieldinit Block_L348C11
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5b57
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L348C11::.ctor
+
+				} // end of class Block_L348C11
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b33
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L328C15::.ctor
+
+			} // end of class Block_L328C15
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b0f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object html,
+				object elementId
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x3924
+			// Header size: 12
+			// Code size: 966 (0x3c6)
+			.maxstack 8
+			.locals init (
+				[0] string,
+				[1] string,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[6] float64,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] object,
+				[11] object,
+				[12] string,
+				[13] object,
+				[14] float64,
+				[15] bool,
+				[16] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] string
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0006: stloc.s 12
+			IL_0008: ldstr "id=\""
+			IL_000d: ldloc.s 12
+			IL_000f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0014: stloc.s 12
+			IL_0016: ldloc.s 12
+			IL_0018: ldstr "\""
+			IL_001d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0022: stloc.s 12
+			IL_0024: ldloc.s 12
+			IL_0026: stloc.0
+			IL_0027: ldarg.3
+			IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002d: stloc.s 12
+			IL_002f: ldstr "id='"
+			IL_0034: ldloc.s 12
+			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
+			IL_003b: stloc.s 12
+			IL_003d: ldloc.s 12
+			IL_003f: ldstr "'"
+			IL_0044: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0049: stloc.s 12
+			IL_004b: ldloc.s 12
+			IL_004d: stloc.1
+			IL_004e: ldarg.2
+			IL_004f: ldstr "indexOf"
+			IL_0054: ldloc.0
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_005a: stloc.s 13
+			IL_005c: ldloc.s 13
+			IL_005e: stloc.2
+			IL_005f: ldloc.2
+			IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0065: stloc.s 14
+			IL_0067: ldloc.s 14
+			IL_0069: ldc.r8 0.0
+			IL_0072: clt
+			IL_0074: brfalse IL_008a
+
+			IL_0079: ldarg.2
+			IL_007a: ldstr "indexOf"
+			IL_007f: ldloc.1
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0085: stloc.s 13
+			IL_0087: ldloc.s 13
+			IL_0089: stloc.2
+
+			IL_008a: ldloc.2
+			IL_008b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0090: stloc.s 14
+			IL_0092: ldloc.s 14
+			IL_0094: ldc.r8 0.0
+			IL_009d: clt
+			IL_009f: brfalse IL_00e9
+
+			IL_00a4: ldarg.3
+			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00aa: stloc.s 12
+			IL_00ac: ldstr "Could not find id '"
+			IL_00b1: ldloc.s 12
+			IL_00b3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b8: stloc.s 12
+			IL_00ba: ldloc.s 12
+			IL_00bc: ldstr "' in input HTML."
+			IL_00c1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00c6: stloc.s 12
+			IL_00c8: ldloc.s 12
+			IL_00ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00d4: dup
+			IL_00d5: isinst [System.Runtime]System.Exception
+			IL_00da: dup
+			IL_00db: brtrue IL_00e7
+
+			IL_00e0: pop
+			IL_00e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00e6: throw
+
+			IL_00e7: pop
+			IL_00e8: throw
+
+			IL_00e9: ldarg.2
+			IL_00ea: ldstr "lastIndexOf"
+			IL_00ef: ldstr "<"
+			IL_00f4: ldloc.2
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00fa: stloc.s 13
+			IL_00fc: ldloc.s 13
+			IL_00fe: stloc.3
+			IL_00ff: ldloc.3
+			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0105: stloc.s 14
+			IL_0107: ldloc.s 14
+			IL_0109: ldc.r8 0.0
+			IL_0112: clt
+			IL_0114: brfalse IL_015e
+
+			IL_0119: ldarg.3
+			IL_011a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_011f: stloc.s 12
+			IL_0121: ldstr "Could not locate tag start for id '"
+			IL_0126: ldloc.s 12
+			IL_0128: call string [System.Runtime]System.String::Concat(string, string)
+			IL_012d: stloc.s 12
+			IL_012f: ldloc.s 12
+			IL_0131: ldstr "'."
+			IL_0136: call string [System.Runtime]System.String::Concat(string, string)
+			IL_013b: stloc.s 12
+			IL_013d: ldloc.s 12
+			IL_013f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0149: dup
+			IL_014a: isinst [System.Runtime]System.Exception
+			IL_014f: dup
+			IL_0150: brtrue IL_015c
+
+			IL_0155: pop
+			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_015b: throw
+
+			IL_015c: pop
+			IL_015d: throw
+
+			IL_015e: ldc.i4.1
+			IL_015f: newarr [System.Runtime]System.Object
+			IL_0164: dup
+			IL_0165: ldc.i4.0
+			IL_0166: ldarg.0
+			IL_0167: stelem.ref
+			IL_0168: ldc.i4.0
+			IL_0169: ldelem.ref
+			IL_016a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_016f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_017a: ldnull
+			IL_017b: ldarg.2
+			IL_017c: ldloc.3
+			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0182: stloc.s 13
+			IL_0184: ldloc.s 13
+			IL_0186: stloc.s 4
+			IL_0188: ldloc.s 4
+			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_018f: ldc.i4.0
+			IL_0190: ceq
+			IL_0192: stloc.s 15
+			IL_0194: ldloc.s 15
+			IL_0196: brfalse IL_01e0
+
+			IL_019b: ldarg.3
+			IL_019c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01a1: stloc.s 12
+			IL_01a3: ldstr "Could not determine tag name for id '"
+			IL_01a8: ldloc.s 12
+			IL_01aa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01af: stloc.s 12
+			IL_01b1: ldloc.s 12
+			IL_01b3: ldstr "'."
+			IL_01b8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01bd: stloc.s 12
+			IL_01bf: ldloc.s 12
+			IL_01c1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01cb: dup
+			IL_01cc: isinst [System.Runtime]System.Exception
+			IL_01d1: dup
+			IL_01d2: brtrue IL_01de
+
+			IL_01d7: pop
+			IL_01d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_01dd: throw
+
+			IL_01de: pop
+			IL_01df: throw
+
+			IL_01e0: ldnull
+			IL_01e1: ldloc.s 4
+			IL_01e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+			IL_01e8: stloc.s 13
+			IL_01ea: ldloc.s 13
+			IL_01ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01f1: stloc.s 12
+			IL_01f3: ldstr "<\\/?"
+			IL_01f8: ldloc.s 12
+			IL_01fa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ff: stloc.s 12
+			IL_0201: ldloc.s 12
+			IL_0203: ldstr "\\b[^>]*>"
+			IL_0208: call string [System.Runtime]System.String::Concat(string, string)
+			IL_020d: stloc.s 12
+			IL_020f: ldloc.s 12
+			IL_0211: ldstr "gi"
+			IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_021b: stloc.s 16
+			IL_021d: ldloc.s 16
+			IL_021f: stloc.s 5
+			IL_0221: ldloc.s 5
+			IL_0223: ldstr "lastIndex"
+			IL_0228: ldloc.3
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_022e: pop
+			IL_022f: ldc.r8 0.0
+			IL_0238: stloc.s 6
+			IL_023a: ldc.r8 1
+			IL_0243: neg
+			IL_0244: box [System.Runtime]System.Double
+			IL_0249: stloc.s 7
+			// loop start (head: IL_024b)
+				IL_024b: ldc.i4.1
+				IL_024c: brfalse IL_035d
+
+				IL_0251: ldloc.s 5
+				IL_0253: ldstr "exec"
+				IL_0258: ldarg.2
+				IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_025e: stloc.s 13
+				IL_0260: ldloc.s 13
+				IL_0262: stloc.s 8
+				IL_0264: ldloc.s 8
+				IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_026b: ldc.i4.0
+				IL_026c: ceq
+				IL_026e: stloc.s 15
+				IL_0270: ldloc.s 15
+				IL_0272: brfalse IL_027c
+
+				IL_0277: br IL_035d
+
+				IL_027c: ldloc.s 8
+				IL_027e: ldc.r8 0.0
+				IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_028c: stloc.s 9
+				IL_028e: ldloc.s 7
+				IL_0290: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0295: stloc.s 14
+				IL_0297: ldloc.s 14
+				IL_0299: ldc.r8 0.0
+				IL_02a2: clt
+				IL_02a4: brfalse IL_02bb
+
+				IL_02a9: ldloc.s 8
+				IL_02ab: ldstr "index"
+				IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02b5: stloc.s 13
+				IL_02b7: ldloc.s 13
+				IL_02b9: stloc.s 7
+
+				IL_02bb: ldloc.s 9
+				IL_02bd: ldstr "startsWith"
+				IL_02c2: ldstr "</"
+				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02cc: stloc.s 13
+				IL_02ce: ldloc.s 13
+				IL_02d0: stloc.s 10
+				IL_02d2: ldloc.s 10
+				IL_02d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d9: stloc.s 15
+				IL_02db: ldloc.s 15
+				IL_02dd: brfalse IL_034a
+
+				IL_02e2: ldloc.s 6
+				IL_02e4: ldc.r8 1
+				IL_02ed: sub
+				IL_02ee: stloc.s 6
+				IL_02f0: ldloc.s 6
+				IL_02f2: ldc.r8 0.0
+				IL_02fb: ceq
+				IL_02fd: brfalse IL_0345
+
+				IL_0302: ldloc.s 5
+				IL_0304: ldstr "lastIndex"
+				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_030e: stloc.s 11
+				IL_0310: ldarg.2
+				IL_0311: ldstr "substring"
+				IL_0316: ldloc.s 7
+				IL_0318: ldloc.s 11
+				IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_031f: stloc.s 13
+				IL_0321: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0326: dup
+				IL_0327: ldstr "tagName"
+				IL_032c: ldloc.s 4
+				IL_032e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0333: dup
+				IL_0334: ldstr "html"
+				IL_0339: ldloc.s 13
+				IL_033b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0340: stloc.s 17
+				IL_0342: ldloc.s 17
+				IL_0344: ret
+
+				IL_0345: br IL_0358
+
+				IL_034a: ldloc.s 6
+				IL_034c: ldc.r8 1
+				IL_0355: add
+				IL_0356: stloc.s 6
+
+				IL_0358: br IL_024b
+			// end loop
+
+			IL_035d: ldloc.s 4
+			IL_035f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0364: stloc.s 12
+			IL_0366: ldstr "Could not find a matching closing </"
+			IL_036b: ldloc.s 12
+			IL_036d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0372: stloc.s 12
+			IL_0374: ldloc.s 12
+			IL_0376: ldstr "> for id '"
+			IL_037b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0380: stloc.s 12
+			IL_0382: ldarg.3
+			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0388: stloc.s 18
+			IL_038a: ldloc.s 12
+			IL_038c: ldloc.s 18
+			IL_038e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0393: stloc.s 18
+			IL_0395: ldloc.s 18
+			IL_0397: ldstr "'."
+			IL_039c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03a1: stloc.s 18
+			IL_03a3: ldloc.s 18
+			IL_03a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03af: dup
+			IL_03b0: isinst [System.Runtime]System.Exception
+			IL_03b5: dup
+			IL_03b6: brtrue IL_03c2
+
+			IL_03bb: pop
+			IL_03bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03c1: throw
+
+			IL_03c2: pop
+			IL_03c3: throw
+
+			IL_03c4: ldnull
+			IL_03c5: ret
+		} // end of method extractElementById::__js_call__
+
+	} // end of class extractElementById
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolveSectionLinkFromMultipageIndexHtml
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b60
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object indexHtml,
+				object section
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x3cf8
+			// Header size: 12
+			// Code size: 452 (0x1c4)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] string,
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[12] bool,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] float64,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldarg.3
+			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+			IL_0007: stloc.s 9
+			IL_0009: ldloc.s 9
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0012: stloc.s 10
+			IL_0014: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_0019: ldloc.s 10
+			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0020: stloc.s 10
+			IL_0022: ldloc.s 10
+			IL_0024: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_0029: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002e: stloc.s 10
+			IL_0030: ldloc.s 10
+			IL_0032: ldstr "i"
+			IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_003c: stloc.s 11
+			IL_003e: ldloc.s 11
+			IL_0040: stloc.1
+			IL_0041: ldloc.1
+			IL_0042: ldstr "exec"
+			IL_0047: ldarg.2
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004d: stloc.s 9
+			IL_004f: ldloc.s 9
+			IL_0051: stloc.2
+			IL_0052: ldloc.2
+			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0058: stloc.s 12
+			IL_005a: ldloc.s 12
+			IL_005c: brfalse IL_00a5
+
+			IL_0061: ldloc.2
+			IL_0062: ldc.r8 1
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0070: stloc.s 9
+			IL_0072: ldloc.s 9
+			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0079: stloc.s 12
+			IL_007b: ldloc.s 12
+			IL_007d: brtrue IL_0098
+
+			IL_0082: ldloc.2
+			IL_0083: ldc.r8 2
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0091: stloc.s 14
+			IL_0093: br IL_009c
+
+			IL_0098: ldloc.s 9
+			IL_009a: stloc.s 14
+
+			IL_009c: ldloc.s 14
+			IL_009e: stloc.s 15
+			IL_00a0: br IL_00a8
+
+			IL_00a5: ldloc.2
+			IL_00a6: stloc.s 15
+
+			IL_00a8: ldloc.s 15
+			IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00af: stloc.s 12
+			IL_00b1: ldloc.s 12
+			IL_00b3: brtrue IL_00c4
+
+			IL_00b8: ldstr ""
+			IL_00bd: stloc.s 15
+			IL_00bf: br IL_00c4
+
+			IL_00c4: ldloc.s 15
+			IL_00c6: stloc.3
+			IL_00c7: ldloc.3
+			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00cd: ldc.i4.0
+			IL_00ce: ceq
+			IL_00d0: stloc.s 12
+			IL_00d2: ldloc.s 12
+			IL_00d4: brfalse IL_00e0
+
+			IL_00d9: ldc.i4.0
+			IL_00da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00df: ret
+
+			IL_00e0: ldloc.3
+			IL_00e1: ldstr "indexOf"
+			IL_00e6: ldstr "#"
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f0: stloc.s 9
+			IL_00f2: ldloc.s 9
+			IL_00f4: stloc.s 4
+			IL_00f6: ldloc.s 4
+			IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00fd: stloc.s 17
+			IL_00ff: ldloc.s 17
+			IL_0101: ldc.r8 0.0
+			IL_010a: clt
+			IL_010c: ldc.i4.0
+			IL_010d: ceq
+			IL_010f: brfalse IL_013a
+
+			IL_0114: ldloc.3
+			IL_0115: castclass [System.Runtime]System.String
+			IL_011a: ldc.r8 0.0
+			IL_0123: box [System.Runtime]System.Double
+			IL_0128: ldloc.s 4
+			IL_012a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_012f: stloc.s 10
+			IL_0131: ldloc.s 10
+			IL_0133: stloc.s 5
+			IL_0135: br IL_013d
+
+			IL_013a: ldloc.3
+			IL_013b: stloc.s 5
+
+			IL_013d: ldloc.s 5
+			IL_013f: stloc.s 6
+			IL_0141: ldloc.s 4
+			IL_0143: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0148: stloc.s 17
+			IL_014a: ldloc.s 17
+			IL_014c: ldc.r8 0.0
+			IL_0155: clt
+			IL_0157: ldc.i4.0
+			IL_0158: ceq
+			IL_015a: brfalse IL_0189
+
+			IL_015f: ldloc.s 4
+			IL_0161: ldc.r8 1
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_016f: stloc.s 15
+			IL_0171: ldloc.3
+			IL_0172: castclass [System.Runtime]System.String
+			IL_0177: ldloc.s 15
+			IL_0179: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_017e: stloc.s 10
+			IL_0180: ldloc.s 10
+			IL_0182: stloc.s 7
+			IL_0184: br IL_0190
+
+			IL_0189: ldstr ""
+			IL_018e: stloc.s 7
+
+			IL_0190: ldloc.s 7
+			IL_0192: stloc.s 8
+			IL_0194: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0199: dup
+			IL_019a: ldstr "href"
+			IL_019f: ldloc.3
+			IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01a5: dup
+			IL_01a6: ldstr "filePart"
+			IL_01ab: ldloc.s 6
+			IL_01ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01b2: dup
+			IL_01b3: ldstr "fragment"
+			IL_01b8: ldloc.s 8
+			IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01bf: stloc.s 18
+			IL_01c1: ldloc.s 18
+			IL_01c3: ret
+		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
+
+	} // end of class resolveSectionLinkFromMultipageIndexHtml
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolveSectionIdFromHtml
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L387C2
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b72
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L387C2::.ctor
+
+			} // end of class Block_L387C2
+
+			.class nested private auto ansi beforefieldinit Block_L398C2
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b7b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L398C2::.ctor
+
+			} // end of class Block_L398C2
+
+			.class nested private auto ansi beforefieldinit Block_L408C2
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b84
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L408C2::.ctor
+
+			} // end of class Block_L408C2
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b69
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object html,
+				object section
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x3ec8
+			// Header size: 12
+			// Code size: 586 (0x24a)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[6] object,
+				[7] object,
+				[8] string,
+				[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[10] bool,
+				[11] object,
+				[12] object,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] string,
+				[17] object,
+				[18] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldarg.3
+			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+			IL_0007: stloc.s 7
+			IL_0009: ldloc.s 7
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0012: stloc.s 8
+			IL_0014: ldstr "<a\\b[^>]*href=(?:\"[^\"]*#([^\"#]+)\"|'[^']*#([^'#]+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_0019: ldloc.s 8
+			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0020: stloc.s 8
+			IL_0022: ldloc.s 8
+			IL_0024: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_0029: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002e: stloc.s 8
+			IL_0030: ldloc.s 8
+			IL_0032: ldstr "i"
+			IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_003c: stloc.s 9
+			IL_003e: ldloc.s 9
+			IL_0040: stloc.1
+			IL_0041: ldloc.1
+			IL_0042: ldstr "exec"
+			IL_0047: ldarg.2
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
+			IL_0051: stloc.2
+			IL_0052: ldloc.2
+			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0058: stloc.s 10
+			IL_005a: ldloc.s 10
+			IL_005c: brfalse IL_00bb
+
+			IL_0061: ldloc.2
+			IL_0062: ldc.r8 1
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0070: stloc.s 7
+			IL_0072: ldloc.s 7
+			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0079: stloc.s 10
+			IL_007b: ldloc.s 10
+			IL_007d: brtrue IL_0098
+
+			IL_0082: ldloc.2
+			IL_0083: ldc.r8 2
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0091: stloc.s 12
+			IL_0093: br IL_009c
+
+			IL_0098: ldloc.s 7
+			IL_009a: stloc.s 12
+
+			IL_009c: ldloc.s 12
+			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00a3: stloc.s 10
+			IL_00a5: ldloc.s 10
+			IL_00a7: brtrue IL_00b8
+
+			IL_00ac: ldstr ""
+			IL_00b1: stloc.s 12
+			IL_00b3: br IL_00b8
+
+			IL_00b8: ldloc.s 12
+			IL_00ba: ret
+
+			IL_00bb: ldloc.0
+			IL_00bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c1: stloc.s 8
+			IL_00c3: ldstr "<emu-clause\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,8000}?<h[1-6]\\b[^>]*>[\\s\\S]{0,1200}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_00c8: ldloc.s 8
+			IL_00ca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00cf: stloc.s 8
+			IL_00d1: ldloc.s 8
+			IL_00d3: ldstr "\\s*<\\/span>[\\s\\S]{0,1200}?<\\/h[1-6]>"
+			IL_00d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00dd: stloc.s 8
+			IL_00df: ldloc.s 8
+			IL_00e1: ldstr "i"
+			IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00eb: stloc.s 9
+			IL_00ed: ldloc.s 9
+			IL_00ef: stloc.3
+			IL_00f0: ldloc.3
+			IL_00f1: ldstr "exec"
+			IL_00f6: ldarg.2
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00fc: stloc.s 7
+			IL_00fe: ldloc.s 7
+			IL_0100: stloc.s 4
+			IL_0102: ldloc.s 4
+			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0109: stloc.s 10
+			IL_010b: ldloc.s 10
+			IL_010d: brfalse IL_016e
+
+			IL_0112: ldloc.s 4
+			IL_0114: ldc.r8 1
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0122: stloc.s 7
+			IL_0124: ldloc.s 7
+			IL_0126: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_012b: stloc.s 10
+			IL_012d: ldloc.s 10
+			IL_012f: brtrue IL_014b
+
+			IL_0134: ldloc.s 4
+			IL_0136: ldc.r8 2
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0144: stloc.s 14
+			IL_0146: br IL_014f
+
+			IL_014b: ldloc.s 7
+			IL_014d: stloc.s 14
+
+			IL_014f: ldloc.s 14
+			IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0156: stloc.s 10
+			IL_0158: ldloc.s 10
+			IL_015a: brtrue IL_016b
+
+			IL_015f: ldstr ""
+			IL_0164: stloc.s 14
+			IL_0166: br IL_016b
+
+			IL_016b: ldloc.s 14
+			IL_016d: ret
+
+			IL_016e: ldloc.0
+			IL_016f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0174: stloc.s 8
+			IL_0176: ldstr "<h[1-6]\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,1200}?(?:\\s*"
+			IL_017b: ldloc.s 8
+			IL_017d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0182: stloc.s 8
+			IL_0184: ldloc.s 8
+			IL_0186: ldstr "\\b|<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_018b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0190: stloc.s 8
+			IL_0192: ldloc.0
+			IL_0193: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0198: stloc.s 16
+			IL_019a: ldloc.s 8
+			IL_019c: ldloc.s 16
+			IL_019e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a3: stloc.s 16
+			IL_01a5: ldloc.s 16
+			IL_01a7: ldstr "\\s*<\\/span>)"
+			IL_01ac: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01b1: stloc.s 16
+			IL_01b3: ldloc.s 16
+			IL_01b5: ldstr "i"
+			IL_01ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01bf: stloc.s 9
+			IL_01c1: ldloc.s 9
+			IL_01c3: stloc.s 5
+			IL_01c5: ldloc.s 5
+			IL_01c7: ldstr "exec"
+			IL_01cc: ldarg.2
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01d2: stloc.s 7
+			IL_01d4: ldloc.s 7
+			IL_01d6: stloc.s 6
+			IL_01d8: ldloc.s 6
+			IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01df: stloc.s 10
+			IL_01e1: ldloc.s 10
+			IL_01e3: brfalse IL_0244
+
+			IL_01e8: ldloc.s 6
+			IL_01ea: ldc.r8 1
+			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01f8: stloc.s 7
+			IL_01fa: ldloc.s 7
+			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0201: stloc.s 10
+			IL_0203: ldloc.s 10
+			IL_0205: brtrue IL_0221
+
+			IL_020a: ldloc.s 6
+			IL_020c: ldc.r8 2
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_021a: stloc.s 17
+			IL_021c: br IL_0225
+
+			IL_0221: ldloc.s 7
+			IL_0223: stloc.s 17
+
+			IL_0225: ldloc.s 17
+			IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_022c: stloc.s 10
+			IL_022e: ldloc.s 10
+			IL_0230: brtrue IL_0241
+
+			IL_0235: ldstr ""
+			IL_023a: stloc.s 17
+			IL_023c: br IL_0241
+
+			IL_0241: ldloc.s 17
+			IL_0243: ret
+
+			IL_0244: ldstr ""
+			IL_0249: ret
+		} // end of method resolveSectionIdFromHtml::__js_call__
+
+	} // end of class resolveSectionIdFromHtml
+
+	.class nested public auto ansi abstract sealed beforefieldinit wrapAsStandaloneHtml
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b8d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object extractedHtml,
+				object options
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x4120
+			// Header size: 12
+			// Code size: 295 (0x127)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] string,
+				[5] object,
+				[6] bool,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] string,
+				[11] string
+			)
+
+			IL_0000: ldarg.2
+			IL_0001: ldstr "title"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000b: stloc.s 5
+			IL_000d: ldloc.s 5
+			IL_000f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0014: stloc.s 6
+			IL_0016: ldloc.s 6
+			IL_0018: brtrue IL_0029
+
+			IL_001d: ldstr "ECMA-262 Section Extract"
+			IL_0022: stloc.s 8
+			IL_0024: br IL_002d
+
+			IL_0029: ldloc.s 5
+			IL_002b: stloc.s 8
+
+			IL_002d: ldloc.s 8
+			IL_002f: stloc.0
+			IL_0030: ldarg.2
+			IL_0031: ldstr "baseHref"
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003b: stloc.s 5
+			IL_003d: ldloc.s 5
+			IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0044: stloc.s 6
+			IL_0046: ldloc.s 6
+			IL_0048: brtrue IL_0059
+
+			IL_004d: ldstr ""
+			IL_0052: stloc.s 9
+			IL_0054: br IL_005d
+
+			IL_0059: ldloc.s 5
+			IL_005b: stloc.s 9
+
+			IL_005d: ldloc.s 9
+			IL_005f: stloc.1
+			IL_0060: ldloc.1
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0066: stloc.s 6
+			IL_0068: ldloc.s 6
+			IL_006a: brfalse IL_009b
+
+			IL_006f: ldloc.1
+			IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0075: stloc.s 10
+			IL_0077: ldstr "  <base href=\""
+			IL_007c: ldloc.s 10
+			IL_007e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0083: stloc.s 10
+			IL_0085: ldloc.s 10
+			IL_0087: ldstr "\">\n"
+			IL_008c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0091: stloc.s 10
+			IL_0093: ldloc.s 10
+			IL_0095: stloc.2
+			IL_0096: br IL_00a1
+
+			IL_009b: ldstr ""
+			IL_00a0: stloc.2
+
+			IL_00a1: ldloc.2
+			IL_00a2: stloc.3
+			IL_00a3: ldstr "  <style>\n    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }\n    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }\n    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }\n    table { border-collapse: collapse; }\n    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }\n    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }\n    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }\n  </style>\n"
+			IL_00a8: stloc.s 4
+			IL_00aa: ldloc.3
+			IL_00ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b0: stloc.s 10
+			IL_00b2: ldstr "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+			IL_00b7: ldloc.s 10
+			IL_00b9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00be: stloc.s 10
+			IL_00c0: ldloc.s 4
+			IL_00c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c7: stloc.s 11
+			IL_00c9: ldloc.s 10
+			IL_00cb: ldloc.s 11
+			IL_00cd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00d2: stloc.s 11
+			IL_00d4: ldloc.s 11
+			IL_00d6: ldstr "  <title>"
+			IL_00db: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00e0: stloc.s 11
+			IL_00e2: ldloc.0
+			IL_00e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e8: stloc.s 10
+			IL_00ea: ldloc.s 11
+			IL_00ec: ldloc.s 10
+			IL_00ee: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00f3: stloc.s 10
+			IL_00f5: ldloc.s 10
+			IL_00f7: ldstr "</title>\n</head>\n<body>\n"
+			IL_00fc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0101: stloc.s 10
+			IL_0103: ldarg.1
+			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0109: stloc.s 11
+			IL_010b: ldloc.s 10
+			IL_010d: ldloc.s 11
+			IL_010f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0114: stloc.s 11
+			IL_0116: ldloc.s 11
+			IL_0118: ldstr "\n</body>\n</html>\n"
+			IL_011d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0122: stloc.s 11
+			IL_0124: ldloc.s 11
+			IL_0126: ret
+		} // end of method wrapAsStandaloneHtml::__js_call__
+
+	} // end of class wrapAsStandaloneHtml
+
+	.class nested public auto ansi abstract sealed beforefieldinit printHelp
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b96
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x4254
+			// Header size: 12
+			// Code size: 322 (0x142)
+			.maxstack 8
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: ldstr "Extract a section's HTML from a locally saved ECMA-262 multipage HTML file."
+			IL_000a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_000f: pop
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0015: ldstr "You can also fetch the input HTML from the web using Node's built-in fetch/https."
+			IL_001a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_001f: pop
+			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0025: ldstr ""
+			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_002f: pop
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0035: ldstr "Usage:"
+			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_003f: pop
+			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0045: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --in <input.html> --out <output.html>"
+			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_004f: pop
+			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0055: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --url <https://...> --out <output.html>"
+			IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_005f: pop
+			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0065: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --auto --out <output.html>"
+			IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_006f: pop
+			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0075: ldstr ""
+			IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_007f: pop
+			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0085: ldstr "Options:"
+			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_008f: pop
+			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0095: ldstr "  --section, -s   Section number to extract (e.g. 27.3)"
+			IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_009f: pop
+			IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00a5: ldstr "  --in, -i        Input HTML file path"
+			IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00af: pop
+			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00b5: ldstr "  --url, -u       Fetch input HTML from URL instead of --in"
+			IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00bf: pop
+			IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00c5: ldstr "  --auto          Auto-discover the correct multipage URL from the multipage index"
+			IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00cf: pop
+			IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00d5: ldstr "  --index-url     Multipage index URL used by --auto (default: https://tc39.es/ecma262/multipage/)"
+			IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00df: pop
+			IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00e5: ldstr "  --out, -o       Output file path"
+			IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00ef: pop
+			IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00f5: ldstr "  --id            Explicit element id to extract (e.g. sec-generatorfunction-objects)"
+			IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00ff: pop
+			IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0105: ldstr "  --wrap          Wrap output as standalone HTML (default)"
+			IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_010f: pop
+			IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0115: ldstr "  --no-wrap       Output only the extracted element HTML"
+			IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_011f: pop
+			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0125: ldstr "  --base          Optional <base href=\"...\"> to inject when wrapping"
+			IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_012f: pop
+			IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0135: ldstr "  --help, -h      Show help"
+			IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_013f: pop
+			IL_0140: ldnull
+			IL_0141: ret
+		} // end of method printHelp::__js_call__
+
+	} // end of class printHelp
+
+	.class nested public auto ansi abstract sealed beforefieldinit main
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L492C92
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+					01 00 12 53 63 6f 70 65 20 61 3d 7b 61 7d 2c 20
+					62 3d 7b 62 7d 00 00
+				)
+				// Fields
+				.field public object a
+				.field public object b
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bc3
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					object a,
+					object b
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+					01 00 00 00 00 00 00 00
+				)
+				// Method begins at RVA 0x5408
+				// Header size: 12
+				// Code size: 10 (0xa)
+				.maxstack 8
+				.locals init (
+					[0] object
+				)
+
+				IL_0000: ldarg.1
+				IL_0001: ldarg.2
+				IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0007: stloc.0
+				IL_0008: ldloc.0
+				IL_0009: ret
+			} // end of method ArrowFunction_L492C92::__js_call__
+
+		} // end of class ArrowFunction_L492C92
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 80 c1 53 63 6f 70 65 20 5f 61 77 61 69 74
+				65 64 31 3d 7b 5f 61 77 61 69 74 65 64 31 7d 2c
+				20 5f 61 77 61 69 74 65 64 32 3d 7b 5f 61 77 61
+				69 74 65 64 32 7d 2c 20 5f 61 77 61 69 74 65 64
+				33 3d 7b 5f 61 77 61 69 74 65 64 33 7d 2c 20 5f
+				61 77 61 69 74 65 64 34 3d 7b 5f 61 77 61 69 74
+				65 64 34 7d 2c 20 5f 61 77 61 69 74 65 64 35 3d
+				7b 5f 61 77 61 69 74 65 64 35 7d 2c 20 5f 61 77
+				61 69 74 65 64 36 3d 7b 5f 61 77 61 69 74 65 64
+				36 7d 2c 20 5f 61 77 61 69 74 65 64 37 3d 7b 5f
+				61 77 61 69 74 65 64 37 7d 2c 20 5f 61 77 61 69
+				74 65 64 38 3d 7b 5f 61 77 61 69 74 65 64 38 7d
+				2c 20 e2 80 a6 00 00
+			)
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L478C17
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5ba8
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L478C17::.ctor
+
+			} // end of class Block_L478C17
+
+			.class nested private auto ansi beforefieldinit Block_L483C21
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bb1
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L483C21::.ctor
+
+			} // end of class Block_L483C21
+
+			.class nested private auto ansi beforefieldinit Block_L488C33
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bba
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L488C33::.ctor
+
+			} // end of class Block_L488C33
+
+			.class nested private auto ansi beforefieldinit Block_L493C28
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bcc
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L493C28::.ctor
+
+			} // end of class Block_L493C28
+
+			.class nested private auto ansi beforefieldinit Block_L497C21
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bd5
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L497C21::.ctor
+
+			} // end of class Block_L497C21
+
+			.class nested private auto ansi beforefieldinit Block_L507C17
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L509C19
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5be7
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L509C19::.ctor
+
+				} // end of class Block_L509C19
+
+				.class nested private auto ansi beforefieldinit Block_L515C15
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5bf0
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L515C15::.ctor
+
+				} // end of class Block_L515C15
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bde
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L507C17::.ctor
+
+			} // end of class Block_L507C17
+
+			.class nested private auto ansi beforefieldinit Block_L524C23
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bf9
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L524C23::.ctor
+
+			} // end of class Block_L524C23
+
+			.class nested private auto ansi beforefieldinit Block_L528C9
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L530C35
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5c0b
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L530C35::.ctor
+
+				} // end of class Block_L530C35
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c02
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L528C9::.ctor
+
+			} // end of class Block_L528C9
+
+			.class nested private auto ansi beforefieldinit Block_L537C48
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c14
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L537C48::.ctor
+
+			} // end of class Block_L537C48
+
+			.class nested private auto ansi beforefieldinit Block_L541C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c1d
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L541C18::.ctor
+
+			} // end of class Block_L541C18
+
+			.class nested private auto ansi beforefieldinit Block_L545C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c26
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L545C18::.ctor
+
+			} // end of class Block_L545C18
+
+			.class nested private auto ansi beforefieldinit Block_L554C17
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c2f
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L554C17::.ctor
+
+			} // end of class Block_L554C17
+
+
+			// Fields
+			.field public object _awaited1
+			.field public object _awaited2
+			.field public object _awaited3
+			.field public object _awaited4
+			.field public object _awaited5
+			.field public object _awaited6
+			.field public object _awaited7
+			.field public object _awaited8
+			.field public object _awaited9
+			.field public object _awaited10
+			.field public object _awaited11
+			.field public object _awaited12
+			.field public object _awaited13
+			.field public object _awaited14
+			.field public object _awaited15
+			.field public object _awaited16
+			.field public object _awaited17
+			.field public object _awaited18
+			.field public object _awaited19
+			.field public object _awaited20
+			.field public object _awaited21
+			.field public object _awaited22
+			.field public object _awaited23
+			.field public object _awaited24
+			.field public object _awaited25
+			.field public object _awaited26
+			.field public object _awaited27
+			.field public object _awaited28
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b9f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget,
+				object argv,
+				object logger
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x43a4
+			// Header size: 12
+			// Code size: 3479 (0xd97)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] string,
+				[9] string,
+				[10] object,
+				[11] object,
+				[12] object,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] object,
+				[18] object,
+				[19] object,
+				[20] object,
+				[21] bool,
+				[22] object,
+				[23] object,
+				[24] object,
+				[25] object,
+				[26] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[27] object,
+				[28] object,
+				[29] string,
+				[30] string,
+				[31] class [System.Runtime]System.Delegate,
+				[32] object,
+				[33] object[],
+				[34] object,
+				[35] object,
+				[36] object,
+				[37] object,
+				[38] object,
+				[39] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope
+			IL_0008: dup
+			IL_0009: brtrue IL_0049
+
+			IL_000e: pop
+			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::.ctor()
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: ldarg.0
+			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
+			IL_001c: starg.s scopes
+			IL_001e: ldloc.0
+			IL_001f: ldnull
+			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+			IL_002b: ldarg.0
+			IL_002c: ldc.i4.2
+			IL_002d: newarr [System.Runtime]System.Object
+			IL_0032: dup
+			IL_0033: ldc.i4.0
+			IL_0034: ldarg.2
+			IL_0035: stelem.ref
+			IL_0036: dup
+			IL_0037: ldc.i4.1
+			IL_0038: ldarg.3
+			IL_0039: stelem.ref
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindMoveNext(object, object[], object[])
+			IL_003f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0044: br IL_004a
+
+			IL_0049: stloc.0
+
+			IL_004a: ldloc.0
+			IL_004b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0050: brtrue IL_0062
+
+			IL_0055: ldloc.0
+			IL_0056: ldc.i4.s 19
+			IL_0058: newarr [System.Runtime]System.Object
+			IL_005d: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+
+			IL_0062: ldloc.0
+			IL_0063: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0068: ldc.i4.0
+			IL_0069: ble.s IL_00e2
+
+			IL_006b: ldloc.0
+			IL_006c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0071: dup
+			IL_0072: ldc.i4.0
+			IL_0073: ldelem.ref
+			IL_0074: stloc.1
+			IL_0075: dup
+			IL_0076: ldc.i4.1
+			IL_0077: ldelem.ref
+			IL_0078: stloc.2
+			IL_0079: dup
+			IL_007a: ldc.i4.2
+			IL_007b: ldelem.ref
+			IL_007c: stloc.3
+			IL_007d: dup
+			IL_007e: ldc.i4.3
+			IL_007f: ldelem.ref
+			IL_0080: stloc.s 4
+			IL_0082: dup
+			IL_0083: ldc.i4.4
+			IL_0084: ldelem.ref
+			IL_0085: stloc.s 5
+			IL_0087: dup
+			IL_0088: ldc.i4.5
+			IL_0089: ldelem.ref
+			IL_008a: stloc.s 6
+			IL_008c: dup
+			IL_008d: ldc.i4.6
+			IL_008e: ldelem.ref
+			IL_008f: stloc.s 7
+			IL_0091: dup
+			IL_0092: ldc.i4.7
+			IL_0093: ldelem.ref
+			IL_0094: castclass [System.Runtime]System.String
+			IL_0099: stloc.s 8
+			IL_009b: dup
+			IL_009c: ldc.i4.8
+			IL_009d: ldelem.ref
+			IL_009e: castclass [System.Runtime]System.String
+			IL_00a3: stloc.s 9
+			IL_00a5: dup
+			IL_00a6: ldc.i4.s 9
+			IL_00a8: ldelem.ref
+			IL_00a9: stloc.s 10
+			IL_00ab: dup
+			IL_00ac: ldc.i4.s 10
+			IL_00ae: ldelem.ref
+			IL_00af: stloc.s 11
+			IL_00b1: dup
+			IL_00b2: ldc.i4.s 11
+			IL_00b4: ldelem.ref
+			IL_00b5: stloc.s 12
+			IL_00b7: dup
+			IL_00b8: ldc.i4.s 12
+			IL_00ba: ldelem.ref
+			IL_00bb: stloc.s 13
+			IL_00bd: dup
+			IL_00be: ldc.i4.s 13
+			IL_00c0: ldelem.ref
+			IL_00c1: stloc.s 14
+			IL_00c3: dup
+			IL_00c4: ldc.i4.s 14
+			IL_00c6: ldelem.ref
+			IL_00c7: stloc.s 15
+			IL_00c9: dup
+			IL_00ca: ldc.i4.s 15
+			IL_00cc: ldelem.ref
+			IL_00cd: stloc.s 16
+			IL_00cf: dup
+			IL_00d0: ldc.i4.s 16
+			IL_00d2: ldelem.ref
+			IL_00d3: stloc.s 17
+			IL_00d5: dup
+			IL_00d6: ldc.i4.s 17
+			IL_00d8: ldelem.ref
+			IL_00d9: stloc.s 18
+			IL_00db: dup
+			IL_00dc: ldc.i4.s 18
+			IL_00de: ldelem.ref
+			IL_00df: stloc.s 19
+			IL_00e1: pop
+
+			IL_00e2: ldloc.0
+			IL_00e3: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00e8: switch (IL_00fd, IL_060d, IL_0846, IL_094b)
+
+			IL_00fd: ldarg.2
+			IL_00fe: brtrue IL_0114
+
+			IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0108: ldstr "argv"
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0112: starg.s argv
+
+			IL_0114: ldarg.3
+			IL_0115: brtrue IL_012b
+
+			IL_011a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_011f: ldstr "log"
+			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0129: starg.s logger
+
+			IL_012b: ldc.i4.1
+			IL_012c: newarr [System.Runtime]System.Object
+			IL_0131: dup
+			IL_0132: ldc.i4.0
+			IL_0133: ldarg.0
+			IL_0134: ldc.i4.1
+			IL_0135: ldelem.ref
+			IL_0136: stelem.ref
+			IL_0137: ldc.i4.0
+			IL_0138: ldelem.ref
+			IL_0139: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_013e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0149: ldnull
+			IL_014a: ldarg.2
+			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0150: stloc.s 20
+			IL_0152: ldloc.s 20
+			IL_0154: stloc.1
+			IL_0155: ldloc.1
+			IL_0156: ldstr "help"
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0165: stloc.s 21
+			IL_0167: ldloc.s 21
+			IL_0169: brfalse IL_01a4
+
+			IL_016e: ldnull
+			IL_016f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/printHelp::__js_call__(object)
+			IL_0174: pop
+			IL_0175: ldloc.0
+			IL_0176: ldc.i4.m1
+			IL_0177: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_017c: ldloc.0
+			IL_017d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0187: ldarg.0
+			IL_0188: ldc.i4.1
+			IL_0189: newarr [System.Runtime]System.Object
+			IL_018e: dup
+			IL_018f: ldc.i4.0
+			IL_0190: ldnull
+			IL_0191: stelem.ref
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0197: pop
+			IL_0198: ldloc.0
+			IL_0199: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_019e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01a3: ret
+
+			IL_01a4: ldloc.1
+			IL_01a5: ldstr "section"
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01b4: ldc.i4.0
+			IL_01b5: ceq
+			IL_01b7: stloc.s 21
+			IL_01b9: ldloc.s 21
+			IL_01bb: brfalse IL_0201
+
+			IL_01c0: ldstr "Missing required --section (e.g. 27.3)."
+			IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01cf: stloc.s 20
+			IL_01d1: ldloc.0
+			IL_01d2: ldc.i4.m1
+			IL_01d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01d8: ldloc.0
+			IL_01d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01e3: ldarg.0
+			IL_01e4: ldc.i4.1
+			IL_01e5: newarr [System.Runtime]System.Object
+			IL_01ea: dup
+			IL_01eb: ldc.i4.0
+			IL_01ec: ldloc.s 20
+			IL_01ee: stelem.ref
+			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01f4: pop
+			IL_01f5: ldloc.0
+			IL_01f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0200: ret
+
+			IL_0201: ldloc.1
+			IL_0202: ldstr "inFile"
+			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0211: ldc.i4.0
+			IL_0212: ceq
+			IL_0214: stloc.s 21
+			IL_0216: ldloc.s 21
+			IL_0218: box [System.Runtime]System.Boolean
+			IL_021d: stloc.s 22
+			IL_021f: ldloc.s 22
+			IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0226: stloc.s 21
+			IL_0228: ldloc.s 21
+			IL_022a: brfalse IL_0256
+
+			IL_022f: ldloc.1
+			IL_0230: ldstr "url"
+			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_023f: ldc.i4.0
+			IL_0240: ceq
+			IL_0242: stloc.s 21
+			IL_0244: ldloc.s 21
+			IL_0246: box [System.Runtime]System.Boolean
+			IL_024b: stloc.s 23
+			IL_024d: ldloc.s 23
+			IL_024f: stloc.s 25
+			IL_0251: br IL_025a
+
+			IL_0256: ldloc.s 22
+			IL_0258: stloc.s 25
+
+			IL_025a: ldloc.s 25
+			IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0261: stloc.s 21
+			IL_0263: ldloc.s 21
+			IL_0265: brfalse IL_027c
+
+			IL_026a: ldloc.1
+			IL_026b: ldstr "auto"
+			IL_0270: ldc.i4.1
+			IL_0271: box [System.Runtime]System.Boolean
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_027b: pop
+
+			IL_027c: ldloc.1
+			IL_027d: ldstr "inFile"
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_028c: stloc.s 21
+			IL_028e: ldloc.s 21
+			IL_0290: brfalse IL_02a9
+
+			IL_0295: ldc.r8 1
+			IL_029e: box [System.Runtime]System.Double
+			IL_02a3: stloc.2
+			IL_02a4: br IL_02b8
+
+			IL_02a9: ldc.r8 0.0
+			IL_02b2: box [System.Runtime]System.Double
+			IL_02b7: stloc.2
+
+			IL_02b8: ldloc.1
+			IL_02b9: ldstr "url"
+			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02c8: stloc.s 21
+			IL_02ca: ldloc.s 21
+			IL_02cc: brfalse IL_02e5
+
+			IL_02d1: ldc.r8 1
+			IL_02da: box [System.Runtime]System.Double
+			IL_02df: stloc.3
+			IL_02e0: br IL_02f4
+
+			IL_02e5: ldc.r8 0.0
+			IL_02ee: box [System.Runtime]System.Double
+			IL_02f3: stloc.3
+
+			IL_02f4: ldloc.1
+			IL_02f5: ldstr "auto"
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0304: stloc.s 21
+			IL_0306: ldloc.s 21
+			IL_0308: brfalse IL_0322
+
+			IL_030d: ldc.r8 1
+			IL_0316: box [System.Runtime]System.Double
+			IL_031b: stloc.s 4
+			IL_031d: br IL_0332
+
+			IL_0322: ldc.r8 0.0
+			IL_032b: box [System.Runtime]System.Double
+			IL_0330: stloc.s 4
+
+			IL_0332: ldc.i4.3
+			IL_0333: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0338: dup
+			IL_0339: ldloc.2
+			IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_033f: dup
+			IL_0340: ldloc.3
+			IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0346: dup
+			IL_0347: ldloc.s 4
+			IL_0349: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_034e: stloc.s 26
+			IL_0350: ldnull
+			IL_0351: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/ArrowFunction_L492C92::__js_call__(object, object, object)
+			IL_0357: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_035c: ldc.i4.1
+			IL_035d: newarr [System.Runtime]System.Object
+			IL_0362: dup
+			IL_0363: ldc.i4.0
+			IL_0364: ldarg.0
+			IL_0365: ldc.i4.1
+			IL_0366: ldelem.ref
+			IL_0367: stelem.ref
+			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0372: stloc.s 20
+			IL_0374: ldloc.s 26
+			IL_0376: ldc.i4.2
+			IL_0377: newarr [System.Runtime]System.Object
+			IL_037c: dup
+			IL_037d: ldc.i4.0
+			IL_037e: ldloc.s 20
+			IL_0380: stelem.ref
+			IL_0381: dup
+			IL_0382: ldc.i4.1
+			IL_0383: ldc.r8 0.0
+			IL_038c: box [System.Runtime]System.Double
+			IL_0391: stelem.ref
+			IL_0392: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::reduce(object[])
+			IL_0397: stloc.s 20
+			IL_0399: ldloc.s 20
+			IL_039b: stloc.s 5
+			IL_039d: ldloc.s 5
+			IL_039f: ldc.r8 1
+			IL_03a8: box [System.Runtime]System.Double
+			IL_03ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03b2: stloc.s 21
+			IL_03b4: ldloc.s 21
+			IL_03b6: brfalse IL_03fc
+
+			IL_03bb: ldstr "Provide exactly one input mode: --in, --url, or --auto."
+			IL_03c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03ca: stloc.s 20
+			IL_03cc: ldloc.0
+			IL_03cd: ldc.i4.m1
+			IL_03ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03d3: ldloc.0
+			IL_03d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_03de: ldarg.0
+			IL_03df: ldc.i4.1
+			IL_03e0: newarr [System.Runtime]System.Object
+			IL_03e5: dup
+			IL_03e6: ldc.i4.0
+			IL_03e7: ldloc.s 20
+			IL_03e9: stelem.ref
+			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03ef: pop
+			IL_03f0: ldloc.0
+			IL_03f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03fb: ret
+
+			IL_03fc: ldloc.1
+			IL_03fd: ldstr "outFile"
+			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0407: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_040c: ldc.i4.0
+			IL_040d: ceq
+			IL_040f: stloc.s 21
+			IL_0411: ldloc.s 21
+			IL_0413: brfalse IL_0459
+
+			IL_0418: ldstr "Missing required --out <output.html>."
+			IL_041d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0422: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0427: stloc.s 20
+			IL_0429: ldloc.0
+			IL_042a: ldc.i4.m1
+			IL_042b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0430: ldloc.0
+			IL_0431: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0436: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_043b: ldarg.0
+			IL_043c: ldc.i4.1
+			IL_043d: newarr [System.Runtime]System.Object
+			IL_0442: dup
+			IL_0443: ldc.i4.0
+			IL_0444: ldloc.s 20
+			IL_0446: stelem.ref
+			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_044c: pop
+			IL_044d: ldloc.0
+			IL_044e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0453: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0458: ret
+
+			IL_0459: ldarg.0
+			IL_045a: ldc.i4.1
+			IL_045b: ldelem.ref
+			IL_045c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0461: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
+			IL_0466: stloc.s 20
+			IL_0468: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_046d: ldstr "cwd"
+			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0477: stloc.s 27
+			IL_0479: ldloc.s 20
+			IL_047b: ldstr "resolve"
+			IL_0480: ldloc.s 27
+			IL_0482: ldloc.1
+			IL_0483: ldstr "outFile"
+			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0492: stloc.s 27
+			IL_0494: ldloc.s 27
+			IL_0496: stloc.s 6
+			IL_0498: ldnull
+			IL_0499: stloc.s 7
+			IL_049b: ldstr ""
+			IL_04a0: stloc.s 8
+			IL_04a2: ldstr ""
+			IL_04a7: stloc.s 9
+			IL_04a9: ldloc.1
+			IL_04aa: ldstr "auto"
+			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04b9: stloc.s 21
+			IL_04bb: ldloc.s 21
+			IL_04bd: brfalse IL_085f
+
+			IL_04c2: ldloc.1
+			IL_04c3: ldstr "indexUrl"
+			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04cd: stloc.s 27
+			IL_04cf: ldloc.s 27
+			IL_04d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04d6: stloc.s 21
+			IL_04d8: ldloc.s 21
+			IL_04da: brtrue IL_04eb
+
+			IL_04df: ldstr "https://tc39.es/ecma262/multipage/"
+			IL_04e4: stloc.s 28
+			IL_04e6: br IL_04ef
+
+			IL_04eb: ldloc.s 27
+			IL_04ed: stloc.s 28
+
+			IL_04ef: ldloc.s 28
+			IL_04f1: castclass [System.Runtime]System.String
+			IL_04f6: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_04fb: stloc.s 29
+			IL_04fd: ldloc.s 29
+			IL_04ff: stloc.s 10
+			IL_0501: ldloc.s 10
+			IL_0503: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0508: ldc.i4.0
+			IL_0509: ceq
+			IL_050b: stloc.s 21
+			IL_050d: ldloc.s 21
+			IL_050f: brfalse IL_0555
+
+			IL_0514: ldstr "Missing --index-url value."
+			IL_0519: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_051e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0523: stloc.s 27
+			IL_0525: ldloc.0
+			IL_0526: ldc.i4.m1
+			IL_0527: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_052c: ldloc.0
+			IL_052d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0532: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0537: ldarg.0
+			IL_0538: ldc.i4.1
+			IL_0539: newarr [System.Runtime]System.Object
+			IL_053e: dup
+			IL_053f: ldc.i4.0
+			IL_0540: ldloc.s 27
+			IL_0542: stelem.ref
+			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0548: pop
+			IL_0549: ldloc.0
+			IL_054a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_054f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0554: ret
+
+			IL_0555: ldc.i4.1
+			IL_0556: newarr [System.Runtime]System.Object
+			IL_055b: dup
+			IL_055c: ldc.i4.0
+			IL_055d: ldarg.0
+			IL_055e: ldc.i4.1
+			IL_055f: ldelem.ref
+			IL_0560: stelem.ref
+			IL_0561: ldc.i4.0
+			IL_0562: ldelem.ref
+			IL_0563: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0568: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+			IL_056e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0573: ldnull
+			IL_0574: ldloc.s 10
+			IL_0576: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_057b: stloc.s 27
+			IL_057d: ldloc.0
+			IL_057e: ldc.i4.1
+			IL_057f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0584: ldloc.0
+			IL_0585: ldloc.s 27
+			IL_0587: ldarg.0
+			IL_0588: ldc.i4.1
+			IL_0589: ldloc.0
+			IL_058a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_058f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0594: ldloc.0
+			IL_0595: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_059a: dup
+			IL_059b: ldc.i4.0
+			IL_059c: ldloc.1
+			IL_059d: stelem.ref
+			IL_059e: dup
+			IL_059f: ldc.i4.1
+			IL_05a0: ldloc.2
+			IL_05a1: stelem.ref
+			IL_05a2: dup
+			IL_05a3: ldc.i4.2
+			IL_05a4: ldloc.3
+			IL_05a5: stelem.ref
+			IL_05a6: dup
+			IL_05a7: ldc.i4.3
+			IL_05a8: ldloc.s 4
+			IL_05aa: stelem.ref
+			IL_05ab: dup
+			IL_05ac: ldc.i4.4
+			IL_05ad: ldloc.s 5
+			IL_05af: stelem.ref
+			IL_05b0: dup
+			IL_05b1: ldc.i4.5
+			IL_05b2: ldloc.s 6
+			IL_05b4: stelem.ref
+			IL_05b5: dup
+			IL_05b6: ldc.i4.6
+			IL_05b7: ldloc.s 7
+			IL_05b9: stelem.ref
+			IL_05ba: dup
+			IL_05bb: ldc.i4.7
+			IL_05bc: ldloc.s 8
+			IL_05be: stelem.ref
+			IL_05bf: dup
+			IL_05c0: ldc.i4.8
+			IL_05c1: ldloc.s 9
+			IL_05c3: stelem.ref
+			IL_05c4: dup
+			IL_05c5: ldc.i4.s 9
+			IL_05c7: ldloc.s 10
+			IL_05c9: stelem.ref
+			IL_05ca: dup
+			IL_05cb: ldc.i4.s 10
+			IL_05cd: ldloc.s 11
+			IL_05cf: stelem.ref
+			IL_05d0: dup
+			IL_05d1: ldc.i4.s 11
+			IL_05d3: ldloc.s 12
+			IL_05d5: stelem.ref
+			IL_05d6: dup
+			IL_05d7: ldc.i4.s 12
+			IL_05d9: ldloc.s 13
+			IL_05db: stelem.ref
+			IL_05dc: dup
+			IL_05dd: ldc.i4.s 13
+			IL_05df: ldloc.s 14
+			IL_05e1: stelem.ref
+			IL_05e2: dup
+			IL_05e3: ldc.i4.s 14
+			IL_05e5: ldloc.s 15
+			IL_05e7: stelem.ref
+			IL_05e8: dup
+			IL_05e9: ldc.i4.s 15
+			IL_05eb: ldloc.s 16
+			IL_05ed: stelem.ref
+			IL_05ee: dup
+			IL_05ef: ldc.i4.s 16
+			IL_05f1: ldloc.s 17
+			IL_05f3: stelem.ref
+			IL_05f4: dup
+			IL_05f5: ldc.i4.s 17
+			IL_05f7: ldloc.s 18
+			IL_05f9: stelem.ref
+			IL_05fa: dup
+			IL_05fb: ldc.i4.s 18
+			IL_05fd: ldloc.s 19
+			IL_05ff: stelem.ref
+			IL_0600: pop
+			IL_0601: ldloc.0
+			IL_0602: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0607: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_060c: ret
+
+			IL_060d: ldloc.0
+			IL_060e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited1
+			IL_0613: stloc.s 27
+			IL_0615: ldloc.s 27
+			IL_0617: stloc.s 11
+			IL_0619: ldloc.1
+			IL_061a: ldstr "section"
+			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0624: ldstr "trim"
+			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_062e: stloc.s 27
+			IL_0630: ldc.i4.1
+			IL_0631: newarr [System.Runtime]System.Object
+			IL_0636: dup
+			IL_0637: ldc.i4.0
+			IL_0638: ldarg.0
+			IL_0639: ldc.i4.1
+			IL_063a: ldelem.ref
+			IL_063b: stelem.ref
+			IL_063c: ldc.i4.0
+			IL_063d: ldelem.ref
+			IL_063e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0643: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0649: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_064e: ldnull
+			IL_064f: ldloc.s 11
+			IL_0651: ldloc.s 27
+			IL_0653: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0658: stloc.s 27
+			IL_065a: ldloc.s 27
+			IL_065c: stloc.s 12
+			IL_065e: ldloc.s 12
+			IL_0660: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0665: ldc.i4.0
+			IL_0666: ceq
+			IL_0668: stloc.s 21
+			IL_066a: ldloc.s 21
+			IL_066c: brfalse IL_06f1
+
+			IL_0671: ldloc.1
+			IL_0672: ldstr "section"
+			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_067c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0681: stloc.s 29
+			IL_0683: ldstr "Could not find section '"
+			IL_0688: ldloc.s 29
+			IL_068a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_068f: stloc.s 29
+			IL_0691: ldloc.s 29
+			IL_0693: ldstr "' in multipage index: "
+			IL_0698: call string [System.Runtime]System.String::Concat(string, string)
+			IL_069d: stloc.s 29
+			IL_069f: ldloc.s 10
+			IL_06a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06a6: stloc.s 30
+			IL_06a8: ldloc.s 29
+			IL_06aa: ldloc.s 30
+			IL_06ac: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06b1: stloc.s 30
+			IL_06b3: ldloc.s 30
+			IL_06b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_06bf: stloc.s 27
+			IL_06c1: ldloc.0
+			IL_06c2: ldc.i4.m1
+			IL_06c3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06c8: ldloc.0
+			IL_06c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_06d3: ldarg.0
+			IL_06d4: ldc.i4.1
+			IL_06d5: newarr [System.Runtime]System.Object
+			IL_06da: dup
+			IL_06db: ldc.i4.0
+			IL_06dc: ldloc.s 27
+			IL_06de: stelem.ref
+			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06e4: pop
+			IL_06e5: ldloc.0
+			IL_06e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06f0: ret
+
+			IL_06f1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
+			IL_06f6: stloc.s 31
+			IL_06f8: ldloc.s 12
+			IL_06fa: ldstr "filePart"
+			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0704: stloc.s 27
+			IL_0706: ldloc.s 27
+			IL_0708: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_070d: stloc.s 21
+			IL_070f: ldloc.s 21
+			IL_0711: brtrue IL_0729
+
+			IL_0716: ldloc.s 12
+			IL_0718: ldstr "href"
+			IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0722: stloc.s 32
+			IL_0724: br IL_072d
+
+			IL_0729: ldloc.s 27
+			IL_072b: stloc.s 32
+
+			IL_072d: ldc.i4.2
+			IL_072e: newarr [System.Runtime]System.Object
+			IL_0733: dup
+			IL_0734: ldc.i4.0
+			IL_0735: ldloc.s 32
+			IL_0737: stelem.ref
+			IL_0738: dup
+			IL_0739: ldc.i4.1
+			IL_073a: ldloc.s 10
+			IL_073c: stelem.ref
+			IL_073d: stloc.s 33
+			IL_073f: ldloc.s 31
+			IL_0741: ldloc.s 33
+			IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0748: stloc.s 27
+			IL_074a: ldloc.s 27
+			IL_074c: ldstr "toString"
+			IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0756: stloc.s 27
+			IL_0758: ldloc.s 27
+			IL_075a: stloc.s 13
+			IL_075c: ldloc.s 12
+			IL_075e: ldstr "fragment"
+			IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0768: stloc.s 27
+			IL_076a: ldloc.s 27
+			IL_076c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0771: stloc.s 21
+			IL_0773: ldloc.s 21
+			IL_0775: brtrue IL_0786
+
+			IL_077a: ldstr ""
+			IL_077f: stloc.s 34
+			IL_0781: br IL_078a
+
+			IL_0786: ldloc.s 27
+			IL_0788: stloc.s 34
+
+			IL_078a: ldloc.s 34
+			IL_078c: stloc.s 9
+			IL_078e: ldc.i4.1
+			IL_078f: newarr [System.Runtime]System.Object
+			IL_0794: dup
+			IL_0795: ldc.i4.0
+			IL_0796: ldarg.0
+			IL_0797: ldc.i4.1
+			IL_0798: ldelem.ref
+			IL_0799: stelem.ref
+			IL_079a: ldc.i4.0
+			IL_079b: ldelem.ref
+			IL_079c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_07a1: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+			IL_07a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_07ac: ldnull
+			IL_07ad: ldloc.s 13
+			IL_07af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_07b4: stloc.s 27
+			IL_07b6: ldloc.0
+			IL_07b7: ldc.i4.2
+			IL_07b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07bd: ldloc.0
+			IL_07be: ldloc.s 27
+			IL_07c0: ldarg.0
+			IL_07c1: ldc.i4.2
+			IL_07c2: ldloc.0
+			IL_07c3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07cd: ldloc.0
+			IL_07ce: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07d3: dup
+			IL_07d4: ldc.i4.0
+			IL_07d5: ldloc.1
+			IL_07d6: stelem.ref
+			IL_07d7: dup
+			IL_07d8: ldc.i4.1
+			IL_07d9: ldloc.2
+			IL_07da: stelem.ref
+			IL_07db: dup
+			IL_07dc: ldc.i4.2
+			IL_07dd: ldloc.3
+			IL_07de: stelem.ref
+			IL_07df: dup
+			IL_07e0: ldc.i4.3
+			IL_07e1: ldloc.s 4
+			IL_07e3: stelem.ref
+			IL_07e4: dup
+			IL_07e5: ldc.i4.4
+			IL_07e6: ldloc.s 5
+			IL_07e8: stelem.ref
+			IL_07e9: dup
+			IL_07ea: ldc.i4.5
+			IL_07eb: ldloc.s 6
+			IL_07ed: stelem.ref
+			IL_07ee: dup
+			IL_07ef: ldc.i4.6
+			IL_07f0: ldloc.s 7
+			IL_07f2: stelem.ref
+			IL_07f3: dup
+			IL_07f4: ldc.i4.7
+			IL_07f5: ldloc.s 8
+			IL_07f7: stelem.ref
+			IL_07f8: dup
+			IL_07f9: ldc.i4.8
+			IL_07fa: ldloc.s 9
+			IL_07fc: stelem.ref
+			IL_07fd: dup
+			IL_07fe: ldc.i4.s 9
+			IL_0800: ldloc.s 10
+			IL_0802: stelem.ref
+			IL_0803: dup
+			IL_0804: ldc.i4.s 10
+			IL_0806: ldloc.s 11
+			IL_0808: stelem.ref
+			IL_0809: dup
+			IL_080a: ldc.i4.s 11
+			IL_080c: ldloc.s 12
+			IL_080e: stelem.ref
+			IL_080f: dup
+			IL_0810: ldc.i4.s 12
+			IL_0812: ldloc.s 13
+			IL_0814: stelem.ref
+			IL_0815: dup
+			IL_0816: ldc.i4.s 13
+			IL_0818: ldloc.s 14
+			IL_081a: stelem.ref
+			IL_081b: dup
+			IL_081c: ldc.i4.s 14
+			IL_081e: ldloc.s 15
+			IL_0820: stelem.ref
+			IL_0821: dup
+			IL_0822: ldc.i4.s 15
+			IL_0824: ldloc.s 16
+			IL_0826: stelem.ref
+			IL_0827: dup
+			IL_0828: ldc.i4.s 16
+			IL_082a: ldloc.s 17
+			IL_082c: stelem.ref
+			IL_082d: dup
+			IL_082e: ldc.i4.s 17
+			IL_0830: ldloc.s 18
+			IL_0832: stelem.ref
+			IL_0833: dup
+			IL_0834: ldc.i4.s 18
+			IL_0836: ldloc.s 19
+			IL_0838: stelem.ref
+			IL_0839: pop
+			IL_083a: ldloc.0
+			IL_083b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0840: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0845: ret
+
+			IL_0846: ldloc.0
+			IL_0847: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited2
+			IL_084c: stloc.s 27
+			IL_084e: ldloc.s 27
+			IL_0850: stloc.s 7
+			IL_0852: ldloc.s 13
+			IL_0854: stloc.s 27
+			IL_0856: ldloc.s 27
+			IL_0858: stloc.s 8
+			IL_085a: br IL_0a4a
+
+			IL_085f: ldloc.1
+			IL_0860: ldstr "url"
+			IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_086a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_086f: stloc.s 21
+			IL_0871: ldloc.s 21
+			IL_0873: brfalse IL_0964
+
+			IL_0878: ldloc.1
+			IL_0879: ldstr "url"
+			IL_087e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0883: ldstr "trim"
+			IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_088d: stloc.s 27
+			IL_088f: ldloc.s 27
+			IL_0891: stloc.s 14
+			IL_0893: ldc.i4.1
+			IL_0894: newarr [System.Runtime]System.Object
+			IL_0899: dup
+			IL_089a: ldc.i4.0
+			IL_089b: ldarg.0
+			IL_089c: ldc.i4.1
+			IL_089d: ldelem.ref
+			IL_089e: stelem.ref
+			IL_089f: ldc.i4.0
+			IL_08a0: ldelem.ref
+			IL_08a1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_08a6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+			IL_08ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_08b1: ldnull
+			IL_08b2: ldloc.s 14
+			IL_08b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_08b9: stloc.s 27
+			IL_08bb: ldloc.0
+			IL_08bc: ldc.i4.3
+			IL_08bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08c2: ldloc.0
+			IL_08c3: ldloc.s 27
+			IL_08c5: ldarg.0
+			IL_08c6: ldc.i4.3
+			IL_08c7: ldloc.0
+			IL_08c8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_08d2: ldloc.0
+			IL_08d3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08d8: dup
+			IL_08d9: ldc.i4.0
+			IL_08da: ldloc.1
+			IL_08db: stelem.ref
+			IL_08dc: dup
+			IL_08dd: ldc.i4.1
+			IL_08de: ldloc.2
+			IL_08df: stelem.ref
+			IL_08e0: dup
+			IL_08e1: ldc.i4.2
+			IL_08e2: ldloc.3
+			IL_08e3: stelem.ref
+			IL_08e4: dup
+			IL_08e5: ldc.i4.3
+			IL_08e6: ldloc.s 4
+			IL_08e8: stelem.ref
+			IL_08e9: dup
+			IL_08ea: ldc.i4.4
+			IL_08eb: ldloc.s 5
+			IL_08ed: stelem.ref
+			IL_08ee: dup
+			IL_08ef: ldc.i4.5
+			IL_08f0: ldloc.s 6
+			IL_08f2: stelem.ref
+			IL_08f3: dup
+			IL_08f4: ldc.i4.6
+			IL_08f5: ldloc.s 7
+			IL_08f7: stelem.ref
+			IL_08f8: dup
+			IL_08f9: ldc.i4.7
+			IL_08fa: ldloc.s 8
+			IL_08fc: stelem.ref
+			IL_08fd: dup
+			IL_08fe: ldc.i4.8
+			IL_08ff: ldloc.s 9
+			IL_0901: stelem.ref
+			IL_0902: dup
+			IL_0903: ldc.i4.s 9
+			IL_0905: ldloc.s 10
+			IL_0907: stelem.ref
+			IL_0908: dup
+			IL_0909: ldc.i4.s 10
+			IL_090b: ldloc.s 11
+			IL_090d: stelem.ref
+			IL_090e: dup
+			IL_090f: ldc.i4.s 11
+			IL_0911: ldloc.s 12
+			IL_0913: stelem.ref
+			IL_0914: dup
+			IL_0915: ldc.i4.s 12
+			IL_0917: ldloc.s 13
+			IL_0919: stelem.ref
+			IL_091a: dup
+			IL_091b: ldc.i4.s 13
+			IL_091d: ldloc.s 14
+			IL_091f: stelem.ref
+			IL_0920: dup
+			IL_0921: ldc.i4.s 14
+			IL_0923: ldloc.s 15
+			IL_0925: stelem.ref
+			IL_0926: dup
+			IL_0927: ldc.i4.s 15
+			IL_0929: ldloc.s 16
+			IL_092b: stelem.ref
+			IL_092c: dup
+			IL_092d: ldc.i4.s 16
+			IL_092f: ldloc.s 17
+			IL_0931: stelem.ref
+			IL_0932: dup
+			IL_0933: ldc.i4.s 17
+			IL_0935: ldloc.s 18
+			IL_0937: stelem.ref
+			IL_0938: dup
+			IL_0939: ldc.i4.s 18
+			IL_093b: ldloc.s 19
+			IL_093d: stelem.ref
+			IL_093e: pop
+			IL_093f: ldloc.0
+			IL_0940: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0945: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_094a: ret
+
+			IL_094b: ldloc.0
+			IL_094c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited3
+			IL_0951: stloc.s 27
+			IL_0953: ldloc.s 27
+			IL_0955: stloc.s 7
+			IL_0957: ldloc.s 14
+			IL_0959: stloc.s 27
+			IL_095b: ldloc.s 27
+			IL_095d: stloc.s 8
+			IL_095f: br IL_0a4a
+
+			IL_0964: ldarg.0
+			IL_0965: ldc.i4.1
+			IL_0966: ldelem.ref
+			IL_0967: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_096c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
+			IL_0971: stloc.s 27
+			IL_0973: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0978: ldstr "cwd"
+			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0982: stloc.s 20
+			IL_0984: ldloc.s 27
+			IL_0986: ldstr "resolve"
+			IL_098b: ldloc.s 20
+			IL_098d: ldloc.1
+			IL_098e: ldstr "inFile"
+			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_099d: stloc.s 20
+			IL_099f: ldloc.s 20
+			IL_09a1: stloc.s 15
+			IL_09a3: ldarg.0
+			IL_09a4: ldc.i4.1
+			IL_09a5: ldelem.ref
+			IL_09a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_09ab: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_09b0: ldstr "existsSync"
+			IL_09b5: ldloc.s 15
+			IL_09b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_09bc: stloc.s 20
+			IL_09be: ldloc.s 20
+			IL_09c0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09c5: ldc.i4.0
+			IL_09c6: ceq
+			IL_09c8: stloc.s 21
+			IL_09ca: ldloc.s 21
+			IL_09cc: brfalse IL_0a26
+
+			IL_09d1: ldloc.s 15
+			IL_09d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09d8: stloc.s 30
+			IL_09da: ldstr "Input file not found: "
+			IL_09df: ldloc.s 30
+			IL_09e1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09e6: stloc.s 30
+			IL_09e8: ldloc.s 30
+			IL_09ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_09f4: stloc.s 20
+			IL_09f6: ldloc.0
+			IL_09f7: ldc.i4.m1
+			IL_09f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09fd: ldloc.0
+			IL_09fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a03: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0a08: ldarg.0
+			IL_0a09: ldc.i4.1
+			IL_0a0a: newarr [System.Runtime]System.Object
+			IL_0a0f: dup
+			IL_0a10: ldc.i4.0
+			IL_0a11: ldloc.s 20
+			IL_0a13: stelem.ref
+			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a19: pop
+			IL_0a1a: ldloc.0
+			IL_0a1b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a20: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a25: ret
+
+			IL_0a26: ldarg.0
+			IL_0a27: ldc.i4.1
+			IL_0a28: ldelem.ref
+			IL_0a29: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0a2e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_0a33: ldstr "readFileSync"
+			IL_0a38: ldloc.s 15
+			IL_0a3a: ldstr "utf8"
+			IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a44: stloc.s 20
+			IL_0a46: ldloc.s 20
+			IL_0a48: stloc.s 7
+
+			IL_0a4a: ldloc.1
+			IL_0a4b: ldstr "id"
+			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a55: stloc.s 20
+			IL_0a57: ldloc.s 20
+			IL_0a59: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0a5e: stloc.s 21
+			IL_0a60: ldloc.s 21
+			IL_0a62: brtrue IL_0a73
+
+			IL_0a67: ldstr ""
+			IL_0a6c: stloc.s 35
+			IL_0a6e: br IL_0a77
+
+			IL_0a73: ldloc.s 20
+			IL_0a75: stloc.s 35
+
+			IL_0a77: ldloc.s 35
+			IL_0a79: castclass [System.Runtime]System.String
+			IL_0a7e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0a83: stloc.s 30
+			IL_0a85: ldloc.s 30
+			IL_0a87: stloc.s 16
+			IL_0a89: ldloc.s 16
+			IL_0a8b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0a90: ldc.i4.0
+			IL_0a91: ceq
+			IL_0a93: stloc.s 21
+			IL_0a95: ldloc.s 21
+			IL_0a97: box [System.Runtime]System.Boolean
+			IL_0a9c: stloc.s 22
+			IL_0a9e: ldloc.s 22
+			IL_0aa0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0aa5: stloc.s 21
+			IL_0aa7: ldloc.s 21
+			IL_0aa9: brfalse IL_0ab7
+
+			IL_0aae: ldloc.s 9
+			IL_0ab0: stloc.s 36
+			IL_0ab2: br IL_0abb
+
+			IL_0ab7: ldloc.s 22
+			IL_0ab9: stloc.s 36
+
+			IL_0abb: ldloc.s 36
+			IL_0abd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0ac2: stloc.s 21
+			IL_0ac4: ldloc.s 21
+			IL_0ac6: brfalse IL_0ad3
+
+			IL_0acb: ldloc.s 9
+			IL_0acd: stloc.s 36
+			IL_0acf: ldloc.s 36
+			IL_0ad1: stloc.s 16
+
+			IL_0ad3: ldloc.s 16
+			IL_0ad5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0ada: ldc.i4.0
+			IL_0adb: ceq
+			IL_0add: stloc.s 21
+			IL_0adf: ldloc.s 21
+			IL_0ae1: brfalse IL_0b2b
+
+			IL_0ae6: ldloc.1
+			IL_0ae7: ldstr "section"
+			IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0af1: ldstr "trim"
+			IL_0af6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0afb: stloc.s 20
+			IL_0afd: ldc.i4.1
+			IL_0afe: newarr [System.Runtime]System.Object
+			IL_0b03: dup
+			IL_0b04: ldc.i4.0
+			IL_0b05: ldarg.0
+			IL_0b06: ldc.i4.1
+			IL_0b07: ldelem.ref
+			IL_0b08: stelem.ref
+			IL_0b09: ldc.i4.0
+			IL_0b0a: ldelem.ref
+			IL_0b0b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0b10: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionIdFromHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0b16: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0b1b: ldnull
+			IL_0b1c: ldloc.s 7
+			IL_0b1e: ldloc.s 20
+			IL_0b20: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0b25: stloc.s 20
+			IL_0b27: ldloc.s 20
+			IL_0b29: stloc.s 16
+
+			IL_0b2b: ldloc.s 16
+			IL_0b2d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0b32: ldc.i4.0
+			IL_0b33: ceq
+			IL_0b35: stloc.s 21
+			IL_0b37: ldloc.s 21
+			IL_0b39: brfalse IL_0baa
+
+			IL_0b3e: ldloc.1
+			IL_0b3f: ldstr "section"
+			IL_0b44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b49: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b4e: stloc.s 30
+			IL_0b50: ldstr "Could not infer an element id for section '"
+			IL_0b55: ldloc.s 30
+			IL_0b57: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b5c: stloc.s 30
+			IL_0b5e: ldloc.s 30
+			IL_0b60: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0b65: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b6a: stloc.s 30
+			IL_0b6c: ldloc.s 30
+			IL_0b6e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b73: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0b78: stloc.s 20
+			IL_0b7a: ldloc.0
+			IL_0b7b: ldc.i4.m1
+			IL_0b7c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b81: ldloc.0
+			IL_0b82: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b87: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0b8c: ldarg.0
+			IL_0b8d: ldc.i4.1
+			IL_0b8e: newarr [System.Runtime]System.Object
+			IL_0b93: dup
+			IL_0b94: ldc.i4.0
+			IL_0b95: ldloc.s 20
+			IL_0b97: stelem.ref
+			IL_0b98: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0b9d: pop
+			IL_0b9e: ldloc.0
+			IL_0b9f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0ba9: ret
+
+			IL_0baa: ldc.i4.1
+			IL_0bab: newarr [System.Runtime]System.Object
+			IL_0bb0: dup
+			IL_0bb1: ldc.i4.0
+			IL_0bb2: ldarg.0
+			IL_0bb3: ldc.i4.1
+			IL_0bb4: ldelem.ref
+			IL_0bb5: stelem.ref
+			IL_0bb6: ldc.i4.0
+			IL_0bb7: ldelem.ref
+			IL_0bb8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0bbd: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0bc3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0bc8: ldnull
+			IL_0bc9: ldloc.s 7
+			IL_0bcb: ldloc.s 16
+			IL_0bcd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0bd2: stloc.s 20
+			IL_0bd4: ldloc.s 20
+			IL_0bd6: stloc.s 17
+			IL_0bd8: ldloc.s 17
+			IL_0bda: ldstr "html"
+			IL_0bdf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0be4: stloc.s 18
+			IL_0be6: ldloc.1
+			IL_0be7: ldstr "wrap"
+			IL_0bec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bf1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0bf6: stloc.s 21
+			IL_0bf8: ldloc.s 21
+			IL_0bfa: brfalse IL_0c9a
+
+			IL_0bff: ldloc.1
+			IL_0c00: ldstr "baseHref"
+			IL_0c05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c0a: stloc.s 20
+			IL_0c0c: ldloc.s 20
+			IL_0c0e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0c13: stloc.s 21
+			IL_0c15: ldloc.s 21
+			IL_0c17: brtrue IL_0c25
+
+			IL_0c1c: ldloc.s 8
+			IL_0c1e: stloc.s 37
+			IL_0c20: br IL_0c29
+
+			IL_0c25: ldloc.s 20
+			IL_0c27: stloc.s 37
+
+			IL_0c29: ldloc.s 37
+			IL_0c2b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0c30: stloc.s 21
+			IL_0c32: ldloc.s 21
+			IL_0c34: brtrue IL_0c45
+
+			IL_0c39: ldstr ""
+			IL_0c3e: stloc.s 37
+			IL_0c40: br IL_0c45
+
+			IL_0c45: ldloc.s 37
+			IL_0c47: stloc.s 19
+			IL_0c49: ldloc.1
+			IL_0c4a: ldstr "section"
+			IL_0c4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c54: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0c59: stloc.s 30
+			IL_0c5b: ldstr "ECMA-262 "
+			IL_0c60: ldloc.s 30
+			IL_0c62: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c67: stloc.s 30
+			IL_0c69: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0c6e: dup
+			IL_0c6f: ldstr "title"
+			IL_0c74: ldloc.s 30
+			IL_0c76: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0c7b: dup
+			IL_0c7c: ldstr "baseHref"
+			IL_0c81: ldloc.s 19
+			IL_0c83: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0c88: stloc.s 39
+			IL_0c8a: ldnull
+			IL_0c8b: ldloc.s 18
+			IL_0c8d: ldloc.s 39
+			IL_0c8f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/wrapAsStandaloneHtml::__js_call__(object, object, object)
+			IL_0c94: stloc.s 20
+			IL_0c96: ldloc.s 20
+			IL_0c98: stloc.s 18
+
+			IL_0c9a: ldc.i4.1
+			IL_0c9b: newarr [System.Runtime]System.Object
+			IL_0ca0: dup
+			IL_0ca1: ldc.i4.0
+			IL_0ca2: ldarg.0
+			IL_0ca3: ldc.i4.1
+			IL_0ca4: ldelem.ref
+			IL_0ca5: stelem.ref
+			IL_0ca6: ldc.i4.0
+			IL_0ca7: ldelem.ref
+			IL_0ca8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0cad: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/writeTextPreserveEol::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0cb3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0cb8: ldnull
+			IL_0cb9: ldloc.s 6
+			IL_0cbb: ldloc.s 18
+			IL_0cbd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0cc2: pop
+			IL_0cc3: ldc.i4.1
+			IL_0cc4: newarr [System.Runtime]System.Object
+			IL_0cc9: dup
+			IL_0cca: ldc.i4.0
+			IL_0ccb: ldarg.0
+			IL_0ccc: ldc.i4.1
+			IL_0ccd: ldelem.ref
+			IL_0cce: stelem.ref
+			IL_0ccf: stloc.s 33
+			IL_0cd1: ldloc.1
+			IL_0cd2: ldstr "section"
+			IL_0cd7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0cdc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ce1: stloc.s 30
+			IL_0ce3: ldstr "Extracted section "
+			IL_0ce8: ldloc.s 30
+			IL_0cea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0cef: stloc.s 30
+			IL_0cf1: ldloc.s 30
+			IL_0cf3: ldstr " (id="
+			IL_0cf8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0cfd: stloc.s 30
+			IL_0cff: ldloc.s 16
+			IL_0d01: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0d06: stloc.s 29
+			IL_0d08: ldloc.s 30
+			IL_0d0a: ldloc.s 29
+			IL_0d0c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d11: stloc.s 29
+			IL_0d13: ldloc.s 29
+			IL_0d15: ldstr ", tag="
+			IL_0d1a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d1f: stloc.s 29
+			IL_0d21: ldloc.s 17
+			IL_0d23: ldstr "tagName"
+			IL_0d28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0d32: stloc.s 30
+			IL_0d34: ldloc.s 29
+			IL_0d36: ldloc.s 30
+			IL_0d38: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d3d: stloc.s 30
+			IL_0d3f: ldloc.s 30
+			IL_0d41: ldstr ") -> "
+			IL_0d46: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d4b: stloc.s 30
+			IL_0d4d: ldloc.s 6
+			IL_0d4f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0d54: stloc.s 29
+			IL_0d56: ldloc.s 30
+			IL_0d58: ldloc.s 29
+			IL_0d5a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d5f: stloc.s 29
+			IL_0d61: ldarg.3
+			IL_0d62: ldloc.s 33
+			IL_0d64: ldloc.s 29
+			IL_0d66: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+			IL_0d6b: pop
+			IL_0d6c: ldloc.0
+			IL_0d6d: ldc.i4.m1
+			IL_0d6e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0d73: ldloc.0
+			IL_0d74: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0d79: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0d7e: ldarg.0
+			IL_0d7f: ldc.i4.1
+			IL_0d80: newarr [System.Runtime]System.Object
+			IL_0d85: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0d8a: pop
+			IL_0d8b: ldloc.0
+			IL_0d8c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0d91: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0d96: ret
+		} // end of method main::__js_call__
+
+	} // end of class main
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L573C16
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
+				72 7d 00 00
+			)
+			// Fields
+			.field public object err
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5c41
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object err
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x5420
+			// Header size: 12
+			// Code size: 108 (0x6c)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[2] bool,
+				[3] object,
+				[4] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: stloc.1
+			IL_0006: ldarg.1
+			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_000c: stloc.2
+			IL_000d: ldloc.2
+			IL_000e: brfalse IL_0025
+
+			IL_0013: ldarg.1
+			IL_0014: ldstr "message"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001e: stloc.s 4
+			IL_0020: br IL_0028
+
+			IL_0025: ldarg.1
+			IL_0026: stloc.s 4
+
+			IL_0028: ldloc.s 4
+			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002f: stloc.2
+			IL_0030: ldloc.2
+			IL_0031: brfalse IL_0047
+
+			IL_0036: ldarg.1
+			IL_0037: ldstr "message"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0041: stloc.0
+			IL_0042: br IL_0049
+
+			IL_0047: ldarg.1
+			IL_0048: stloc.0
+
+			IL_0049: ldloc.1
+			IL_004a: ldloc.0
+			IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0050: pop
+			IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0056: ldstr "exitCode"
+			IL_005b: ldc.r8 1
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_0069: pop
+			IL_006a: ldnull
+			IL_006b: ret
+		} // end of method ArrowFunction_L573C16::__js_call__
+
+	} // end of class ArrowFunction_L573C16
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 80 d3 53 63 6f 70 65 20 66 73 3d 7b 66 73
+			7d 2c 20 68 74 74 70 3d 7b 68 74 74 70 7d 2c 20
+			70 61 74 68 3d 7b 70 61 74 68 7d 2c 20 68 74 74
+			70 73 3d 7b 68 74 74 70 73 7d 2c 20 70 61 72 73
+			65 41 72 67 73 3d 7b 70 61 72 73 65 41 72 67 73
+			7d 2c 20 66 65 74 63 68 54 65 78 74 57 69 74 68
+			48 74 74 70 3d 7b 66 65 74 63 68 54 65 78 74 57
+			69 74 68 48 74 74 70 7d 2c 20 66 65 74 63 68 54
+			65 78 74 57 69 74 68 48 74 74 70 73 3d 7b 66 65
+			74 63 68 54 65 78 74 57 69 74 68 48 74 74 70 73
+			7d 2c 20 66 65 74 63 68 54 65 78 74 57 69 74 68
+			54 72 61 6e 73 70 6f 72 74 3d 7b 66 65 74 63 68
+			54 65 78 74 57 69 74 68 54 72 61 6e 73 70 6f 72
+			74 7d 2c 20 e2 80 a6 00 00
+		)
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Block_L572C29
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5c38
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L572C29::.ctor
+
+		} // end of class Block_L572C29
+
+
+		// Fields
+		.field public object fs
+		.field public object http
+		.field public object path
+		.field public object https
+		.field public object parseArgs
+		.field public object fetchTextWithHttp
+		.field public object fetchTextWithHttps
+		.field public object fetchTextWithTransport
+		.field public object fetchText
+		.field public object fetchTextWithNodeRequest
+		.field public object detectEol
+		.field public object escapeRegExp
+		.field public object writeTextPreserveEol
+		.field public object findTagNameAt
+		.field public object extractElementById
+		.field public object resolveSectionLinkFromMultipageIndexHtml
+		.field public object resolveSectionIdFromHtml
+		.field public object wrapAsStandaloneHtml
+		.field public object printHelp
+		.field public object main
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x5956
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2108
+		// Header size: 12
+		// Code size: 704 (0x2c0)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[5] bool,
+			[6] object
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldloc.0
+		IL_000f: stelem.ref
+		IL_0010: ldc.i4.0
+		IL_0011: ldelem.ref
+		IL_0012: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_0017: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0022: stloc.3
+		IL_0023: ldloc.0
+		IL_0024: ldloc.3
+		IL_0025: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::parseArgs
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.0
+		IL_0033: stelem.ref
+		IL_0034: ldc.i4.0
+		IL_0035: ldelem.ref
+		IL_0036: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_003b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttp::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0046: stloc.3
+		IL_0047: ldloc.0
+		IL_0048: ldloc.3
+		IL_0049: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithHttp
+		IL_004e: ldc.i4.1
+		IL_004f: newarr [System.Runtime]System.Object
+		IL_0054: dup
+		IL_0055: ldc.i4.0
+		IL_0056: ldloc.0
+		IL_0057: stelem.ref
+		IL_0058: ldc.i4.0
+		IL_0059: ldelem.ref
+		IL_005a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_005f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttps::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_006a: stloc.3
+		IL_006b: ldloc.0
+		IL_006c: ldloc.3
+		IL_006d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithHttps
+		IL_0072: ldc.i4.1
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldloc.0
+		IL_007b: stelem.ref
+		IL_007c: ldc.i4.0
+		IL_007d: ldelem.ref
+		IL_007e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_0083: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
+		IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_008e: stloc.3
+		IL_008f: ldloc.0
+		IL_0090: ldloc.3
+		IL_0091: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithTransport
+		IL_0096: ldc.i4.1
+		IL_0097: newarr [System.Runtime]System.Object
+		IL_009c: dup
+		IL_009d: ldc.i4.0
+		IL_009e: ldloc.0
+		IL_009f: stelem.ref
+		IL_00a0: ldc.i4.0
+		IL_00a1: ldelem.ref
+		IL_00a2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_00a7: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00b2: stloc.3
+		IL_00b3: ldloc.3
+		IL_00b4: stloc.1
+		IL_00b5: ldc.i4.1
+		IL_00b6: newarr [System.Runtime]System.Object
+		IL_00bb: dup
+		IL_00bc: ldc.i4.0
+		IL_00bd: ldloc.0
+		IL_00be: stelem.ref
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldelem.ref
+		IL_00c1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_00c6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00d1: stloc.3
+		IL_00d2: ldloc.0
+		IL_00d3: ldloc.3
+		IL_00d4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithNodeRequest
+		IL_00d9: ldnull
+		IL_00da: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/detectEol::__js_call__(object, object)
+		IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00e5: stloc.3
+		IL_00e6: ldloc.0
+		IL_00e7: ldloc.3
+		IL_00e8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::detectEol
+		IL_00ed: ldnull
+		IL_00ee: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+		IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f9: stloc.3
+		IL_00fa: ldloc.0
+		IL_00fb: ldloc.3
+		IL_00fc: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::escapeRegExp
+		IL_0101: ldc.i4.1
+		IL_0102: newarr [System.Runtime]System.Object
+		IL_0107: dup
+		IL_0108: ldc.i4.0
+		IL_0109: ldloc.0
+		IL_010a: stelem.ref
+		IL_010b: ldc.i4.0
+		IL_010c: ldelem.ref
+		IL_010d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_0112: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/writeTextPreserveEol::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_011d: stloc.3
+		IL_011e: ldloc.0
+		IL_011f: ldloc.3
+		IL_0120: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::writeTextPreserveEol
+		IL_0125: ldc.i4.1
+		IL_0126: newarr [System.Runtime]System.Object
+		IL_012b: dup
+		IL_012c: ldc.i4.0
+		IL_012d: ldloc.0
+		IL_012e: stelem.ref
+		IL_012f: ldc.i4.0
+		IL_0130: ldelem.ref
+		IL_0131: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_0136: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_013c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0141: stloc.3
+		IL_0142: ldloc.0
+		IL_0143: ldloc.3
+		IL_0144: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::findTagNameAt
+		IL_0149: ldc.i4.1
+		IL_014a: newarr [System.Runtime]System.Object
+		IL_014f: dup
+		IL_0150: ldc.i4.0
+		IL_0151: ldloc.0
+		IL_0152: stelem.ref
+		IL_0153: ldc.i4.0
+		IL_0154: ldelem.ref
+		IL_0155: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_015a: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0165: stloc.3
+		IL_0166: ldloc.0
+		IL_0167: ldloc.3
+		IL_0168: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::extractElementById
+		IL_016d: ldc.i4.1
+		IL_016e: newarr [System.Runtime]System.Object
+		IL_0173: dup
+		IL_0174: ldc.i4.0
+		IL_0175: ldloc.0
+		IL_0176: stelem.ref
+		IL_0177: ldc.i4.0
+		IL_0178: ldelem.ref
+		IL_0179: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_017e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0189: stloc.3
+		IL_018a: ldloc.0
+		IL_018b: ldloc.3
+		IL_018c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::resolveSectionLinkFromMultipageIndexHtml
+		IL_0191: ldc.i4.1
+		IL_0192: newarr [System.Runtime]System.Object
+		IL_0197: dup
+		IL_0198: ldc.i4.0
+		IL_0199: ldloc.0
+		IL_019a: stelem.ref
+		IL_019b: ldc.i4.0
+		IL_019c: ldelem.ref
+		IL_019d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_01a2: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionIdFromHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01ad: stloc.3
+		IL_01ae: ldloc.0
+		IL_01af: ldloc.3
+		IL_01b0: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::resolveSectionIdFromHtml
+		IL_01b5: ldnull
+		IL_01b6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/wrapAsStandaloneHtml::__js_call__(object, object, object)
+		IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01c1: stloc.3
+		IL_01c2: ldloc.0
+		IL_01c3: ldloc.3
+		IL_01c4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::wrapAsStandaloneHtml
+		IL_01c9: ldnull
+		IL_01ca: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/printHelp::__js_call__(object)
+		IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01d5: stloc.3
+		IL_01d6: ldloc.0
+		IL_01d7: ldloc.3
+		IL_01d8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::printHelp
+		IL_01dd: ldc.i4.1
+		IL_01de: newarr [System.Runtime]System.Object
+		IL_01e3: dup
+		IL_01e4: ldc.i4.0
+		IL_01e5: ldloc.0
+		IL_01e6: stelem.ref
+		IL_01e7: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
+		IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01f2: stloc.3
+		IL_01f3: ldloc.3
+		IL_01f4: stloc.2
+		IL_01f5: ldarg.1
+		IL_01f6: ldstr "fs"
+		IL_01fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0200: stloc.3
+		IL_0201: ldloc.0
+		IL_0202: ldloc.3
+		IL_0203: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+		IL_0208: ldarg.1
+		IL_0209: ldstr "http"
+		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0213: stloc.3
+		IL_0214: ldloc.0
+		IL_0215: ldloc.3
+		IL_0216: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::http
+		IL_021b: ldarg.1
+		IL_021c: ldstr "path"
+		IL_0221: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0226: stloc.3
+		IL_0227: ldloc.0
+		IL_0228: ldloc.3
+		IL_0229: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
+		IL_022e: ldarg.1
+		IL_022f: ldstr "https"
+		IL_0234: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0239: stloc.3
+		IL_023a: ldloc.0
+		IL_023b: ldloc.3
+		IL_023c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::https
+		IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0246: dup
+		IL_0247: ldstr "main"
+		IL_024c: ldloc.2
+		IL_024d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0252: stloc.s 4
+		IL_0254: ldarg.2
+		IL_0255: ldstr "exports"
+		IL_025a: ldloc.s 4
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_0261: pop
+		IL_0262: ldarg.1
+		IL_0263: ldstr "main"
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026d: ldarg.2
+		IL_026e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0273: stloc.s 5
+		IL_0275: ldloc.s 5
+		IL_0277: brfalse IL_02bf
+
+		IL_027c: ldc.i4.1
+		IL_027d: newarr [System.Runtime]System.Object
+		IL_0282: dup
+		IL_0283: ldc.i4.0
+		IL_0284: ldloc.0
+		IL_0285: stelem.ref
+		IL_0286: ldnull
+		IL_0287: ldnull
+		IL_0288: ldnull
+		IL_0289: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
+		IL_028e: stloc.3
+		IL_028f: ldnull
+		IL_0290: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/ArrowFunction_L573C16::__js_call__(object, object)
+		IL_0296: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_029b: ldc.i4.1
+		IL_029c: newarr [System.Runtime]System.Object
+		IL_02a1: dup
+		IL_02a2: ldc.i4.0
+		IL_02a3: ldloc.0
+		IL_02a4: stelem.ref
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02af: stloc.s 6
+		IL_02b1: ldloc.3
+		IL_02b2: ldstr "catch"
+		IL_02b7: ldloc.s 6
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02be: pop
+
+		IL_02bf: ret
+	} // end of method Compile_Scripts_ExtractEcma262SectionHtml::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x5c4a
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class interface public auto ansi abstract Js2IL.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.ICompileScriptsExtractEcma262SectionHtmlExports
+	implements [System.Runtime]System.IDisposable
+{
+	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
+		01 00 29 43 6f 6d 70 69 6c 65 5f 53 63 72 69 70
+		74 73 5f 45 78 74 72 61 63 74 45 63 6d 61 32 36
+		32 53 65 63 74 69 6f 6e 48 74 6d 6c 00 00
+	)
+	// Methods
+	.method public hidebysig newslot abstract virtual 
+		instance class [System.Runtime]System.Threading.Tasks.Task Main (
+			object arg1,
+			object arg2
+		) cil managed 
+	{
+	} // end of method ICompileScriptsExtractEcma262SectionHtmlExports::Main
+
+} // end of class Js2IL.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.ICompileScriptsExtractEcma262SectionHtmlExports
+

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -7,6 +7,405 @@
 	extends [System.Runtime]System.Object
 {
 	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit run
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 32 53 63 6f 70 65 20 5f 61 77 61 69 74 65
+				64 31 3d 7b 5f 61 77 61 69 74 65 64 31 7d 2c 20
+				5f 61 77 61 69 74 65 64 32 3d 7b 5f 61 77 61 69
+				74 65 64 32 7d 00 00
+			)
+			// Fields
+			.field public object _awaited1
+			.field public object _awaited2
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x408b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2278
+			// Header size: 12
+			// Code size: 255 (0xff)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope,
+				[1] object,
+				[2] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope
+			IL_0008: dup
+			IL_0009: brtrue IL_003b
+
+			IL_000e: pop
+			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::.ctor()
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: ldarg.0
+			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
+			IL_001c: starg.s scopes
+			IL_001e: ldloc.0
+			IL_001f: ldnull
+			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_002b: ldarg.0
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+			IL_0031: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0036: br IL_003c
+
+			IL_003b: stloc.0
+
+			IL_003c: ldloc.0
+			IL_003d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0042: brtrue IL_0053
+
+			IL_0047: ldloc.0
+			IL_0048: ldc.i4.1
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+
+			IL_0053: ldloc.0
+			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0059: ldc.i4.0
+			IL_005a: ble.s IL_0067
+
+			IL_005c: ldloc.0
+			IL_005d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0062: dup
+			IL_0063: ldc.i4.0
+			IL_0064: ldelem.ref
+			IL_0065: stloc.1
+			IL_0066: pop
+
+			IL_0067: ldloc.0
+			IL_0068: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_006d: switch (IL_007a, IL_00cd)
+
+			IL_007a: ldarg.0
+			IL_007b: ldc.i4.1
+			IL_007c: ldelem.ref
+			IL_007d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
+			IL_0082: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
+			IL_0087: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml_TestHarness"
+			IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0091: stloc.2
+			IL_0092: ldloc.2
+			IL_0093: stloc.1
+			IL_0094: ldloc.1
+			IL_0095: ldstr "runHarnessCli"
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_009f: stloc.2
+			IL_00a0: ldloc.0
+			IL_00a1: ldc.i4.1
+			IL_00a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00a7: ldloc.0
+			IL_00a8: ldloc.2
+			IL_00a9: ldarg.0
+			IL_00aa: ldc.i4.1
+			IL_00ab: ldloc.0
+			IL_00ac: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00b6: ldloc.0
+			IL_00b7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00bc: dup
+			IL_00bd: ldc.i4.0
+			IL_00be: ldloc.1
+			IL_00bf: stelem.ref
+			IL_00c0: pop
+			IL_00c1: ldloc.0
+			IL_00c2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00c7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00cc: ret
+
+			IL_00cd: ldloc.0
+			IL_00ce: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::_awaited1
+			IL_00d3: pop
+			IL_00d4: ldloc.0
+			IL_00d5: ldc.i4.m1
+			IL_00d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00db: ldloc.0
+			IL_00dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_00e6: ldarg.0
+			IL_00e7: ldc.i4.1
+			IL_00e8: newarr [System.Runtime]System.Object
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_00f2: pop
+			IL_00f3: ldloc.0
+			IL_00f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00f9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00fe: ret
+		} // end of method run::__js_call__
+
+	} // end of class run
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L8C13
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
+				72 7d 00 00
+			)
+			// Fields
+			.field public object err
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4094
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object err
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2384
+			// Header size: 12
+			// Code size: 175 (0xaf)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[3] bool,
+				[4] object,
+				[5] object,
+				[6] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: stloc.2
+			IL_0006: ldarg.1
+			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_000c: stloc.3
+			IL_000d: ldloc.3
+			IL_000e: brfalse IL_0025
+
+			IL_0013: ldarg.1
+			IL_0014: ldstr "stack"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001e: stloc.s 5
+			IL_0020: br IL_0028
+
+			IL_0025: ldarg.1
+			IL_0026: stloc.s 5
+
+			IL_0028: ldloc.s 5
+			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002f: stloc.3
+			IL_0030: ldloc.3
+			IL_0031: brfalse IL_0047
+
+			IL_0036: ldarg.1
+			IL_0037: ldstr "stack"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0041: stloc.0
+			IL_0042: br IL_008c
+
+			IL_0047: ldarg.1
+			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: brfalse IL_0066
+
+			IL_0054: ldarg.1
+			IL_0055: ldstr "message"
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005f: stloc.s 6
+			IL_0061: br IL_0069
+
+			IL_0066: ldarg.1
+			IL_0067: stloc.s 6
+
+			IL_0069: ldloc.s 6
+			IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: brfalse IL_0088
+
+			IL_0077: ldarg.1
+			IL_0078: ldstr "message"
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0082: stloc.1
+			IL_0083: br IL_008a
+
+			IL_0088: ldarg.1
+			IL_0089: stloc.1
+
+			IL_008a: ldloc.1
+			IL_008b: stloc.0
+
+			IL_008c: ldloc.2
+			IL_008d: ldloc.0
+			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0093: pop
+			IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0099: ldstr "exitCode"
+			IL_009e: ldc.r8 1
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_00ac: pop
+			IL_00ad: ldnull
+			IL_00ae: ret
+		} // end of method ArrowFunction_L8C13::__js_call__
+
+	} // end of class ArrowFunction_L8C13
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 22 53 63 6f 70 65 20 72 65 71 75 69 72 65
+			3d 7b 72 65 71 75 69 72 65 7d 2c 20 72 75 6e 3d
+			7b 72 75 6e 7d 00 00
+		)
+		// Fields
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
+		.field public object run
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x4082
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 101 (0x65)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope,
+			[1] object,
+			[2] object,
+			[3] object
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
+		IL_000d: ldc.i4.1
+		IL_000e: newarr [System.Runtime]System.Object
+		IL_0013: dup
+		IL_0014: ldc.i4.0
+		IL_0015: ldloc.0
+		IL_0016: stelem.ref
+		IL_0017: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
+		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0022: stloc.2
+		IL_0023: ldloc.2
+		IL_0024: stloc.1
+		IL_0025: ldc.i4.1
+		IL_0026: newarr [System.Runtime]System.Object
+		IL_002b: dup
+		IL_002c: ldc.i4.0
+		IL_002d: ldloc.0
+		IL_002e: stelem.ref
+		IL_002f: ldnull
+		IL_0030: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
+		IL_0035: stloc.2
+		IL_0036: ldnull
+		IL_0037: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/ArrowFunction_L8C13::__js_call__(object, object)
+		IL_003d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0042: ldc.i4.1
+		IL_0043: newarr [System.Runtime]System.Object
+		IL_0048: dup
+		IL_0049: ldc.i4.0
+		IL_004a: ldloc.0
+		IL_004b: stelem.ref
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0056: stloc.3
+		IL_0057: ldloc.2
+		IL_0058: ldstr "catch"
+		IL_005d: ldloc.3
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0063: pop
+		IL_0064: ret
+	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_UrlMode::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
+
+.class private auto ansi beforefieldinit Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
 	.class nested public auto ansi abstract sealed beforefieldinit normalize
 		extends [System.Runtime]System.Object
 	{
@@ -15,14 +414,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L7C29
+			.class nested private auto ansi beforefieldinit Block_L10C29
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x592c
+					// Method begins at RVA 0x40af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -31,16 +430,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L7C29::.ctor
+				} // end of method Block_L10C29::.ctor
 
-			} // end of class Block_L7C29
+			} // end of class Block_L10C29
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5923
+				// Method begins at RVA 0x40a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +464,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23d4
+			// Method begins at RVA 0x2440
 			// Header size: 12
 			// Code size: 249 (0xf9)
 			.maxstack 8
@@ -158,776 +557,6 @@
 
 	} // end of class normalize
 
-	.class nested public auto ansi abstract sealed beforefieldinit run
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L22C19
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-					01 00 13 53 63 6f 70 65 20 76 61 6c 75 65 3d 7b
-					76 61 6c 75 65 7d 00 00
-				)
-				// Fields
-				.field public object 'value'
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x593e
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object[] scopes,
-					object newTarget,
-					object 'value'
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-					01 00 02 00 00 00 00 00
-				)
-				// Method begins at RVA 0x28d0
-				// Header size: 12
-				// Code size: 29 (0x1d)
-				.maxstack 8
-				.locals init (
-					[0] string
-				)
-
-				IL_0000: ldarg.2
-				IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0006: stloc.0
-				IL_0007: ldarg.0
-				IL_0008: ldc.i4.1
-				IL_0009: ldelem.ref
-				IL_000a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope
-				IL_000f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::lines
-				IL_0014: ldloc.0
-				IL_0015: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_001a: pop
-				IL_001b: ldnull
-				IL_001c: ret
-			} // end of method ArrowFunction_L22C19::__js_call__
-
-		} // end of class ArrowFunction_L22C19
-
-		.class nested private auto ansi beforefieldinit Scope
-			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
-		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 13 53 63 6f 70 65 20 6c 69 6e 65 73 3d 7b
-				6c 69 6e 65 73 7d 00 00
-			)
-			// Fields
-			.field public class [JavaScriptRuntime]JavaScriptRuntime.Array lines
-			.field public object _awaited1
-			.field public object _awaited2
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5935
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-		.class nested private auto ansi beforefieldinit Scope_ForOf_L39C7
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L39C28
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5950
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L39C28::.ctor
-
-			} // end of class Block_L39C28
-
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5947
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope_ForOf_L39C7::.ctor
-
-		} // end of class Scope_ForOf_L39C7
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object[] scopes,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 02 00 00 00 00 00
-			)
-			// Method begins at RVA 0x24dc
-			// Header size: 12
-			// Code size: 793 (0x319)
-			.maxstack 8
-			.locals init (
-				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope,
-				[1] object,
-				[2] object,
-				[3] object,
-				[4] object,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
-				[6] bool,
-				[7] bool,
-				[8] object,
-				[9] object,
-				[10] object,
-				[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[12] bool
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldc.i4.0
-			IL_0002: ldelem.ref
-			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope
-			IL_0008: dup
-			IL_0009: brtrue IL_003b
-
-			IL_000e: pop
-			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::.ctor()
-			IL_0014: stloc.0
-			IL_0015: ldloc.0
-			IL_0016: ldarg.0
-			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
-			IL_001c: starg.s scopes
-			IL_001e: ldloc.0
-			IL_001f: ldnull
-			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
-			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_002b: ldarg.0
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
-			IL_0031: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0036: br IL_003c
-
-			IL_003b: stloc.0
-
-			IL_003c: ldloc.0
-			IL_003d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0042: brtrue IL_0053
-
-			IL_0047: ldloc.0
-			IL_0048: ldc.i4.8
-			IL_0049: newarr [System.Runtime]System.Object
-			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-
-			IL_0053: ldloc.0
-			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0059: ldc.i4.0
-			IL_005a: ble.s IL_0097
-
-			IL_005c: ldloc.0
-			IL_005d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0062: dup
-			IL_0063: ldc.i4.0
-			IL_0064: ldelem.ref
-			IL_0065: stloc.1
-			IL_0066: dup
-			IL_0067: ldc.i4.1
-			IL_0068: ldelem.ref
-			IL_0069: stloc.2
-			IL_006a: dup
-			IL_006b: ldc.i4.2
-			IL_006c: ldelem.ref
-			IL_006d: stloc.3
-			IL_006e: dup
-			IL_006f: ldc.i4.3
-			IL_0070: ldelem.ref
-			IL_0071: stloc.s 4
-			IL_0073: dup
-			IL_0074: ldc.i4.4
-			IL_0075: ldelem.ref
-			IL_0076: castclass [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator
-			IL_007b: stloc.s 5
-			IL_007d: dup
-			IL_007e: ldc.i4.5
-			IL_007f: ldelem.ref
-			IL_0080: unbox.any [System.Runtime]System.Boolean
-			IL_0085: stloc.s 6
-			IL_0087: dup
-			IL_0088: ldc.i4.6
-			IL_0089: ldelem.ref
-			IL_008a: unbox.any [System.Runtime]System.Boolean
-			IL_008f: stloc.s 7
-			IL_0091: dup
-			IL_0092: ldc.i4.7
-			IL_0093: ldelem.ref
-			IL_0094: stloc.s 8
-			IL_0096: pop
-
-			IL_0097: ldloc.0
-			IL_0098: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_009d: switch (IL_00aa, IL_022d)
-
-			IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_00af: ldstr "argv"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b9: ldc.r8 2
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00c7: stloc.1
-			IL_00c8: ldarg.0
-			IL_00c9: ldc.i4.1
-			IL_00ca: ldelem.ref
-			IL_00cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
-			IL_00d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::path
-			IL_00d5: stloc.s 9
-			IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_00dc: ldstr "cwd"
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e6: stloc.s 10
-			IL_00e8: ldloc.s 9
-			IL_00ea: ldstr "join"
-			IL_00ef: ldloc.s 10
-			IL_00f1: ldstr "section-url.html"
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fb: stloc.s 10
-			IL_00fd: ldloc.s 10
-			IL_00ff: stloc.2
-			IL_0100: ldarg.0
-			IL_0101: ldc.i4.1
-			IL_0102: ldelem.ref
-			IL_0103: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
-			IL_0108: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
-			IL_010d: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml"
-			IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-			IL_0117: stloc.s 10
-			IL_0119: ldloc.s 10
-			IL_011b: stloc.3
-			IL_011c: ldloc.0
-			IL_011d: ldc.i4.0
-			IL_011e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0123: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::lines
-			IL_0128: ldnull
-			IL_0129: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/ArrowFunction_L22C19::__js_call__(object[], object, object)
-			IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0134: ldc.i4.2
-			IL_0135: newarr [System.Runtime]System.Object
-			IL_013a: dup
-			IL_013b: ldc.i4.0
-			IL_013c: ldarg.0
-			IL_013d: ldc.i4.1
-			IL_013e: ldelem.ref
-			IL_013f: stelem.ref
-			IL_0140: dup
-			IL_0141: ldc.i4.1
-			IL_0142: ldloc.0
-			IL_0143: stelem.ref
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_014e: stloc.s 10
-			IL_0150: ldloc.s 10
-			IL_0152: stloc.s 4
-			IL_0154: ldc.i4.s 10
-			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_015b: dup
-			IL_015c: ldstr "dotnet"
-			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0166: dup
-			IL_0167: ldstr "extractEcma262SectionHtml.js"
-			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0171: dup
-			IL_0172: ldstr "--section"
-			IL_0177: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_017c: dup
-			IL_017d: ldstr "27.3"
-			IL_0182: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0187: dup
-			IL_0188: ldstr "--url"
-			IL_018d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0192: dup
-			IL_0193: ldloc.1
-			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0199: dup
-			IL_019a: ldstr "--id"
-			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01a4: dup
-			IL_01a5: ldstr "sec-generatorfunction-objects"
-			IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01af: dup
-			IL_01b0: ldstr "--out"
-			IL_01b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01ba: dup
-			IL_01bb: ldloc.2
-			IL_01bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01c1: stloc.s 11
-			IL_01c3: ldloc.3
-			IL_01c4: ldstr "main"
-			IL_01c9: ldloc.s 11
-			IL_01cb: ldloc.s 4
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01d2: stloc.s 10
-			IL_01d4: ldloc.0
-			IL_01d5: ldc.i4.1
-			IL_01d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01db: ldloc.0
-			IL_01dc: ldloc.s 10
-			IL_01de: ldarg.0
-			IL_01df: ldc.i4.1
-			IL_01e0: ldloc.0
-			IL_01e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01eb: ldloc.0
-			IL_01ec: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01f1: dup
-			IL_01f2: ldc.i4.0
-			IL_01f3: ldloc.1
-			IL_01f4: stelem.ref
-			IL_01f5: dup
-			IL_01f6: ldc.i4.1
-			IL_01f7: ldloc.2
-			IL_01f8: stelem.ref
-			IL_01f9: dup
-			IL_01fa: ldc.i4.2
-			IL_01fb: ldloc.3
-			IL_01fc: stelem.ref
-			IL_01fd: dup
-			IL_01fe: ldc.i4.3
-			IL_01ff: ldloc.s 4
-			IL_0201: stelem.ref
-			IL_0202: dup
-			IL_0203: ldc.i4.4
-			IL_0204: ldloc.s 5
-			IL_0206: stelem.ref
-			IL_0207: dup
-			IL_0208: ldc.i4.5
-			IL_0209: ldloc.s 6
-			IL_020b: box [System.Runtime]System.Boolean
-			IL_0210: stelem.ref
-			IL_0211: dup
-			IL_0212: ldc.i4.6
-			IL_0213: ldloc.s 7
-			IL_0215: box [System.Runtime]System.Boolean
-			IL_021a: stelem.ref
-			IL_021b: dup
-			IL_021c: ldc.i4.7
-			IL_021d: ldloc.s 8
-			IL_021f: stelem.ref
-			IL_0220: pop
-			IL_0221: ldloc.0
-			IL_0222: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0227: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_022c: ret
-
-			IL_022d: ldloc.0
-			IL_022e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::_awaited1
-			IL_0233: pop
-			IL_0234: ldloc.0
-			IL_0235: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::lines
-			IL_023a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_023f: stloc.s 5
-			IL_0241: ldc.i4.0
-			IL_0242: stloc.s 6
-			IL_0244: ldc.i4.0
-			IL_0245: stloc.s 7
-			.try
-			{
-				// loop start (head: IL_0247)
-					IL_0247: ldloc.s 5
-					IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_024e: stloc.s 10
-					IL_0250: ldloc.s 10
-					IL_0252: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0257: stloc.s 12
-					IL_0259: ldloc.s 12
-					IL_025b: brtrue IL_0299
-
-					IL_0260: ldloc.s 10
-					IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0267: stloc.s 10
-					IL_0269: ldloc.s 10
-					IL_026b: stloc.s 8
-					IL_026d: ldnull
-					IL_026e: ldloc.s 8
-					IL_0270: ldloc.2
-					IL_0271: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/normalize::__js_call__(object, object, object)
-					IL_0276: stloc.s 10
-					IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-					IL_027d: ldloc.s 10
-					IL_027f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-					IL_0284: pop
-					IL_0285: br IL_0247
-				// end loop
-				IL_028a: ldloc.s 5
-				IL_028c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0291: ldc.i4.1
-				IL_0292: stloc.s 7
-				IL_0294: leave IL_02b7
-
-				IL_0299: ldc.i4.1
-				IL_029a: stloc.s 6
-				IL_029c: leave IL_02b7
-			} // end .try
-			finally
-			{
-				IL_02a1: ldloc.s 6
-				IL_02a3: brtrue IL_02b6
-
-				IL_02a8: ldloc.s 7
-				IL_02aa: brtrue IL_02b6
-
-				IL_02af: ldloc.s 5
-				IL_02b1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-
-				IL_02b6: endfinally
-			} // end handler
-
-			IL_02b7: ldarg.0
-			IL_02b8: ldc.i4.1
-			IL_02b9: ldelem.ref
-			IL_02ba: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
-			IL_02bf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::fs
-			IL_02c4: ldstr "readFileSync"
-			IL_02c9: ldloc.2
-			IL_02ca: ldstr "utf8"
-			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02d4: stloc.s 10
-			IL_02d6: ldnull
-			IL_02d7: ldloc.s 10
-			IL_02d9: ldloc.2
-			IL_02da: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/normalize::__js_call__(object, object, object)
-			IL_02df: stloc.s 10
-			IL_02e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02e6: ldloc.s 10
-			IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02ed: pop
-			IL_02ee: ldloc.0
-			IL_02ef: ldc.i4.m1
-			IL_02f0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02f5: ldloc.0
-			IL_02f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0300: ldarg.0
-			IL_0301: ldc.i4.1
-			IL_0302: newarr [System.Runtime]System.Object
-			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_030c: pop
-			IL_030d: ldloc.0
-			IL_030e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0313: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0318: ret
-		} // end of method run::__js_call__
-
-	} // end of class run
-
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L46C13
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
-				72 7d 00 00
-			)
-			// Fields
-			.field public object err
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5959
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object err
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x2814
-			// Header size: 12
-			// Code size: 175 (0xaf)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[3] bool,
-				[4] object,
-				[5] object,
-				[6] object
-			)
-
-			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0005: stloc.2
-			IL_0006: ldarg.1
-			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_000c: stloc.3
-			IL_000d: ldloc.3
-			IL_000e: brfalse IL_0025
-
-			IL_0013: ldarg.1
-			IL_0014: ldstr "stack"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.s 5
-			IL_0020: br IL_0028
-
-			IL_0025: ldarg.1
-			IL_0026: stloc.s 5
-
-			IL_0028: ldloc.s 5
-			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002f: stloc.3
-			IL_0030: ldloc.3
-			IL_0031: brfalse IL_0047
-
-			IL_0036: ldarg.1
-			IL_0037: ldstr "stack"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.0
-			IL_0042: br IL_008c
-
-			IL_0047: ldarg.1
-			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_004d: stloc.3
-			IL_004e: ldloc.3
-			IL_004f: brfalse IL_0066
-
-			IL_0054: ldarg.1
-			IL_0055: ldstr "message"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: stloc.s 6
-			IL_0061: br IL_0069
-
-			IL_0066: ldarg.1
-			IL_0067: stloc.s 6
-
-			IL_0069: ldloc.s 6
-			IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0070: stloc.3
-			IL_0071: ldloc.3
-			IL_0072: brfalse IL_0088
-
-			IL_0077: ldarg.1
-			IL_0078: ldstr "message"
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0082: stloc.1
-			IL_0083: br IL_008a
-
-			IL_0088: ldarg.1
-			IL_0089: stloc.1
-
-			IL_008a: ldloc.1
-			IL_008b: stloc.0
-
-			IL_008c: ldloc.2
-			IL_008d: ldloc.0
-			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0093: pop
-			IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0099: ldstr "exitCode"
-			IL_009e: ldc.r8 1
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
-			IL_00ac: pop
-			IL_00ad: ldnull
-			IL_00ae: ret
-		} // end of method ArrowFunction_L46C13::__js_call__
-
-	} // end of class ArrowFunction_L46C13
-
-	.class nested private auto ansi beforefieldinit Scope
-		extends [System.Runtime]System.Object
-	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 4f 53 63 6f 70 65 20 72 65 71 75 69 72 65
-			3d 7b 72 65 71 75 69 72 65 7d 2c 20 66 73 3d 7b
-			66 73 7d 2c 20 70 61 74 68 3d 7b 70 61 74 68 7d
-			2c 20 6e 6f 72 6d 61 6c 69 7a 65 3d 7b 6e 6f 72
-			6d 61 6c 69 7a 65 7d 2c 20 72 75 6e 3d 7b 72 75
-			6e 7d 00 00
-		)
-		// Fields
-		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
-		.field public object fs
-		.field public object path
-		.field public object normalize
-		.field public object run
-
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x591a
-			// Header size: 1
-			// Code size: 8 (0x8)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: nop
-			IL_0007: ret
-		} // end of method Scope::.ctor
-
-	} // end of class Scope
-
-
-	// Methods
-	.method public hidebysig static 
-		void __js_module_init__ (
-			object exports,
-			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
-			object module,
-			string __filename,
-			string __dirname
-		) cil managed 
-	{
-		// Method begins at RVA 0x2050
-		// Header size: 12
-		// Code size: 169 (0xa9)
-		.maxstack 8
-		.locals init (
-			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope,
-			[1] object,
-			[2] object,
-			[3] object
-		)
-
-		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldloc.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
-		IL_000d: ldnull
-		IL_000e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/normalize::__js_call__(object, object, object)
-		IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0019: stloc.2
-		IL_001a: ldloc.0
-		IL_001b: ldloc.2
-		IL_001c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::normalize
-		IL_0021: ldc.i4.1
-		IL_0022: newarr [System.Runtime]System.Object
-		IL_0027: dup
-		IL_0028: ldc.i4.0
-		IL_0029: ldloc.0
-		IL_002a: stelem.ref
-		IL_002b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
-		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0036: stloc.2
-		IL_0037: ldloc.2
-		IL_0038: stloc.1
-		IL_0039: ldloc.0
-		IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
-		IL_003f: ldstr "fs"
-		IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0049: stloc.2
-		IL_004a: ldloc.0
-		IL_004b: ldloc.2
-		IL_004c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::fs
-		IL_0051: ldloc.0
-		IL_0052: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
-		IL_0057: ldstr "path"
-		IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0061: stloc.2
-		IL_0062: ldloc.0
-		IL_0063: ldloc.2
-		IL_0064: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::path
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: ldnull
-		IL_0074: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
-		IL_0079: stloc.2
-		IL_007a: ldnull
-		IL_007b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/ArrowFunction_L46C13::__js_call__(object, object)
-		IL_0081: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0086: ldc.i4.1
-		IL_0087: newarr [System.Runtime]System.Object
-		IL_008c: dup
-		IL_008d: ldc.i4.0
-		IL_008e: ldloc.0
-		IL_008f: stelem.ref
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_009a: stloc.3
-		IL_009b: ldloc.2
-		IL_009c: ldstr "catch"
-		IL_00a1: ldloc.3
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a7: pop
-		IL_00a8: ret
-	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_UrlMode::__js_module_init__
-
-} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
-
-.class private auto ansi beforefieldinit Modules.Compile_Scripts_ExtractEcma262SectionHtml
-	extends [System.Runtime]System.Object
-{
-	// Nested Types
 	.class nested public auto ansi abstract sealed beforefieldinit parseArgs
 		extends [System.Runtime]System.Object
 	{
@@ -939,7 +568,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x596b
+				// Method begins at RVA 0x40b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -952,22 +581,22 @@
 
 		} // end of class Scope
 
-		.class nested private auto ansi beforefieldinit Scope_For_L49C7
+		.class nested private auto ansi beforefieldinit Scope_For_L30C7
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L49C40
+			.class nested private auto ansi beforefieldinit Block_L30C40
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L52C38
+				.class nested private auto ansi beforefieldinit Block_L33C31
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5986
+						// Method begins at RVA 0x40d3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -976,18 +605,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L52C38::.ctor
+					} // end of method Block_L33C31::.ctor
 
-				} // end of class Block_L52C38
+				} // end of class Block_L33C31
 
-				.class nested private auto ansi beforefieldinit Block_L57C41
+				.class nested private auto ansi beforefieldinit Block_L39C27
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x598f
+						// Method begins at RVA 0x40dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -996,18 +625,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L57C41::.ctor
+					} // end of method Block_L39C27::.ctor
 
-				} // end of class Block_L57C41
+				} // end of class Block_L39C27
 
-				.class nested private auto ansi beforefieldinit Block_L63C36
+				.class nested private auto ansi beforefieldinit Block_L45C28
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5998
+						// Method begins at RVA 0x40e5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1016,18 +645,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L63C36::.ctor
+					} // end of method Block_L45C28::.ctor
 
-				} // end of class Block_L63C36
+				} // end of class Block_L45C28
 
-				.class nested private auto ansi beforefieldinit Block_L68C36
+				.class nested private auto ansi beforefieldinit Block_L50C33
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x59a1
+						// Method begins at RVA 0x40ee
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1036,18 +665,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L68C36::.ctor
+					} // end of method Block_L50C33::.ctor
 
-				} // end of class Block_L68C36
+				} // end of class Block_L50C33
 
-				.class nested private auto ansi beforefieldinit Block_L74C31
+				.class nested private auto ansi beforefieldinit Block_L56C27
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x59aa
+						// Method begins at RVA 0x40f7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1056,18 +685,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L74C31::.ctor
+					} // end of method Block_L56C27::.ctor
 
-				} // end of class Block_L74C31
+				} // end of class Block_L56C27
 
-				.class nested private auto ansi beforefieldinit Block_L79C37
+				.class nested private auto ansi beforefieldinit Block_L62C26
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x59b3
+						// Method begins at RVA 0x4100
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1076,256 +705,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L79C37::.ctor
+					} // end of method Block_L62C26::.ctor
 
-				} // end of class Block_L79C37
-
-				.class nested private auto ansi beforefieldinit Block_L85C32
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59bc
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L85C32::.ctor
-
-				} // end of class Block_L85C32
-
-				.class nested private auto ansi beforefieldinit Block_L90C24
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59c5
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L90C24::.ctor
-
-				} // end of class Block_L90C24
-
-				.class nested private auto ansi beforefieldinit Block_L95C29
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59ce
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L95C29::.ctor
-
-				} // end of class Block_L95C29
-
-				.class nested private auto ansi beforefieldinit Block_L101C38
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59d7
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L101C38::.ctor
-
-				} // end of class Block_L101C38
-
-				.class nested private auto ansi beforefieldinit Block_L106C37
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59e0
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L106C37::.ctor
-
-				} // end of class Block_L106C37
-
-				.class nested private auto ansi beforefieldinit Block_L112C32
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59e9
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L112C32::.ctor
-
-				} // end of class Block_L112C32
-
-				.class nested private auto ansi beforefieldinit Block_L117C22
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59f2
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L117C22::.ctor
-
-				} // end of class Block_L117C22
-
-				.class nested private auto ansi beforefieldinit Block_L123C31
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x59fb
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L123C31::.ctor
-
-				} // end of class Block_L123C31
-
-				.class nested private auto ansi beforefieldinit Block_L128C24
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a04
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L128C24::.ctor
-
-				} // end of class Block_L128C24
-
-				.class nested private auto ansi beforefieldinit Block_L133C27
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a0d
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L133C27::.ctor
-
-				} // end of class Block_L133C27
-
-				.class nested private auto ansi beforefieldinit Block_L138C24
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a16
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L138C24::.ctor
-
-				} // end of class Block_L138C24
-
-				.class nested private auto ansi beforefieldinit Block_L144C33
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a1f
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L144C33::.ctor
-
-				} // end of class Block_L144C33
+				} // end of class Block_L62C26
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x597d
+					// Method begins at RVA 0x40ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1334,16 +723,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L49C40::.ctor
+				} // end of method Block_L30C40::.ctor
 
-			} // end of class Block_L49C40
+			} // end of class Block_L30C40
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5974
+				// Method begins at RVA 0x40c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1352,15 +741,15 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Scope_For_L49C7::.ctor
+			} // end of method Scope_For_L30C7::.ctor
 
-		} // end of class Scope_For_L49C7
+		} // end of class Scope_For_L30C7
 
 
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
 				object argv
 			) cil managed 
@@ -1368,38 +757,24 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x28fc
+			// Method begins at RVA 0x2548
 			// Header size: 12
-			// Code size: 2463 (0x99f)
+			// Code size: 680 (0x2a8)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] float64,
-				[3] object,
-				[4] bool,
+				[1] float64,
+				[2] object,
+				[3] bool,
+				[4] object,
 				[5] object,
 				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
-				[10] object,
-				[11] object,
-				[12] object,
-				[13] object,
-				[14] object,
-				[15] object,
-				[16] object,
-				[17] object,
-				[18] object,
-				[19] object,
-				[20] object,
-				[21] object,
-				[22] object,
-				[23] object,
-				[24] object
+				[10] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -1408,1027 +783,265 @@
 			IL_000b: ldstr ""
 			IL_0010: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0015: dup
-			IL_0016: ldstr "inFile"
+			IL_0016: ldstr "url"
 			IL_001b: ldstr ""
 			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0025: dup
-			IL_0026: ldstr "url"
-			IL_002b: ldstr ""
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0035: dup
-			IL_0036: ldstr "auto"
-			IL_003b: ldc.i4.0
-			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0026: ldstr "auto"
+			IL_002b: ldc.i4.0
+			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0031: dup
+			IL_0032: ldstr "indexUrl"
+			IL_0037: ldstr ""
+			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0041: dup
-			IL_0042: ldstr "indexUrl"
-			IL_0047: ldstr "https://tc39.es/ecma262/multipage/"
+			IL_0042: ldstr "outFile"
+			IL_0047: ldstr ""
 			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0051: dup
-			IL_0052: ldstr "outFile"
+			IL_0052: ldstr "id"
 			IL_0057: ldstr ""
 			IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0061: dup
-			IL_0062: ldstr "id"
-			IL_0067: ldstr ""
-			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0071: dup
-			IL_0072: ldstr "wrap"
-			IL_0077: ldc.i4.1
-			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_007d: dup
-			IL_007e: ldstr "baseHref"
-			IL_0083: ldstr ""
-			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_008d: dup
-			IL_008e: ldstr "help"
-			IL_0093: ldc.i4.0
-			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0099: stloc.0
-			IL_009a: ldc.i4.0
-			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00a0: stloc.1
-			IL_00a1: ldc.r8 2
-			IL_00aa: stloc.2
-			// loop start (head: IL_00ab)
-				IL_00ab: ldloc.2
-				IL_00ac: ldarg.2
-				IL_00ad: ldstr "length"
-				IL_00b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_00b7: clt
-				IL_00b9: brfalse IL_07ec
+			IL_0061: stloc.0
+			IL_0062: ldc.r8 2
+			IL_006b: stloc.1
+			// loop start (head: IL_006c)
+				IL_006c: ldloc.1
+				IL_006d: ldarg.2
+				IL_006e: ldstr "length"
+				IL_0073: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0078: clt
+				IL_007a: brfalse IL_02a6
 
-				IL_00be: ldarg.2
-				IL_00bf: ldloc.2
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00c5: stloc.3
-				IL_00c6: ldloc.3
-				IL_00c7: ldstr "--help"
-				IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00d1: stloc.s 4
-				IL_00d3: ldloc.s 4
-				IL_00d5: box [System.Runtime]System.Boolean
-				IL_00da: stloc.s 5
-				IL_00dc: ldloc.s 5
-				IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00e3: stloc.s 4
-				IL_00e5: ldloc.s 4
-				IL_00e7: brtrue IL_010b
+				IL_007f: ldarg.2
+				IL_0080: ldloc.1
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0086: stloc.2
+				IL_0087: ldloc.2
+				IL_0088: ldstr "--section"
+				IL_008d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0092: stloc.3
+				IL_0093: ldloc.3
+				IL_0094: brfalse IL_00e9
 
-				IL_00ec: ldloc.3
-				IL_00ed: ldstr "-h"
-				IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00f7: stloc.s 4
-				IL_00f9: ldloc.s 4
-				IL_00fb: box [System.Runtime]System.Boolean
-				IL_0100: stloc.s 6
-				IL_0102: ldloc.s 6
-				IL_0104: stloc.s 8
-				IL_0106: br IL_010f
+				IL_0099: ldarg.2
+				IL_009a: ldloc.1
+				IL_009b: ldc.r8 1
+				IL_00a4: add
+				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00aa: stloc.s 4
+				IL_00ac: ldloc.s 4
+				IL_00ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00b3: stloc.3
+				IL_00b4: ldloc.3
+				IL_00b5: brtrue IL_00c6
 
-				IL_010b: ldloc.s 5
-				IL_010d: stloc.s 8
+				IL_00ba: ldstr ""
+				IL_00bf: stloc.s 6
+				IL_00c1: br IL_00ca
 
-				IL_010f: ldloc.s 8
-				IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0116: stloc.s 4
-				IL_0118: ldloc.s 4
-				IL_011a: brfalse IL_0136
+				IL_00c6: ldloc.s 4
+				IL_00c8: stloc.s 6
 
-				IL_011f: ldloc.0
-				IL_0120: ldstr "help"
-				IL_0125: ldc.i4.1
-				IL_0126: box [System.Runtime]System.Boolean
-				IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0130: pop
-				IL_0131: br IL_07db
+				IL_00ca: ldloc.0
+				IL_00cb: ldstr "section"
+				IL_00d0: ldloc.s 6
+				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_00d7: pop
+				IL_00d8: ldloc.1
+				IL_00d9: ldc.r8 1
+				IL_00e2: add
+				IL_00e3: stloc.1
+				IL_00e4: br IL_0295
 
-				IL_0136: ldloc.3
-				IL_0137: ldstr "--section"
-				IL_013c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0141: stloc.s 4
-				IL_0143: ldloc.s 4
-				IL_0145: box [System.Runtime]System.Boolean
-				IL_014a: stloc.s 5
-				IL_014c: ldloc.s 5
-				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0153: stloc.s 4
-				IL_0155: ldloc.s 4
-				IL_0157: brtrue IL_017b
+				IL_00e9: ldloc.2
+				IL_00ea: ldstr "--url"
+				IL_00ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00f4: stloc.3
+				IL_00f5: ldloc.3
+				IL_00f6: brfalse IL_014b
 
-				IL_015c: ldloc.3
-				IL_015d: ldstr "-s"
-				IL_0162: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0167: stloc.s 4
-				IL_0169: ldloc.s 4
-				IL_016b: box [System.Runtime]System.Boolean
-				IL_0170: stloc.s 6
-				IL_0172: ldloc.s 6
-				IL_0174: stloc.s 9
-				IL_0176: br IL_017f
+				IL_00fb: ldarg.2
+				IL_00fc: ldloc.1
+				IL_00fd: ldc.r8 1
+				IL_0106: add
+				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_010c: stloc.s 4
+				IL_010e: ldloc.s 4
+				IL_0110: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0115: stloc.3
+				IL_0116: ldloc.3
+				IL_0117: brtrue IL_0128
 
-				IL_017b: ldloc.s 5
-				IL_017d: stloc.s 9
+				IL_011c: ldstr ""
+				IL_0121: stloc.s 7
+				IL_0123: br IL_012c
 
-				IL_017f: ldloc.s 9
-				IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0186: stloc.s 4
-				IL_0188: ldloc.s 4
-				IL_018a: brfalse IL_01e1
+				IL_0128: ldloc.s 4
+				IL_012a: stloc.s 7
 
-				IL_018f: ldarg.2
-				IL_0190: ldloc.2
-				IL_0191: ldc.r8 1
-				IL_019a: add
-				IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01a0: stloc.s 10
-				IL_01a2: ldloc.s 10
-				IL_01a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01a9: stloc.s 4
-				IL_01ab: ldloc.s 4
-				IL_01ad: brtrue IL_01be
+				IL_012c: ldloc.0
+				IL_012d: ldstr "url"
+				IL_0132: ldloc.s 7
+				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0139: pop
+				IL_013a: ldloc.1
+				IL_013b: ldc.r8 1
+				IL_0144: add
+				IL_0145: stloc.1
+				IL_0146: br IL_0295
 
-				IL_01b2: ldstr ""
-				IL_01b7: stloc.s 11
-				IL_01b9: br IL_01c2
+				IL_014b: ldloc.2
+				IL_014c: ldstr "--auto"
+				IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0156: stloc.3
+				IL_0157: ldloc.3
+				IL_0158: brfalse IL_0174
 
-				IL_01be: ldloc.s 10
-				IL_01c0: stloc.s 11
+				IL_015d: ldloc.0
+				IL_015e: ldstr "auto"
+				IL_0163: ldc.i4.1
+				IL_0164: box [System.Runtime]System.Boolean
+				IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_016e: pop
+				IL_016f: br IL_0295
 
-				IL_01c2: ldloc.0
-				IL_01c3: ldstr "section"
-				IL_01c8: ldloc.s 11
-				IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_01cf: pop
-				IL_01d0: ldloc.2
-				IL_01d1: ldc.r8 1
-				IL_01da: add
-				IL_01db: stloc.2
-				IL_01dc: br IL_07db
+				IL_0174: ldloc.2
+				IL_0175: ldstr "--index-url"
+				IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_017f: stloc.3
+				IL_0180: ldloc.3
+				IL_0181: brfalse IL_01d6
 
-				IL_01e1: ldloc.3
-				IL_01e2: ldstr "startsWith"
-				IL_01e7: ldstr "--section="
-				IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01f1: stloc.s 10
-				IL_01f3: ldloc.s 10
-				IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01fa: stloc.s 4
-				IL_01fc: ldloc.s 4
-				IL_01fe: brfalse IL_0233
+				IL_0186: ldarg.2
+				IL_0187: ldloc.1
+				IL_0188: ldc.r8 1
+				IL_0191: add
+				IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0197: stloc.s 4
+				IL_0199: ldloc.s 4
+				IL_019b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01a0: stloc.3
+				IL_01a1: ldloc.3
+				IL_01a2: brtrue IL_01b3
 
+				IL_01a7: ldstr ""
+				IL_01ac: stloc.s 8
+				IL_01ae: br IL_01b7
+
+				IL_01b3: ldloc.s 4
+				IL_01b5: stloc.s 8
+
+				IL_01b7: ldloc.0
+				IL_01b8: ldstr "indexUrl"
+				IL_01bd: ldloc.s 8
+				IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_01c4: pop
+				IL_01c5: ldloc.1
+				IL_01c6: ldc.r8 1
+				IL_01cf: add
+				IL_01d0: stloc.1
+				IL_01d1: br IL_0295
+
+				IL_01d6: ldloc.2
+				IL_01d7: ldstr "--out"
+				IL_01dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01e1: stloc.3
+				IL_01e2: ldloc.3
+				IL_01e3: brfalse IL_0238
+
+				IL_01e8: ldarg.2
+				IL_01e9: ldloc.1
+				IL_01ea: ldc.r8 1
+				IL_01f3: add
+				IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01f9: stloc.s 4
+				IL_01fb: ldloc.s 4
+				IL_01fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0202: stloc.3
 				IL_0203: ldloc.3
-				IL_0204: ldstr "substring"
-				IL_0209: ldstr "--section="
-				IL_020e: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0213: conv.r8
-				IL_0214: box [System.Runtime]System.Double
-				IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_021e: stloc.s 10
-				IL_0220: ldloc.0
-				IL_0221: ldstr "section"
-				IL_0226: ldloc.s 10
-				IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_022d: pop
-				IL_022e: br IL_07db
+				IL_0204: brtrue IL_0215
 
-				IL_0233: ldloc.3
-				IL_0234: ldstr "--in"
-				IL_0239: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_023e: stloc.s 4
-				IL_0240: ldloc.s 4
-				IL_0242: box [System.Runtime]System.Boolean
-				IL_0247: stloc.s 5
-				IL_0249: ldloc.s 5
-				IL_024b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0250: stloc.s 4
-				IL_0252: ldloc.s 4
-				IL_0254: brtrue IL_0278
+				IL_0209: ldstr ""
+				IL_020e: stloc.s 9
+				IL_0210: br IL_0219
 
-				IL_0259: ldloc.3
-				IL_025a: ldstr "-i"
-				IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0264: stloc.s 4
-				IL_0266: ldloc.s 4
-				IL_0268: box [System.Runtime]System.Boolean
-				IL_026d: stloc.s 6
-				IL_026f: ldloc.s 6
-				IL_0271: stloc.s 12
-				IL_0273: br IL_027c
+				IL_0215: ldloc.s 4
+				IL_0217: stloc.s 9
 
-				IL_0278: ldloc.s 5
-				IL_027a: stloc.s 12
+				IL_0219: ldloc.0
+				IL_021a: ldstr "outFile"
+				IL_021f: ldloc.s 9
+				IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0226: pop
+				IL_0227: ldloc.1
+				IL_0228: ldc.r8 1
+				IL_0231: add
+				IL_0232: stloc.1
+				IL_0233: br IL_0295
 
-				IL_027c: ldloc.s 12
-				IL_027e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0283: stloc.s 4
-				IL_0285: ldloc.s 4
-				IL_0287: brfalse IL_02de
+				IL_0238: ldloc.2
+				IL_0239: ldstr "--id"
+				IL_023e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0243: stloc.3
+				IL_0244: ldloc.3
+				IL_0245: brfalse IL_0295
 
-				IL_028c: ldarg.2
-				IL_028d: ldloc.2
-				IL_028e: ldc.r8 1
-				IL_0297: add
-				IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_029d: stloc.s 10
-				IL_029f: ldloc.s 10
-				IL_02a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02a6: stloc.s 4
-				IL_02a8: ldloc.s 4
-				IL_02aa: brtrue IL_02bb
+				IL_024a: ldarg.2
+				IL_024b: ldloc.1
+				IL_024c: ldc.r8 1
+				IL_0255: add
+				IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_025b: stloc.s 4
+				IL_025d: ldloc.s 4
+				IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0264: stloc.3
+				IL_0265: ldloc.3
+				IL_0266: brtrue IL_0277
 
-				IL_02af: ldstr ""
-				IL_02b4: stloc.s 13
-				IL_02b6: br IL_02bf
+				IL_026b: ldstr ""
+				IL_0270: stloc.s 10
+				IL_0272: br IL_027b
 
-				IL_02bb: ldloc.s 10
-				IL_02bd: stloc.s 13
+				IL_0277: ldloc.s 4
+				IL_0279: stloc.s 10
 
-				IL_02bf: ldloc.0
-				IL_02c0: ldstr "inFile"
-				IL_02c5: ldloc.s 13
-				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_02cc: pop
-				IL_02cd: ldloc.2
-				IL_02ce: ldc.r8 1
-				IL_02d7: add
-				IL_02d8: stloc.2
-				IL_02d9: br IL_07db
+				IL_027b: ldloc.0
+				IL_027c: ldstr "id"
+				IL_0281: ldloc.s 10
+				IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0288: pop
+				IL_0289: ldloc.1
+				IL_028a: ldc.r8 1
+				IL_0293: add
+				IL_0294: stloc.1
 
-				IL_02de: ldloc.3
-				IL_02df: ldstr "startsWith"
-				IL_02e4: ldstr "--in="
-				IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02ee: stloc.s 10
-				IL_02f0: ldloc.s 10
-				IL_02f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02f7: stloc.s 4
-				IL_02f9: ldloc.s 4
-				IL_02fb: brfalse IL_0330
-
-				IL_0300: ldloc.3
-				IL_0301: ldstr "substring"
-				IL_0306: ldstr "--in="
-				IL_030b: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0310: conv.r8
-				IL_0311: box [System.Runtime]System.Double
-				IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_031b: stloc.s 10
-				IL_031d: ldloc.0
-				IL_031e: ldstr "inFile"
-				IL_0323: ldloc.s 10
-				IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_032a: pop
-				IL_032b: br IL_07db
-
-				IL_0330: ldloc.3
-				IL_0331: ldstr "--url"
-				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_033b: stloc.s 4
-				IL_033d: ldloc.s 4
-				IL_033f: box [System.Runtime]System.Boolean
-				IL_0344: stloc.s 5
-				IL_0346: ldloc.s 5
-				IL_0348: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_034d: stloc.s 4
-				IL_034f: ldloc.s 4
-				IL_0351: brtrue IL_0375
-
-				IL_0356: ldloc.3
-				IL_0357: ldstr "-u"
-				IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0361: stloc.s 4
-				IL_0363: ldloc.s 4
-				IL_0365: box [System.Runtime]System.Boolean
-				IL_036a: stloc.s 6
-				IL_036c: ldloc.s 6
-				IL_036e: stloc.s 14
-				IL_0370: br IL_0379
-
-				IL_0375: ldloc.s 5
-				IL_0377: stloc.s 14
-
-				IL_0379: ldloc.s 14
-				IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0380: stloc.s 4
-				IL_0382: ldloc.s 4
-				IL_0384: brfalse IL_03db
-
-				IL_0389: ldarg.2
-				IL_038a: ldloc.2
-				IL_038b: ldc.r8 1
-				IL_0394: add
-				IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_039a: stloc.s 10
-				IL_039c: ldloc.s 10
-				IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03a3: stloc.s 4
-				IL_03a5: ldloc.s 4
-				IL_03a7: brtrue IL_03b8
-
-				IL_03ac: ldstr ""
-				IL_03b1: stloc.s 15
-				IL_03b3: br IL_03bc
-
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 15
-
-				IL_03bc: ldloc.0
-				IL_03bd: ldstr "url"
-				IL_03c2: ldloc.s 15
-				IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_03c9: pop
-				IL_03ca: ldloc.2
-				IL_03cb: ldc.r8 1
-				IL_03d4: add
-				IL_03d5: stloc.2
-				IL_03d6: br IL_07db
-
-				IL_03db: ldloc.3
-				IL_03dc: ldstr "startsWith"
-				IL_03e1: ldstr "--url="
-				IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_03eb: stloc.s 10
-				IL_03ed: ldloc.s 10
-				IL_03ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03f4: stloc.s 4
-				IL_03f6: ldloc.s 4
-				IL_03f8: brfalse IL_042d
-
-				IL_03fd: ldloc.3
-				IL_03fe: ldstr "substring"
-				IL_0403: ldstr "--url="
-				IL_0408: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_040d: conv.r8
-				IL_040e: box [System.Runtime]System.Double
-				IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0418: stloc.s 10
-				IL_041a: ldloc.0
-				IL_041b: ldstr "url"
-				IL_0420: ldloc.s 10
-				IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0427: pop
-				IL_0428: br IL_07db
-
-				IL_042d: ldloc.3
-				IL_042e: ldstr "--auto"
-				IL_0433: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0438: stloc.s 4
-				IL_043a: ldloc.s 4
-				IL_043c: brfalse IL_0458
-
-				IL_0441: ldloc.0
-				IL_0442: ldstr "auto"
-				IL_0447: ldc.i4.1
-				IL_0448: box [System.Runtime]System.Boolean
-				IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0452: pop
-				IL_0453: br IL_07db
-
-				IL_0458: ldloc.3
-				IL_0459: ldstr "--index-url"
-				IL_045e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0463: stloc.s 4
-				IL_0465: ldloc.s 4
-				IL_0467: brfalse IL_04be
-
-				IL_046c: ldarg.2
-				IL_046d: ldloc.2
-				IL_046e: ldc.r8 1
-				IL_0477: add
-				IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_047d: stloc.s 10
-				IL_047f: ldloc.s 10
-				IL_0481: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0486: stloc.s 4
-				IL_0488: ldloc.s 4
-				IL_048a: brtrue IL_049b
-
-				IL_048f: ldstr ""
-				IL_0494: stloc.s 16
-				IL_0496: br IL_049f
-
-				IL_049b: ldloc.s 10
-				IL_049d: stloc.s 16
-
-				IL_049f: ldloc.0
-				IL_04a0: ldstr "indexUrl"
-				IL_04a5: ldloc.s 16
-				IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_04ac: pop
-				IL_04ad: ldloc.2
-				IL_04ae: ldc.r8 1
-				IL_04b7: add
-				IL_04b8: stloc.2
-				IL_04b9: br IL_07db
-
-				IL_04be: ldloc.3
-				IL_04bf: ldstr "startsWith"
-				IL_04c4: ldstr "--index-url="
-				IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_04ce: stloc.s 10
-				IL_04d0: ldloc.s 10
-				IL_04d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_04d7: stloc.s 4
-				IL_04d9: ldloc.s 4
-				IL_04db: brfalse IL_0510
-
-				IL_04e0: ldloc.3
-				IL_04e1: ldstr "substring"
-				IL_04e6: ldstr "--index-url="
-				IL_04eb: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_04f0: conv.r8
-				IL_04f1: box [System.Runtime]System.Double
-				IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_04fb: stloc.s 10
-				IL_04fd: ldloc.0
-				IL_04fe: ldstr "indexUrl"
-				IL_0503: ldloc.s 10
-				IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_050a: pop
-				IL_050b: br IL_07db
-
-				IL_0510: ldloc.3
-				IL_0511: ldstr "--out"
-				IL_0516: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_051b: stloc.s 4
-				IL_051d: ldloc.s 4
-				IL_051f: box [System.Runtime]System.Boolean
-				IL_0524: stloc.s 5
-				IL_0526: ldloc.s 5
-				IL_0528: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_052d: stloc.s 4
-				IL_052f: ldloc.s 4
-				IL_0531: brtrue IL_0555
-
-				IL_0536: ldloc.3
-				IL_0537: ldstr "-o"
-				IL_053c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0541: stloc.s 4
-				IL_0543: ldloc.s 4
-				IL_0545: box [System.Runtime]System.Boolean
-				IL_054a: stloc.s 6
-				IL_054c: ldloc.s 6
-				IL_054e: stloc.s 17
-				IL_0550: br IL_0559
-
-				IL_0555: ldloc.s 5
-				IL_0557: stloc.s 17
-
-				IL_0559: ldloc.s 17
-				IL_055b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0560: stloc.s 4
-				IL_0562: ldloc.s 4
-				IL_0564: brfalse IL_05bb
-
-				IL_0569: ldarg.2
-				IL_056a: ldloc.2
-				IL_056b: ldc.r8 1
-				IL_0574: add
-				IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_057a: stloc.s 10
-				IL_057c: ldloc.s 10
-				IL_057e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0583: stloc.s 4
-				IL_0585: ldloc.s 4
-				IL_0587: brtrue IL_0598
-
-				IL_058c: ldstr ""
-				IL_0591: stloc.s 18
-				IL_0593: br IL_059c
-
-				IL_0598: ldloc.s 10
-				IL_059a: stloc.s 18
-
-				IL_059c: ldloc.0
-				IL_059d: ldstr "outFile"
-				IL_05a2: ldloc.s 18
-				IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_05a9: pop
-				IL_05aa: ldloc.2
-				IL_05ab: ldc.r8 1
-				IL_05b4: add
-				IL_05b5: stloc.2
-				IL_05b6: br IL_07db
-
-				IL_05bb: ldloc.3
-				IL_05bc: ldstr "startsWith"
-				IL_05c1: ldstr "--out="
-				IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_05cb: stloc.s 10
-				IL_05cd: ldloc.s 10
-				IL_05cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_05d4: stloc.s 4
-				IL_05d6: ldloc.s 4
-				IL_05d8: brfalse IL_060d
-
-				IL_05dd: ldloc.3
-				IL_05de: ldstr "substring"
-				IL_05e3: ldstr "--out="
-				IL_05e8: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_05ed: conv.r8
-				IL_05ee: box [System.Runtime]System.Double
-				IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_05f8: stloc.s 10
-				IL_05fa: ldloc.0
-				IL_05fb: ldstr "outFile"
-				IL_0600: ldloc.s 10
-				IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0607: pop
-				IL_0608: br IL_07db
-
-				IL_060d: ldloc.3
-				IL_060e: ldstr "--id"
-				IL_0613: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0618: stloc.s 4
-				IL_061a: ldloc.s 4
-				IL_061c: brfalse IL_0673
-
-				IL_0621: ldarg.2
-				IL_0622: ldloc.2
-				IL_0623: ldc.r8 1
-				IL_062c: add
-				IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0632: stloc.s 10
-				IL_0634: ldloc.s 10
-				IL_0636: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_063b: stloc.s 4
-				IL_063d: ldloc.s 4
-				IL_063f: brtrue IL_0650
-
-				IL_0644: ldstr ""
-				IL_0649: stloc.s 19
-				IL_064b: br IL_0654
-
-				IL_0650: ldloc.s 10
-				IL_0652: stloc.s 19
-
-				IL_0654: ldloc.0
-				IL_0655: ldstr "id"
-				IL_065a: ldloc.s 19
-				IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0661: pop
-				IL_0662: ldloc.2
-				IL_0663: ldc.r8 1
-				IL_066c: add
-				IL_066d: stloc.2
-				IL_066e: br IL_07db
-
-				IL_0673: ldloc.3
-				IL_0674: ldstr "startsWith"
-				IL_0679: ldstr "--id="
-				IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0683: stloc.s 10
-				IL_0685: ldloc.s 10
-				IL_0687: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_068c: stloc.s 4
-				IL_068e: ldloc.s 4
-				IL_0690: brfalse IL_06c5
-
-				IL_0695: ldloc.3
-				IL_0696: ldstr "substring"
-				IL_069b: ldstr "--id="
-				IL_06a0: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_06a5: conv.r8
-				IL_06a6: box [System.Runtime]System.Double
-				IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_06b0: stloc.s 10
-				IL_06b2: ldloc.0
-				IL_06b3: ldstr "id"
-				IL_06b8: ldloc.s 10
-				IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_06bf: pop
-				IL_06c0: br IL_07db
-
-				IL_06c5: ldloc.3
-				IL_06c6: ldstr "--wrap"
-				IL_06cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_06d0: stloc.s 4
-				IL_06d2: ldloc.s 4
-				IL_06d4: brfalse IL_06f0
-
-				IL_06d9: ldloc.0
-				IL_06da: ldstr "wrap"
-				IL_06df: ldc.i4.1
-				IL_06e0: box [System.Runtime]System.Boolean
-				IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_06ea: pop
-				IL_06eb: br IL_07db
-
-				IL_06f0: ldloc.3
-				IL_06f1: ldstr "--no-wrap"
-				IL_06f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_06fb: stloc.s 4
-				IL_06fd: ldloc.s 4
-				IL_06ff: brfalse IL_071b
-
-				IL_0704: ldloc.0
-				IL_0705: ldstr "wrap"
-				IL_070a: ldc.i4.0
-				IL_070b: box [System.Runtime]System.Boolean
-				IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_0715: pop
-				IL_0716: br IL_07db
-
-				IL_071b: ldloc.3
-				IL_071c: ldstr "--base"
-				IL_0721: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0726: stloc.s 4
-				IL_0728: ldloc.s 4
-				IL_072a: brfalse IL_0781
-
-				IL_072f: ldarg.2
-				IL_0730: ldloc.2
-				IL_0731: ldc.r8 1
-				IL_073a: add
-				IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0740: stloc.s 10
-				IL_0742: ldloc.s 10
-				IL_0744: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0749: stloc.s 4
-				IL_074b: ldloc.s 4
-				IL_074d: brtrue IL_075e
-
-				IL_0752: ldstr ""
-				IL_0757: stloc.s 20
-				IL_0759: br IL_0762
-
-				IL_075e: ldloc.s 10
-				IL_0760: stloc.s 20
-
-				IL_0762: ldloc.0
-				IL_0763: ldstr "baseHref"
-				IL_0768: ldloc.s 20
-				IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_076f: pop
-				IL_0770: ldloc.2
-				IL_0771: ldc.r8 1
-				IL_077a: add
-				IL_077b: stloc.2
-				IL_077c: br IL_07db
-
-				IL_0781: ldloc.3
-				IL_0782: ldstr "startsWith"
-				IL_0787: ldstr "--base="
-				IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0791: stloc.s 10
-				IL_0793: ldloc.s 10
-				IL_0795: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_079a: stloc.s 4
-				IL_079c: ldloc.s 4
-				IL_079e: brfalse IL_07d3
-
-				IL_07a3: ldloc.3
-				IL_07a4: ldstr "substring"
-				IL_07a9: ldstr "--base="
-				IL_07ae: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_07b3: conv.r8
-				IL_07b4: box [System.Runtime]System.Double
-				IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_07be: stloc.s 10
-				IL_07c0: ldloc.0
-				IL_07c1: ldstr "baseHref"
-				IL_07c6: ldloc.s 10
-				IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-				IL_07cd: pop
-				IL_07ce: br IL_07db
-
-				IL_07d3: ldloc.1
-				IL_07d4: ldloc.3
-				IL_07d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_07da: pop
-
-				IL_07db: ldloc.2
-				IL_07dc: ldc.r8 1
-				IL_07e5: add
-				IL_07e6: stloc.2
-				IL_07e7: br IL_00ab
+				IL_0295: ldloc.1
+				IL_0296: ldc.r8 1
+				IL_029f: add
+				IL_02a0: stloc.1
+				IL_02a1: br IL_006c
 			// end loop
 
-			IL_07ec: ldloc.0
-			IL_07ed: ldstr "section"
-			IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_07fc: ldc.i4.0
-			IL_07fd: ceq
-			IL_07ff: stloc.s 4
-			IL_0801: ldloc.s 4
-			IL_0803: box [System.Runtime]System.Boolean
-			IL_0808: stloc.s 5
-			IL_080a: ldloc.s 5
-			IL_080c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0811: stloc.s 4
-			IL_0813: ldloc.s 4
-			IL_0815: brfalse IL_083b
-
-			IL_081a: ldloc.1
-			IL_081b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0820: conv.r8
-			IL_0821: ldc.r8 1
-			IL_082a: clt
-			IL_082c: ldc.i4.0
-			IL_082d: ceq
-			IL_082f: box [System.Runtime]System.Boolean
-			IL_0834: stloc.s 21
-			IL_0836: br IL_083f
-
-			IL_083b: ldloc.s 5
-			IL_083d: stloc.s 21
-
-			IL_083f: ldloc.s 21
-			IL_0841: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0846: stloc.s 4
-			IL_0848: ldloc.s 4
-			IL_084a: brfalse IL_086a
-
-			IL_084f: ldloc.0
-			IL_0850: ldstr "section"
-			IL_0855: ldloc.1
-			IL_0856: ldc.r8 0.0
-			IL_085f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-			IL_0869: pop
-
-			IL_086a: ldloc.0
-			IL_086b: ldstr "inFile"
-			IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0875: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_087a: ldc.i4.0
-			IL_087b: ceq
-			IL_087d: stloc.s 4
-			IL_087f: ldloc.s 4
-			IL_0881: box [System.Runtime]System.Boolean
-			IL_0886: stloc.s 5
-			IL_0888: ldloc.s 5
-			IL_088a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_088f: stloc.s 4
-			IL_0891: ldloc.s 4
-			IL_0893: brfalse IL_08bf
-
-			IL_0898: ldloc.0
-			IL_0899: ldstr "url"
-			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08a8: ldc.i4.0
-			IL_08a9: ceq
-			IL_08ab: stloc.s 4
-			IL_08ad: ldloc.s 4
-			IL_08af: box [System.Runtime]System.Boolean
-			IL_08b4: stloc.s 6
-			IL_08b6: ldloc.s 6
-			IL_08b8: stloc.s 22
-			IL_08ba: br IL_08c3
-
-			IL_08bf: ldloc.s 5
-			IL_08c1: stloc.s 22
-
-			IL_08c3: ldloc.s 22
-			IL_08c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_08ca: stloc.s 4
-			IL_08cc: ldloc.s 4
-			IL_08ce: brfalse IL_08f4
-
-			IL_08d3: ldloc.1
-			IL_08d4: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_08d9: conv.r8
-			IL_08da: ldc.r8 2
-			IL_08e3: clt
-			IL_08e5: ldc.i4.0
-			IL_08e6: ceq
-			IL_08e8: box [System.Runtime]System.Boolean
-			IL_08ed: stloc.s 22
-			IL_08ef: br IL_08f4
-
-			IL_08f4: ldloc.s 22
-			IL_08f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_08fb: stloc.s 4
-			IL_08fd: ldloc.s 4
-			IL_08ff: brfalse IL_091f
-
-			IL_0904: ldloc.0
-			IL_0905: ldstr "inFile"
-			IL_090a: ldloc.1
-			IL_090b: ldc.r8 1
-			IL_0914: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0919: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-			IL_091e: pop
-
-			IL_091f: ldloc.0
-			IL_0920: ldstr "outFile"
-			IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_092a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_092f: ldc.i4.0
-			IL_0930: ceq
-			IL_0932: stloc.s 4
-			IL_0934: ldloc.s 4
-			IL_0936: box [System.Runtime]System.Boolean
-			IL_093b: stloc.s 5
-			IL_093d: ldloc.s 5
-			IL_093f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0944: stloc.s 4
-			IL_0946: ldloc.s 4
-			IL_0948: brfalse IL_096e
-
-			IL_094d: ldloc.1
-			IL_094e: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0953: conv.r8
-			IL_0954: ldc.r8 3
-			IL_095d: clt
-			IL_095f: ldc.i4.0
-			IL_0960: ceq
-			IL_0962: box [System.Runtime]System.Boolean
-			IL_0967: stloc.s 24
-			IL_0969: br IL_0972
-
-			IL_096e: ldloc.s 5
-			IL_0970: stloc.s 24
-
-			IL_0972: ldloc.s 24
-			IL_0974: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0979: stloc.s 4
-			IL_097b: ldloc.s 4
-			IL_097d: brfalse IL_099d
-
-			IL_0982: ldloc.0
-			IL_0983: ldstr "outFile"
-			IL_0988: ldloc.1
-			IL_0989: ldc.r8 2
-			IL_0992: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0997: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-			IL_099c: pop
-
-			IL_099d: ldloc.0
-			IL_099e: ret
+			IL_02a6: ldloc.0
+			IL_02a7: ret
 		} // end of method parseArgs::__js_call__
 
 	} // end of class parseArgs
 
-	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithHttp
+	.class nested public auto ansi abstract sealed beforefieldinit fetchText
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5a28
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object urlString,
-				object maxRedirects
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x32a8
-			// Header size: 12
-			// Code size: 66 (0x42)
-			.maxstack 8
-			.locals init (
-				[0] object
-			)
-
-			IL_0000: ldarg.3
-			IL_0001: brtrue IL_0016
-
-			IL_0006: ldc.r8 5
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: starg.s maxRedirects
-
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: ldc.i4.0
-			IL_0021: ldelem.ref
-			IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0027: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
-			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0032: ldnull
-			IL_0033: ldstr "http"
-			IL_0038: ldarg.2
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_003f: stloc.0
-			IL_0040: ldloc.0
-			IL_0041: ret
-		} // end of method fetchTextWithHttp::__js_call__
-
-	} // end of class fetchTextWithHttp
-
-	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithHttps
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5a31
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object urlString,
-				object maxRedirects
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x32f8
-			// Header size: 12
-			// Code size: 66 (0x42)
-			.maxstack 8
-			.locals init (
-				[0] object
-			)
-
-			IL_0000: ldarg.3
-			IL_0001: brtrue IL_0016
-
-			IL_0006: ldc.r8 5
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: starg.s maxRedirects
-
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: ldc.i4.0
-			IL_0021: ldelem.ref
-			IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0027: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
-			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0032: ldnull
-			IL_0033: ldstr "https"
-			IL_0038: ldarg.2
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_003f: stloc.0
-			IL_0040: ldloc.0
-			IL_0041: ret
-		} // end of method fetchTextWithHttps::__js_call__
-
-	} // end of class fetchTextWithHttps
-
-	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithTransport
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L170C22
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L72C22
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L194C7
+			.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L91C7
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L219C24
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L116C24
 					extends [System.Runtime]System.Object
 				{
 					// Nested Types
@@ -2446,7 +1059,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5a8b
+							// Method begins at RVA 0x4151
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2471,7 +1084,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x589c
+						// Method begins at RVA 0x4004
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -2482,24 +1095,24 @@
 						IL_0000: ldarg.0
 						IL_0001: ldc.i4.3
 						IL_0002: ldelem.ref
-						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
-						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
 						IL_000d: ldarg.2
 						IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 						IL_0013: stloc.0
 						IL_0014: ldarg.0
 						IL_0015: ldc.i4.3
 						IL_0016: ldelem.ref
-						IL_0017: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
+						IL_0017: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
 						IL_001c: ldloc.0
-						IL_001d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_001d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
 						IL_0022: ldnull
 						IL_0023: ret
-					} // end of method ArrowFunction_L219C24::__js_call__
+					} // end of method ArrowFunction_L116C24::__js_call__
 
-				} // end of class ArrowFunction_L219C24
+				} // end of class ArrowFunction_L116C24
 
-				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L222C23
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L119C23
 					extends [System.Runtime]System.Object
 				{
 					// Nested Types
@@ -2510,7 +1123,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5a94
+							// Method begins at RVA 0x415a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2534,13 +1147,12 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x58cc
+						// Method begins at RVA 0x4034
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
 						.locals init (
-							[0] object[],
-							[1] object
+							[0] object[]
 						)
 
 						IL_0000: ldc.i4.4
@@ -2573,21 +1185,21 @@
 						IL_001f: ldarg.0
 						IL_0020: ldc.i4.2
 						IL_0021: ldelem.ref
-						IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-						IL_0027: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+						IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+						IL_0027: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
 						IL_002c: ldloc.0
 						IL_002d: ldarg.0
 						IL_002e: ldc.i4.3
 						IL_002f: ldelem.ref
-						IL_0030: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
-						IL_0035: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_0030: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+						IL_0035: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
 						IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-						IL_003f: stloc.1
-						IL_0040: ldloc.1
+						IL_003f: pop
+						IL_0040: ldnull
 						IL_0041: ret
-					} // end of method ArrowFunction_L222C23::__js_call__
+					} // end of method ArrowFunction_L119C23::__js_call__
 
-				} // end of class ArrowFunction_L222C23
+				} // end of class ArrowFunction_L119C23
 
 				.class nested private auto ansi beforefieldinit Scope
 					extends [System.Runtime]System.Object
@@ -2597,18 +1209,18 @@
 						73 7d 2c 20 64 61 74 61 3d 7b 64 61 74 61 7d 00 00
 					)
 					// Nested Types
-					.class nested private auto ansi beforefieldinit Block_L198C55
+					.class nested private auto ansi beforefieldinit Block_L95C55
 						extends [System.Runtime]System.Object
 					{
 						// Nested Types
-						.class nested private auto ansi beforefieldinit Block_L199C33
+						.class nested private auto ansi beforefieldinit Block_L96C33
 							extends [System.Runtime]System.Object
 						{
 							// Methods
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x5a79
+								// Method begins at RVA 0x413f
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -2617,16 +1229,16 @@
 								IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 								IL_0006: nop
 								IL_0007: ret
-							} // end of method Block_L199C33::.ctor
+							} // end of method Block_L96C33::.ctor
 
-						} // end of class Block_L199C33
+						} // end of class Block_L96C33
 
 
 						// Methods
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5a70
+							// Method begins at RVA 0x4136
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2635,18 +1247,18 @@
 							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 							IL_0006: nop
 							IL_0007: ret
-						} // end of method Block_L198C55::.ctor
+						} // end of method Block_L95C55::.ctor
 
-					} // end of class Block_L198C55
+					} // end of class Block_L95C55
 
-					.class nested private auto ansi beforefieldinit Block_L211C43
+					.class nested private auto ansi beforefieldinit Block_L108C43
 						extends [System.Runtime]System.Object
 					{
 						// Methods
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5a82
+							// Method begins at RVA 0x4148
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2655,9 +1267,9 @@
 							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 							IL_0006: nop
 							IL_0007: ret
-						} // end of method Block_L211C43::.ctor
+						} // end of method Block_L108C43::.ctor
 
-					} // end of class Block_L211C43
+					} // end of class Block_L108C43
 
 
 					// Fields
@@ -2668,7 +1280,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5a67
+						// Method begins at RVA 0x412d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2693,12 +1305,12 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x54a4
+					// Method begins at RVA 0x3c04
 					// Header size: 12
-					// Code size: 1001 (0x3e9)
+					// Code size: 1009 (0x3f1)
 					.maxstack 8
 					.locals init (
-						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope,
+						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
 						[1] object,
 						[2] object,
 						[3] object,
@@ -2714,13 +1326,12 @@
 						[13] object[],
 						[14] string,
 						[15] object,
-						[16] class [System.Runtime]System.Delegate,
+						[16] object,
 						[17] object,
-						[18] object,
-						[19] string
+						[18] string
 					)
 
-					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::.ctor()
+					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
 					IL_0005: stloc.0
 					IL_0006: ldarg.2
 					IL_0007: ldstr "statusCode"
@@ -2797,13 +1408,13 @@
 					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d4: stloc.s 5
 					IL_00d6: ldloc.s 5
-					IL_00d8: brfalse IL_0239
+					IL_00d8: brfalse IL_0241
 
 					IL_00dd: ldarg.0
 					IL_00de: ldc.i4.1
 					IL_00df: ldelem.ref
-					IL_00e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_00e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
+					IL_00e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_00e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
 					IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 					IL_00ef: ldc.r8 0.0
 					IL_00f8: cgt
@@ -2818,8 +1429,8 @@
 					IL_010e: ldarg.0
 					IL_010f: ldc.i4.2
 					IL_0110: ldelem.ref
-					IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
 					IL_011b: stloc.s 4
 					IL_011d: ldc.i4.3
 					IL_011e: newarr [System.Runtime]System.Object
@@ -2845,8 +1456,8 @@
 					IL_0137: ldarg.0
 					IL_0138: ldc.i4.1
 					IL_0139: ldelem.ref
-					IL_013a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_013f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_013a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_013f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
 					IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 					IL_0149: stloc.s 14
 					IL_014b: ldstr "Too many redirects fetching "
@@ -2865,275 +1476,279 @@
 					IL_0173: ldnull
 					IL_0174: ret
 
-					IL_0175: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
-					IL_017a: stloc.s 16
-					IL_017c: ldc.i4.2
-					IL_017d: newarr [System.Runtime]System.Object
-					IL_0182: dup
-					IL_0183: ldc.i4.0
-					IL_0184: ldloc.2
-					IL_0185: stelem.ref
-					IL_0186: dup
-					IL_0187: ldc.i4.1
-					IL_0188: ldarg.0
-					IL_0189: ldc.i4.2
-					IL_018a: ldelem.ref
-					IL_018b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_0190: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
-					IL_0195: stelem.ref
-					IL_0196: stloc.s 13
-					IL_0198: ldloc.s 16
-					IL_019a: ldloc.s 13
-					IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_01a1: stloc.s 15
-					IL_01a3: ldloc.s 15
-					IL_01a5: ldstr "toString"
-					IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01af: stloc.s 15
-					IL_01b1: ldloc.s 15
-					IL_01b3: stloc.3
-					IL_01b4: ldarg.2
-					IL_01b5: ldstr "resume"
-					IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01bf: pop
-					IL_01c0: ldarg.0
-					IL_01c1: ldc.i4.1
-					IL_01c2: ldelem.ref
-					IL_01c3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_01c8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
-					IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01d2: ldc.r8 1
-					IL_01db: sub
-					IL_01dc: box [System.Runtime]System.Double
-					IL_01e1: stloc.s 17
-					IL_01e3: ldc.i4.1
-					IL_01e4: newarr [System.Runtime]System.Object
-					IL_01e9: dup
-					IL_01ea: ldc.i4.0
-					IL_01eb: ldarg.0
-					IL_01ec: ldc.i4.0
-					IL_01ed: ldelem.ref
-					IL_01ee: stelem.ref
-					IL_01ef: ldc.i4.0
-					IL_01f0: ldelem.ref
-					IL_01f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-					IL_01f6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-					IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-					IL_0201: ldnull
-					IL_0202: ldloc.3
-					IL_0203: ldloc.s 17
-					IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-					IL_020a: stloc.s 15
-					IL_020c: ldarg.0
-					IL_020d: ldc.i4.2
-					IL_020e: ldelem.ref
-					IL_020f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_0214: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
-					IL_0219: stloc.s 4
-					IL_021b: ldloc.s 15
-					IL_021d: ldstr "then"
-					IL_0222: ldloc.s 4
-					IL_0224: ldarg.0
-					IL_0225: ldc.i4.2
-					IL_0226: ldelem.ref
-					IL_0227: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_022c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-					IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0236: pop
-					IL_0237: ldnull
-					IL_0238: ret
+					IL_0175: ldarg.0
+					IL_0176: ldc.i4.0
+					IL_0177: ldelem.ref
+					IL_0178: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_017d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_0182: stloc.s 15
+					IL_0184: ldc.i4.2
+					IL_0185: newarr [System.Runtime]System.Object
+					IL_018a: dup
+					IL_018b: ldc.i4.0
+					IL_018c: ldloc.2
+					IL_018d: stelem.ref
+					IL_018e: dup
+					IL_018f: ldc.i4.1
+					IL_0190: ldarg.0
+					IL_0191: ldc.i4.2
+					IL_0192: ldelem.ref
+					IL_0193: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0198: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_019d: stelem.ref
+					IL_019e: stloc.s 13
+					IL_01a0: ldloc.s 15
+					IL_01a2: ldloc.s 13
+					IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01a9: stloc.s 15
+					IL_01ab: ldloc.s 15
+					IL_01ad: ldstr "toString"
+					IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01b7: stloc.s 15
+					IL_01b9: ldloc.s 15
+					IL_01bb: stloc.3
+					IL_01bc: ldarg.2
+					IL_01bd: ldstr "resume"
+					IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01c7: pop
+					IL_01c8: ldarg.0
+					IL_01c9: ldc.i4.1
+					IL_01ca: ldelem.ref
+					IL_01cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_01d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_01d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01da: ldc.r8 1
+					IL_01e3: sub
+					IL_01e4: box [System.Runtime]System.Double
+					IL_01e9: stloc.s 16
+					IL_01eb: ldc.i4.1
+					IL_01ec: newarr [System.Runtime]System.Object
+					IL_01f1: dup
+					IL_01f2: ldc.i4.0
+					IL_01f3: ldarg.0
+					IL_01f4: ldc.i4.0
+					IL_01f5: ldelem.ref
+					IL_01f6: stelem.ref
+					IL_01f7: ldc.i4.0
+					IL_01f8: ldelem.ref
+					IL_01f9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_01fe: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+					IL_0204: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+					IL_0209: ldnull
+					IL_020a: ldloc.3
+					IL_020b: ldloc.s 16
+					IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+					IL_0212: stloc.s 15
+					IL_0214: ldarg.0
+					IL_0215: ldc.i4.2
+					IL_0216: ldelem.ref
+					IL_0217: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_021c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0221: stloc.s 4
+					IL_0223: ldloc.s 15
+					IL_0225: ldstr "then"
+					IL_022a: ldloc.s 4
+					IL_022c: ldarg.0
+					IL_022d: ldc.i4.2
+					IL_022e: ldelem.ref
+					IL_022f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0234: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_023e: pop
+					IL_023f: ldnull
+					IL_0240: ret
 
-					IL_0239: ldloc.1
-					IL_023a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_023f: stloc.s 8
-					IL_0241: ldloc.s 8
-					IL_0243: ldc.r8 200
-					IL_024c: clt
-					IL_024e: stloc.s 5
-					IL_0250: ldloc.s 5
-					IL_0252: box [System.Runtime]System.Boolean
-					IL_0257: stloc.s 9
-					IL_0259: ldloc.s 9
-					IL_025b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0260: stloc.s 5
-					IL_0262: ldloc.s 5
-					IL_0264: brtrue IL_0295
+					IL_0241: ldloc.1
+					IL_0242: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0247: stloc.s 8
+					IL_0249: ldloc.s 8
+					IL_024b: ldc.r8 200
+					IL_0254: clt
+					IL_0256: stloc.s 5
+					IL_0258: ldloc.s 5
+					IL_025a: box [System.Runtime]System.Boolean
+					IL_025f: stloc.s 9
+					IL_0261: ldloc.s 9
+					IL_0263: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0268: stloc.s 5
+					IL_026a: ldloc.s 5
+					IL_026c: brtrue IL_029d
 
-					IL_0269: ldloc.1
-					IL_026a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_026f: stloc.s 8
-					IL_0271: ldloc.s 8
-					IL_0273: ldc.r8 300
-					IL_027c: clt
-					IL_027e: ldc.i4.0
-					IL_027f: ceq
-					IL_0281: stloc.s 5
-					IL_0283: ldloc.s 5
-					IL_0285: box [System.Runtime]System.Boolean
-					IL_028a: stloc.s 10
-					IL_028c: ldloc.s 10
-					IL_028e: stloc.s 18
-					IL_0290: br IL_0299
+					IL_0271: ldloc.1
+					IL_0272: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0277: stloc.s 8
+					IL_0279: ldloc.s 8
+					IL_027b: ldc.r8 300
+					IL_0284: clt
+					IL_0286: ldc.i4.0
+					IL_0287: ceq
+					IL_0289: stloc.s 5
+					IL_028b: ldloc.s 5
+					IL_028d: box [System.Runtime]System.Boolean
+					IL_0292: stloc.s 10
+					IL_0294: ldloc.s 10
+					IL_0296: stloc.s 17
+					IL_0298: br IL_02a1
 
-					IL_0295: ldloc.s 9
-					IL_0297: stloc.s 18
+					IL_029d: ldloc.s 9
+					IL_029f: stloc.s 17
 
-					IL_0299: ldloc.s 18
-					IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02a0: stloc.s 5
-					IL_02a2: ldloc.s 5
-					IL_02a4: brfalse IL_033d
+					IL_02a1: ldloc.s 17
+					IL_02a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a8: stloc.s 5
+					IL_02aa: ldloc.s 5
+					IL_02ac: brfalse IL_0345
 
-					IL_02a9: ldarg.2
-					IL_02aa: ldstr "resume"
-					IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02b4: pop
-					IL_02b5: ldarg.0
-					IL_02b6: ldc.i4.2
-					IL_02b7: ldelem.ref
-					IL_02b8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
-					IL_02bd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-					IL_02c2: stloc.s 4
-					IL_02c4: ldc.i4.3
-					IL_02c5: newarr [System.Runtime]System.Object
-					IL_02ca: dup
-					IL_02cb: ldc.i4.0
-					IL_02cc: ldarg.0
-					IL_02cd: ldc.i4.0
-					IL_02ce: ldelem.ref
-					IL_02cf: stelem.ref
-					IL_02d0: dup
-					IL_02d1: ldc.i4.1
-					IL_02d2: ldarg.0
-					IL_02d3: ldc.i4.1
-					IL_02d4: ldelem.ref
-					IL_02d5: stelem.ref
-					IL_02d6: dup
-					IL_02d7: ldc.i4.2
-					IL_02d8: ldarg.0
-					IL_02d9: ldc.i4.2
-					IL_02da: ldelem.ref
-					IL_02db: stelem.ref
-					IL_02dc: stloc.s 13
-					IL_02de: ldloc.1
-					IL_02df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_02e4: stloc.s 14
-					IL_02e6: ldstr "HTTP "
-					IL_02eb: ldloc.s 14
-					IL_02ed: call string [System.Runtime]System.String::Concat(string, string)
-					IL_02f2: stloc.s 14
-					IL_02f4: ldloc.s 14
-					IL_02f6: ldstr " fetching "
-					IL_02fb: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0300: stloc.s 14
-					IL_0302: ldarg.0
-					IL_0303: ldc.i4.1
-					IL_0304: ldelem.ref
-					IL_0305: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_030a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-					IL_030f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0314: stloc.s 19
-					IL_0316: ldloc.s 14
-					IL_0318: ldloc.s 19
-					IL_031a: call string [System.Runtime]System.String::Concat(string, string)
-					IL_031f: stloc.s 19
-					IL_0321: ldloc.s 19
-					IL_0323: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0328: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_032d: stloc.s 15
-					IL_032f: ldloc.s 4
-					IL_0331: ldloc.s 13
-					IL_0333: ldloc.s 15
-					IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-					IL_033a: pop
-					IL_033b: ldnull
-					IL_033c: ret
+					IL_02b1: ldarg.2
+					IL_02b2: ldstr "resume"
+					IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02bc: pop
+					IL_02bd: ldarg.0
+					IL_02be: ldc.i4.2
+					IL_02bf: ldelem.ref
+					IL_02c0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02c5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_02ca: stloc.s 4
+					IL_02cc: ldc.i4.3
+					IL_02cd: newarr [System.Runtime]System.Object
+					IL_02d2: dup
+					IL_02d3: ldc.i4.0
+					IL_02d4: ldarg.0
+					IL_02d5: ldc.i4.0
+					IL_02d6: ldelem.ref
+					IL_02d7: stelem.ref
+					IL_02d8: dup
+					IL_02d9: ldc.i4.1
+					IL_02da: ldarg.0
+					IL_02db: ldc.i4.1
+					IL_02dc: ldelem.ref
+					IL_02dd: stelem.ref
+					IL_02de: dup
+					IL_02df: ldc.i4.2
+					IL_02e0: ldarg.0
+					IL_02e1: ldc.i4.2
+					IL_02e2: ldelem.ref
+					IL_02e3: stelem.ref
+					IL_02e4: stloc.s 13
+					IL_02e6: ldloc.1
+					IL_02e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_02ec: stloc.s 14
+					IL_02ee: ldstr "HTTP "
+					IL_02f3: ldloc.s 14
+					IL_02f5: call string [System.Runtime]System.String::Concat(string, string)
+					IL_02fa: stloc.s 14
+					IL_02fc: ldloc.s 14
+					IL_02fe: ldstr " fetching "
+					IL_0303: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0308: stloc.s 14
+					IL_030a: ldarg.0
+					IL_030b: ldc.i4.1
+					IL_030c: ldelem.ref
+					IL_030d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0312: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0317: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_031c: stloc.s 18
+					IL_031e: ldloc.s 14
+					IL_0320: ldloc.s 18
+					IL_0322: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0327: stloc.s 18
+					IL_0329: ldloc.s 18
+					IL_032b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0330: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0335: stloc.s 15
+					IL_0337: ldloc.s 4
+					IL_0339: ldloc.s 13
+					IL_033b: ldloc.s 15
+					IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_0342: pop
+					IL_0343: ldnull
+					IL_0344: ret
 
-					IL_033d: ldarg.2
-					IL_033e: ldstr "setEncoding"
-					IL_0343: ldstr "utf8"
-					IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_034d: pop
-					IL_034e: ldloc.0
-					IL_034f: ldstr ""
-					IL_0354: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
-					IL_0359: ldnull
-					IL_035a: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/ArrowFunction_L219C24::__js_call__(object[], object, object)
-					IL_0360: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_0365: ldc.i4.4
-					IL_0366: newarr [System.Runtime]System.Object
-					IL_036b: dup
-					IL_036c: ldc.i4.0
-					IL_036d: ldarg.0
-					IL_036e: ldc.i4.0
-					IL_036f: ldelem.ref
-					IL_0370: stelem.ref
-					IL_0371: dup
-					IL_0372: ldc.i4.1
-					IL_0373: ldarg.0
-					IL_0374: ldc.i4.1
-					IL_0375: ldelem.ref
-					IL_0376: stelem.ref
-					IL_0377: dup
-					IL_0378: ldc.i4.2
-					IL_0379: ldarg.0
-					IL_037a: ldc.i4.2
-					IL_037b: ldelem.ref
-					IL_037c: stelem.ref
-					IL_037d: dup
-					IL_037e: ldc.i4.3
-					IL_037f: ldloc.0
-					IL_0380: stelem.ref
-					IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_038b: stloc.s 15
-					IL_038d: ldarg.2
-					IL_038e: ldstr "on"
-					IL_0393: ldstr "data"
-					IL_0398: ldloc.s 15
-					IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_039f: pop
-					IL_03a0: ldnull
-					IL_03a1: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/ArrowFunction_L222C23::__js_call__(object[], object)
-					IL_03a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_03ac: ldc.i4.4
-					IL_03ad: newarr [System.Runtime]System.Object
-					IL_03b2: dup
-					IL_03b3: ldc.i4.0
-					IL_03b4: ldarg.0
-					IL_03b5: ldc.i4.0
-					IL_03b6: ldelem.ref
-					IL_03b7: stelem.ref
-					IL_03b8: dup
-					IL_03b9: ldc.i4.1
-					IL_03ba: ldarg.0
-					IL_03bb: ldc.i4.1
-					IL_03bc: ldelem.ref
-					IL_03bd: stelem.ref
-					IL_03be: dup
-					IL_03bf: ldc.i4.2
-					IL_03c0: ldarg.0
-					IL_03c1: ldc.i4.2
-					IL_03c2: ldelem.ref
-					IL_03c3: stelem.ref
-					IL_03c4: dup
-					IL_03c5: ldc.i4.3
-					IL_03c6: ldloc.0
-					IL_03c7: stelem.ref
-					IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03d2: stloc.s 15
-					IL_03d4: ldarg.2
-					IL_03d5: ldstr "on"
-					IL_03da: ldstr "end"
-					IL_03df: ldloc.s 15
-					IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_03e6: pop
-					IL_03e7: ldnull
-					IL_03e8: ret
-				} // end of method ArrowFunction_L194C7::__js_call__
+					IL_0345: ldarg.2
+					IL_0346: ldstr "setEncoding"
+					IL_034b: ldstr "utf8"
+					IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0355: pop
+					IL_0356: ldloc.0
+					IL_0357: ldstr ""
+					IL_035c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_0361: ldnull
+					IL_0362: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_0368: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_036d: ldc.i4.4
+					IL_036e: newarr [System.Runtime]System.Object
+					IL_0373: dup
+					IL_0374: ldc.i4.0
+					IL_0375: ldarg.0
+					IL_0376: ldc.i4.0
+					IL_0377: ldelem.ref
+					IL_0378: stelem.ref
+					IL_0379: dup
+					IL_037a: ldc.i4.1
+					IL_037b: ldarg.0
+					IL_037c: ldc.i4.1
+					IL_037d: ldelem.ref
+					IL_037e: stelem.ref
+					IL_037f: dup
+					IL_0380: ldc.i4.2
+					IL_0381: ldarg.0
+					IL_0382: ldc.i4.2
+					IL_0383: ldelem.ref
+					IL_0384: stelem.ref
+					IL_0385: dup
+					IL_0386: ldc.i4.3
+					IL_0387: ldloc.0
+					IL_0388: stelem.ref
+					IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0393: stloc.s 15
+					IL_0395: ldarg.2
+					IL_0396: ldstr "on"
+					IL_039b: ldstr "data"
+					IL_03a0: ldloc.s 15
+					IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03a7: pop
+					IL_03a8: ldnull
+					IL_03a9: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_03af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_03b4: ldc.i4.4
+					IL_03b5: newarr [System.Runtime]System.Object
+					IL_03ba: dup
+					IL_03bb: ldc.i4.0
+					IL_03bc: ldarg.0
+					IL_03bd: ldc.i4.0
+					IL_03be: ldelem.ref
+					IL_03bf: stelem.ref
+					IL_03c0: dup
+					IL_03c1: ldc.i4.1
+					IL_03c2: ldarg.0
+					IL_03c3: ldc.i4.1
+					IL_03c4: ldelem.ref
+					IL_03c5: stelem.ref
+					IL_03c6: dup
+					IL_03c7: ldc.i4.2
+					IL_03c8: ldarg.0
+					IL_03c9: ldc.i4.2
+					IL_03ca: ldelem.ref
+					IL_03cb: stelem.ref
+					IL_03cc: dup
+					IL_03cd: ldc.i4.3
+					IL_03ce: ldloc.0
+					IL_03cf: stelem.ref
+					IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03da: stloc.s 15
+					IL_03dc: ldarg.2
+					IL_03dd: ldstr "on"
+					IL_03e2: ldstr "end"
+					IL_03e7: ldloc.s 15
+					IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03ee: pop
+					IL_03ef: ldnull
+					IL_03f0: ret
+				} // end of method ArrowFunction_L91C7::__js_call__
 
-			} // end of class ArrowFunction_L194C7
+			} // end of class ArrowFunction_L91C7
 
 			.class nested private auto ansi beforefieldinit Scope
 				extends [System.Runtime]System.Object
@@ -3145,14 +1760,14 @@
 					4f 62 6a 3d 7b 75 72 6c 4f 62 6a 7d 00 00
 				)
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L172C8
+				.class nested private auto ansi beforefieldinit Block_L74C8
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5a4c
+						// Method begins at RVA 0x411b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3161,18 +1776,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L172C8::.ctor
+					} // end of method Block_L74C8::.ctor
 
-				} // end of class Block_L172C8
+				} // end of class Block_L74C8
 
-				.class nested private auto ansi beforefieldinit Block_L174C12
+				.class nested private auto ansi beforefieldinit Block_L76C12
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5a55
+						// Method begins at RVA 0x4124
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3181,29 +1796,9 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L174C12::.ctor
+					} // end of method Block_L76C12::.ctor
 
-				} // end of class Block_L174C12
-
-				.class nested private auto ansi beforefieldinit Block_L179C44
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5a5e
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L179C44::.ctor
-
-				} // end of class Block_L179C44
+				} // end of class Block_L76C12
 
 
 				// Fields
@@ -3215,7 +1810,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5a43
+					// Method begins at RVA 0x4112
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3241,312 +1836,221 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x5154
+				// Method begins at RVA 0x3a28
 				// Header size: 12
-				// Code size: 674 (0x2a2)
+				// Code size: 448 (0x1c0)
 				.maxstack 8
 				.locals init (
-					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope,
+					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
 					[1] class [System.Runtime]System.Exception,
 					[2] object,
 					[3] object,
 					[4] object,
-					[5] class [System.Runtime]System.Delegate,
+					[5] object,
 					[6] object,
 					[7] object[],
 					[8] string,
 					[9] object,
-					[10] object,
-					[11] bool,
-					[12] string,
-					[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[10] bool,
+					[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
-				IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::.ctor()
+				IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::.ctor()
 				IL_0005: stloc.0
 				IL_0006: ldloc.0
 				IL_0007: ldarg.2
-				IL_0008: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+				IL_0008: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
 				IL_000d: ldloc.0
 				IL_000e: ldarg.3
-				IL_000f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+				IL_000f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
 				IL_0014: ldloc.0
 				IL_0015: ldnull
-				IL_0016: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+				IL_0016: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
 				.try
 				{
-					IL_001b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
-					IL_0020: stloc.s 5
-					IL_0022: ldloc.s 5
-					IL_0024: ldc.i4.1
-					IL_0025: newarr [System.Runtime]System.Object
-					IL_002a: dup
-					IL_002b: ldc.i4.0
-					IL_002c: ldarg.0
-					IL_002d: ldc.i4.1
-					IL_002e: ldelem.ref
-					IL_002f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_0034: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-					IL_0039: stelem.ref
-					IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_003f: stloc.s 6
-					IL_0041: ldloc.0
-					IL_0042: ldloc.s 6
-					IL_0044: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
-					IL_0049: leave IL_00b5
+					IL_001b: ldarg.0
+					IL_001c: ldc.i4.0
+					IL_001d: ldelem.ref
+					IL_001e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_0023: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_0028: stloc.s 6
+					IL_002a: ldloc.s 6
+					IL_002c: ldc.i4.1
+					IL_002d: newarr [System.Runtime]System.Object
+					IL_0032: dup
+					IL_0033: ldc.i4.0
+					IL_0034: ldarg.0
+					IL_0035: ldc.i4.1
+					IL_0036: ldelem.ref
+					IL_0037: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_003c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0041: stelem.ref
+					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_0047: stloc.s 6
+					IL_0049: ldloc.0
+					IL_004a: ldloc.s 6
+					IL_004c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_0051: leave IL_00bd
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
-					IL_004e: stloc.1
-					IL_004f: ldloc.0
-					IL_0050: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-					IL_0055: stloc.s 6
-					IL_0057: ldc.i4.2
-					IL_0058: newarr [System.Runtime]System.Object
-					IL_005d: dup
-					IL_005e: ldc.i4.0
-					IL_005f: ldarg.0
-					IL_0060: ldc.i4.0
-					IL_0061: ldelem.ref
-					IL_0062: stelem.ref
-					IL_0063: dup
-					IL_0064: ldc.i4.1
-					IL_0065: ldarg.0
-					IL_0066: ldc.i4.1
-					IL_0067: ldelem.ref
-					IL_0068: stelem.ref
-					IL_0069: stloc.s 7
-					IL_006b: ldarg.0
+					IL_0056: stloc.1
+					IL_0057: ldloc.0
+					IL_0058: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_005d: stloc.s 6
+					IL_005f: ldc.i4.2
+					IL_0060: newarr [System.Runtime]System.Object
+					IL_0065: dup
+					IL_0066: ldc.i4.0
+					IL_0067: ldarg.0
+					IL_0068: ldc.i4.0
+					IL_0069: ldelem.ref
+					IL_006a: stelem.ref
+					IL_006b: dup
 					IL_006c: ldc.i4.1
-					IL_006d: ldelem.ref
-					IL_006e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-					IL_0073: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-					IL_0078: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_007d: stloc.s 8
-					IL_007f: ldstr "Invalid URL: "
-					IL_0084: ldloc.s 8
-					IL_0086: call string [System.Runtime]System.String::Concat(string, string)
-					IL_008b: stloc.s 8
-					IL_008d: ldloc.s 8
-					IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0099: stloc.s 9
-					IL_009b: ldloc.s 6
-					IL_009d: ldloc.s 7
-					IL_009f: ldloc.s 9
-					IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-					IL_00a6: pop
-					IL_00a7: ldnull
-					IL_00a8: stloc.2
-					IL_00a9: ldnull
-					IL_00aa: stloc.2
-					IL_00ab: leave IL_02a0
+					IL_006d: ldarg.0
+					IL_006e: ldc.i4.1
+					IL_006f: ldelem.ref
+					IL_0070: stelem.ref
+					IL_0071: stloc.s 7
+					IL_0073: ldarg.0
+					IL_0074: ldc.i4.1
+					IL_0075: ldelem.ref
+					IL_0076: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_007b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0080: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0085: stloc.s 8
+					IL_0087: ldstr "Invalid URL: "
+					IL_008c: ldloc.s 8
+					IL_008e: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0093: stloc.s 8
+					IL_0095: ldloc.s 8
+					IL_0097: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_009c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00a1: stloc.s 9
+					IL_00a3: ldloc.s 6
+					IL_00a5: ldloc.s 7
+					IL_00a7: ldloc.s 9
+					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_00ae: pop
+					IL_00af: ldnull
+					IL_00b0: stloc.2
+					IL_00b1: ldnull
+					IL_00b2: stloc.2
+					IL_00b3: leave IL_01be
 
-					IL_00b0: leave IL_00b5
+					IL_00b8: leave IL_00bd
 				} // end handler
 
-				IL_00b5: ldloc.0
-				IL_00b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
-				IL_00bb: ldstr "protocol"
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00c5: stloc.s 9
-				IL_00c7: ldarg.0
-				IL_00c8: ldc.i4.1
-				IL_00c9: ldelem.ref
-				IL_00ca: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_00cf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-				IL_00d4: ldstr ":"
-				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00de: stloc.s 10
-				IL_00e0: ldloc.s 9
-				IL_00e2: ldloc.s 10
-				IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_00e9: stloc.s 11
-				IL_00eb: ldloc.s 11
-				IL_00ed: brfalse IL_01a6
+				IL_00bd: ldloc.0
+				IL_00be: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_00c3: ldstr "protocol"
+				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00cd: ldstr "https:"
+				IL_00d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00d7: stloc.s 10
+				IL_00d9: ldloc.s 10
+				IL_00db: brfalse IL_00f3
 
-				IL_00f2: ldloc.0
-				IL_00f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-				IL_00f8: stloc.s 9
-				IL_00fa: ldc.i4.2
-				IL_00fb: newarr [System.Runtime]System.Object
-				IL_0100: dup
-				IL_0101: ldc.i4.0
-				IL_0102: ldarg.0
-				IL_0103: ldc.i4.0
-				IL_0104: ldelem.ref
-				IL_0105: stelem.ref
-				IL_0106: dup
-				IL_0107: ldc.i4.1
-				IL_0108: ldarg.0
-				IL_0109: ldc.i4.1
-				IL_010a: ldelem.ref
-				IL_010b: stelem.ref
-				IL_010c: stloc.s 7
-				IL_010e: ldarg.0
-				IL_010f: ldc.i4.1
-				IL_0110: ldelem.ref
-				IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-				IL_011b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0120: stloc.s 8
-				IL_0122: ldstr "Only "
-				IL_0127: ldloc.s 8
-				IL_0129: call string [System.Runtime]System.String::Concat(string, string)
-				IL_012e: stloc.s 8
-				IL_0130: ldloc.s 8
-				IL_0132: ldstr ":// URLs are supported by the "
-				IL_0137: call string [System.Runtime]System.String::Concat(string, string)
-				IL_013c: stloc.s 8
-				IL_013e: ldarg.0
-				IL_013f: ldc.i4.1
-				IL_0140: ldelem.ref
-				IL_0141: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_0146: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-				IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0150: stloc.s 12
-				IL_0152: ldloc.s 8
-				IL_0154: ldloc.s 12
-				IL_0156: call string [System.Runtime]System.String::Concat(string, string)
-				IL_015b: stloc.s 12
-				IL_015d: ldloc.s 12
-				IL_015f: ldstr " fallback. Got: "
-				IL_0164: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0169: stloc.s 12
-				IL_016b: ldarg.0
+				IL_00e0: ldarg.0
+				IL_00e1: ldc.i4.0
+				IL_00e2: ldelem.ref
+				IL_00e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00ed: stloc.3
+				IL_00ee: br IL_0101
+
+				IL_00f3: ldarg.0
+				IL_00f4: ldc.i4.0
+				IL_00f5: ldelem.ref
+				IL_00f6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00fb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_0100: stloc.3
+
+				IL_0101: ldloc.3
+				IL_0102: stloc.s 4
+				IL_0104: ldloc.0
+				IL_0105: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_010a: stloc.s 9
+				IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0111: dup
+				IL_0112: ldstr "method"
+				IL_0117: ldstr "GET"
+				IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0121: dup
+				IL_0122: ldstr "headers"
+				IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_012c: dup
+				IL_012d: ldstr "Accept-Encoding"
+				IL_0132: ldstr "identity"
+				IL_0137: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_013c: dup
+				IL_013d: ldstr "User-Agent"
+				IL_0142: ldstr "js2il-docs-script"
+				IL_0147: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_014c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0151: stloc.s 11
+				IL_0153: ldnull
+				IL_0154: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_015f: ldc.i4.3
+				IL_0160: newarr [System.Runtime]System.Object
+				IL_0165: dup
+				IL_0166: ldc.i4.0
+				IL_0167: ldarg.0
+				IL_0168: ldc.i4.0
+				IL_0169: ldelem.ref
+				IL_016a: stelem.ref
+				IL_016b: dup
 				IL_016c: ldc.i4.1
-				IL_016d: ldelem.ref
-				IL_016e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_0173: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-				IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_017d: stloc.s 8
-				IL_017f: ldloc.s 12
-				IL_0181: ldloc.s 8
-				IL_0183: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0188: stloc.s 8
-				IL_018a: ldloc.s 8
-				IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0196: stloc.s 6
-				IL_0198: ldloc.s 9
-				IL_019a: ldloc.s 7
-				IL_019c: ldloc.s 6
-				IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-				IL_01a3: pop
-				IL_01a4: ldnull
-				IL_01a5: ret
+				IL_016d: ldarg.0
+				IL_016e: ldc.i4.1
+				IL_016f: ldelem.ref
+				IL_0170: stelem.ref
+				IL_0171: dup
+				IL_0172: ldc.i4.2
+				IL_0173: ldloc.0
+				IL_0174: stelem.ref
+				IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_017f: stloc.s 6
+				IL_0181: ldloc.s 4
+				IL_0183: ldstr "request"
+				IL_0188: ldloc.s 9
+				IL_018a: ldloc.s 11
+				IL_018c: ldloc.s 6
+				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0193: stloc.s 6
+				IL_0195: ldloc.s 6
+				IL_0197: stloc.s 5
+				IL_0199: ldloc.s 5
+				IL_019b: ldstr "on"
+				IL_01a0: ldstr "error"
+				IL_01a5: ldloc.0
+				IL_01a6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01b0: pop
+				IL_01b1: ldloc.s 5
+				IL_01b3: ldstr "end"
+				IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_01bd: pop
 
-				IL_01a6: ldarg.0
-				IL_01a7: ldc.i4.1
-				IL_01a8: ldelem.ref
-				IL_01a9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
-				IL_01ae: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-				IL_01b3: ldstr "http"
-				IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01bd: stloc.s 11
-				IL_01bf: ldloc.s 11
-				IL_01c1: brfalse IL_01d9
+				IL_01be: ldloc.2
+				IL_01bf: ret
+			} // end of method ArrowFunction_L72C22::__js_call__
 
-				IL_01c6: ldarg.0
-				IL_01c7: ldc.i4.0
-				IL_01c8: ldelem.ref
-				IL_01c9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-				IL_01ce: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::http
-				IL_01d3: stloc.3
-				IL_01d4: br IL_01e7
-
-				IL_01d9: ldarg.0
-				IL_01da: ldc.i4.0
-				IL_01db: ldelem.ref
-				IL_01dc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-				IL_01e1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::https
-				IL_01e6: stloc.3
-
-				IL_01e7: ldloc.0
-				IL_01e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
-				IL_01ed: stloc.s 6
-				IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_01f4: dup
-				IL_01f5: ldstr "method"
-				IL_01fa: ldstr "GET"
-				IL_01ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0204: dup
-				IL_0205: ldstr "headers"
-				IL_020a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_020f: dup
-				IL_0210: ldstr "Accept-Encoding"
-				IL_0215: ldstr "identity"
-				IL_021a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_021f: dup
-				IL_0220: ldstr "User-Agent"
-				IL_0225: ldstr "js2il-docs-script"
-				IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0234: stloc.s 13
-				IL_0236: ldnull
-				IL_0237: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7::__js_call__(object[], object, object)
-				IL_023d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_0242: ldc.i4.3
-				IL_0243: newarr [System.Runtime]System.Object
-				IL_0248: dup
-				IL_0249: ldc.i4.0
-				IL_024a: ldarg.0
-				IL_024b: ldc.i4.0
-				IL_024c: ldelem.ref
-				IL_024d: stelem.ref
-				IL_024e: dup
-				IL_024f: ldc.i4.1
-				IL_0250: ldarg.0
-				IL_0251: ldc.i4.1
-				IL_0252: ldelem.ref
-				IL_0253: stelem.ref
-				IL_0254: dup
-				IL_0255: ldc.i4.2
-				IL_0256: ldloc.0
-				IL_0257: stelem.ref
-				IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_0262: stloc.s 9
-				IL_0264: ldloc.3
-				IL_0265: ldstr "request"
-				IL_026a: ldloc.s 6
-				IL_026c: ldloc.s 13
-				IL_026e: ldloc.s 9
-				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_0275: stloc.s 9
-				IL_0277: ldloc.s 9
-				IL_0279: stloc.s 4
-				IL_027b: ldloc.s 4
-				IL_027d: ldstr "on"
-				IL_0282: ldstr "error"
-				IL_0287: ldloc.0
-				IL_0288: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
-				IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0292: pop
-				IL_0293: ldloc.s 4
-				IL_0295: ldstr "end"
-				IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_029f: pop
-
-				IL_02a0: ldloc.2
-				IL_02a1: ret
-			} // end of method ArrowFunction_L170C22::__js_call__
-
-		} // end of class ArrowFunction_L170C22
+		} // end of class ArrowFunction_L72C22
 
 		.class nested private auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
 			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 4d 53 63 6f 70 65 20 70 72 6f 74 6f 63 6f
-				6c 3d 7b 70 72 6f 74 6f 63 6f 6c 7d 2c 20 75 72
-				6c 53 74 72 69 6e 67 3d 7b 75 72 6c 53 74 72 69
-				6e 67 7d 2c 20 6d 61 78 52 65 64 69 72 65 63 74
-				73 3d 7b 6d 61 78 52 65 64 69 72 65 63 74 73 7d
-				00 00
+				01 00 38 53 63 6f 70 65 20 75 72 6c 53 74 72 69
+				6e 67 3d 7b 75 72 6c 53 74 72 69 6e 67 7d 2c 20
+				6d 61 78 52 65 64 69 72 65 63 74 73 3d 7b 6d 61
+				78 52 65 64 69 72 65 63 74 73 7d 00 00
 			)
 			// Fields
-			.field public object protocol
 			.field public object urlString
 			.field public object maxRedirects
 
@@ -3554,7 +2058,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5a3a
+				// Method begins at RVA 0x4109
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3571,9 +2075,8 @@
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
-				object protocol,
 				object urlString,
 				object maxRedirects
 			) cil managed 
@@ -3581,463 +2084,57 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3348
+			// Method begins at RVA 0x27fc
 			// Header size: 12
-			// Code size: 97 (0x61)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope,
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise
 			)
 
-			IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::.ctor()
+			IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldarg.s maxRedirects
-			IL_0008: brtrue IL_001d
+			IL_0006: ldarg.3
+			IL_0007: brtrue IL_001c
 
-			IL_000d: ldc.r8 5
-			IL_0016: box [System.Runtime]System.Double
-			IL_001b: starg.s maxRedirects
+			IL_000c: ldc.r8 5
+			IL_0015: box [System.Runtime]System.Double
+			IL_001a: starg.s maxRedirects
 
-			IL_001d: ldloc.0
-			IL_001e: ldarg.2
-			IL_001f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
-			IL_0024: ldloc.0
-			IL_0025: ldarg.3
-			IL_0026: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
-			IL_002b: ldloc.0
-			IL_002c: ldarg.s maxRedirects
-			IL_002e: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
-			IL_0033: ldnull
-			IL_0034: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22::__js_call__(object[], object, object, object)
-			IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
-			IL_003f: ldc.i4.2
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldloc.0
-			IL_004c: stelem.ref
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0057: stloc.1
-			IL_0058: ldloc.1
-			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
-			IL_005e: stloc.2
-			IL_005f: ldloc.2
-			IL_0060: ret
-		} // end of method fetchTextWithTransport::__js_call__
-
-	} // end of class fetchTextWithTransport
-
-	.class nested public auto ansi abstract sealed beforefieldinit fetchText
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5a9d
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object urlString
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x33b8
-			// Header size: 12
-			// Code size: 39 (0x27)
-			.maxstack 8
-			.locals init (
-				[0] object
-			)
-
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0011: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_001c: ldnull
+			IL_001c: ldloc.0
 			IL_001d: ldarg.2
-			IL_001e: ldnull
-			IL_001f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0024: stloc.0
-			IL_0025: ldloc.0
-			IL_0026: ret
+			IL_001e: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+			IL_0023: ldloc.0
+			IL_0024: ldarg.3
+			IL_0025: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+			IL_002a: ldnull
+			IL_002b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22::__js_call__(object[], object, object, object)
+			IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+			IL_0036: ldc.i4.2
+			IL_0037: newarr [System.Runtime]System.Object
+			IL_003c: dup
+			IL_003d: ldc.i4.0
+			IL_003e: ldarg.0
+			IL_003f: stelem.ref
+			IL_0040: dup
+			IL_0041: ldc.i4.1
+			IL_0042: ldloc.0
+			IL_0043: stelem.ref
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_004e: stloc.1
+			IL_004f: ldloc.1
+			IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+			IL_0055: stloc.2
+			IL_0056: ldloc.2
+			IL_0057: ret
 		} // end of method fetchText::__js_call__
 
 	} // end of class fetchText
-
-	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithNodeRequest
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L237C6
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5aaf
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L237C6::.ctor
-
-			} // end of class Block_L237C6
-
-			.class nested private auto ansi beforefieldinit Block_L239C10
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5ab8
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L239C10::.ctor
-
-			} // end of class Block_L239C10
-
-			.class nested private auto ansi beforefieldinit Block_L243C35
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5ac1
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L243C35::.ctor
-
-			} // end of class Block_L243C35
-
-			.class nested private auto ansi beforefieldinit Block_L247C36
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5aca
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L247C36::.ctor
-
-			} // end of class Block_L247C36
-
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5aa6
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object urlString,
-				object maxRedirects
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x33ec
-			// Header size: 12
-			// Code size: 309 (0x135)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] class [System.Runtime]System.Exception,
-				[2] object,
-				[3] class [System.Runtime]System.Delegate,
-				[4] object,
-				[5] string,
-				[6] bool
-			)
-
-			IL_0000: ldarg.3
-			IL_0001: brtrue IL_0016
-
-			IL_0006: ldc.r8 5
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: starg.s maxRedirects
-
-			IL_0016: ldnull
-			IL_0017: stloc.0
-			.try
-			{
-				IL_0018: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
-				IL_001d: stloc.3
-				IL_001e: ldloc.3
-				IL_001f: ldc.i4.1
-				IL_0020: newarr [System.Runtime]System.Object
-				IL_0025: dup
-				IL_0026: ldc.i4.0
-				IL_0027: ldarg.2
-				IL_0028: stelem.ref
-				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-				IL_002e: stloc.s 4
-				IL_0030: ldloc.s 4
-				IL_0032: stloc.0
-				IL_0033: leave IL_0075
-			} // end .try
-			catch [System.Runtime]System.Exception
-			{
-				IL_0038: stloc.1
-				IL_0039: ldarg.2
-				IL_003a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_003f: stloc.s 5
-				IL_0041: ldstr "Invalid URL: "
-				IL_0046: ldloc.s 5
-				IL_0048: call string [System.Runtime]System.String::Concat(string, string)
-				IL_004d: stloc.s 5
-				IL_004f: ldloc.s 5
-				IL_0051: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0056: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_005b: stloc.s 4
-				IL_005d: ldloc.s 4
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-				IL_0064: stloc.s 4
-				IL_0066: ldnull
-				IL_0067: stloc.2
-				IL_0068: ldloc.s 4
-				IL_006a: stloc.2
-				IL_006b: leave IL_0133
-
-				IL_0070: leave IL_0075
-			} // end handler
-
-			IL_0075: ldloc.0
-			IL_0076: ldstr "protocol"
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0080: ldstr "http:"
-			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_008a: stloc.s 6
-			IL_008c: ldloc.s 6
-			IL_008e: brfalse IL_00bc
-
-			IL_0093: ldc.i4.1
-			IL_0094: newarr [System.Runtime]System.Object
-			IL_0099: dup
-			IL_009a: ldc.i4.0
-			IL_009b: ldarg.0
-			IL_009c: stelem.ref
-			IL_009d: ldc.i4.0
-			IL_009e: ldelem.ref
-			IL_009f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_00a4: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttp::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_00af: ldnull
-			IL_00b0: ldarg.2
-			IL_00b1: ldarg.3
-			IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_00b7: stloc.s 4
-			IL_00b9: ldloc.s 4
-			IL_00bb: ret
-
-			IL_00bc: ldloc.0
-			IL_00bd: ldstr "protocol"
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c7: ldstr "https:"
-			IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00d1: stloc.s 6
-			IL_00d3: ldloc.s 6
-			IL_00d5: brfalse IL_0103
-
-			IL_00da: ldc.i4.1
-			IL_00db: newarr [System.Runtime]System.Object
-			IL_00e0: dup
-			IL_00e1: ldc.i4.0
-			IL_00e2: ldarg.0
-			IL_00e3: stelem.ref
-			IL_00e4: ldc.i4.0
-			IL_00e5: ldelem.ref
-			IL_00e6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_00eb: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttps::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_00f6: ldnull
-			IL_00f7: ldarg.2
-			IL_00f8: ldarg.3
-			IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_00fe: stloc.s 4
-			IL_0100: ldloc.s 4
-			IL_0102: ret
-
-			IL_0103: ldarg.2
-			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0109: stloc.s 5
-			IL_010b: ldstr "Only http:// and https:// URLs are supported by the request fallback. Got: "
-			IL_0110: ldloc.s 5
-			IL_0112: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0117: stloc.s 5
-			IL_0119: ldloc.s 5
-			IL_011b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0125: stloc.s 4
-			IL_0127: ldloc.s 4
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-			IL_012e: stloc.s 4
-			IL_0130: ldloc.s 4
-			IL_0132: ret
-
-			IL_0133: ldloc.2
-			IL_0134: ret
-		} // end of method fetchTextWithNodeRequest::__js_call__
-
-	} // end of class fetchTextWithNodeRequest
-
-	.class nested public auto ansi abstract sealed beforefieldinit detectEol
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5ad3
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object text
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x3540
-			// Header size: 12
-			// Code size: 49 (0x31)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] bool
-			)
-
-			IL_0000: ldarg.1
-			IL_0001: ldstr "includes"
-			IL_0006: ldstr "\r\n"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0017: stloc.2
-			IL_0018: ldloc.2
-			IL_0019: brfalse IL_0029
-
-			IL_001e: ldstr "\r\n"
-			IL_0023: stloc.0
-			IL_0024: br IL_002f
-
-			IL_0029: ldstr "\n"
-			IL_002e: stloc.0
-
-			IL_002f: ldloc.0
-			IL_0030: ret
-		} // end of method detectEol::__js_call__
-
-	} // end of class detectEol
 
 	.class nested public auto ansi abstract sealed beforefieldinit escapeRegExp
 		extends [System.Runtime]System.Object
@@ -4050,7 +2147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5adc
+				// Method begins at RVA 0x4163
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4074,7 +2171,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3580
+			// Method begins at RVA 0x2860
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -4099,220 +2196,6 @@
 
 	} // end of class escapeRegExp
 
-	.class nested public auto ansi abstract sealed beforefieldinit writeTextPreserveEol
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L266C31
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5aee
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L266C31::.ctor
-
-			} // end of class Block_L266C31
-
-			.class nested private auto ansi beforefieldinit Block_L274C60
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5af7
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L274C60::.ctor
-
-			} // end of class Block_L274C60
-
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5ae5
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object filePath,
-				object text
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x35b0
-			// Header size: 12
-			// Code size: 286 (0x11e)
-			.maxstack 8
-			.locals init (
-				[0] string,
-				[1] object,
-				[2] object,
-				[3] object,
-				[4] bool,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[6] object,
-				[7] object,
-				[8] object,
-				[9] object,
-				[10] object
-			)
-
-			IL_0000: ldstr "\n"
-			IL_0005: stloc.0
-			IL_0006: ldc.i4.0
-			IL_0007: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_000c: stloc.1
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_0013: ldstr "existsSync"
-			IL_0018: ldarg.2
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001e: stloc.3
-			IL_001f: ldloc.3
-			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0025: stloc.s 4
-			IL_0027: ldloc.s 4
-			IL_0029: brfalse IL_0051
-
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_0034: ldstr "readFileSync"
-			IL_0039: ldarg.2
-			IL_003a: ldstr "utf8"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0044: stloc.3
-			IL_0045: ldloc.3
-			IL_0046: stloc.1
-			IL_0047: ldnull
-			IL_0048: ldloc.1
-			IL_0049: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/detectEol::__js_call__(object, object)
-			IL_004e: stloc.3
-			IL_004f: ldloc.3
-			IL_0050: stloc.0
-
-			IL_0051: ldstr "\\r\\n|\\n"
-			IL_0056: ldstr "g"
-			IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0060: stloc.s 5
-			IL_0062: ldarg.3
-			IL_0063: ldstr "replace"
-			IL_0068: ldloc.s 5
-			IL_006a: ldloc.0
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0070: stloc.3
-			IL_0071: ldloc.3
-			IL_0072: stloc.2
-			IL_0073: ldloc.1
-			IL_0074: ldc.i4.0
-			IL_0075: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_007f: stloc.s 4
-			IL_0081: ldloc.s 4
-			IL_0083: box [System.Runtime]System.Boolean
-			IL_0088: stloc.s 6
-			IL_008a: ldloc.s 6
-			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0091: stloc.s 4
-			IL_0093: ldloc.s 4
-			IL_0095: brfalse IL_00b5
-
-			IL_009a: ldloc.1
-			IL_009b: ldloc.2
-			IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00a1: stloc.s 4
-			IL_00a3: ldloc.s 4
-			IL_00a5: box [System.Runtime]System.Boolean
-			IL_00aa: stloc.s 7
-			IL_00ac: ldloc.s 7
-			IL_00ae: stloc.s 9
-			IL_00b0: br IL_00b9
-
-			IL_00b5: ldloc.s 6
-			IL_00b7: stloc.s 9
-
-			IL_00b9: ldloc.s 9
-			IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00c0: stloc.s 4
-			IL_00c2: ldloc.s 4
-			IL_00c4: brfalse IL_00cb
-
-			IL_00c9: ldnull
-			IL_00ca: ret
-
-			IL_00cb: ldarg.0
-			IL_00cc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_00d1: stloc.3
-			IL_00d2: ldarg.0
-			IL_00d3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
-			IL_00d8: ldstr "dirname"
-			IL_00dd: ldarg.2
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00e3: stloc.s 10
-			IL_00e5: ldloc.3
-			IL_00e6: ldstr "mkdirSync"
-			IL_00eb: ldloc.s 10
-			IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00f2: dup
-			IL_00f3: ldstr "recursive"
-			IL_00f8: ldc.i4.1
-			IL_00f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0103: pop
-			IL_0104: ldarg.0
-			IL_0105: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_010a: ldstr "writeFileSync"
-			IL_010f: ldarg.2
-			IL_0110: ldloc.2
-			IL_0111: ldstr "utf8"
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_011b: pop
-			IL_011c: ldnull
-			IL_011d: ret
-		} // end of method writeTextPreserveEol::__js_call__
-
-	} // end of class writeTextPreserveEol
-
 	.class nested public auto ansi abstract sealed beforefieldinit findTagNameAt
 		extends [System.Runtime]System.Object
 	{
@@ -4321,36 +2204,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L290C26
+			.class nested private auto ansi beforefieldinit Block_L135C46
 				extends [System.Runtime]System.Object
 			{
-				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L292C93
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5b12
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L292C93::.ctor
-
-				} // end of class Block_L292C93
-
-
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b09
+					// Method begins at RVA 0x4175
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4359,16 +2220,58 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L290C26::.ctor
+				} // end of method Block_L135C46::.ctor
 
-			} // end of class Block_L290C26
+			} // end of class Block_L135C46
+
+			.class nested private auto ansi beforefieldinit Block_L140C30
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L142C93
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4187
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L142C93::.ctor
+
+				} // end of class Block_L142C93
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x417e
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L140C30::.ctor
+
+			} // end of class Block_L140C30
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b00
+				// Method begins at RVA 0x416c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4385,7 +2288,7 @@
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
 				object html,
 				object tagStart
@@ -4394,249 +2297,223 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x36dc
+			// Method begins at RVA 0x2890
 			// Header size: 12
-			// Code size: 584 (0x248)
+			// Code size: 507 (0x1fb)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] bool,
-				[2] object,
+				[1] object,
+				[2] float64,
 				[3] object,
-				[4] object,
+				[4] bool,
 				[5] object,
-				[6] float64,
+				[6] object,
 				[7] object,
-				[8] bool,
+				[8] object,
 				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] object,
-				[16] object,
-				[17] object,
-				[18] object
+				[14] object
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: stloc.s 6
-			IL_0008: ldloc.s 6
-			IL_000a: ldc.r8 0.0
-			IL_0013: clt
-			IL_0015: box [System.Runtime]System.Boolean
-			IL_001a: stloc.s 7
-			IL_001c: ldloc.s 7
-			IL_001e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0023: stloc.s 8
-			IL_0025: ldloc.s 8
-			IL_0027: brtrue IL_0052
+			IL_0006: stloc.2
+			IL_0007: ldloc.2
+			IL_0008: ldc.r8 0.0
+			IL_0011: clt
+			IL_0013: box [System.Runtime]System.Boolean
+			IL_0018: stloc.3
+			IL_0019: ldloc.3
+			IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_001f: stloc.s 4
+			IL_0021: ldloc.s 4
+			IL_0023: brtrue IL_004d
 
-			IL_002c: ldarg.2
-			IL_002d: ldloc.s 6
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0034: ldstr "<"
-			IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_003e: stloc.s 8
-			IL_0040: ldloc.s 8
-			IL_0042: box [System.Runtime]System.Boolean
-			IL_0047: stloc.s 9
-			IL_0049: ldloc.s 9
-			IL_004b: stloc.s 11
-			IL_004d: br IL_0056
+			IL_0028: ldarg.2
+			IL_0029: ldloc.2
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_002f: ldstr "<"
+			IL_0034: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0039: stloc.s 4
+			IL_003b: ldloc.s 4
+			IL_003d: box [System.Runtime]System.Boolean
+			IL_0042: stloc.s 5
+			IL_0044: ldloc.s 5
+			IL_0046: stloc.s 7
+			IL_0048: br IL_0050
 
-			IL_0052: ldloc.s 7
-			IL_0054: stloc.s 11
+			IL_004d: ldloc.3
+			IL_004e: stloc.s 7
 
-			IL_0056: ldloc.s 11
-			IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005d: stloc.s 8
-			IL_005f: ldloc.s 8
-			IL_0061: brfalse IL_006c
+			IL_0050: ldloc.s 7
+			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0057: stloc.s 4
+			IL_0059: ldloc.s 4
+			IL_005b: brfalse IL_0066
 
-			IL_0066: ldstr ""
-			IL_006b: ret
+			IL_0060: ldstr ""
+			IL_0065: ret
 
-			IL_006c: ldarg.3
-			IL_006d: ldc.r8 1
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_007b: stloc.s 11
-			IL_007d: ldloc.s 11
-			IL_007f: stloc.0
-			IL_0080: ldarg.2
-			IL_0081: ldloc.0
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0087: ldstr "/"
-			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
-			IL_0095: stloc.1
-			IL_0096: ldloc.1
-			IL_0097: brfalse IL_00b5
+			IL_0066: ldarg.3
+			IL_0067: ldc.r8 1
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0075: stloc.s 7
+			IL_0077: ldloc.s 7
+			IL_0079: stloc.0
+			// loop start (head: IL_007a)
+				IL_007a: ldarg.2
+				IL_007b: ldstr "length"
+				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0085: stloc.s 8
+				IL_0087: ldloc.0
+				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_008d: stloc.2
+				IL_008e: ldloc.2
+				IL_008f: ldloc.s 8
+				IL_0091: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0096: clt
+				IL_0098: brfalse IL_01d7
 
-			IL_009c: ldloc.0
-			IL_009d: ldc.r8 1
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00ab: stloc.s 11
-			IL_00ad: ldloc.s 11
-			IL_00af: stloc.2
-			IL_00b0: br IL_00b7
+				IL_009d: ldarg.2
+				IL_009e: ldloc.0
+				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_00a4: stloc.1
+				IL_00a5: ldloc.1
+				IL_00a6: ldstr " "
+				IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00b0: stloc.s 4
+				IL_00b2: ldloc.s 4
+				IL_00b4: box [System.Runtime]System.Boolean
+				IL_00b9: stloc.3
+				IL_00ba: ldloc.3
+				IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00c0: stloc.s 4
+				IL_00c2: ldloc.s 4
+				IL_00c4: brtrue IL_00e8
 
-			IL_00b5: ldloc.0
-			IL_00b6: stloc.2
+				IL_00c9: ldloc.1
+				IL_00ca: ldstr "\t"
+				IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00d4: stloc.s 4
+				IL_00d6: ldloc.s 4
+				IL_00d8: box [System.Runtime]System.Boolean
+				IL_00dd: stloc.s 5
+				IL_00df: ldloc.s 5
+				IL_00e1: stloc.s 9
+				IL_00e3: br IL_00eb
 
-			IL_00b7: ldloc.2
-			IL_00b8: stloc.3
-			IL_00b9: ldloc.3
-			IL_00ba: stloc.s 4
-			// loop start (head: IL_00bc)
-				IL_00bc: ldarg.2
-				IL_00bd: ldstr "length"
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00c7: stloc.s 12
-				IL_00c9: ldloc.s 4
-				IL_00cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00d0: stloc.s 6
-				IL_00d2: ldloc.s 6
-				IL_00d4: ldloc.s 12
-				IL_00d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00db: clt
-				IL_00dd: brfalse IL_0235
+				IL_00e8: ldloc.3
+				IL_00e9: stloc.s 9
 
-				IL_00e2: ldarg.2
-				IL_00e3: ldloc.s 4
-				IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00ea: stloc.s 5
-				IL_00ec: ldloc.s 5
-				IL_00ee: ldstr " "
-				IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00f8: stloc.s 8
-				IL_00fa: ldloc.s 8
-				IL_00fc: box [System.Runtime]System.Boolean
-				IL_0101: stloc.s 7
-				IL_0103: ldloc.s 7
-				IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_010a: stloc.s 8
-				IL_010c: ldloc.s 8
-				IL_010e: brtrue IL_0133
+				IL_00eb: ldloc.s 9
+				IL_00ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00f2: stloc.s 4
+				IL_00f4: ldloc.s 4
+				IL_00f6: brtrue IL_0118
 
-				IL_0113: ldloc.s 5
-				IL_0115: ldstr "\t"
-				IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_011f: stloc.s 8
-				IL_0121: ldloc.s 8
-				IL_0123: box [System.Runtime]System.Boolean
-				IL_0128: stloc.s 9
-				IL_012a: ldloc.s 9
-				IL_012c: stloc.s 13
-				IL_012e: br IL_0137
+				IL_00fb: ldloc.1
+				IL_00fc: ldstr "\r"
+				IL_0101: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0106: stloc.s 4
+				IL_0108: ldloc.s 4
+				IL_010a: box [System.Runtime]System.Boolean
+				IL_010f: stloc.3
+				IL_0110: ldloc.3
+				IL_0111: stloc.s 9
+				IL_0113: br IL_0118
 
-				IL_0133: ldloc.s 7
-				IL_0135: stloc.s 13
+				IL_0118: ldloc.s 9
+				IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_011f: stloc.s 4
+				IL_0121: ldloc.s 4
+				IL_0123: brtrue IL_0145
 
-				IL_0137: ldloc.s 13
-				IL_0139: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013e: stloc.s 8
-				IL_0140: ldloc.s 8
-				IL_0142: brtrue IL_0167
+				IL_0128: ldloc.1
+				IL_0129: ldstr "\n"
+				IL_012e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0133: stloc.s 4
+				IL_0135: ldloc.s 4
+				IL_0137: box [System.Runtime]System.Boolean
+				IL_013c: stloc.3
+				IL_013d: ldloc.3
+				IL_013e: stloc.s 9
+				IL_0140: br IL_0145
 
-				IL_0147: ldloc.s 5
-				IL_0149: ldstr "\r"
-				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0153: stloc.s 8
-				IL_0155: ldloc.s 8
-				IL_0157: box [System.Runtime]System.Boolean
-				IL_015c: stloc.s 7
-				IL_015e: ldloc.s 7
-				IL_0160: stloc.s 13
-				IL_0162: br IL_0167
+				IL_0145: ldloc.s 9
+				IL_0147: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_014c: stloc.s 4
+				IL_014e: ldloc.s 4
+				IL_0150: brtrue IL_0172
 
-				IL_0167: ldloc.s 13
-				IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_016e: stloc.s 8
-				IL_0170: ldloc.s 8
-				IL_0172: brtrue IL_0197
+				IL_0155: ldloc.1
+				IL_0156: ldstr ">"
+				IL_015b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0160: stloc.s 4
+				IL_0162: ldloc.s 4
+				IL_0164: box [System.Runtime]System.Boolean
+				IL_0169: stloc.3
+				IL_016a: ldloc.3
+				IL_016b: stloc.s 9
+				IL_016d: br IL_0172
 
-				IL_0177: ldloc.s 5
-				IL_0179: ldstr "\n"
-				IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0183: stloc.s 8
-				IL_0185: ldloc.s 8
-				IL_0187: box [System.Runtime]System.Boolean
-				IL_018c: stloc.s 7
-				IL_018e: ldloc.s 7
-				IL_0190: stloc.s 13
-				IL_0192: br IL_0197
+				IL_0172: ldloc.s 9
+				IL_0174: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0179: stloc.s 4
+				IL_017b: ldloc.s 4
+				IL_017d: brtrue IL_019f
 
-				IL_0197: ldloc.s 13
-				IL_0199: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_019e: stloc.s 8
-				IL_01a0: ldloc.s 8
-				IL_01a2: brtrue IL_01c7
+				IL_0182: ldloc.1
+				IL_0183: ldstr "/"
+				IL_0188: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_018d: stloc.s 4
+				IL_018f: ldloc.s 4
+				IL_0191: box [System.Runtime]System.Boolean
+				IL_0196: stloc.3
+				IL_0197: ldloc.3
+				IL_0198: stloc.s 9
+				IL_019a: br IL_019f
 
-				IL_01a7: ldloc.s 5
-				IL_01a9: ldstr ">"
-				IL_01ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01b3: stloc.s 8
-				IL_01b5: ldloc.s 8
-				IL_01b7: box [System.Runtime]System.Boolean
-				IL_01bc: stloc.s 7
-				IL_01be: ldloc.s 7
-				IL_01c0: stloc.s 13
-				IL_01c2: br IL_01c7
+				IL_019f: ldloc.s 9
+				IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01a6: stloc.s 4
+				IL_01a8: ldloc.s 4
+				IL_01aa: brfalse IL_01b4
 
-				IL_01c7: ldloc.s 13
-				IL_01c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01ce: stloc.s 8
-				IL_01d0: ldloc.s 8
-				IL_01d2: brtrue IL_01f7
+				IL_01af: br IL_01d7
 
-				IL_01d7: ldloc.s 5
-				IL_01d9: ldstr "/"
-				IL_01de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01e3: stloc.s 8
-				IL_01e5: ldloc.s 8
-				IL_01e7: box [System.Runtime]System.Boolean
-				IL_01ec: stloc.s 7
-				IL_01ee: ldloc.s 7
-				IL_01f0: stloc.s 13
-				IL_01f2: br IL_01f7
-
-				IL_01f7: ldloc.s 13
-				IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01fe: stloc.s 8
-				IL_0200: ldloc.s 8
-				IL_0202: brfalse IL_020c
-
-				IL_0207: br IL_0235
-
-				IL_020c: ldloc.s 4
-				IL_020e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0213: stloc.s 6
-				IL_0215: ldloc.s 6
-				IL_0217: ldc.r8 1
-				IL_0220: add
-				IL_0221: stloc.s 6
-				IL_0223: ldloc.s 6
-				IL_0225: box [System.Runtime]System.Double
-				IL_022a: stloc.s 18
-				IL_022c: ldloc.s 18
-				IL_022e: stloc.s 4
-				IL_0230: br IL_00bc
+				IL_01b4: ldloc.0
+				IL_01b5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01ba: stloc.2
+				IL_01bb: ldloc.2
+				IL_01bc: ldc.r8 1
+				IL_01c5: add
+				IL_01c6: stloc.2
+				IL_01c7: ldloc.2
+				IL_01c8: box [System.Runtime]System.Double
+				IL_01cd: stloc.s 14
+				IL_01cf: ldloc.s 14
+				IL_01d1: stloc.0
+				IL_01d2: br IL_007a
 			// end loop
 
-			IL_0235: ldarg.2
-			IL_0236: ldstr "substring"
-			IL_023b: ldloc.3
-			IL_023c: ldloc.s 4
-			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0243: stloc.s 12
-			IL_0245: ldloc.s 12
-			IL_0247: ret
+			IL_01d7: ldarg.3
+			IL_01d8: ldc.r8 1
+			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01e6: stloc.s 9
+			IL_01e8: ldarg.2
+			IL_01e9: ldstr "substring"
+			IL_01ee: ldloc.s 9
+			IL_01f0: ldloc.0
+			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01f6: stloc.s 8
+			IL_01f8: ldloc.s 8
+			IL_01fa: ret
 		} // end of method findTagNameAt::__js_call__
 
 	} // end of class findTagNameAt
@@ -4649,14 +2526,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L307C19
+			.class nested private auto ansi beforefieldinit Block_L156C19
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b24
+					// Method begins at RVA 0x4199
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4665,18 +2542,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L307C19::.ctor
+				} // end of method Block_L156C19::.ctor
 
-			} // end of class Block_L307C19
+			} // end of class Block_L156C19
 
-			.class nested private auto ansi beforefieldinit Block_L312C20
+			.class nested private auto ansi beforefieldinit Block_L160C19
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b2d
+					// Method begins at RVA 0x41a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4685,18 +2562,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L312C20::.ctor
+				} // end of method Block_L160C19::.ctor
 
-			} // end of class Block_L312C20
+			} // end of class Block_L160C19
 
-			.class nested private auto ansi beforefieldinit Block_L317C16
+			.class nested private auto ansi beforefieldinit Block_L165C20
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b36
+					// Method begins at RVA 0x41ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4705,22 +2582,42 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L317C16::.ctor
+				} // end of method Block_L165C20::.ctor
 
-			} // end of class Block_L317C16
+			} // end of class Block_L165C20
 
-			.class nested private auto ansi beforefieldinit Block_L328C15
+			.class nested private auto ansi beforefieldinit Block_L170C16
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x41b4
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L170C16::.ctor
+
+			} // end of class Block_L170C16
+
+			.class nested private auto ansi beforefieldinit Block_L180C15
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L334C24
+				.class nested private auto ansi beforefieldinit Block_L182C16
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5b48
+						// Method begins at RVA 0x41c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4729,22 +2626,42 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L334C24::.ctor
+					} // end of method Block_L182C16::.ctor
 
-				} // end of class Block_L334C24
+				} // end of class Block_L182C16
 
-				.class nested private auto ansi beforefieldinit Block_L339C17
+				.class nested private auto ansi beforefieldinit Block_L187C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x41cf
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L187C24::.ctor
+
+				} // end of class Block_L187C24
+
+				.class nested private auto ansi beforefieldinit Block_L191C32
 					extends [System.Runtime]System.Object
 				{
 					// Nested Types
-					.class nested private auto ansi beforefieldinit Block_L341C23
+					.class nested private auto ansi beforefieldinit Block_L193C23
 						extends [System.Runtime]System.Object
 					{
 						// Methods
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x5b5a
+							// Method begins at RVA 0x41e1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -4753,16 +2670,16 @@
 							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 							IL_0006: nop
 							IL_0007: ret
-						} // end of method Block_L341C23::.ctor
+						} // end of method Block_L193C23::.ctor
 
-					} // end of class Block_L341C23
+					} // end of class Block_L193C23
 
 
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5b51
+						// Method begins at RVA 0x41d8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4771,18 +2688,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L339C17::.ctor
+					} // end of method Block_L191C32::.ctor
 
-				} // end of class Block_L339C17
+				} // end of class Block_L191C32
 
-				.class nested private auto ansi beforefieldinit Block_L348C11
+				.class nested private auto ansi beforefieldinit Block_L199C11
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5b63
+						// Method begins at RVA 0x41ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4791,16 +2708,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L348C11::.ctor
+					} // end of method Block_L199C11::.ctor
 
-				} // end of class Block_L348C11
+				} // end of class Block_L199C11
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5b3f
+					// Method begins at RVA 0x41bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4809,16 +2726,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L328C15::.ctor
+				} // end of method Block_L180C15::.ctor
 
-			} // end of class Block_L328C15
+			} // end of class Block_L180C15
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b1b
+				// Method begins at RVA 0x4190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4835,7 +2752,7 @@
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
 				object html,
 				object elementId
@@ -4844,11 +2761,11 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3930
+			// Method begins at RVA 0x2a98
 			// Header size: 12
-			// Code size: 966 (0x3c6)
+			// Code size: 958 (0x3be)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4861,54 +2778,52 @@
 				[7] object,
 				[8] object,
 				[9] object,
-				[10] object,
+				[10] string,
 				[11] object,
-				[12] string,
-				[13] object,
-				[14] float64,
-				[15] bool,
-				[16] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[18] string
+				[12] float64,
+				[13] bool,
+				[14] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[16] string
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0006: stloc.s 12
+			IL_0006: stloc.s 10
 			IL_0008: ldstr "id=\""
-			IL_000d: ldloc.s 12
+			IL_000d: ldloc.s 10
 			IL_000f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0014: stloc.s 12
-			IL_0016: ldloc.s 12
+			IL_0014: stloc.s 10
+			IL_0016: ldloc.s 10
 			IL_0018: ldstr "\""
 			IL_001d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0022: stloc.s 12
-			IL_0024: ldloc.s 12
+			IL_0022: stloc.s 10
+			IL_0024: ldloc.s 10
 			IL_0026: stloc.0
 			IL_0027: ldarg.3
 			IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002d: stloc.s 12
+			IL_002d: stloc.s 10
 			IL_002f: ldstr "id='"
-			IL_0034: ldloc.s 12
+			IL_0034: ldloc.s 10
 			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.s 12
-			IL_003d: ldloc.s 12
+			IL_003b: stloc.s 10
+			IL_003d: ldloc.s 10
 			IL_003f: ldstr "'"
 			IL_0044: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0049: stloc.s 12
-			IL_004b: ldloc.s 12
+			IL_0049: stloc.s 10
+			IL_004b: ldloc.s 10
 			IL_004d: stloc.1
 			IL_004e: ldarg.2
 			IL_004f: ldstr "indexOf"
 			IL_0054: ldloc.0
 			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005a: stloc.s 13
-			IL_005c: ldloc.s 13
+			IL_005a: stloc.s 11
+			IL_005c: ldloc.s 11
 			IL_005e: stloc.2
 			IL_005f: ldloc.2
 			IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0065: stloc.s 14
-			IL_0067: ldloc.s 14
+			IL_0065: stloc.s 12
+			IL_0067: ldloc.s 12
 			IL_0069: ldc.r8 0.0
 			IL_0072: clt
 			IL_0074: brfalse IL_008a
@@ -4917,30 +2832,30 @@
 			IL_007a: ldstr "indexOf"
 			IL_007f: ldloc.1
 			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0085: stloc.s 13
-			IL_0087: ldloc.s 13
+			IL_0085: stloc.s 11
+			IL_0087: ldloc.s 11
 			IL_0089: stloc.2
 
 			IL_008a: ldloc.2
 			IL_008b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0090: stloc.s 14
-			IL_0092: ldloc.s 14
+			IL_0090: stloc.s 12
+			IL_0092: ldloc.s 12
 			IL_0094: ldc.r8 0.0
 			IL_009d: clt
 			IL_009f: brfalse IL_00e9
 
 			IL_00a4: ldarg.3
 			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00aa: stloc.s 12
+			IL_00aa: stloc.s 10
 			IL_00ac: ldstr "Could not find id '"
-			IL_00b1: ldloc.s 12
+			IL_00b1: ldloc.s 10
 			IL_00b3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b8: stloc.s 12
-			IL_00ba: ldloc.s 12
+			IL_00b8: stloc.s 10
+			IL_00ba: ldloc.s 10
 			IL_00bc: ldstr "' in input HTML."
 			IL_00c1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c6: stloc.s 12
-			IL_00c8: ldloc.s 12
+			IL_00c6: stloc.s 10
+			IL_00c8: ldloc.s 10
 			IL_00ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 			IL_00d4: dup
@@ -4960,29 +2875,29 @@
 			IL_00ef: ldstr "<"
 			IL_00f4: ldloc.2
 			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fa: stloc.s 13
-			IL_00fc: ldloc.s 13
+			IL_00fa: stloc.s 11
+			IL_00fc: ldloc.s 11
 			IL_00fe: stloc.3
 			IL_00ff: ldloc.3
 			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0105: stloc.s 14
-			IL_0107: ldloc.s 14
+			IL_0105: stloc.s 12
+			IL_0107: ldloc.s 12
 			IL_0109: ldc.r8 0.0
 			IL_0112: clt
 			IL_0114: brfalse IL_015e
 
 			IL_0119: ldarg.3
 			IL_011a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_011f: stloc.s 12
+			IL_011f: stloc.s 10
 			IL_0121: ldstr "Could not locate tag start for id '"
-			IL_0126: ldloc.s 12
+			IL_0126: ldloc.s 10
 			IL_0128: call string [System.Runtime]System.String::Concat(string, string)
-			IL_012d: stloc.s 12
-			IL_012f: ldloc.s 12
+			IL_012d: stloc.s 10
+			IL_012f: ldloc.s 10
 			IL_0131: ldstr "'."
 			IL_0136: call string [System.Runtime]System.String::Concat(string, string)
-			IL_013b: stloc.s 12
-			IL_013d: ldloc.s 12
+			IL_013b: stloc.s 10
+			IL_013d: ldloc.s 10
 			IL_013f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 			IL_0149: dup
@@ -5005,36 +2920,36 @@
 			IL_0167: stelem.ref
 			IL_0168: ldc.i4.0
 			IL_0169: ldelem.ref
-			IL_016a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_016f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_016a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_016f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 			IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
 			IL_017a: ldnull
 			IL_017b: ldarg.2
 			IL_017c: ldloc.3
 			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0182: stloc.s 13
-			IL_0184: ldloc.s 13
+			IL_0182: stloc.s 11
+			IL_0184: ldloc.s 11
 			IL_0186: stloc.s 4
 			IL_0188: ldloc.s 4
 			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_018f: ldc.i4.0
 			IL_0190: ceq
-			IL_0192: stloc.s 15
-			IL_0194: ldloc.s 15
+			IL_0192: stloc.s 13
+			IL_0194: ldloc.s 13
 			IL_0196: brfalse IL_01e0
 
 			IL_019b: ldarg.3
 			IL_019c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a1: stloc.s 12
+			IL_01a1: stloc.s 10
 			IL_01a3: ldstr "Could not determine tag name for id '"
-			IL_01a8: ldloc.s 12
+			IL_01a8: ldloc.s 10
 			IL_01aa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01af: stloc.s 12
-			IL_01b1: ldloc.s 12
+			IL_01af: stloc.s 10
+			IL_01b1: ldloc.s 10
 			IL_01b3: ldstr "'."
 			IL_01b8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01bd: stloc.s 12
-			IL_01bf: ldloc.s 12
+			IL_01bd: stloc.s 10
+			IL_01bf: ldloc.s 10
 			IL_01c1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_01c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 			IL_01cb: dup
@@ -5051,24 +2966,24 @@
 
 			IL_01e0: ldnull
 			IL_01e1: ldloc.s 4
-			IL_01e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
-			IL_01e8: stloc.s 13
-			IL_01ea: ldloc.s 13
+			IL_01e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+			IL_01e8: stloc.s 11
+			IL_01ea: ldloc.s 11
 			IL_01ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01f1: stloc.s 12
+			IL_01f1: stloc.s 10
 			IL_01f3: ldstr "<\\/?"
-			IL_01f8: ldloc.s 12
+			IL_01f8: ldloc.s 10
 			IL_01fa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ff: stloc.s 12
-			IL_0201: ldloc.s 12
+			IL_01ff: stloc.s 10
+			IL_0201: ldloc.s 10
 			IL_0203: ldstr "\\b[^>]*>"
 			IL_0208: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020d: stloc.s 12
-			IL_020f: ldloc.s 12
+			IL_020d: stloc.s 10
+			IL_020f: ldloc.s 10
 			IL_0211: ldstr "gi"
 			IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_021b: stloc.s 16
-			IL_021d: ldloc.s 16
+			IL_021b: stloc.s 14
+			IL_021d: ldloc.s 14
 			IL_021f: stloc.s 5
 			IL_0221: ldloc.s 5
 			IL_0223: ldstr "lastIndex"
@@ -5083,24 +2998,24 @@
 			IL_0249: stloc.s 7
 			// loop start (head: IL_024b)
 				IL_024b: ldc.i4.1
-				IL_024c: brfalse IL_035d
+				IL_024c: brfalse IL_0355
 
 				IL_0251: ldloc.s 5
 				IL_0253: ldstr "exec"
 				IL_0258: ldarg.2
 				IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_025e: stloc.s 13
-				IL_0260: ldloc.s 13
+				IL_025e: stloc.s 11
+				IL_0260: ldloc.s 11
 				IL_0262: stloc.s 8
 				IL_0264: ldloc.s 8
 				IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_026b: ldc.i4.0
 				IL_026c: ceq
-				IL_026e: stloc.s 15
-				IL_0270: ldloc.s 15
+				IL_026e: stloc.s 13
+				IL_0270: ldloc.s 13
 				IL_0272: brfalse IL_027c
 
-				IL_0277: br IL_035d
+				IL_0277: br IL_0355
 
 				IL_027c: ldloc.s 8
 				IL_027e: ldc.r8 0.0
@@ -5108,8 +3023,8 @@
 				IL_028c: stloc.s 9
 				IL_028e: ldloc.s 7
 				IL_0290: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0295: stloc.s 14
-				IL_0297: ldloc.s 14
+				IL_0295: stloc.s 12
+				IL_0297: ldloc.s 12
 				IL_0299: ldc.r8 0.0
 				IL_02a2: clt
 				IL_02a4: brfalse IL_02bb
@@ -5117,104 +3032,100 @@
 				IL_02a9: ldloc.s 8
 				IL_02ab: ldstr "index"
 				IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02b5: stloc.s 13
-				IL_02b7: ldloc.s 13
+				IL_02b5: stloc.s 11
+				IL_02b7: ldloc.s 11
 				IL_02b9: stloc.s 7
 
 				IL_02bb: ldloc.s 9
 				IL_02bd: ldstr "startsWith"
 				IL_02c2: ldstr "</"
 				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02cc: stloc.s 13
-				IL_02ce: ldloc.s 13
-				IL_02d0: stloc.s 10
-				IL_02d2: ldloc.s 10
-				IL_02d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02d9: stloc.s 15
-				IL_02db: ldloc.s 15
-				IL_02dd: brfalse IL_034a
+				IL_02cc: stloc.s 11
+				IL_02ce: ldloc.s 11
+				IL_02d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d5: stloc.s 13
+				IL_02d7: ldloc.s 13
+				IL_02d9: brfalse IL_0342
 
-				IL_02e2: ldloc.s 6
-				IL_02e4: ldc.r8 1
-				IL_02ed: sub
-				IL_02ee: stloc.s 6
-				IL_02f0: ldloc.s 6
-				IL_02f2: ldc.r8 0.0
-				IL_02fb: ceq
-				IL_02fd: brfalse IL_0345
+				IL_02de: ldloc.s 6
+				IL_02e0: ldc.r8 1
+				IL_02e9: sub
+				IL_02ea: stloc.s 6
+				IL_02ec: ldloc.s 6
+				IL_02ee: ldc.r8 0.0
+				IL_02f7: ceq
+				IL_02f9: brfalse IL_033d
 
-				IL_0302: ldloc.s 5
-				IL_0304: ldstr "lastIndex"
-				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_030e: stloc.s 11
-				IL_0310: ldarg.2
-				IL_0311: ldstr "substring"
-				IL_0316: ldloc.s 7
-				IL_0318: ldloc.s 11
-				IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_031f: stloc.s 13
-				IL_0321: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0326: dup
-				IL_0327: ldstr "tagName"
-				IL_032c: ldloc.s 4
-				IL_032e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0333: dup
-				IL_0334: ldstr "html"
-				IL_0339: ldloc.s 13
-				IL_033b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0340: stloc.s 17
-				IL_0342: ldloc.s 17
-				IL_0344: ret
+				IL_02fe: ldarg.2
+				IL_02ff: ldstr "substring"
+				IL_0304: ldloc.s 7
+				IL_0306: ldloc.s 5
+				IL_0308: ldstr "lastIndex"
+				IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0317: stloc.s 11
+				IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_031e: dup
+				IL_031f: ldstr "tagName"
+				IL_0324: ldloc.s 4
+				IL_0326: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_032b: dup
+				IL_032c: ldstr "html"
+				IL_0331: ldloc.s 11
+				IL_0333: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0338: stloc.s 15
+				IL_033a: ldloc.s 15
+				IL_033c: ret
 
-				IL_0345: br IL_0358
+				IL_033d: br IL_0350
 
-				IL_034a: ldloc.s 6
-				IL_034c: ldc.r8 1
-				IL_0355: add
-				IL_0356: stloc.s 6
+				IL_0342: ldloc.s 6
+				IL_0344: ldc.r8 1
+				IL_034d: add
+				IL_034e: stloc.s 6
 
-				IL_0358: br IL_024b
+				IL_0350: br IL_024b
 			// end loop
 
-			IL_035d: ldloc.s 4
-			IL_035f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0364: stloc.s 12
-			IL_0366: ldstr "Could not find a matching closing </"
-			IL_036b: ldloc.s 12
-			IL_036d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0372: stloc.s 12
-			IL_0374: ldloc.s 12
-			IL_0376: ldstr "> for id '"
-			IL_037b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0380: stloc.s 12
-			IL_0382: ldarg.3
-			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0388: stloc.s 18
-			IL_038a: ldloc.s 12
-			IL_038c: ldloc.s 18
-			IL_038e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0393: stloc.s 18
-			IL_0395: ldloc.s 18
-			IL_0397: ldstr "'."
-			IL_039c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03a1: stloc.s 18
-			IL_03a3: ldloc.s 18
-			IL_03a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03af: dup
-			IL_03b0: isinst [System.Runtime]System.Exception
-			IL_03b5: dup
-			IL_03b6: brtrue IL_03c2
+			IL_0355: ldloc.s 4
+			IL_0357: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_035c: stloc.s 10
+			IL_035e: ldstr "Could not find a matching closing </"
+			IL_0363: ldloc.s 10
+			IL_0365: call string [System.Runtime]System.String::Concat(string, string)
+			IL_036a: stloc.s 10
+			IL_036c: ldloc.s 10
+			IL_036e: ldstr "> for id '"
+			IL_0373: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0378: stloc.s 10
+			IL_037a: ldarg.3
+			IL_037b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0380: stloc.s 16
+			IL_0382: ldloc.s 10
+			IL_0384: ldloc.s 16
+			IL_0386: call string [System.Runtime]System.String::Concat(string, string)
+			IL_038b: stloc.s 16
+			IL_038d: ldloc.s 16
+			IL_038f: ldstr "'."
+			IL_0394: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0399: stloc.s 16
+			IL_039b: ldloc.s 16
+			IL_039d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03a7: dup
+			IL_03a8: isinst [System.Runtime]System.Exception
+			IL_03ad: dup
+			IL_03ae: brtrue IL_03ba
 
-			IL_03bb: pop
-			IL_03bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03c1: throw
+			IL_03b3: pop
+			IL_03b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03b9: throw
 
-			IL_03c2: pop
-			IL_03c3: throw
+			IL_03ba: pop
+			IL_03bb: throw
 
-			IL_03c4: ldnull
-			IL_03c5: ret
+			IL_03bc: ldnull
+			IL_03bd: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -5226,11 +3137,33 @@
 		.class nested private auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L215C13
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x41fc
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L215C13::.ctor
+
+			} // end of class Block_L215C13
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b6c
+				// Method begins at RVA 0x41f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5247,7 +3180,7 @@
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope scope,
 				object newTarget,
 				object indexHtml,
 				object section
@@ -5256,11 +3189,11 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3d04
+			// Method begins at RVA 0x2e64
 			// Header size: 12
-			// Code size: 452 (0x1c4)
+			// Code size: 444 (0x1bc)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5271,300 +3204,6 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] object,
-				[10] string,
-				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[12] bool,
-				[13] object,
-				[14] object,
-				[15] object,
-				[16] object,
-				[17] float64,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
-			)
-
-			IL_0000: ldnull
-			IL_0001: ldarg.3
-			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
-			IL_0007: stloc.s 9
-			IL_0009: ldloc.s 9
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0012: stloc.s 10
-			IL_0014: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_0019: ldloc.s 10
-			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0020: stloc.s 10
-			IL_0022: ldloc.s 10
-			IL_0024: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
-			IL_0029: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002e: stloc.s 10
-			IL_0030: ldloc.s 10
-			IL_0032: ldstr "i"
-			IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_003c: stloc.s 11
-			IL_003e: ldloc.s 11
-			IL_0040: stloc.1
-			IL_0041: ldloc.1
-			IL_0042: ldstr "exec"
-			IL_0047: ldarg.2
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_004d: stloc.s 9
-			IL_004f: ldloc.s 9
-			IL_0051: stloc.2
-			IL_0052: ldloc.2
-			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0058: stloc.s 12
-			IL_005a: ldloc.s 12
-			IL_005c: brfalse IL_00a5
-
-			IL_0061: ldloc.2
-			IL_0062: ldc.r8 1
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0070: stloc.s 9
-			IL_0072: ldloc.s 9
-			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0079: stloc.s 12
-			IL_007b: ldloc.s 12
-			IL_007d: brtrue IL_0098
-
-			IL_0082: ldloc.2
-			IL_0083: ldc.r8 2
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0091: stloc.s 14
-			IL_0093: br IL_009c
-
-			IL_0098: ldloc.s 9
-			IL_009a: stloc.s 14
-
-			IL_009c: ldloc.s 14
-			IL_009e: stloc.s 15
-			IL_00a0: br IL_00a8
-
-			IL_00a5: ldloc.2
-			IL_00a6: stloc.s 15
-
-			IL_00a8: ldloc.s 15
-			IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00af: stloc.s 12
-			IL_00b1: ldloc.s 12
-			IL_00b3: brtrue IL_00c4
-
-			IL_00b8: ldstr ""
-			IL_00bd: stloc.s 15
-			IL_00bf: br IL_00c4
-
-			IL_00c4: ldloc.s 15
-			IL_00c6: stloc.3
-			IL_00c7: ldloc.3
-			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00cd: ldc.i4.0
-			IL_00ce: ceq
-			IL_00d0: stloc.s 12
-			IL_00d2: ldloc.s 12
-			IL_00d4: brfalse IL_00e0
-
-			IL_00d9: ldc.i4.0
-			IL_00da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00df: ret
-
-			IL_00e0: ldloc.3
-			IL_00e1: ldstr "indexOf"
-			IL_00e6: ldstr "#"
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f0: stloc.s 9
-			IL_00f2: ldloc.s 9
-			IL_00f4: stloc.s 4
-			IL_00f6: ldloc.s 4
-			IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00fd: stloc.s 17
-			IL_00ff: ldloc.s 17
-			IL_0101: ldc.r8 0.0
-			IL_010a: clt
-			IL_010c: ldc.i4.0
-			IL_010d: ceq
-			IL_010f: brfalse IL_013a
-
-			IL_0114: ldloc.3
-			IL_0115: castclass [System.Runtime]System.String
-			IL_011a: ldc.r8 0.0
-			IL_0123: box [System.Runtime]System.Double
-			IL_0128: ldloc.s 4
-			IL_012a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_012f: stloc.s 10
-			IL_0131: ldloc.s 10
-			IL_0133: stloc.s 5
-			IL_0135: br IL_013d
-
-			IL_013a: ldloc.3
-			IL_013b: stloc.s 5
-
-			IL_013d: ldloc.s 5
-			IL_013f: stloc.s 6
-			IL_0141: ldloc.s 4
-			IL_0143: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0148: stloc.s 17
-			IL_014a: ldloc.s 17
-			IL_014c: ldc.r8 0.0
-			IL_0155: clt
-			IL_0157: ldc.i4.0
-			IL_0158: ceq
-			IL_015a: brfalse IL_0189
-
-			IL_015f: ldloc.s 4
-			IL_0161: ldc.r8 1
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_016f: stloc.s 15
-			IL_0171: ldloc.3
-			IL_0172: castclass [System.Runtime]System.String
-			IL_0177: ldloc.s 15
-			IL_0179: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_017e: stloc.s 10
-			IL_0180: ldloc.s 10
-			IL_0182: stloc.s 7
-			IL_0184: br IL_0190
-
-			IL_0189: ldstr ""
-			IL_018e: stloc.s 7
-
-			IL_0190: ldloc.s 7
-			IL_0192: stloc.s 8
-			IL_0194: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0199: dup
-			IL_019a: ldstr "href"
-			IL_019f: ldloc.3
-			IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01a5: dup
-			IL_01a6: ldstr "filePart"
-			IL_01ab: ldloc.s 6
-			IL_01ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01b2: dup
-			IL_01b3: ldstr "fragment"
-			IL_01b8: ldloc.s 8
-			IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01bf: stloc.s 18
-			IL_01c1: ldloc.s 18
-			IL_01c3: ret
-		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
-
-	} // end of class resolveSectionLinkFromMultipageIndexHtml
-
-	.class nested public auto ansi abstract sealed beforefieldinit resolveSectionIdFromHtml
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L387C2
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5b7e
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L387C2::.ctor
-
-			} // end of class Block_L387C2
-
-			.class nested private auto ansi beforefieldinit Block_L398C2
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5b87
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L398C2::.ctor
-
-			} // end of class Block_L398C2
-
-			.class nested private auto ansi beforefieldinit Block_L408C2
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5b90
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L408C2::.ctor
-
-			} // end of class Block_L408C2
-
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5b75
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
-				object newTarget,
-				object html,
-				object section
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
-			)
-			// Method begins at RVA 0x3ed4
-			// Header size: 12
-			// Code size: 586 (0x24a)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[4] object,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[6] object,
-				[7] object,
 				[8] string,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[10] bool,
@@ -5572,22 +3211,20 @@
 				[12] object,
 				[13] object,
 				[14] object,
-				[15] object,
-				[16] string,
-				[17] object,
-				[18] object
+				[15] float64,
+				[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldnull
 			IL_0001: ldarg.3
-			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
 			IL_0007: stloc.s 7
 			IL_0009: ldloc.s 7
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0012: stloc.s 8
-			IL_0014: ldstr "<a\\b[^>]*href=(?:\"[^\"]*#([^\"#]+)\"|'[^']*#([^'#]+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_0014: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
 			IL_0019: ldloc.s 8
 			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0020: stloc.s 8
@@ -5612,7 +3249,7 @@
 			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0058: stloc.s 10
 			IL_005a: ldloc.s 10
-			IL_005c: brfalse IL_00bb
+			IL_005c: brfalse IL_00a5
 
 			IL_0061: ldloc.2
 			IL_0062: ldc.r8 1
@@ -5634,158 +3271,112 @@
 			IL_009a: stloc.s 12
 
 			IL_009c: ldloc.s 12
-			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a3: stloc.s 10
-			IL_00a5: ldloc.s 10
-			IL_00a7: brtrue IL_00b8
+			IL_009e: stloc.s 13
+			IL_00a0: br IL_00a8
 
-			IL_00ac: ldstr ""
-			IL_00b1: stloc.s 12
-			IL_00b3: br IL_00b8
+			IL_00a5: ldloc.2
+			IL_00a6: stloc.s 13
 
-			IL_00b8: ldloc.s 12
-			IL_00ba: ret
+			IL_00a8: ldloc.s 13
+			IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00af: stloc.s 10
+			IL_00b1: ldloc.s 10
+			IL_00b3: brtrue IL_00c4
 
-			IL_00bb: ldloc.0
-			IL_00bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c1: stloc.s 8
-			IL_00c3: ldstr "<emu-clause\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,8000}?<h[1-6]\\b[^>]*>[\\s\\S]{0,1200}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_00c8: ldloc.s 8
-			IL_00ca: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00cf: stloc.s 8
-			IL_00d1: ldloc.s 8
-			IL_00d3: ldstr "\\s*<\\/span>[\\s\\S]{0,1200}?<\\/h[1-6]>"
-			IL_00d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00dd: stloc.s 8
-			IL_00df: ldloc.s 8
-			IL_00e1: ldstr "i"
-			IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00eb: stloc.s 9
-			IL_00ed: ldloc.s 9
-			IL_00ef: stloc.3
-			IL_00f0: ldloc.3
-			IL_00f1: ldstr "exec"
-			IL_00f6: ldarg.2
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00fc: stloc.s 7
-			IL_00fe: ldloc.s 7
-			IL_0100: stloc.s 4
-			IL_0102: ldloc.s 4
-			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0109: stloc.s 10
-			IL_010b: ldloc.s 10
-			IL_010d: brfalse IL_016e
+			IL_00b8: ldstr ""
+			IL_00bd: stloc.s 13
+			IL_00bf: br IL_00c4
 
-			IL_0112: ldloc.s 4
-			IL_0114: ldc.r8 1
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0122: stloc.s 7
-			IL_0124: ldloc.s 7
-			IL_0126: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012b: stloc.s 10
-			IL_012d: ldloc.s 10
-			IL_012f: brtrue IL_014b
+			IL_00c4: ldloc.s 13
+			IL_00c6: stloc.3
+			IL_00c7: ldloc.3
+			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00cd: ldc.i4.0
+			IL_00ce: ceq
+			IL_00d0: stloc.s 10
+			IL_00d2: ldloc.s 10
+			IL_00d4: brfalse IL_00e0
 
-			IL_0134: ldloc.s 4
-			IL_0136: ldc.r8 2
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0144: stloc.s 14
-			IL_0146: br IL_014f
+			IL_00d9: ldc.i4.0
+			IL_00da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00df: ret
 
-			IL_014b: ldloc.s 7
-			IL_014d: stloc.s 14
+			IL_00e0: ldloc.3
+			IL_00e1: ldstr "indexOf"
+			IL_00e6: ldstr "#"
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f0: stloc.s 7
+			IL_00f2: ldloc.s 7
+			IL_00f4: stloc.s 4
+			IL_00f6: ldloc.s 4
+			IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00fd: stloc.s 15
+			IL_00ff: ldloc.s 15
+			IL_0101: ldc.r8 0.0
+			IL_010a: clt
+			IL_010c: ldc.i4.0
+			IL_010d: ceq
+			IL_010f: brfalse IL_013a
 
-			IL_014f: ldloc.s 14
-			IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0156: stloc.s 10
-			IL_0158: ldloc.s 10
-			IL_015a: brtrue IL_016b
+			IL_0114: ldloc.3
+			IL_0115: castclass [System.Runtime]System.String
+			IL_011a: ldc.r8 0.0
+			IL_0123: box [System.Runtime]System.Double
+			IL_0128: ldloc.s 4
+			IL_012a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_012f: stloc.s 8
+			IL_0131: ldloc.s 8
+			IL_0133: stloc.s 5
+			IL_0135: br IL_013d
 
-			IL_015f: ldstr ""
-			IL_0164: stloc.s 14
-			IL_0166: br IL_016b
+			IL_013a: ldloc.3
+			IL_013b: stloc.s 5
 
-			IL_016b: ldloc.s 14
-			IL_016d: ret
+			IL_013d: ldloc.s 4
+			IL_013f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0144: stloc.s 15
+			IL_0146: ldloc.s 15
+			IL_0148: ldc.r8 0.0
+			IL_0151: clt
+			IL_0153: ldc.i4.0
+			IL_0154: ceq
+			IL_0156: brfalse IL_0185
 
-			IL_016e: ldloc.0
-			IL_016f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0174: stloc.s 8
-			IL_0176: ldstr "<h[1-6]\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,1200}?(?:\\s*"
-			IL_017b: ldloc.s 8
-			IL_017d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0182: stloc.s 8
-			IL_0184: ldloc.s 8
-			IL_0186: ldstr "\\b|<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_018b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0190: stloc.s 8
-			IL_0192: ldloc.0
-			IL_0193: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0198: stloc.s 16
-			IL_019a: ldloc.s 8
-			IL_019c: ldloc.s 16
-			IL_019e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a3: stloc.s 16
-			IL_01a5: ldloc.s 16
-			IL_01a7: ldstr "\\s*<\\/span>)"
-			IL_01ac: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b1: stloc.s 16
-			IL_01b3: ldloc.s 16
-			IL_01b5: ldstr "i"
-			IL_01ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_01bf: stloc.s 9
-			IL_01c1: ldloc.s 9
-			IL_01c3: stloc.s 5
-			IL_01c5: ldloc.s 5
-			IL_01c7: ldstr "exec"
-			IL_01cc: ldarg.2
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01d2: stloc.s 7
-			IL_01d4: ldloc.s 7
-			IL_01d6: stloc.s 6
-			IL_01d8: ldloc.s 6
-			IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01df: stloc.s 10
-			IL_01e1: ldloc.s 10
-			IL_01e3: brfalse IL_0244
+			IL_015b: ldloc.s 4
+			IL_015d: ldc.r8 1
+			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_016b: stloc.s 13
+			IL_016d: ldloc.3
+			IL_016e: castclass [System.Runtime]System.String
+			IL_0173: ldloc.s 13
+			IL_0175: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_017a: stloc.s 8
+			IL_017c: ldloc.s 8
+			IL_017e: stloc.s 6
+			IL_0180: br IL_018c
 
-			IL_01e8: ldloc.s 6
-			IL_01ea: ldc.r8 1
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01f8: stloc.s 7
-			IL_01fa: ldloc.s 7
-			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0201: stloc.s 10
-			IL_0203: ldloc.s 10
-			IL_0205: brtrue IL_0221
+			IL_0185: ldstr ""
+			IL_018a: stloc.s 6
 
-			IL_020a: ldloc.s 6
-			IL_020c: ldc.r8 2
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_021a: stloc.s 17
-			IL_021c: br IL_0225
+			IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0191: dup
+			IL_0192: ldstr "href"
+			IL_0197: ldloc.3
+			IL_0198: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_019d: dup
+			IL_019e: ldstr "filePart"
+			IL_01a3: ldloc.s 5
+			IL_01a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01aa: dup
+			IL_01ab: ldstr "fragment"
+			IL_01b0: ldloc.s 6
+			IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01b7: stloc.s 16
+			IL_01b9: ldloc.s 16
+			IL_01bb: ret
+		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
-			IL_0221: ldloc.s 7
-			IL_0223: stloc.s 17
-
-			IL_0225: ldloc.s 17
-			IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022c: stloc.s 10
-			IL_022e: ldloc.s 10
-			IL_0230: brtrue IL_0241
-
-			IL_0235: ldstr ""
-			IL_023a: stloc.s 17
-			IL_023c: br IL_0241
-
-			IL_0241: ldloc.s 17
-			IL_0243: ret
-
-			IL_0244: ldstr ""
-			IL_0249: ret
-		} // end of method resolveSectionIdFromHtml::__js_call__
-
-	} // end of class resolveSectionIdFromHtml
+	} // end of class resolveSectionLinkFromMultipageIndexHtml
 
 	.class nested public auto ansi abstract sealed beforefieldinit wrapAsStandaloneHtml
 		extends [System.Runtime]System.Object
@@ -5798,7 +3389,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b99
+				// Method begins at RVA 0x4205
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5817,334 +3408,94 @@
 			object __js_call__ (
 				object newTarget,
 				object extractedHtml,
-				object options
+				object title,
+				object baseHref
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x412c
+			// Method begins at RVA 0x302c
 			// Header size: 12
-			// Code size: 295 (0x127)
+			// Code size: 152 (0x98)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] object,
-				[3] object,
-				[4] string,
-				[5] object,
-				[6] bool,
-				[7] object,
-				[8] object,
-				[9] object,
-				[10] string,
-				[11] string
+				[2] bool,
+				[3] string,
+				[4] string
 			)
 
-			IL_0000: ldarg.2
-			IL_0001: ldstr "title"
-			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_000b: stloc.s 5
-			IL_000d: ldloc.s 5
-			IL_000f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0014: stloc.s 6
-			IL_0016: ldloc.s 6
-			IL_0018: brtrue IL_0029
+			IL_0000: ldarg.3
+			IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0006: stloc.2
+			IL_0007: ldloc.2
+			IL_0008: brfalse IL_0033
 
-			IL_001d: ldstr "ECMA-262 Section Extract"
-			IL_0022: stloc.s 8
-			IL_0024: br IL_002d
+			IL_000d: ldarg.3
+			IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0013: stloc.3
+			IL_0014: ldstr "  <base href=\""
+			IL_0019: ldloc.3
+			IL_001a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_001f: stloc.3
+			IL_0020: ldloc.3
+			IL_0021: ldstr "\">\n"
+			IL_0026: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002b: stloc.3
+			IL_002c: ldloc.3
+			IL_002d: stloc.0
+			IL_002e: br IL_0039
 
-			IL_0029: ldloc.s 5
-			IL_002b: stloc.s 8
+			IL_0033: ldstr ""
+			IL_0038: stloc.0
 
-			IL_002d: ldloc.s 8
-			IL_002f: stloc.0
-			IL_0030: ldarg.2
-			IL_0031: ldstr "baseHref"
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003b: stloc.s 5
-			IL_003d: ldloc.s 5
-			IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0044: stloc.s 6
-			IL_0046: ldloc.s 6
-			IL_0048: brtrue IL_0059
-
-			IL_004d: ldstr ""
-			IL_0052: stloc.s 9
-			IL_0054: br IL_005d
-
-			IL_0059: ldloc.s 5
-			IL_005b: stloc.s 9
-
-			IL_005d: ldloc.s 9
-			IL_005f: stloc.1
-			IL_0060: ldloc.1
-			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0066: stloc.s 6
-			IL_0068: ldloc.s 6
-			IL_006a: brfalse IL_009b
-
-			IL_006f: ldloc.1
-			IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0075: stloc.s 10
-			IL_0077: ldstr "  <base href=\""
-			IL_007c: ldloc.s 10
-			IL_007e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0083: stloc.s 10
-			IL_0085: ldloc.s 10
-			IL_0087: ldstr "\">\n"
-			IL_008c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0091: stloc.s 10
-			IL_0093: ldloc.s 10
-			IL_0095: stloc.2
-			IL_0096: br IL_00a1
-
-			IL_009b: ldstr ""
-			IL_00a0: stloc.2
-
-			IL_00a1: ldloc.2
-			IL_00a2: stloc.3
-			IL_00a3: ldstr "  <style>\n    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }\n    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }\n    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }\n    table { border-collapse: collapse; }\n    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }\n    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }\n    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }\n  </style>\n"
-			IL_00a8: stloc.s 4
-			IL_00aa: ldloc.3
-			IL_00ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00b0: stloc.s 10
-			IL_00b2: ldstr "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
-			IL_00b7: ldloc.s 10
-			IL_00b9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00be: stloc.s 10
-			IL_00c0: ldloc.s 4
-			IL_00c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c7: stloc.s 11
-			IL_00c9: ldloc.s 10
-			IL_00cb: ldloc.s 11
-			IL_00cd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d2: stloc.s 11
-			IL_00d4: ldloc.s 11
-			IL_00d6: ldstr "  <title>"
-			IL_00db: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00e0: stloc.s 11
-			IL_00e2: ldloc.0
-			IL_00e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00e8: stloc.s 10
-			IL_00ea: ldloc.s 11
-			IL_00ec: ldloc.s 10
-			IL_00ee: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00f3: stloc.s 10
-			IL_00f5: ldloc.s 10
-			IL_00f7: ldstr "</title>\n</head>\n<body>\n"
-			IL_00fc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0101: stloc.s 10
-			IL_0103: ldarg.1
-			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0109: stloc.s 11
-			IL_010b: ldloc.s 10
-			IL_010d: ldloc.s 11
-			IL_010f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0114: stloc.s 11
-			IL_0116: ldloc.s 11
-			IL_0118: ldstr "\n</body>\n</html>\n"
-			IL_011d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0122: stloc.s 11
-			IL_0124: ldloc.s 11
-			IL_0126: ret
+			IL_0039: ldloc.0
+			IL_003a: stloc.1
+			IL_003b: ldloc.1
+			IL_003c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0041: stloc.3
+			IL_0042: ldstr "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+			IL_0047: ldloc.3
+			IL_0048: call string [System.Runtime]System.String::Concat(string, string)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: ldstr "  <style>\n    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }\n    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }\n    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }\n    table { border-collapse: collapse; }\n    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }\n    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }\n    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }\n  </style>\n  <title>"
+			IL_0054: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0059: stloc.3
+			IL_005a: ldarg.2
+			IL_005b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0060: stloc.s 4
+			IL_0062: ldloc.3
+			IL_0063: ldloc.s 4
+			IL_0065: call string [System.Runtime]System.String::Concat(string, string)
+			IL_006a: stloc.s 4
+			IL_006c: ldloc.s 4
+			IL_006e: ldstr "</title>\n</head>\n<body>\n"
+			IL_0073: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0078: stloc.s 4
+			IL_007a: ldarg.1
+			IL_007b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0080: stloc.3
+			IL_0081: ldloc.s 4
+			IL_0083: ldloc.3
+			IL_0084: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0089: stloc.3
+			IL_008a: ldloc.3
+			IL_008b: ldstr "\n</body>\n</html>\n"
+			IL_0090: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0095: stloc.3
+			IL_0096: ldloc.3
+			IL_0097: ret
 		} // end of method wrapAsStandaloneHtml::__js_call__
 
 	} // end of class wrapAsStandaloneHtml
 
-	.class nested public auto ansi abstract sealed beforefieldinit printHelp
+	.class nested public auto ansi abstract sealed beforefieldinit runHarnessCli
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5ba2
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x4260
-			// Header size: 12
-			// Code size: 322 (0x142)
-			.maxstack 8
-
-			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0005: ldstr "Extract a section's HTML from a locally saved ECMA-262 multipage HTML file."
-			IL_000a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_000f: pop
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0015: ldstr "You can also fetch the input HTML from the web using Node's built-in fetch/https."
-			IL_001a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_001f: pop
-			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0025: ldstr ""
-			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_002f: pop
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldstr "Usage:"
-			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003f: pop
-			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0045: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --in <input.html> --out <output.html>"
-			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_004f: pop
-			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0055: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --url <https://...> --out <output.html>"
-			IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_005f: pop
-			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0065: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --auto --out <output.html>"
-			IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_006f: pop
-			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0075: ldstr ""
-			IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_007f: pop
-			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0085: ldstr "Options:"
-			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_008f: pop
-			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0095: ldstr "  --section, -s   Section number to extract (e.g. 27.3)"
-			IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_009f: pop
-			IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00a5: ldstr "  --in, -i        Input HTML file path"
-			IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00af: pop
-			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00b5: ldstr "  --url, -u       Fetch input HTML from URL instead of --in"
-			IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bf: pop
-			IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00c5: ldstr "  --auto          Auto-discover the correct multipage URL from the multipage index"
-			IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00cf: pop
-			IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00d5: ldstr "  --index-url     Multipage index URL used by --auto (default: https://tc39.es/ecma262/multipage/)"
-			IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00df: pop
-			IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00e5: ldstr "  --out, -o       Output file path"
-			IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00ef: pop
-			IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00f5: ldstr "  --id            Explicit element id to extract (e.g. sec-generatorfunction-objects)"
-			IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00ff: pop
-			IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0105: ldstr "  --wrap          Wrap output as standalone HTML (default)"
-			IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_010f: pop
-			IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0115: ldstr "  --no-wrap       Output only the extracted element HTML"
-			IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_011f: pop
-			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0125: ldstr "  --base          Optional <base href=\"...\"> to inject when wrapping"
-			IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_012f: pop
-			IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0135: ldstr "  --help, -h      Show help"
-			IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_013f: pop
-			IL_0140: ldnull
-			IL_0141: ret
-		} // end of method printHelp::__js_call__
-
-	} // end of class printHelp
-
-	.class nested public auto ansi abstract sealed beforefieldinit main
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L492C92
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested private auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-					01 00 12 53 63 6f 70 65 20 61 3d 7b 61 7d 2c 20
-					62 3d 7b 62 7d 00 00
-				)
-				// Fields
-				.field public object a
-				.field public object b
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5bcf
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object newTarget,
-					object a,
-					object b
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-					01 00 00 00 00 00 00 00
-				)
-				// Method begins at RVA 0x5414
-				// Header size: 12
-				// Code size: 10 (0xa)
-				.maxstack 8
-				.locals init (
-					[0] object
-				)
-
-				IL_0000: ldarg.1
-				IL_0001: ldarg.2
-				IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0007: stloc.0
-				IL_0008: ldloc.0
-				IL_0009: ret
-			} // end of method ArrowFunction_L492C92::__js_call__
-
-		} // end of class ArrowFunction_L492C92
-
 		.class nested private auto ansi beforefieldinit Scope
 			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
 		{
@@ -6164,14 +3515,14 @@
 				2c 20 e2 80 a6 00 00
 			)
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L478C17
+			.class nested private auto ansi beforefieldinit Block_L254C21
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5bb4
+					// Method begins at RVA 0x4217
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6180,18 +3531,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L478C17::.ctor
+				} // end of method Block_L254C21::.ctor
 
-			} // end of class Block_L478C17
+			} // end of class Block_L254C21
 
-			.class nested private auto ansi beforefieldinit Block_L483C21
+			.class nested private auto ansi beforefieldinit Block_L258C21
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5bbd
+					// Method begins at RVA 0x4220
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6200,18 +3551,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L483C21::.ctor
+				} // end of method Block_L258C21::.ctor
 
-			} // end of class Block_L483C21
+			} // end of class Block_L258C21
 
-			.class nested private auto ansi beforefieldinit Block_L488C33
+			.class nested private auto ansi beforefieldinit Block_L263C28
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5bc6
+					// Method begins at RVA 0x4229
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6220,62 +3571,22 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L488C33::.ctor
+				} // end of method Block_L263C28::.ctor
 
-			} // end of class Block_L488C33
+			} // end of class Block_L263C28
 
-			.class nested private auto ansi beforefieldinit Block_L493C28
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5bd8
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L493C28::.ctor
-
-			} // end of class Block_L493C28
-
-			.class nested private auto ansi beforefieldinit Block_L497C21
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5be1
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L497C21::.ctor
-
-			} // end of class Block_L497C21
-
-			.class nested private auto ansi beforefieldinit Block_L507C17
+			.class nested private auto ansi beforefieldinit Block_L271C17
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L509C19
+				.class nested private auto ansi beforefieldinit Block_L275C15
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5bf3
+						// Method begins at RVA 0x423b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6284,18 +3595,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L509C19::.ctor
+					} // end of method Block_L275C15::.ctor
 
-				} // end of class Block_L509C19
+				} // end of class Block_L275C15
 
-				.class nested private auto ansi beforefieldinit Block_L515C15
+				.class nested private auto ansi beforefieldinit Block_L282C20
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5bfc
+						// Method begins at RVA 0x4244
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6304,16 +3615,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L515C15::.ctor
+					} // end of method Block_L282C20::.ctor
 
-				} // end of class Block_L515C15
+				} // end of class Block_L282C20
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5bea
+					// Method begins at RVA 0x4232
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6322,18 +3633,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L507C17::.ctor
+				} // end of method Block_L271C17::.ctor
 
-			} // end of class Block_L507C17
+			} // end of class Block_L271C17
 
-			.class nested private auto ansi beforefieldinit Block_L524C23
+			.class nested private auto ansi beforefieldinit Block_L285C9
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5c05
+					// Method begins at RVA 0x424d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6342,60 +3653,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L524C23::.ctor
+				} // end of method Block_L285C9::.ctor
 
-			} // end of class Block_L524C23
+			} // end of class Block_L285C9
 
-			.class nested private auto ansi beforefieldinit Block_L528C9
-				extends [System.Runtime]System.Object
-			{
-				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L530C35
-					extends [System.Runtime]System.Object
-				{
-					// Methods
-					.method public hidebysig specialname rtspecialname 
-						instance void .ctor () cil managed 
-					{
-						// Method begins at RVA 0x5c17
-						// Header size: 1
-						// Code size: 8 (0x8)
-						.maxstack 8
-
-						IL_0000: ldarg.0
-						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-						IL_0006: nop
-						IL_0007: ret
-					} // end of method Block_L530C35::.ctor
-
-				} // end of class Block_L530C35
-
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c0e
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L528C9::.ctor
-
-			} // end of class Block_L528C9
-
-			.class nested private auto ansi beforefieldinit Block_L537C48
+			.class nested private auto ansi beforefieldinit Block_L291C18
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5c20
+					// Method begins at RVA 0x4256
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6404,69 +3673,9 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L537C48::.ctor
+				} // end of method Block_L291C18::.ctor
 
-			} // end of class Block_L537C48
-
-			.class nested private auto ansi beforefieldinit Block_L541C18
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c29
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L541C18::.ctor
-
-			} // end of class Block_L541C18
-
-			.class nested private auto ansi beforefieldinit Block_L545C18
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c32
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L545C18::.ctor
-
-			} // end of class Block_L545C18
-
-			.class nested private auto ansi beforefieldinit Block_L554C17
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c3b
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Block_L554C17::.ctor
-
-			} // end of class Block_L554C17
+			} // end of class Block_L291C18
 
 
 			// Fields
@@ -6490,20 +3699,12 @@
 			.field public object _awaited18
 			.field public object _awaited19
 			.field public object _awaited20
-			.field public object _awaited21
-			.field public object _awaited22
-			.field public object _awaited23
-			.field public object _awaited24
-			.field public object _awaited25
-			.field public object _awaited26
-			.field public object _awaited27
-			.field public object _awaited28
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bab
+				// Method begins at RVA 0x420e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6521,29 +3722,27 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object[] scopes,
-				object newTarget,
-				object argv,
-				object logger
+				object newTarget
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x43b0
+			// Method begins at RVA 0x30d0
 			// Header size: 12
-			// Code size: 3479 (0xd97)
+			// Code size: 2378 (0x94a)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope,
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
 				[1] object,
 				[2] object,
 				[3] object,
 				[4] object,
 				[5] object,
 				[6] object,
-				[7] object,
-				[8] string,
-				[9] string,
+				[7] string,
+				[8] object,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -6551,40 +3750,26 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
+				[17] bool,
 				[18] object,
 				[19] object,
-				[20] object,
-				[21] bool,
+				[20] string,
+				[21] string,
 				[22] object,
 				[23] object,
-				[24] object,
-				[25] object,
-				[26] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[27] object,
-				[28] object,
-				[29] string,
-				[30] string,
-				[31] class [System.Runtime]System.Delegate,
-				[32] object,
-				[33] object[],
-				[34] object,
-				[35] object,
-				[36] object,
-				[37] object,
-				[38] object,
-				[39] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[24] object[],
+				[25] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.0
 			IL_0002: ldelem.ref
-			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope
+			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope
 			IL_0008: dup
-			IL_0009: brtrue IL_0049
+			IL_0009: brtrue IL_003b
 
 			IL_000e: pop
-			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::.ctor()
+			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::.ctor()
 			IL_0014: stloc.0
 			IL_0015: ldloc.0
 			IL_0016: ldarg.0
@@ -6592,1602 +3777,1022 @@
 			IL_001c: starg.s scopes
 			IL_001e: ldloc.0
 			IL_001f: ldnull
-			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
-			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldc.i4.2
-			IL_002d: newarr [System.Runtime]System.Object
-			IL_0032: dup
-			IL_0033: ldc.i4.0
-			IL_0034: ldarg.2
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.1
-			IL_0038: ldarg.3
-			IL_0039: stelem.ref
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindMoveNext(object, object[], object[])
-			IL_003f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0044: br IL_004a
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+			IL_0031: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0036: br IL_003c
 
-			IL_0049: stloc.0
+			IL_003b: stloc.0
 
-			IL_004a: ldloc.0
-			IL_004b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0050: brtrue IL_0062
+			IL_003c: ldloc.0
+			IL_003d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0042: brtrue IL_0054
 
-			IL_0055: ldloc.0
-			IL_0056: ldc.i4.s 19
-			IL_0058: newarr [System.Runtime]System.Object
-			IL_005d: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0047: ldloc.0
+			IL_0048: ldc.i4.s 15
+			IL_004a: newarr [System.Runtime]System.Object
+			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
-			IL_0062: ldloc.0
-			IL_0063: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0068: ldc.i4.0
-			IL_0069: ble.s IL_00e2
+			IL_0054: ldloc.0
+			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_005a: ldc.i4.0
+			IL_005b: ble.s IL_00b7
 
-			IL_006b: ldloc.0
-			IL_006c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0071: dup
-			IL_0072: ldc.i4.0
-			IL_0073: ldelem.ref
-			IL_0074: stloc.1
-			IL_0075: dup
-			IL_0076: ldc.i4.1
-			IL_0077: ldelem.ref
-			IL_0078: stloc.2
+			IL_005d: ldloc.0
+			IL_005e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0063: dup
+			IL_0064: ldc.i4.0
+			IL_0065: ldelem.ref
+			IL_0066: stloc.1
+			IL_0067: dup
+			IL_0068: ldc.i4.1
+			IL_0069: ldelem.ref
+			IL_006a: stloc.2
+			IL_006b: dup
+			IL_006c: ldc.i4.2
+			IL_006d: ldelem.ref
+			IL_006e: stloc.3
+			IL_006f: dup
+			IL_0070: ldc.i4.3
+			IL_0071: ldelem.ref
+			IL_0072: stloc.s 4
+			IL_0074: dup
+			IL_0075: ldc.i4.4
+			IL_0076: ldelem.ref
+			IL_0077: stloc.s 5
 			IL_0079: dup
-			IL_007a: ldc.i4.2
+			IL_007a: ldc.i4.5
 			IL_007b: ldelem.ref
-			IL_007c: stloc.3
-			IL_007d: dup
-			IL_007e: ldc.i4.3
-			IL_007f: ldelem.ref
-			IL_0080: stloc.s 4
-			IL_0082: dup
-			IL_0083: ldc.i4.4
-			IL_0084: ldelem.ref
-			IL_0085: stloc.s 5
-			IL_0087: dup
-			IL_0088: ldc.i4.5
-			IL_0089: ldelem.ref
-			IL_008a: stloc.s 6
-			IL_008c: dup
-			IL_008d: ldc.i4.6
-			IL_008e: ldelem.ref
-			IL_008f: stloc.s 7
-			IL_0091: dup
-			IL_0092: ldc.i4.7
-			IL_0093: ldelem.ref
-			IL_0094: castclass [System.Runtime]System.String
-			IL_0099: stloc.s 8
-			IL_009b: dup
-			IL_009c: ldc.i4.8
-			IL_009d: ldelem.ref
-			IL_009e: castclass [System.Runtime]System.String
-			IL_00a3: stloc.s 9
-			IL_00a5: dup
-			IL_00a6: ldc.i4.s 9
-			IL_00a8: ldelem.ref
-			IL_00a9: stloc.s 10
-			IL_00ab: dup
-			IL_00ac: ldc.i4.s 10
-			IL_00ae: ldelem.ref
-			IL_00af: stloc.s 11
-			IL_00b1: dup
-			IL_00b2: ldc.i4.s 11
-			IL_00b4: ldelem.ref
-			IL_00b5: stloc.s 12
-			IL_00b7: dup
-			IL_00b8: ldc.i4.s 12
-			IL_00ba: ldelem.ref
-			IL_00bb: stloc.s 13
-			IL_00bd: dup
-			IL_00be: ldc.i4.s 13
-			IL_00c0: ldelem.ref
-			IL_00c1: stloc.s 14
-			IL_00c3: dup
-			IL_00c4: ldc.i4.s 14
-			IL_00c6: ldelem.ref
-			IL_00c7: stloc.s 15
-			IL_00c9: dup
-			IL_00ca: ldc.i4.s 15
-			IL_00cc: ldelem.ref
-			IL_00cd: stloc.s 16
-			IL_00cf: dup
-			IL_00d0: ldc.i4.s 16
-			IL_00d2: ldelem.ref
-			IL_00d3: stloc.s 17
-			IL_00d5: dup
-			IL_00d6: ldc.i4.s 17
-			IL_00d8: ldelem.ref
-			IL_00d9: stloc.s 18
-			IL_00db: dup
-			IL_00dc: ldc.i4.s 18
-			IL_00de: ldelem.ref
-			IL_00df: stloc.s 19
-			IL_00e1: pop
+			IL_007c: stloc.s 6
+			IL_007e: dup
+			IL_007f: ldc.i4.6
+			IL_0080: ldelem.ref
+			IL_0081: castclass [System.Runtime]System.String
+			IL_0086: stloc.s 7
+			IL_0088: dup
+			IL_0089: ldc.i4.7
+			IL_008a: ldelem.ref
+			IL_008b: stloc.s 8
+			IL_008d: dup
+			IL_008e: ldc.i4.8
+			IL_008f: ldelem.ref
+			IL_0090: stloc.s 9
+			IL_0092: dup
+			IL_0093: ldc.i4.s 9
+			IL_0095: ldelem.ref
+			IL_0096: stloc.s 10
+			IL_0098: dup
+			IL_0099: ldc.i4.s 10
+			IL_009b: ldelem.ref
+			IL_009c: stloc.s 11
+			IL_009e: dup
+			IL_009f: ldc.i4.s 11
+			IL_00a1: ldelem.ref
+			IL_00a2: stloc.s 12
+			IL_00a4: dup
+			IL_00a5: ldc.i4.s 12
+			IL_00a7: ldelem.ref
+			IL_00a8: stloc.s 13
+			IL_00aa: dup
+			IL_00ab: ldc.i4.s 13
+			IL_00ad: ldelem.ref
+			IL_00ae: stloc.s 14
+			IL_00b0: dup
+			IL_00b1: ldc.i4.s 14
+			IL_00b3: ldelem.ref
+			IL_00b4: stloc.s 15
+			IL_00b6: pop
 
-			IL_00e2: ldloc.0
-			IL_00e3: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e8: switch (IL_00fd, IL_060d, IL_0846, IL_094b)
+			IL_00b7: ldloc.0
+			IL_00b8: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00bd: switch (IL_00d2, IL_03ca, IL_05c2, IL_06dc)
 
-			IL_00fd: ldarg.2
-			IL_00fe: brtrue IL_0114
+			IL_00d2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00d7: ldstr "argv"
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e1: stloc.s 16
+			IL_00e3: ldc.i4.1
+			IL_00e4: newarr [System.Runtime]System.Object
+			IL_00e9: dup
+			IL_00ea: ldc.i4.0
+			IL_00eb: ldarg.0
+			IL_00ec: ldc.i4.1
+			IL_00ed: ldelem.ref
+			IL_00ee: stelem.ref
+			IL_00ef: ldc.i4.0
+			IL_00f0: ldelem.ref
+			IL_00f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_00f6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+			IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0101: ldnull
+			IL_0102: ldloc.s 16
+			IL_0104: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0109: stloc.s 16
+			IL_010b: ldloc.s 16
+			IL_010d: stloc.1
+			IL_010e: ldloc.1
+			IL_010f: ldstr "section"
+			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_011e: ldc.i4.0
+			IL_011f: ceq
+			IL_0121: stloc.s 17
+			IL_0123: ldloc.s 17
+			IL_0125: brfalse IL_016b
 
-			IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0108: ldstr "argv"
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0112: starg.s argv
+			IL_012a: ldstr "Missing required --section (e.g. 27.3)."
+			IL_012f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0134: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0139: stloc.s 16
+			IL_013b: ldloc.0
+			IL_013c: ldc.i4.m1
+			IL_013d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0142: ldloc.0
+			IL_0143: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_014d: ldarg.0
+			IL_014e: ldc.i4.1
+			IL_014f: newarr [System.Runtime]System.Object
+			IL_0154: dup
+			IL_0155: ldc.i4.0
+			IL_0156: ldloc.s 16
+			IL_0158: stelem.ref
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_015e: pop
+			IL_015f: ldloc.0
+			IL_0160: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0165: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_016a: ret
 
-			IL_0114: ldarg.3
-			IL_0115: brtrue IL_012b
+			IL_016b: ldloc.1
+			IL_016c: ldstr "outFile"
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_017b: ldc.i4.0
+			IL_017c: ceq
+			IL_017e: stloc.s 17
+			IL_0180: ldloc.s 17
+			IL_0182: brfalse IL_01c8
 
-			IL_011a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_011f: ldstr "log"
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0129: starg.s logger
-
-			IL_012b: ldc.i4.1
-			IL_012c: newarr [System.Runtime]System.Object
-			IL_0131: dup
-			IL_0132: ldc.i4.0
-			IL_0133: ldarg.0
-			IL_0134: ldc.i4.1
-			IL_0135: ldelem.ref
-			IL_0136: stelem.ref
-			IL_0137: ldc.i4.0
-			IL_0138: ldelem.ref
-			IL_0139: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_013e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0149: ldnull
-			IL_014a: ldarg.2
-			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0150: stloc.s 20
-			IL_0152: ldloc.s 20
-			IL_0154: stloc.1
-			IL_0155: ldloc.1
-			IL_0156: ldstr "help"
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0165: stloc.s 21
-			IL_0167: ldloc.s 21
-			IL_0169: brfalse IL_01a4
-
-			IL_016e: ldnull
-			IL_016f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/printHelp::__js_call__(object)
-			IL_0174: pop
-			IL_0175: ldloc.0
-			IL_0176: ldc.i4.m1
-			IL_0177: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_017c: ldloc.0
-			IL_017d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0187: ldarg.0
-			IL_0188: ldc.i4.1
-			IL_0189: newarr [System.Runtime]System.Object
-			IL_018e: dup
-			IL_018f: ldc.i4.0
-			IL_0190: ldnull
-			IL_0191: stelem.ref
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0197: pop
+			IL_0187: ldstr "Missing required --out <output.html>."
+			IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0196: stloc.s 16
 			IL_0198: ldloc.0
-			IL_0199: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_019e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01a3: ret
+			IL_0199: ldc.i4.m1
+			IL_019a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_019f: ldloc.0
+			IL_01a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01aa: ldarg.0
+			IL_01ab: ldc.i4.1
+			IL_01ac: newarr [System.Runtime]System.Object
+			IL_01b1: dup
+			IL_01b2: ldc.i4.0
+			IL_01b3: ldloc.s 16
+			IL_01b5: stelem.ref
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01bb: pop
+			IL_01bc: ldloc.0
+			IL_01bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01c7: ret
 
-			IL_01a4: ldloc.1
-			IL_01a5: ldstr "section"
-			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01b4: ldc.i4.0
-			IL_01b5: ceq
-			IL_01b7: stloc.s 21
-			IL_01b9: ldloc.s 21
-			IL_01bb: brfalse IL_0201
+			IL_01c8: ldloc.1
+			IL_01c9: ldstr "url"
+			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01d8: stloc.s 17
+			IL_01da: ldloc.s 17
+			IL_01dc: brfalse IL_01f5
 
-			IL_01c0: ldstr "Missing required --section (e.g. 27.3)."
-			IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01cf: stloc.s 20
-			IL_01d1: ldloc.0
-			IL_01d2: ldc.i4.m1
-			IL_01d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d8: ldloc.0
-			IL_01d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01e3: ldarg.0
-			IL_01e4: ldc.i4.1
-			IL_01e5: newarr [System.Runtime]System.Object
-			IL_01ea: dup
-			IL_01eb: ldc.i4.0
-			IL_01ec: ldloc.s 20
-			IL_01ee: stelem.ref
-			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01f4: pop
-			IL_01f5: ldloc.0
-			IL_01f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0200: ret
+			IL_01e1: ldc.r8 1
+			IL_01ea: box [System.Runtime]System.Double
+			IL_01ef: stloc.2
+			IL_01f0: br IL_0204
 
-			IL_0201: ldloc.1
-			IL_0202: ldstr "inFile"
-			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_020c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0211: ldc.i4.0
-			IL_0212: ceq
-			IL_0214: stloc.s 21
-			IL_0216: ldloc.s 21
-			IL_0218: box [System.Runtime]System.Boolean
-			IL_021d: stloc.s 22
-			IL_021f: ldloc.s 22
-			IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0226: stloc.s 21
-			IL_0228: ldloc.s 21
-			IL_022a: brfalse IL_0256
+			IL_01f5: ldc.r8 0.0
+			IL_01fe: box [System.Runtime]System.Double
+			IL_0203: stloc.2
 
-			IL_022f: ldloc.1
-			IL_0230: ldstr "url"
-			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_023f: ldc.i4.0
-			IL_0240: ceq
-			IL_0242: stloc.s 21
-			IL_0244: ldloc.s 21
-			IL_0246: box [System.Runtime]System.Boolean
-			IL_024b: stloc.s 23
-			IL_024d: ldloc.s 23
-			IL_024f: stloc.s 25
-			IL_0251: br IL_025a
+			IL_0204: ldloc.1
+			IL_0205: ldstr "auto"
+			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0214: stloc.s 17
+			IL_0216: ldloc.s 17
+			IL_0218: brfalse IL_0231
 
-			IL_0256: ldloc.s 22
-			IL_0258: stloc.s 25
+			IL_021d: ldc.r8 1
+			IL_0226: box [System.Runtime]System.Double
+			IL_022b: stloc.3
+			IL_022c: br IL_0240
 
-			IL_025a: ldloc.s 25
-			IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0261: stloc.s 21
-			IL_0263: ldloc.s 21
-			IL_0265: brfalse IL_027c
+			IL_0231: ldc.r8 0.0
+			IL_023a: box [System.Runtime]System.Double
+			IL_023f: stloc.3
 
-			IL_026a: ldloc.1
-			IL_026b: ldstr "auto"
-			IL_0270: ldc.i4.1
-			IL_0271: box [System.Runtime]System.Boolean
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-			IL_027b: pop
+			IL_0240: ldloc.2
+			IL_0241: ldloc.3
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0247: stloc.s 18
+			IL_0249: ldloc.s 18
+			IL_024b: stloc.s 4
+			IL_024d: ldloc.s 4
+			IL_024f: ldc.r8 1
+			IL_0258: box [System.Runtime]System.Double
+			IL_025d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0262: stloc.s 17
+			IL_0264: ldloc.s 17
+			IL_0266: brfalse IL_02ac
 
-			IL_027c: ldloc.1
-			IL_027d: ldstr "inFile"
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_028c: stloc.s 21
-			IL_028e: ldloc.s 21
-			IL_0290: brfalse IL_02a9
+			IL_026b: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_0270: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0275: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_027a: stloc.s 16
+			IL_027c: ldloc.0
+			IL_027d: ldc.i4.m1
+			IL_027e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0283: ldloc.0
+			IL_0284: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0289: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_028e: ldarg.0
+			IL_028f: ldc.i4.1
+			IL_0290: newarr [System.Runtime]System.Object
+			IL_0295: dup
+			IL_0296: ldc.i4.0
+			IL_0297: ldloc.s 16
+			IL_0299: stelem.ref
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_029f: pop
+			IL_02a0: ldloc.0
+			IL_02a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02a6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02ab: ret
 
-			IL_0295: ldc.r8 1
-			IL_029e: box [System.Runtime]System.Double
-			IL_02a3: stloc.2
-			IL_02a4: br IL_02b8
+			IL_02ac: ldnull
+			IL_02ad: stloc.s 5
+			IL_02af: ldloc.1
+			IL_02b0: ldstr "id"
+			IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ba: stloc.s 16
+			IL_02bc: ldloc.s 16
+			IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02c3: stloc.s 17
+			IL_02c5: ldloc.s 17
+			IL_02c7: brtrue IL_02d8
 
-			IL_02a9: ldc.r8 0.0
-			IL_02b2: box [System.Runtime]System.Double
-			IL_02b7: stloc.2
+			IL_02cc: ldstr ""
+			IL_02d1: stloc.s 19
+			IL_02d3: br IL_02dc
 
-			IL_02b8: ldloc.1
-			IL_02b9: ldstr "url"
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02c8: stloc.s 21
-			IL_02ca: ldloc.s 21
-			IL_02cc: brfalse IL_02e5
+			IL_02d8: ldloc.s 16
+			IL_02da: stloc.s 19
 
-			IL_02d1: ldc.r8 1
-			IL_02da: box [System.Runtime]System.Double
-			IL_02df: stloc.3
-			IL_02e0: br IL_02f4
+			IL_02dc: ldloc.s 19
+			IL_02de: castclass [System.Runtime]System.String
+			IL_02e3: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_02e8: stloc.s 20
+			IL_02ea: ldloc.s 20
+			IL_02ec: stloc.s 6
+			IL_02ee: ldstr ""
+			IL_02f3: stloc.s 7
+			IL_02f5: ldloc.1
+			IL_02f6: ldstr "auto"
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0300: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0305: stloc.s 17
+			IL_0307: ldloc.s 17
+			IL_0309: brfalse IL_0620
 
-			IL_02e5: ldc.r8 0.0
-			IL_02ee: box [System.Runtime]System.Double
-			IL_02f3: stloc.3
+			IL_030e: ldloc.1
+			IL_030f: ldstr "indexUrl"
+			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0319: ldstr "trim"
+			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0323: stloc.s 16
+			IL_0325: ldloc.s 16
+			IL_0327: stloc.s 8
+			IL_0329: ldc.i4.1
+			IL_032a: newarr [System.Runtime]System.Object
+			IL_032f: dup
+			IL_0330: ldc.i4.0
+			IL_0331: ldarg.0
+			IL_0332: ldc.i4.1
+			IL_0333: ldelem.ref
+			IL_0334: stelem.ref
+			IL_0335: ldc.i4.0
+			IL_0336: ldelem.ref
+			IL_0337: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_033c: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0342: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0347: ldnull
+			IL_0348: ldloc.s 8
+			IL_034a: ldnull
+			IL_034b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0350: stloc.s 16
+			IL_0352: ldloc.0
+			IL_0353: ldc.i4.1
+			IL_0354: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0359: ldloc.0
+			IL_035a: ldloc.s 16
+			IL_035c: ldarg.0
+			IL_035d: ldc.i4.1
+			IL_035e: ldloc.0
+			IL_035f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0369: ldloc.0
+			IL_036a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_036f: dup
+			IL_0370: ldc.i4.0
+			IL_0371: ldloc.1
+			IL_0372: stelem.ref
+			IL_0373: dup
+			IL_0374: ldc.i4.1
+			IL_0375: ldloc.2
+			IL_0376: stelem.ref
+			IL_0377: dup
+			IL_0378: ldc.i4.2
+			IL_0379: ldloc.3
+			IL_037a: stelem.ref
+			IL_037b: dup
+			IL_037c: ldc.i4.3
+			IL_037d: ldloc.s 4
+			IL_037f: stelem.ref
+			IL_0380: dup
+			IL_0381: ldc.i4.4
+			IL_0382: ldloc.s 5
+			IL_0384: stelem.ref
+			IL_0385: dup
+			IL_0386: ldc.i4.5
+			IL_0387: ldloc.s 6
+			IL_0389: stelem.ref
+			IL_038a: dup
+			IL_038b: ldc.i4.6
+			IL_038c: ldloc.s 7
+			IL_038e: stelem.ref
+			IL_038f: dup
+			IL_0390: ldc.i4.7
+			IL_0391: ldloc.s 8
+			IL_0393: stelem.ref
+			IL_0394: dup
+			IL_0395: ldc.i4.8
+			IL_0396: ldloc.s 9
+			IL_0398: stelem.ref
+			IL_0399: dup
+			IL_039a: ldc.i4.s 9
+			IL_039c: ldloc.s 10
+			IL_039e: stelem.ref
+			IL_039f: dup
+			IL_03a0: ldc.i4.s 10
+			IL_03a2: ldloc.s 11
+			IL_03a4: stelem.ref
+			IL_03a5: dup
+			IL_03a6: ldc.i4.s 11
+			IL_03a8: ldloc.s 12
+			IL_03aa: stelem.ref
+			IL_03ab: dup
+			IL_03ac: ldc.i4.s 12
+			IL_03ae: ldloc.s 13
+			IL_03b0: stelem.ref
+			IL_03b1: dup
+			IL_03b2: ldc.i4.s 13
+			IL_03b4: ldloc.s 14
+			IL_03b6: stelem.ref
+			IL_03b7: dup
+			IL_03b8: ldc.i4.s 14
+			IL_03ba: ldloc.s 15
+			IL_03bc: stelem.ref
+			IL_03bd: pop
+			IL_03be: ldloc.0
+			IL_03bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03c4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03c9: ret
 
-			IL_02f4: ldloc.1
-			IL_02f5: ldstr "auto"
-			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0304: stloc.s 21
-			IL_0306: ldloc.s 21
-			IL_0308: brfalse IL_0322
+			IL_03ca: ldloc.0
+			IL_03cb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_03d0: stloc.s 16
+			IL_03d2: ldloc.s 16
+			IL_03d4: stloc.s 9
+			IL_03d6: ldloc.1
+			IL_03d7: ldstr "section"
+			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e1: ldstr "trim"
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03eb: stloc.s 16
+			IL_03ed: ldc.i4.1
+			IL_03ee: newarr [System.Runtime]System.Object
+			IL_03f3: dup
+			IL_03f4: ldc.i4.0
+			IL_03f5: ldarg.0
+			IL_03f6: ldc.i4.1
+			IL_03f7: ldelem.ref
+			IL_03f8: stelem.ref
+			IL_03f9: ldc.i4.0
+			IL_03fa: ldelem.ref
+			IL_03fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0400: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0406: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_040b: ldnull
+			IL_040c: ldloc.s 9
+			IL_040e: ldloc.s 16
+			IL_0410: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0415: stloc.s 16
+			IL_0417: ldloc.s 16
+			IL_0419: stloc.s 10
+			IL_041b: ldloc.s 10
+			IL_041d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0422: ldc.i4.0
+			IL_0423: ceq
+			IL_0425: stloc.s 17
+			IL_0427: ldloc.s 17
+			IL_0429: brfalse IL_04ae
 
-			IL_030d: ldc.r8 1
-			IL_0316: box [System.Runtime]System.Double
-			IL_031b: stloc.s 4
-			IL_031d: br IL_0332
+			IL_042e: ldloc.1
+			IL_042f: ldstr "section"
+			IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0439: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_043e: stloc.s 20
+			IL_0440: ldstr "Could not find section '"
+			IL_0445: ldloc.s 20
+			IL_0447: call string [System.Runtime]System.String::Concat(string, string)
+			IL_044c: stloc.s 20
+			IL_044e: ldloc.s 20
+			IL_0450: ldstr "' in multipage index: "
+			IL_0455: call string [System.Runtime]System.String::Concat(string, string)
+			IL_045a: stloc.s 20
+			IL_045c: ldloc.s 8
+			IL_045e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0463: stloc.s 21
+			IL_0465: ldloc.s 20
+			IL_0467: ldloc.s 21
+			IL_0469: call string [System.Runtime]System.String::Concat(string, string)
+			IL_046e: stloc.s 21
+			IL_0470: ldloc.s 21
+			IL_0472: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0477: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_047c: stloc.s 16
+			IL_047e: ldloc.0
+			IL_047f: ldc.i4.m1
+			IL_0480: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0485: ldloc.0
+			IL_0486: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_048b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0490: ldarg.0
+			IL_0491: ldc.i4.1
+			IL_0492: newarr [System.Runtime]System.Object
+			IL_0497: dup
+			IL_0498: ldc.i4.0
+			IL_0499: ldloc.s 16
+			IL_049b: stelem.ref
+			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04a1: pop
+			IL_04a2: ldloc.0
+			IL_04a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04ad: ret
 
-			IL_0322: ldc.r8 0.0
-			IL_032b: box [System.Runtime]System.Double
-			IL_0330: stloc.s 4
+			IL_04ae: ldarg.0
+			IL_04af: ldc.i4.1
+			IL_04b0: ldelem.ref
+			IL_04b1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_04bb: stloc.s 16
+			IL_04bd: ldloc.s 10
+			IL_04bf: ldstr "filePart"
+			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04c9: stloc.s 22
+			IL_04cb: ldloc.s 22
+			IL_04cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04d2: stloc.s 17
+			IL_04d4: ldloc.s 17
+			IL_04d6: brtrue IL_04ee
 
-			IL_0332: ldc.i4.3
-			IL_0333: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0338: dup
-			IL_0339: ldloc.2
-			IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_033f: dup
-			IL_0340: ldloc.3
-			IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0346: dup
-			IL_0347: ldloc.s 4
-			IL_0349: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_034e: stloc.s 26
-			IL_0350: ldnull
-			IL_0351: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/ArrowFunction_L492C92::__js_call__(object, object, object)
-			IL_0357: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_035c: ldc.i4.1
-			IL_035d: newarr [System.Runtime]System.Object
-			IL_0362: dup
-			IL_0363: ldc.i4.0
-			IL_0364: ldarg.0
-			IL_0365: ldc.i4.1
-			IL_0366: ldelem.ref
-			IL_0367: stelem.ref
-			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0372: stloc.s 20
-			IL_0374: ldloc.s 26
-			IL_0376: ldc.i4.2
-			IL_0377: newarr [System.Runtime]System.Object
-			IL_037c: dup
-			IL_037d: ldc.i4.0
-			IL_037e: ldloc.s 20
-			IL_0380: stelem.ref
-			IL_0381: dup
-			IL_0382: ldc.i4.1
-			IL_0383: ldc.r8 0.0
-			IL_038c: box [System.Runtime]System.Double
-			IL_0391: stelem.ref
-			IL_0392: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::reduce(object[])
-			IL_0397: stloc.s 20
-			IL_0399: ldloc.s 20
-			IL_039b: stloc.s 5
-			IL_039d: ldloc.s 5
-			IL_039f: ldc.r8 1
-			IL_03a8: box [System.Runtime]System.Double
-			IL_03ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03b2: stloc.s 21
-			IL_03b4: ldloc.s 21
-			IL_03b6: brfalse IL_03fc
+			IL_04db: ldloc.s 10
+			IL_04dd: ldstr "href"
+			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04e7: stloc.s 23
+			IL_04e9: br IL_04f2
 
-			IL_03bb: ldstr "Provide exactly one input mode: --in, --url, or --auto."
-			IL_03c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03ca: stloc.s 20
-			IL_03cc: ldloc.0
-			IL_03cd: ldc.i4.m1
-			IL_03ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03d3: ldloc.0
-			IL_03d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_03de: ldarg.0
-			IL_03df: ldc.i4.1
-			IL_03e0: newarr [System.Runtime]System.Object
-			IL_03e5: dup
-			IL_03e6: ldc.i4.0
-			IL_03e7: ldloc.s 20
-			IL_03e9: stelem.ref
-			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03ef: pop
-			IL_03f0: ldloc.0
-			IL_03f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03fb: ret
+			IL_04ee: ldloc.s 22
+			IL_04f0: stloc.s 23
 
-			IL_03fc: ldloc.1
-			IL_03fd: ldstr "outFile"
-			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0407: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_040c: ldc.i4.0
-			IL_040d: ceq
-			IL_040f: stloc.s 21
-			IL_0411: ldloc.s 21
-			IL_0413: brfalse IL_0459
-
-			IL_0418: ldstr "Missing required --out <output.html>."
-			IL_041d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0422: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0427: stloc.s 20
-			IL_0429: ldloc.0
-			IL_042a: ldc.i4.m1
-			IL_042b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0430: ldloc.0
-			IL_0431: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0436: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_043b: ldarg.0
-			IL_043c: ldc.i4.1
-			IL_043d: newarr [System.Runtime]System.Object
-			IL_0442: dup
-			IL_0443: ldc.i4.0
-			IL_0444: ldloc.s 20
-			IL_0446: stelem.ref
-			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_044c: pop
-			IL_044d: ldloc.0
-			IL_044e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0453: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0458: ret
-
-			IL_0459: ldarg.0
-			IL_045a: ldc.i4.1
-			IL_045b: ldelem.ref
-			IL_045c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0461: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
-			IL_0466: stloc.s 20
-			IL_0468: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_046d: ldstr "cwd"
-			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0477: stloc.s 27
-			IL_0479: ldloc.s 20
-			IL_047b: ldstr "resolve"
-			IL_0480: ldloc.s 27
-			IL_0482: ldloc.1
-			IL_0483: ldstr "outFile"
-			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0492: stloc.s 27
-			IL_0494: ldloc.s 27
-			IL_0496: stloc.s 6
-			IL_0498: ldnull
-			IL_0499: stloc.s 7
-			IL_049b: ldstr ""
-			IL_04a0: stloc.s 8
-			IL_04a2: ldstr ""
-			IL_04a7: stloc.s 9
-			IL_04a9: ldloc.1
-			IL_04aa: ldstr "auto"
-			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04b9: stloc.s 21
-			IL_04bb: ldloc.s 21
-			IL_04bd: brfalse IL_085f
-
-			IL_04c2: ldloc.1
-			IL_04c3: ldstr "indexUrl"
-			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04cd: stloc.s 27
-			IL_04cf: ldloc.s 27
-			IL_04d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04d6: stloc.s 21
-			IL_04d8: ldloc.s 21
-			IL_04da: brtrue IL_04eb
-
-			IL_04df: ldstr "https://tc39.es/ecma262/multipage/"
-			IL_04e4: stloc.s 28
-			IL_04e6: br IL_04ef
-
-			IL_04eb: ldloc.s 27
-			IL_04ed: stloc.s 28
-
-			IL_04ef: ldloc.s 28
-			IL_04f1: castclass [System.Runtime]System.String
-			IL_04f6: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_04fb: stloc.s 29
-			IL_04fd: ldloc.s 29
-			IL_04ff: stloc.s 10
-			IL_0501: ldloc.s 10
-			IL_0503: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0508: ldc.i4.0
-			IL_0509: ceq
-			IL_050b: stloc.s 21
-			IL_050d: ldloc.s 21
-			IL_050f: brfalse IL_0555
-
-			IL_0514: ldstr "Missing --index-url value."
-			IL_0519: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_051e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0523: stloc.s 27
-			IL_0525: ldloc.0
-			IL_0526: ldc.i4.m1
-			IL_0527: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_052c: ldloc.0
-			IL_052d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0532: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0537: ldarg.0
-			IL_0538: ldc.i4.1
-			IL_0539: newarr [System.Runtime]System.Object
-			IL_053e: dup
-			IL_053f: ldc.i4.0
-			IL_0540: ldloc.s 27
-			IL_0542: stelem.ref
-			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0548: pop
-			IL_0549: ldloc.0
-			IL_054a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_054f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0554: ret
-
-			IL_0555: ldc.i4.1
-			IL_0556: newarr [System.Runtime]System.Object
-			IL_055b: dup
-			IL_055c: ldc.i4.0
-			IL_055d: ldarg.0
-			IL_055e: ldc.i4.1
-			IL_055f: ldelem.ref
-			IL_0560: stelem.ref
-			IL_0561: ldc.i4.0
-			IL_0562: ldelem.ref
-			IL_0563: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0568: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-			IL_056e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0573: ldnull
-			IL_0574: ldloc.s 10
-			IL_0576: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_057b: stloc.s 27
-			IL_057d: ldloc.0
-			IL_057e: ldc.i4.1
-			IL_057f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0584: ldloc.0
-			IL_0585: ldloc.s 27
-			IL_0587: ldarg.0
-			IL_0588: ldc.i4.1
-			IL_0589: ldloc.0
-			IL_058a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_058f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0594: ldloc.0
-			IL_0595: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_059a: dup
-			IL_059b: ldc.i4.0
-			IL_059c: ldloc.1
-			IL_059d: stelem.ref
-			IL_059e: dup
-			IL_059f: ldc.i4.1
-			IL_05a0: ldloc.2
-			IL_05a1: stelem.ref
-			IL_05a2: dup
-			IL_05a3: ldc.i4.2
-			IL_05a4: ldloc.3
-			IL_05a5: stelem.ref
-			IL_05a6: dup
-			IL_05a7: ldc.i4.3
-			IL_05a8: ldloc.s 4
-			IL_05aa: stelem.ref
-			IL_05ab: dup
-			IL_05ac: ldc.i4.4
-			IL_05ad: ldloc.s 5
-			IL_05af: stelem.ref
-			IL_05b0: dup
-			IL_05b1: ldc.i4.5
-			IL_05b2: ldloc.s 6
+			IL_04f2: ldc.i4.2
+			IL_04f3: newarr [System.Runtime]System.Object
+			IL_04f8: dup
+			IL_04f9: ldc.i4.0
+			IL_04fa: ldloc.s 23
+			IL_04fc: stelem.ref
+			IL_04fd: dup
+			IL_04fe: ldc.i4.1
+			IL_04ff: ldloc.s 8
+			IL_0501: stelem.ref
+			IL_0502: stloc.s 24
+			IL_0504: ldloc.s 16
+			IL_0506: ldloc.s 24
+			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_050d: stloc.s 16
+			IL_050f: ldloc.s 16
+			IL_0511: ldstr "toString"
+			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_051b: stloc.s 16
+			IL_051d: ldloc.s 16
+			IL_051f: stloc.s 11
+			IL_0521: ldc.i4.1
+			IL_0522: newarr [System.Runtime]System.Object
+			IL_0527: dup
+			IL_0528: ldc.i4.0
+			IL_0529: ldarg.0
+			IL_052a: ldc.i4.1
+			IL_052b: ldelem.ref
+			IL_052c: stelem.ref
+			IL_052d: ldc.i4.0
+			IL_052e: ldelem.ref
+			IL_052f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0534: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_053a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_053f: ldnull
+			IL_0540: ldloc.s 11
+			IL_0542: ldnull
+			IL_0543: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0548: stloc.s 16
+			IL_054a: ldloc.0
+			IL_054b: ldc.i4.2
+			IL_054c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0551: ldloc.0
+			IL_0552: ldloc.s 16
+			IL_0554: ldarg.0
+			IL_0555: ldc.i4.2
+			IL_0556: ldloc.0
+			IL_0557: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_055c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0561: ldloc.0
+			IL_0562: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0567: dup
+			IL_0568: ldc.i4.0
+			IL_0569: ldloc.1
+			IL_056a: stelem.ref
+			IL_056b: dup
+			IL_056c: ldc.i4.1
+			IL_056d: ldloc.2
+			IL_056e: stelem.ref
+			IL_056f: dup
+			IL_0570: ldc.i4.2
+			IL_0571: ldloc.3
+			IL_0572: stelem.ref
+			IL_0573: dup
+			IL_0574: ldc.i4.3
+			IL_0575: ldloc.s 4
+			IL_0577: stelem.ref
+			IL_0578: dup
+			IL_0579: ldc.i4.4
+			IL_057a: ldloc.s 5
+			IL_057c: stelem.ref
+			IL_057d: dup
+			IL_057e: ldc.i4.5
+			IL_057f: ldloc.s 6
+			IL_0581: stelem.ref
+			IL_0582: dup
+			IL_0583: ldc.i4.6
+			IL_0584: ldloc.s 7
+			IL_0586: stelem.ref
+			IL_0587: dup
+			IL_0588: ldc.i4.7
+			IL_0589: ldloc.s 8
+			IL_058b: stelem.ref
+			IL_058c: dup
+			IL_058d: ldc.i4.8
+			IL_058e: ldloc.s 9
+			IL_0590: stelem.ref
+			IL_0591: dup
+			IL_0592: ldc.i4.s 9
+			IL_0594: ldloc.s 10
+			IL_0596: stelem.ref
+			IL_0597: dup
+			IL_0598: ldc.i4.s 10
+			IL_059a: ldloc.s 11
+			IL_059c: stelem.ref
+			IL_059d: dup
+			IL_059e: ldc.i4.s 11
+			IL_05a0: ldloc.s 12
+			IL_05a2: stelem.ref
+			IL_05a3: dup
+			IL_05a4: ldc.i4.s 12
+			IL_05a6: ldloc.s 13
+			IL_05a8: stelem.ref
+			IL_05a9: dup
+			IL_05aa: ldc.i4.s 13
+			IL_05ac: ldloc.s 14
+			IL_05ae: stelem.ref
+			IL_05af: dup
+			IL_05b0: ldc.i4.s 14
+			IL_05b2: ldloc.s 15
 			IL_05b4: stelem.ref
-			IL_05b5: dup
-			IL_05b6: ldc.i4.6
-			IL_05b7: ldloc.s 7
-			IL_05b9: stelem.ref
-			IL_05ba: dup
-			IL_05bb: ldc.i4.7
-			IL_05bc: ldloc.s 8
-			IL_05be: stelem.ref
-			IL_05bf: dup
-			IL_05c0: ldc.i4.8
-			IL_05c1: ldloc.s 9
-			IL_05c3: stelem.ref
-			IL_05c4: dup
-			IL_05c5: ldc.i4.s 9
-			IL_05c7: ldloc.s 10
-			IL_05c9: stelem.ref
-			IL_05ca: dup
-			IL_05cb: ldc.i4.s 10
-			IL_05cd: ldloc.s 11
-			IL_05cf: stelem.ref
-			IL_05d0: dup
-			IL_05d1: ldc.i4.s 11
-			IL_05d3: ldloc.s 12
-			IL_05d5: stelem.ref
-			IL_05d6: dup
-			IL_05d7: ldc.i4.s 12
-			IL_05d9: ldloc.s 13
-			IL_05db: stelem.ref
-			IL_05dc: dup
-			IL_05dd: ldc.i4.s 13
-			IL_05df: ldloc.s 14
-			IL_05e1: stelem.ref
-			IL_05e2: dup
-			IL_05e3: ldc.i4.s 14
-			IL_05e5: ldloc.s 15
-			IL_05e7: stelem.ref
-			IL_05e8: dup
-			IL_05e9: ldc.i4.s 15
-			IL_05eb: ldloc.s 16
-			IL_05ed: stelem.ref
-			IL_05ee: dup
-			IL_05ef: ldc.i4.s 16
-			IL_05f1: ldloc.s 17
-			IL_05f3: stelem.ref
-			IL_05f4: dup
-			IL_05f5: ldc.i4.s 17
-			IL_05f7: ldloc.s 18
-			IL_05f9: stelem.ref
-			IL_05fa: dup
-			IL_05fb: ldc.i4.s 18
-			IL_05fd: ldloc.s 19
-			IL_05ff: stelem.ref
-			IL_0600: pop
-			IL_0601: ldloc.0
-			IL_0602: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0607: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_060c: ret
+			IL_05b5: pop
+			IL_05b6: ldloc.0
+			IL_05b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05bc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05c1: ret
 
-			IL_060d: ldloc.0
-			IL_060e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited1
-			IL_0613: stloc.s 27
-			IL_0615: ldloc.s 27
-			IL_0617: stloc.s 11
-			IL_0619: ldloc.1
-			IL_061a: ldstr "section"
-			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0624: ldstr "trim"
-			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_062e: stloc.s 27
-			IL_0630: ldc.i4.1
-			IL_0631: newarr [System.Runtime]System.Object
-			IL_0636: dup
-			IL_0637: ldc.i4.0
-			IL_0638: ldarg.0
-			IL_0639: ldc.i4.1
-			IL_063a: ldelem.ref
-			IL_063b: stelem.ref
-			IL_063c: ldc.i4.0
-			IL_063d: ldelem.ref
-			IL_063e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0643: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0649: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_064e: ldnull
-			IL_064f: ldloc.s 11
-			IL_0651: ldloc.s 27
-			IL_0653: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0658: stloc.s 27
-			IL_065a: ldloc.s 27
-			IL_065c: stloc.s 12
-			IL_065e: ldloc.s 12
-			IL_0660: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0665: ldc.i4.0
-			IL_0666: ceq
-			IL_0668: stloc.s 21
-			IL_066a: ldloc.s 21
-			IL_066c: brfalse IL_06f1
+			IL_05c2: ldloc.0
+			IL_05c3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_05c8: stloc.s 16
+			IL_05ca: ldloc.s 16
+			IL_05cc: stloc.s 5
+			IL_05ce: ldloc.s 11
+			IL_05d0: stloc.s 16
+			IL_05d2: ldloc.s 16
+			IL_05d4: stloc.s 7
+			IL_05d6: ldloc.s 6
+			IL_05d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05dd: ldc.i4.0
+			IL_05de: ceq
+			IL_05e0: stloc.s 17
+			IL_05e2: ldloc.s 17
+			IL_05e4: brfalse IL_061b
 
-			IL_0671: ldloc.1
-			IL_0672: ldstr "section"
-			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_067c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0681: stloc.s 29
-			IL_0683: ldstr "Could not find section '"
-			IL_0688: ldloc.s 29
-			IL_068a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_068f: stloc.s 29
-			IL_0691: ldloc.s 29
-			IL_0693: ldstr "' in multipage index: "
-			IL_0698: call string [System.Runtime]System.String::Concat(string, string)
-			IL_069d: stloc.s 29
-			IL_069f: ldloc.s 10
-			IL_06a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06a6: stloc.s 30
-			IL_06a8: ldloc.s 29
-			IL_06aa: ldloc.s 30
-			IL_06ac: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06b1: stloc.s 30
-			IL_06b3: ldloc.s 30
-			IL_06b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_06bf: stloc.s 27
-			IL_06c1: ldloc.0
-			IL_06c2: ldc.i4.m1
-			IL_06c3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06c8: ldloc.0
-			IL_06c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_06d3: ldarg.0
-			IL_06d4: ldc.i4.1
-			IL_06d5: newarr [System.Runtime]System.Object
-			IL_06da: dup
-			IL_06db: ldc.i4.0
-			IL_06dc: ldloc.s 27
-			IL_06de: stelem.ref
-			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06e4: pop
-			IL_06e5: ldloc.0
-			IL_06e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06f0: ret
+			IL_05e9: ldloc.s 10
+			IL_05eb: ldstr "fragment"
+			IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f5: stloc.s 16
+			IL_05f7: ldloc.s 16
+			IL_05f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05fe: stloc.s 17
+			IL_0600: ldloc.s 17
+			IL_0602: brtrue IL_0613
 
-			IL_06f1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
-			IL_06f6: stloc.s 31
-			IL_06f8: ldloc.s 12
-			IL_06fa: ldstr "filePart"
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0704: stloc.s 27
-			IL_0706: ldloc.s 27
-			IL_0708: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_070d: stloc.s 21
-			IL_070f: ldloc.s 21
-			IL_0711: brtrue IL_0729
+			IL_0607: ldstr ""
+			IL_060c: stloc.s 25
+			IL_060e: br IL_0617
 
-			IL_0716: ldloc.s 12
-			IL_0718: ldstr "href"
-			IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0722: stloc.s 32
-			IL_0724: br IL_072d
+			IL_0613: ldloc.s 16
+			IL_0615: stloc.s 25
 
-			IL_0729: ldloc.s 27
-			IL_072b: stloc.s 32
+			IL_0617: ldloc.s 25
+			IL_0619: stloc.s 6
 
-			IL_072d: ldc.i4.2
-			IL_072e: newarr [System.Runtime]System.Object
-			IL_0733: dup
-			IL_0734: ldc.i4.0
-			IL_0735: ldloc.s 32
-			IL_0737: stelem.ref
-			IL_0738: dup
-			IL_0739: ldc.i4.1
-			IL_073a: ldloc.s 10
-			IL_073c: stelem.ref
-			IL_073d: stloc.s 33
-			IL_073f: ldloc.s 31
-			IL_0741: ldloc.s 33
-			IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0748: stloc.s 27
-			IL_074a: ldloc.s 27
-			IL_074c: ldstr "toString"
-			IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0756: stloc.s 27
-			IL_0758: ldloc.s 27
-			IL_075a: stloc.s 13
-			IL_075c: ldloc.s 12
-			IL_075e: ldstr "fragment"
-			IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0768: stloc.s 27
-			IL_076a: ldloc.s 27
-			IL_076c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0771: stloc.s 21
-			IL_0773: ldloc.s 21
-			IL_0775: brtrue IL_0786
+			IL_061b: br IL_06f0
 
-			IL_077a: ldstr ""
-			IL_077f: stloc.s 34
-			IL_0781: br IL_078a
+			IL_0620: ldloc.1
+			IL_0621: ldstr "url"
+			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_062b: ldstr "trim"
+			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0635: stloc.s 16
+			IL_0637: ldloc.s 16
+			IL_0639: stloc.s 12
+			IL_063b: ldc.i4.1
+			IL_063c: newarr [System.Runtime]System.Object
+			IL_0641: dup
+			IL_0642: ldc.i4.0
+			IL_0643: ldarg.0
+			IL_0644: ldc.i4.1
+			IL_0645: ldelem.ref
+			IL_0646: stelem.ref
+			IL_0647: ldc.i4.0
+			IL_0648: ldelem.ref
+			IL_0649: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_064e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0654: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0659: ldnull
+			IL_065a: ldloc.s 12
+			IL_065c: ldnull
+			IL_065d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0662: stloc.s 16
+			IL_0664: ldloc.0
+			IL_0665: ldc.i4.3
+			IL_0666: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_066b: ldloc.0
+			IL_066c: ldloc.s 16
+			IL_066e: ldarg.0
+			IL_066f: ldc.i4.3
+			IL_0670: ldloc.0
+			IL_0671: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0676: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_067b: ldloc.0
+			IL_067c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0681: dup
+			IL_0682: ldc.i4.0
+			IL_0683: ldloc.1
+			IL_0684: stelem.ref
+			IL_0685: dup
+			IL_0686: ldc.i4.1
+			IL_0687: ldloc.2
+			IL_0688: stelem.ref
+			IL_0689: dup
+			IL_068a: ldc.i4.2
+			IL_068b: ldloc.3
+			IL_068c: stelem.ref
+			IL_068d: dup
+			IL_068e: ldc.i4.3
+			IL_068f: ldloc.s 4
+			IL_0691: stelem.ref
+			IL_0692: dup
+			IL_0693: ldc.i4.4
+			IL_0694: ldloc.s 5
+			IL_0696: stelem.ref
+			IL_0697: dup
+			IL_0698: ldc.i4.5
+			IL_0699: ldloc.s 6
+			IL_069b: stelem.ref
+			IL_069c: dup
+			IL_069d: ldc.i4.6
+			IL_069e: ldloc.s 7
+			IL_06a0: stelem.ref
+			IL_06a1: dup
+			IL_06a2: ldc.i4.7
+			IL_06a3: ldloc.s 8
+			IL_06a5: stelem.ref
+			IL_06a6: dup
+			IL_06a7: ldc.i4.8
+			IL_06a8: ldloc.s 9
+			IL_06aa: stelem.ref
+			IL_06ab: dup
+			IL_06ac: ldc.i4.s 9
+			IL_06ae: ldloc.s 10
+			IL_06b0: stelem.ref
+			IL_06b1: dup
+			IL_06b2: ldc.i4.s 10
+			IL_06b4: ldloc.s 11
+			IL_06b6: stelem.ref
+			IL_06b7: dup
+			IL_06b8: ldc.i4.s 11
+			IL_06ba: ldloc.s 12
+			IL_06bc: stelem.ref
+			IL_06bd: dup
+			IL_06be: ldc.i4.s 12
+			IL_06c0: ldloc.s 13
+			IL_06c2: stelem.ref
+			IL_06c3: dup
+			IL_06c4: ldc.i4.s 13
+			IL_06c6: ldloc.s 14
+			IL_06c8: stelem.ref
+			IL_06c9: dup
+			IL_06ca: ldc.i4.s 14
+			IL_06cc: ldloc.s 15
+			IL_06ce: stelem.ref
+			IL_06cf: pop
+			IL_06d0: ldloc.0
+			IL_06d1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06d6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06db: ret
 
-			IL_0786: ldloc.s 27
-			IL_0788: stloc.s 34
+			IL_06dc: ldloc.0
+			IL_06dd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_06e2: stloc.s 16
+			IL_06e4: ldloc.s 16
+			IL_06e6: stloc.s 5
+			IL_06e8: ldloc.s 12
+			IL_06ea: stloc.s 16
+			IL_06ec: ldloc.s 16
+			IL_06ee: stloc.s 7
 
-			IL_078a: ldloc.s 34
-			IL_078c: stloc.s 9
-			IL_078e: ldc.i4.1
-			IL_078f: newarr [System.Runtime]System.Object
-			IL_0794: dup
-			IL_0795: ldc.i4.0
-			IL_0796: ldarg.0
-			IL_0797: ldc.i4.1
-			IL_0798: ldelem.ref
-			IL_0799: stelem.ref
-			IL_079a: ldc.i4.0
-			IL_079b: ldelem.ref
-			IL_079c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_07a1: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-			IL_07a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_07ac: ldnull
-			IL_07ad: ldloc.s 13
-			IL_07af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_07b4: stloc.s 27
-			IL_07b6: ldloc.0
-			IL_07b7: ldc.i4.2
-			IL_07b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07bd: ldloc.0
-			IL_07be: ldloc.s 27
-			IL_07c0: ldarg.0
-			IL_07c1: ldc.i4.2
-			IL_07c2: ldloc.0
-			IL_07c3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_07cd: ldloc.0
-			IL_07ce: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_07d3: dup
-			IL_07d4: ldc.i4.0
-			IL_07d5: ldloc.1
-			IL_07d6: stelem.ref
-			IL_07d7: dup
-			IL_07d8: ldc.i4.1
-			IL_07d9: ldloc.2
-			IL_07da: stelem.ref
-			IL_07db: dup
-			IL_07dc: ldc.i4.2
-			IL_07dd: ldloc.3
-			IL_07de: stelem.ref
-			IL_07df: dup
-			IL_07e0: ldc.i4.3
-			IL_07e1: ldloc.s 4
-			IL_07e3: stelem.ref
-			IL_07e4: dup
-			IL_07e5: ldc.i4.4
-			IL_07e6: ldloc.s 5
-			IL_07e8: stelem.ref
-			IL_07e9: dup
-			IL_07ea: ldc.i4.5
-			IL_07eb: ldloc.s 6
-			IL_07ed: stelem.ref
-			IL_07ee: dup
-			IL_07ef: ldc.i4.6
-			IL_07f0: ldloc.s 7
-			IL_07f2: stelem.ref
-			IL_07f3: dup
-			IL_07f4: ldc.i4.7
-			IL_07f5: ldloc.s 8
-			IL_07f7: stelem.ref
-			IL_07f8: dup
-			IL_07f9: ldc.i4.8
-			IL_07fa: ldloc.s 9
-			IL_07fc: stelem.ref
-			IL_07fd: dup
-			IL_07fe: ldc.i4.s 9
-			IL_0800: ldloc.s 10
-			IL_0802: stelem.ref
-			IL_0803: dup
-			IL_0804: ldc.i4.s 10
-			IL_0806: ldloc.s 11
-			IL_0808: stelem.ref
-			IL_0809: dup
-			IL_080a: ldc.i4.s 11
-			IL_080c: ldloc.s 12
-			IL_080e: stelem.ref
-			IL_080f: dup
-			IL_0810: ldc.i4.s 12
-			IL_0812: ldloc.s 13
-			IL_0814: stelem.ref
-			IL_0815: dup
-			IL_0816: ldc.i4.s 13
-			IL_0818: ldloc.s 14
-			IL_081a: stelem.ref
-			IL_081b: dup
-			IL_081c: ldc.i4.s 14
-			IL_081e: ldloc.s 15
-			IL_0820: stelem.ref
-			IL_0821: dup
-			IL_0822: ldc.i4.s 15
-			IL_0824: ldloc.s 16
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.s 16
-			IL_082a: ldloc.s 17
-			IL_082c: stelem.ref
-			IL_082d: dup
-			IL_082e: ldc.i4.s 17
-			IL_0830: ldloc.s 18
-			IL_0832: stelem.ref
-			IL_0833: dup
-			IL_0834: ldc.i4.s 18
-			IL_0836: ldloc.s 19
-			IL_0838: stelem.ref
-			IL_0839: pop
-			IL_083a: ldloc.0
-			IL_083b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0840: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0845: ret
+			IL_06f0: ldloc.s 6
+			IL_06f2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06f7: ldc.i4.0
+			IL_06f8: ceq
+			IL_06fa: stloc.s 17
+			IL_06fc: ldloc.s 17
+			IL_06fe: brfalse IL_076f
 
-			IL_0846: ldloc.0
-			IL_0847: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited2
-			IL_084c: stloc.s 27
-			IL_084e: ldloc.s 27
-			IL_0850: stloc.s 7
-			IL_0852: ldloc.s 13
-			IL_0854: stloc.s 27
-			IL_0856: ldloc.s 27
-			IL_0858: stloc.s 8
-			IL_085a: br IL_0a4a
+			IL_0703: ldloc.1
+			IL_0704: ldstr "section"
+			IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_070e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0713: stloc.s 21
+			IL_0715: ldstr "Could not infer an element id for section '"
+			IL_071a: ldloc.s 21
+			IL_071c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0721: stloc.s 21
+			IL_0723: ldloc.s 21
+			IL_0725: ldstr "'. Try passing --id sec-... explicitly."
+			IL_072a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_072f: stloc.s 21
+			IL_0731: ldloc.s 21
+			IL_0733: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0738: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_073d: stloc.s 16
+			IL_073f: ldloc.0
+			IL_0740: ldc.i4.m1
+			IL_0741: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0746: ldloc.0
+			IL_0747: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_074c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0751: ldarg.0
+			IL_0752: ldc.i4.1
+			IL_0753: newarr [System.Runtime]System.Object
+			IL_0758: dup
+			IL_0759: ldc.i4.0
+			IL_075a: ldloc.s 16
+			IL_075c: stelem.ref
+			IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0762: pop
+			IL_0763: ldloc.0
+			IL_0764: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0769: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_076e: ret
 
-			IL_085f: ldloc.1
-			IL_0860: ldstr "url"
-			IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_086a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_086f: stloc.s 21
-			IL_0871: ldloc.s 21
-			IL_0873: brfalse IL_0964
+			IL_076f: ldc.i4.1
+			IL_0770: newarr [System.Runtime]System.Object
+			IL_0775: dup
+			IL_0776: ldc.i4.0
+			IL_0777: ldarg.0
+			IL_0778: ldc.i4.1
+			IL_0779: ldelem.ref
+			IL_077a: stelem.ref
+			IL_077b: ldc.i4.0
+			IL_077c: ldelem.ref
+			IL_077d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0782: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0788: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_078d: ldnull
+			IL_078e: ldloc.s 5
+			IL_0790: ldloc.s 6
+			IL_0792: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0797: stloc.s 16
+			IL_0799: ldloc.s 16
+			IL_079b: stloc.s 13
+			IL_079d: ldarg.0
+			IL_079e: ldc.i4.1
+			IL_079f: ldelem.ref
+			IL_07a0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07a5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_07aa: stloc.s 16
+			IL_07ac: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_07b1: ldstr "cwd"
+			IL_07b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_07bb: stloc.s 22
+			IL_07bd: ldloc.s 16
+			IL_07bf: ldstr "join"
+			IL_07c4: ldloc.s 22
+			IL_07c6: ldloc.1
+			IL_07c7: ldstr "outFile"
+			IL_07cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_07d6: stloc.s 22
+			IL_07d8: ldloc.s 22
+			IL_07da: stloc.s 14
+			IL_07dc: ldloc.s 13
+			IL_07de: ldstr "html"
+			IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07e8: stloc.s 22
+			IL_07ea: ldloc.1
+			IL_07eb: ldstr "section"
+			IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07fa: stloc.s 21
+			IL_07fc: ldstr "ECMA-262 "
+			IL_0801: ldloc.s 21
+			IL_0803: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0808: stloc.s 21
+			IL_080a: ldnull
+			IL_080b: ldloc.s 22
+			IL_080d: ldloc.s 21
+			IL_080f: ldloc.s 7
+			IL_0811: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+			IL_0816: stloc.s 22
+			IL_0818: ldloc.s 22
+			IL_081a: stloc.s 15
+			IL_081c: ldarg.0
+			IL_081d: ldc.i4.1
+			IL_081e: ldelem.ref
+			IL_081f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0824: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0829: ldstr "writeFileSync"
+			IL_082e: ldloc.s 14
+			IL_0830: ldloc.s 15
+			IL_0832: ldstr "utf8"
+			IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_083c: pop
+			IL_083d: ldloc.1
+			IL_083e: ldstr "section"
+			IL_0843: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0848: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_084d: stloc.s 21
+			IL_084f: ldstr "Extracted section "
+			IL_0854: ldloc.s 21
+			IL_0856: call string [System.Runtime]System.String::Concat(string, string)
+			IL_085b: stloc.s 21
+			IL_085d: ldloc.s 21
+			IL_085f: ldstr " (id="
+			IL_0864: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0869: stloc.s 21
+			IL_086b: ldloc.s 6
+			IL_086d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0872: stloc.s 20
+			IL_0874: ldloc.s 21
+			IL_0876: ldloc.s 20
+			IL_0878: call string [System.Runtime]System.String::Concat(string, string)
+			IL_087d: stloc.s 20
+			IL_087f: ldloc.s 20
+			IL_0881: ldstr ", tag="
+			IL_0886: call string [System.Runtime]System.String::Concat(string, string)
+			IL_088b: stloc.s 20
+			IL_088d: ldloc.s 13
+			IL_088f: ldstr "tagName"
+			IL_0894: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0899: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_089e: stloc.s 21
+			IL_08a0: ldloc.s 20
+			IL_08a2: ldloc.s 21
+			IL_08a4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08a9: stloc.s 21
+			IL_08ab: ldloc.s 21
+			IL_08ad: ldstr ") -> "
+			IL_08b2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08b7: stloc.s 21
+			IL_08b9: ldloc.s 14
+			IL_08bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08c0: stloc.s 20
+			IL_08c2: ldloc.s 21
+			IL_08c4: ldloc.s 20
+			IL_08c6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08cb: stloc.s 20
+			IL_08cd: ldnull
+			IL_08ce: ldloc.s 20
+			IL_08d0: ldloc.s 14
+			IL_08d2: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_08d7: stloc.s 22
+			IL_08d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08de: ldloc.s 22
+			IL_08e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08e5: pop
+			IL_08e6: ldarg.0
+			IL_08e7: ldc.i4.1
+			IL_08e8: ldelem.ref
+			IL_08e9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08ee: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_08f3: ldstr "readFileSync"
+			IL_08f8: ldloc.s 14
+			IL_08fa: ldstr "utf8"
+			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0904: stloc.s 22
+			IL_0906: ldnull
+			IL_0907: ldloc.s 22
+			IL_0909: ldloc.s 14
+			IL_090b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0910: stloc.s 22
+			IL_0912: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0917: ldloc.s 22
+			IL_0919: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_091e: pop
+			IL_091f: ldloc.0
+			IL_0920: ldc.i4.m1
+			IL_0921: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0926: ldloc.0
+			IL_0927: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_092c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0931: ldarg.0
+			IL_0932: ldc.i4.1
+			IL_0933: newarr [System.Runtime]System.Object
+			IL_0938: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_093d: pop
+			IL_093e: ldloc.0
+			IL_093f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0944: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0949: ret
+		} // end of method runHarnessCli::__js_call__
 
-			IL_0878: ldloc.1
-			IL_0879: ldstr "url"
-			IL_087e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0883: ldstr "trim"
-			IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_088d: stloc.s 27
-			IL_088f: ldloc.s 27
-			IL_0891: stloc.s 14
-			IL_0893: ldc.i4.1
-			IL_0894: newarr [System.Runtime]System.Object
-			IL_0899: dup
-			IL_089a: ldc.i4.0
-			IL_089b: ldarg.0
-			IL_089c: ldc.i4.1
-			IL_089d: ldelem.ref
-			IL_089e: stelem.ref
-			IL_089f: ldc.i4.0
-			IL_08a0: ldelem.ref
-			IL_08a1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_08a6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-			IL_08ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_08b1: ldnull
-			IL_08b2: ldloc.s 14
-			IL_08b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_08b9: stloc.s 27
-			IL_08bb: ldloc.0
-			IL_08bc: ldc.i4.3
-			IL_08bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08c2: ldloc.0
-			IL_08c3: ldloc.s 27
-			IL_08c5: ldarg.0
-			IL_08c6: ldc.i4.3
-			IL_08c7: ldloc.0
-			IL_08c8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_08cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_08d2: ldloc.0
-			IL_08d3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_08d8: dup
-			IL_08d9: ldc.i4.0
-			IL_08da: ldloc.1
-			IL_08db: stelem.ref
-			IL_08dc: dup
-			IL_08dd: ldc.i4.1
-			IL_08de: ldloc.2
-			IL_08df: stelem.ref
-			IL_08e0: dup
-			IL_08e1: ldc.i4.2
-			IL_08e2: ldloc.3
-			IL_08e3: stelem.ref
-			IL_08e4: dup
-			IL_08e5: ldc.i4.3
-			IL_08e6: ldloc.s 4
-			IL_08e8: stelem.ref
-			IL_08e9: dup
-			IL_08ea: ldc.i4.4
-			IL_08eb: ldloc.s 5
-			IL_08ed: stelem.ref
-			IL_08ee: dup
-			IL_08ef: ldc.i4.5
-			IL_08f0: ldloc.s 6
-			IL_08f2: stelem.ref
-			IL_08f3: dup
-			IL_08f4: ldc.i4.6
-			IL_08f5: ldloc.s 7
-			IL_08f7: stelem.ref
-			IL_08f8: dup
-			IL_08f9: ldc.i4.7
-			IL_08fa: ldloc.s 8
-			IL_08fc: stelem.ref
-			IL_08fd: dup
-			IL_08fe: ldc.i4.8
-			IL_08ff: ldloc.s 9
-			IL_0901: stelem.ref
-			IL_0902: dup
-			IL_0903: ldc.i4.s 9
-			IL_0905: ldloc.s 10
-			IL_0907: stelem.ref
-			IL_0908: dup
-			IL_0909: ldc.i4.s 10
-			IL_090b: ldloc.s 11
-			IL_090d: stelem.ref
-			IL_090e: dup
-			IL_090f: ldc.i4.s 11
-			IL_0911: ldloc.s 12
-			IL_0913: stelem.ref
-			IL_0914: dup
-			IL_0915: ldc.i4.s 12
-			IL_0917: ldloc.s 13
-			IL_0919: stelem.ref
-			IL_091a: dup
-			IL_091b: ldc.i4.s 13
-			IL_091d: ldloc.s 14
-			IL_091f: stelem.ref
-			IL_0920: dup
-			IL_0921: ldc.i4.s 14
-			IL_0923: ldloc.s 15
-			IL_0925: stelem.ref
-			IL_0926: dup
-			IL_0927: ldc.i4.s 15
-			IL_0929: ldloc.s 16
-			IL_092b: stelem.ref
-			IL_092c: dup
-			IL_092d: ldc.i4.s 16
-			IL_092f: ldloc.s 17
-			IL_0931: stelem.ref
-			IL_0932: dup
-			IL_0933: ldc.i4.s 17
-			IL_0935: ldloc.s 18
-			IL_0937: stelem.ref
-			IL_0938: dup
-			IL_0939: ldc.i4.s 18
-			IL_093b: ldloc.s 19
-			IL_093d: stelem.ref
-			IL_093e: pop
-			IL_093f: ldloc.0
-			IL_0940: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0945: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_094a: ret
-
-			IL_094b: ldloc.0
-			IL_094c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited3
-			IL_0951: stloc.s 27
-			IL_0953: ldloc.s 27
-			IL_0955: stloc.s 7
-			IL_0957: ldloc.s 14
-			IL_0959: stloc.s 27
-			IL_095b: ldloc.s 27
-			IL_095d: stloc.s 8
-			IL_095f: br IL_0a4a
-
-			IL_0964: ldarg.0
-			IL_0965: ldc.i4.1
-			IL_0966: ldelem.ref
-			IL_0967: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_096c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
-			IL_0971: stloc.s 27
-			IL_0973: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0978: ldstr "cwd"
-			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0982: stloc.s 20
-			IL_0984: ldloc.s 27
-			IL_0986: ldstr "resolve"
-			IL_098b: ldloc.s 20
-			IL_098d: ldloc.1
-			IL_098e: ldstr "inFile"
-			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_099d: stloc.s 20
-			IL_099f: ldloc.s 20
-			IL_09a1: stloc.s 15
-			IL_09a3: ldarg.0
-			IL_09a4: ldc.i4.1
-			IL_09a5: ldelem.ref
-			IL_09a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_09ab: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_09b0: ldstr "existsSync"
-			IL_09b5: ldloc.s 15
-			IL_09b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_09bc: stloc.s 20
-			IL_09be: ldloc.s 20
-			IL_09c0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_09c5: ldc.i4.0
-			IL_09c6: ceq
-			IL_09c8: stloc.s 21
-			IL_09ca: ldloc.s 21
-			IL_09cc: brfalse IL_0a26
-
-			IL_09d1: ldloc.s 15
-			IL_09d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09d8: stloc.s 30
-			IL_09da: ldstr "Input file not found: "
-			IL_09df: ldloc.s 30
-			IL_09e1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09e6: stloc.s 30
-			IL_09e8: ldloc.s 30
-			IL_09ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_09f4: stloc.s 20
-			IL_09f6: ldloc.0
-			IL_09f7: ldc.i4.m1
-			IL_09f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_09fd: ldloc.0
-			IL_09fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a03: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0a08: ldarg.0
-			IL_0a09: ldc.i4.1
-			IL_0a0a: newarr [System.Runtime]System.Object
-			IL_0a0f: dup
-			IL_0a10: ldc.i4.0
-			IL_0a11: ldloc.s 20
-			IL_0a13: stelem.ref
-			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0a19: pop
-			IL_0a1a: ldloc.0
-			IL_0a1b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a20: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a25: ret
-
-			IL_0a26: ldarg.0
-			IL_0a27: ldc.i4.1
-			IL_0a28: ldelem.ref
-			IL_0a29: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0a2e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-			IL_0a33: ldstr "readFileSync"
-			IL_0a38: ldloc.s 15
-			IL_0a3a: ldstr "utf8"
-			IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a44: stloc.s 20
-			IL_0a46: ldloc.s 20
-			IL_0a48: stloc.s 7
-
-			IL_0a4a: ldloc.1
-			IL_0a4b: ldstr "id"
-			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a55: stloc.s 20
-			IL_0a57: ldloc.s 20
-			IL_0a59: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0a5e: stloc.s 21
-			IL_0a60: ldloc.s 21
-			IL_0a62: brtrue IL_0a73
-
-			IL_0a67: ldstr ""
-			IL_0a6c: stloc.s 35
-			IL_0a6e: br IL_0a77
-
-			IL_0a73: ldloc.s 20
-			IL_0a75: stloc.s 35
-
-			IL_0a77: ldloc.s 35
-			IL_0a79: castclass [System.Runtime]System.String
-			IL_0a7e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0a83: stloc.s 30
-			IL_0a85: ldloc.s 30
-			IL_0a87: stloc.s 16
-			IL_0a89: ldloc.s 16
-			IL_0a8b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a90: ldc.i4.0
-			IL_0a91: ceq
-			IL_0a93: stloc.s 21
-			IL_0a95: ldloc.s 21
-			IL_0a97: box [System.Runtime]System.Boolean
-			IL_0a9c: stloc.s 22
-			IL_0a9e: ldloc.s 22
-			IL_0aa0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0aa5: stloc.s 21
-			IL_0aa7: ldloc.s 21
-			IL_0aa9: brfalse IL_0ab7
-
-			IL_0aae: ldloc.s 9
-			IL_0ab0: stloc.s 36
-			IL_0ab2: br IL_0abb
-
-			IL_0ab7: ldloc.s 22
-			IL_0ab9: stloc.s 36
-
-			IL_0abb: ldloc.s 36
-			IL_0abd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0ac2: stloc.s 21
-			IL_0ac4: ldloc.s 21
-			IL_0ac6: brfalse IL_0ad3
-
-			IL_0acb: ldloc.s 9
-			IL_0acd: stloc.s 36
-			IL_0acf: ldloc.s 36
-			IL_0ad1: stloc.s 16
-
-			IL_0ad3: ldloc.s 16
-			IL_0ad5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0ada: ldc.i4.0
-			IL_0adb: ceq
-			IL_0add: stloc.s 21
-			IL_0adf: ldloc.s 21
-			IL_0ae1: brfalse IL_0b2b
-
-			IL_0ae6: ldloc.1
-			IL_0ae7: ldstr "section"
-			IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0af1: ldstr "trim"
-			IL_0af6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0afb: stloc.s 20
-			IL_0afd: ldc.i4.1
-			IL_0afe: newarr [System.Runtime]System.Object
-			IL_0b03: dup
-			IL_0b04: ldc.i4.0
-			IL_0b05: ldarg.0
-			IL_0b06: ldc.i4.1
-			IL_0b07: ldelem.ref
-			IL_0b08: stelem.ref
-			IL_0b09: ldc.i4.0
-			IL_0b0a: ldelem.ref
-			IL_0b0b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0b10: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionIdFromHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0b16: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0b1b: ldnull
-			IL_0b1c: ldloc.s 7
-			IL_0b1e: ldloc.s 20
-			IL_0b20: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0b25: stloc.s 20
-			IL_0b27: ldloc.s 20
-			IL_0b29: stloc.s 16
-
-			IL_0b2b: ldloc.s 16
-			IL_0b2d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0b32: ldc.i4.0
-			IL_0b33: ceq
-			IL_0b35: stloc.s 21
-			IL_0b37: ldloc.s 21
-			IL_0b39: brfalse IL_0baa
-
-			IL_0b3e: ldloc.1
-			IL_0b3f: ldstr "section"
-			IL_0b44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b49: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b4e: stloc.s 30
-			IL_0b50: ldstr "Could not infer an element id for section '"
-			IL_0b55: ldloc.s 30
-			IL_0b57: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b5c: stloc.s 30
-			IL_0b5e: ldloc.s 30
-			IL_0b60: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0b65: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b6a: stloc.s 30
-			IL_0b6c: ldloc.s 30
-			IL_0b6e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b73: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0b78: stloc.s 20
-			IL_0b7a: ldloc.0
-			IL_0b7b: ldc.i4.m1
-			IL_0b7c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b81: ldloc.0
-			IL_0b82: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0b87: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0b8c: ldarg.0
-			IL_0b8d: ldc.i4.1
-			IL_0b8e: newarr [System.Runtime]System.Object
-			IL_0b93: dup
-			IL_0b94: ldc.i4.0
-			IL_0b95: ldloc.s 20
-			IL_0b97: stelem.ref
-			IL_0b98: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0b9d: pop
-			IL_0b9e: ldloc.0
-			IL_0b9f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ba4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ba9: ret
-
-			IL_0baa: ldc.i4.1
-			IL_0bab: newarr [System.Runtime]System.Object
-			IL_0bb0: dup
-			IL_0bb1: ldc.i4.0
-			IL_0bb2: ldarg.0
-			IL_0bb3: ldc.i4.1
-			IL_0bb4: ldelem.ref
-			IL_0bb5: stelem.ref
-			IL_0bb6: ldc.i4.0
-			IL_0bb7: ldelem.ref
-			IL_0bb8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0bbd: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0bc3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0bc8: ldnull
-			IL_0bc9: ldloc.s 7
-			IL_0bcb: ldloc.s 16
-			IL_0bcd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0bd2: stloc.s 20
-			IL_0bd4: ldloc.s 20
-			IL_0bd6: stloc.s 17
-			IL_0bd8: ldloc.s 17
-			IL_0bda: ldstr "html"
-			IL_0bdf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0be4: stloc.s 18
-			IL_0be6: ldloc.1
-			IL_0be7: ldstr "wrap"
-			IL_0bec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bf1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0bf6: stloc.s 21
-			IL_0bf8: ldloc.s 21
-			IL_0bfa: brfalse IL_0c9a
-
-			IL_0bff: ldloc.1
-			IL_0c00: ldstr "baseHref"
-			IL_0c05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c0a: stloc.s 20
-			IL_0c0c: ldloc.s 20
-			IL_0c0e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0c13: stloc.s 21
-			IL_0c15: ldloc.s 21
-			IL_0c17: brtrue IL_0c25
-
-			IL_0c1c: ldloc.s 8
-			IL_0c1e: stloc.s 37
-			IL_0c20: br IL_0c29
-
-			IL_0c25: ldloc.s 20
-			IL_0c27: stloc.s 37
-
-			IL_0c29: ldloc.s 37
-			IL_0c2b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0c30: stloc.s 21
-			IL_0c32: ldloc.s 21
-			IL_0c34: brtrue IL_0c45
-
-			IL_0c39: ldstr ""
-			IL_0c3e: stloc.s 37
-			IL_0c40: br IL_0c45
-
-			IL_0c45: ldloc.s 37
-			IL_0c47: stloc.s 19
-			IL_0c49: ldloc.1
-			IL_0c4a: ldstr "section"
-			IL_0c4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c54: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0c59: stloc.s 30
-			IL_0c5b: ldstr "ECMA-262 "
-			IL_0c60: ldloc.s 30
-			IL_0c62: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c67: stloc.s 30
-			IL_0c69: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0c6e: dup
-			IL_0c6f: ldstr "title"
-			IL_0c74: ldloc.s 30
-			IL_0c76: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0c7b: dup
-			IL_0c7c: ldstr "baseHref"
-			IL_0c81: ldloc.s 19
-			IL_0c83: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0c88: stloc.s 39
-			IL_0c8a: ldnull
-			IL_0c8b: ldloc.s 18
-			IL_0c8d: ldloc.s 39
-			IL_0c8f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/wrapAsStandaloneHtml::__js_call__(object, object, object)
-			IL_0c94: stloc.s 20
-			IL_0c96: ldloc.s 20
-			IL_0c98: stloc.s 18
-
-			IL_0c9a: ldc.i4.1
-			IL_0c9b: newarr [System.Runtime]System.Object
-			IL_0ca0: dup
-			IL_0ca1: ldc.i4.0
-			IL_0ca2: ldarg.0
-			IL_0ca3: ldc.i4.1
-			IL_0ca4: ldelem.ref
-			IL_0ca5: stelem.ref
-			IL_0ca6: ldc.i4.0
-			IL_0ca7: ldelem.ref
-			IL_0ca8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-			IL_0cad: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/writeTextPreserveEol::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-			IL_0cb3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0cb8: ldnull
-			IL_0cb9: ldloc.s 6
-			IL_0cbb: ldloc.s 18
-			IL_0cbd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0cc2: pop
-			IL_0cc3: ldc.i4.1
-			IL_0cc4: newarr [System.Runtime]System.Object
-			IL_0cc9: dup
-			IL_0cca: ldc.i4.0
-			IL_0ccb: ldarg.0
-			IL_0ccc: ldc.i4.1
-			IL_0ccd: ldelem.ref
-			IL_0cce: stelem.ref
-			IL_0ccf: stloc.s 33
-			IL_0cd1: ldloc.1
-			IL_0cd2: ldstr "section"
-			IL_0cd7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cdc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ce1: stloc.s 30
-			IL_0ce3: ldstr "Extracted section "
-			IL_0ce8: ldloc.s 30
-			IL_0cea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cef: stloc.s 30
-			IL_0cf1: ldloc.s 30
-			IL_0cf3: ldstr " (id="
-			IL_0cf8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cfd: stloc.s 30
-			IL_0cff: ldloc.s 16
-			IL_0d01: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0d06: stloc.s 29
-			IL_0d08: ldloc.s 30
-			IL_0d0a: ldloc.s 29
-			IL_0d0c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d11: stloc.s 29
-			IL_0d13: ldloc.s 29
-			IL_0d15: ldstr ", tag="
-			IL_0d1a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d1f: stloc.s 29
-			IL_0d21: ldloc.s 17
-			IL_0d23: ldstr "tagName"
-			IL_0d28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0d32: stloc.s 30
-			IL_0d34: ldloc.s 29
-			IL_0d36: ldloc.s 30
-			IL_0d38: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d3d: stloc.s 30
-			IL_0d3f: ldloc.s 30
-			IL_0d41: ldstr ") -> "
-			IL_0d46: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d4b: stloc.s 30
-			IL_0d4d: ldloc.s 6
-			IL_0d4f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0d54: stloc.s 29
-			IL_0d56: ldloc.s 30
-			IL_0d58: ldloc.s 29
-			IL_0d5a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0d5f: stloc.s 29
-			IL_0d61: ldarg.3
-			IL_0d62: ldloc.s 33
-			IL_0d64: ldloc.s 29
-			IL_0d66: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-			IL_0d6b: pop
-			IL_0d6c: ldloc.0
-			IL_0d6d: ldc.i4.m1
-			IL_0d6e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0d73: ldloc.0
-			IL_0d74: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0d79: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0d7e: ldarg.0
-			IL_0d7f: ldc.i4.1
-			IL_0d80: newarr [System.Runtime]System.Object
-			IL_0d85: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0d8a: pop
-			IL_0d8b: ldloc.0
-			IL_0d8c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0d91: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0d96: ret
-		} // end of method main::__js_call__
-
-	} // end of class main
-
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L573C16
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
-				72 7d 00 00
-			)
-			// Fields
-			.field public object err
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c4d
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				object newTarget,
-				object err
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
-				01 00 00 00 00 00 00 00
-			)
-			// Method begins at RVA 0x542c
-			// Header size: 12
-			// Code size: 108 (0x6c)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[2] bool,
-				[3] object,
-				[4] object
-			)
-
-			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0005: stloc.1
-			IL_0006: ldarg.1
-			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_000c: stloc.2
-			IL_000d: ldloc.2
-			IL_000e: brfalse IL_0025
-
-			IL_0013: ldarg.1
-			IL_0014: ldstr "message"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.s 4
-			IL_0020: br IL_0028
-
-			IL_0025: ldarg.1
-			IL_0026: stloc.s 4
-
-			IL_0028: ldloc.s 4
-			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002f: stloc.2
-			IL_0030: ldloc.2
-			IL_0031: brfalse IL_0047
-
-			IL_0036: ldarg.1
-			IL_0037: ldstr "message"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.0
-			IL_0042: br IL_0049
-
-			IL_0047: ldarg.1
-			IL_0048: stloc.0
-
-			IL_0049: ldloc.1
-			IL_004a: ldloc.0
-			IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0050: pop
-			IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0056: ldstr "exitCode"
-			IL_005b: ldc.r8 1
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
-			IL_0069: pop
-			IL_006a: ldnull
-			IL_006b: ret
-		} // end of method ArrowFunction_L573C16::__js_call__
-
-	} // end of class ArrowFunction_L573C16
+	} // end of class runHarnessCli
 
 	.class nested private auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
 		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 80 d3 53 63 6f 70 65 20 66 73 3d 7b 66 73
+			01 00 80 93 53 63 6f 70 65 20 66 73 3d 7b 66 73
 			7d 2c 20 68 74 74 70 3d 7b 68 74 74 70 7d 2c 20
-			70 61 74 68 3d 7b 70 61 74 68 7d 2c 20 68 74 74
-			70 73 3d 7b 68 74 74 70 73 7d 2c 20 70 61 72 73
-			65 41 72 67 73 3d 7b 70 61 72 73 65 41 72 67 73
-			7d 2c 20 66 65 74 63 68 54 65 78 74 57 69 74 68
-			48 74 74 70 3d 7b 66 65 74 63 68 54 65 78 74 57
-			69 74 68 48 74 74 70 7d 2c 20 66 65 74 63 68 54
-			65 78 74 57 69 74 68 48 74 74 70 73 3d 7b 66 65
-			74 63 68 54 65 78 74 57 69 74 68 48 74 74 70 73
-			7d 2c 20 66 65 74 63 68 54 65 78 74 57 69 74 68
-			54 72 61 6e 73 70 6f 72 74 3d 7b 66 65 74 63 68
-			54 65 78 74 57 69 74 68 54 72 61 6e 73 70 6f 72
+			68 74 74 70 73 3d 7b 68 74 74 70 73 7d 2c 20 70
+			61 74 68 3d 7b 70 61 74 68 7d 2c 20 4e 6f 64 65
+			55 72 6c 3d 7b 4e 6f 64 65 55 72 6c 7d 2c 20 6e
+			6f 72 6d 61 6c 69 7a 65 3d 7b 6e 6f 72 6d 61 6c
+			69 7a 65 7d 2c 20 70 61 72 73 65 41 72 67 73 3d
+			7b 70 61 72 73 65 41 72 67 73 7d 2c 20 66 65 74
+			63 68 54 65 78 74 3d 7b 66 65 74 63 68 54 65 78
 			74 7d 2c 20 e2 80 a6 00 00
 		)
-		// Nested Types
-		.class nested private auto ansi beforefieldinit Block_L572C29
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c44
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Block_L572C29::.ctor
-
-		} // end of class Block_L572C29
-
-
 		// Fields
 		.field public object fs
 		.field public object http
-		.field public object path
 		.field public object https
+		.field public object path
+		.field public object NodeUrl
+		.field public object normalize
 		.field public object parseArgs
-		.field public object fetchTextWithHttp
-		.field public object fetchTextWithHttps
-		.field public object fetchTextWithTransport
 		.field public object fetchText
-		.field public object fetchTextWithNodeRequest
-		.field public object detectEol
 		.field public object escapeRegExp
-		.field public object writeTextPreserveEol
 		.field public object findTagNameAt
 		.field public object extractElementById
 		.field public object resolveSectionLinkFromMultipageIndexHtml
-		.field public object resolveSectionIdFromHtml
 		.field public object wrapAsStandaloneHtml
-		.field public object printHelp
-		.field public object main
+		.field public object runHarnessCli
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5962
+			// Method begins at RVA 0x409d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8211,306 +4816,185 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2108
+		// Method begins at RVA 0x20c4
 		// Header size: 12
-		// Code size: 704 (0x2c0)
+		// Code size: 424 (0x1a8)
 		.maxstack 8
 		.locals init (
-			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope,
+			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope,
 			[1] object,
-			[2] object,
-			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] bool,
-			[6] object
+			[2] object
 		)
 
-		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::.ctor()
+		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldloc.0
-		IL_000f: stelem.ref
-		IL_0010: ldc.i4.0
-		IL_0011: ldelem.ref
-		IL_0012: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_0017: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0022: stloc.3
-		IL_0023: ldloc.0
-		IL_0024: ldloc.3
-		IL_0025: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::parseArgs
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
-		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.i4.0
-		IL_0035: ldelem.ref
-		IL_0036: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_003b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttp::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0046: stloc.3
-		IL_0047: ldloc.0
-		IL_0048: ldloc.3
-		IL_0049: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithHttp
-		IL_004e: ldc.i4.1
-		IL_004f: newarr [System.Runtime]System.Object
-		IL_0054: dup
-		IL_0055: ldc.i4.0
-		IL_0056: ldloc.0
-		IL_0057: stelem.ref
-		IL_0058: ldc.i4.0
-		IL_0059: ldelem.ref
-		IL_005a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_005f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttps::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_006a: stloc.3
-		IL_006b: ldloc.0
-		IL_006c: ldloc.3
-		IL_006d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithHttps
-		IL_0072: ldc.i4.1
-		IL_0073: newarr [System.Runtime]System.Object
-		IL_0078: dup
-		IL_0079: ldc.i4.0
-		IL_007a: ldloc.0
-		IL_007b: stelem.ref
-		IL_007c: ldc.i4.0
-		IL_007d: ldelem.ref
-		IL_007e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_0083: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
-		IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-		IL_008e: stloc.3
-		IL_008f: ldloc.0
-		IL_0090: ldloc.3
-		IL_0091: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithTransport
-		IL_0096: ldc.i4.1
-		IL_0097: newarr [System.Runtime]System.Object
-		IL_009c: dup
-		IL_009d: ldc.i4.0
-		IL_009e: ldloc.0
-		IL_009f: stelem.ref
-		IL_00a0: ldc.i4.0
-		IL_00a1: ldelem.ref
-		IL_00a2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_00a7: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
-		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00b2: stloc.3
-		IL_00b3: ldloc.3
-		IL_00b4: stloc.1
-		IL_00b5: ldc.i4.1
-		IL_00b6: newarr [System.Runtime]System.Object
-		IL_00bb: dup
-		IL_00bc: ldc.i4.0
-		IL_00bd: ldloc.0
-		IL_00be: stelem.ref
-		IL_00bf: ldc.i4.0
-		IL_00c0: ldelem.ref
-		IL_00c1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_00c6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00d1: stloc.3
-		IL_00d2: ldloc.0
-		IL_00d3: ldloc.3
-		IL_00d4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithNodeRequest
-		IL_00d9: ldnull
-		IL_00da: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/detectEol::__js_call__(object, object)
-		IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00e5: stloc.3
-		IL_00e6: ldloc.0
-		IL_00e7: ldloc.3
-		IL_00e8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::detectEol
-		IL_00ed: ldnull
-		IL_00ee: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
-		IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00f9: stloc.3
-		IL_00fa: ldloc.0
-		IL_00fb: ldloc.3
-		IL_00fc: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::escapeRegExp
-		IL_0101: ldc.i4.1
-		IL_0102: newarr [System.Runtime]System.Object
-		IL_0107: dup
-		IL_0108: ldc.i4.0
-		IL_0109: ldloc.0
-		IL_010a: stelem.ref
-		IL_010b: ldc.i4.0
-		IL_010c: ldelem.ref
-		IL_010d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_0112: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/writeTextPreserveEol::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_011d: stloc.3
-		IL_011e: ldloc.0
-		IL_011f: ldloc.3
-		IL_0120: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::writeTextPreserveEol
-		IL_0125: ldc.i4.1
-		IL_0126: newarr [System.Runtime]System.Object
-		IL_012b: dup
-		IL_012c: ldc.i4.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0012: stloc.2
+		IL_0013: ldloc.0
+		IL_0014: ldloc.2
+		IL_0015: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+		IL_001a: ldc.i4.1
+		IL_001b: newarr [System.Runtime]System.Object
+		IL_0020: dup
+		IL_0021: ldc.i4.0
+		IL_0022: ldloc.0
+		IL_0023: stelem.ref
+		IL_0024: ldc.i4.0
+		IL_0025: ldelem.ref
+		IL_0026: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_002b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0036: stloc.2
+		IL_0037: ldloc.0
+		IL_0038: ldloc.2
+		IL_0039: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
+		IL_003e: ldc.i4.1
+		IL_003f: newarr [System.Runtime]System.Object
+		IL_0044: dup
+		IL_0045: ldc.i4.0
+		IL_0046: ldloc.0
+		IL_0047: stelem.ref
+		IL_0048: ldc.i4.0
+		IL_0049: ldelem.ref
+		IL_004a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_004f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_005a: stloc.2
+		IL_005b: ldloc.0
+		IL_005c: ldloc.2
+		IL_005d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+		IL_0062: ldnull
+		IL_0063: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+		IL_0069: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_006e: stloc.2
+		IL_006f: ldloc.0
+		IL_0070: ldloc.2
+		IL_0071: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: ldc.i4.0
+		IL_0081: ldelem.ref
+		IL_0082: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_0087: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+		IL_008d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0092: stloc.2
+		IL_0093: ldloc.0
+		IL_0094: ldloc.2
+		IL_0095: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+		IL_009a: ldc.i4.1
+		IL_009b: newarr [System.Runtime]System.Object
+		IL_00a0: dup
+		IL_00a1: ldc.i4.0
+		IL_00a2: ldloc.0
+		IL_00a3: stelem.ref
+		IL_00a4: ldc.i4.0
+		IL_00a5: ldelem.ref
+		IL_00a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_00ab: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+		IL_00b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00b6: stloc.2
+		IL_00b7: ldloc.0
+		IL_00b8: ldloc.2
+		IL_00b9: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+		IL_00be: ldc.i4.1
+		IL_00bf: newarr [System.Runtime]System.Object
+		IL_00c4: dup
+		IL_00c5: ldc.i4.0
+		IL_00c6: ldloc.0
+		IL_00c7: stelem.ref
+		IL_00c8: ldc.i4.0
+		IL_00c9: ldelem.ref
+		IL_00ca: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+		IL_00cf: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+		IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00da: stloc.2
+		IL_00db: ldloc.0
+		IL_00dc: ldloc.2
+		IL_00dd: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+		IL_00e2: ldnull
+		IL_00e3: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+		IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_00ee: stloc.2
+		IL_00ef: ldloc.0
+		IL_00f0: ldloc.2
+		IL_00f1: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+		IL_00f6: ldc.i4.1
+		IL_00f7: newarr [System.Runtime]System.Object
+		IL_00fc: dup
+		IL_00fd: ldc.i4.0
+		IL_00fe: ldloc.0
+		IL_00ff: stelem.ref
+		IL_0100: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
+		IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_010b: stloc.2
+		IL_010c: ldloc.2
+		IL_010d: stloc.1
+		IL_010e: ldarg.1
+		IL_010f: ldstr "fs"
+		IL_0114: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0119: stloc.2
+		IL_011a: ldloc.0
+		IL_011b: ldloc.2
+		IL_011c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+		IL_0121: ldarg.1
+		IL_0122: ldstr "node:http"
+		IL_0127: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_012c: stloc.2
 		IL_012d: ldloc.0
-		IL_012e: stelem.ref
-		IL_012f: ldc.i4.0
-		IL_0130: ldelem.ref
-		IL_0131: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_0136: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_013c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0141: stloc.3
-		IL_0142: ldloc.0
-		IL_0143: ldloc.3
-		IL_0144: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::findTagNameAt
-		IL_0149: ldc.i4.1
-		IL_014a: newarr [System.Runtime]System.Object
-		IL_014f: dup
-		IL_0150: ldc.i4.0
-		IL_0151: ldloc.0
-		IL_0152: stelem.ref
-		IL_0153: ldc.i4.0
-		IL_0154: ldelem.ref
-		IL_0155: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_015a: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0165: stloc.3
-		IL_0166: ldloc.0
-		IL_0167: ldloc.3
-		IL_0168: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::extractElementById
-		IL_016d: ldc.i4.1
-		IL_016e: newarr [System.Runtime]System.Object
-		IL_0173: dup
-		IL_0174: ldc.i4.0
-		IL_0175: ldloc.0
-		IL_0176: stelem.ref
-		IL_0177: ldc.i4.0
-		IL_0178: ldelem.ref
-		IL_0179: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_017e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0189: stloc.3
-		IL_018a: ldloc.0
-		IL_018b: ldloc.3
-		IL_018c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::resolveSectionLinkFromMultipageIndexHtml
-		IL_0191: ldc.i4.1
-		IL_0192: newarr [System.Runtime]System.Object
-		IL_0197: dup
-		IL_0198: ldc.i4.0
-		IL_0199: ldloc.0
-		IL_019a: stelem.ref
-		IL_019b: ldc.i4.0
-		IL_019c: ldelem.ref
-		IL_019d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
-		IL_01a2: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionIdFromHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
-		IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01ad: stloc.3
-		IL_01ae: ldloc.0
-		IL_01af: ldloc.3
-		IL_01b0: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::resolveSectionIdFromHtml
-		IL_01b5: ldnull
-		IL_01b6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/wrapAsStandaloneHtml::__js_call__(object, object, object)
-		IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01c1: stloc.3
-		IL_01c2: ldloc.0
-		IL_01c3: ldloc.3
-		IL_01c4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::wrapAsStandaloneHtml
-		IL_01c9: ldnull
-		IL_01ca: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/printHelp::__js_call__(object)
-		IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01d5: stloc.3
-		IL_01d6: ldloc.0
-		IL_01d7: ldloc.3
-		IL_01d8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::printHelp
-		IL_01dd: ldc.i4.1
-		IL_01de: newarr [System.Runtime]System.Object
-		IL_01e3: dup
-		IL_01e4: ldc.i4.0
-		IL_01e5: ldloc.0
-		IL_01e6: stelem.ref
-		IL_01e7: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
-		IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01f2: stloc.3
-		IL_01f3: ldloc.3
-		IL_01f4: stloc.2
-		IL_01f5: ldarg.1
-		IL_01f6: ldstr "fs"
-		IL_01fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0200: stloc.3
-		IL_0201: ldloc.0
-		IL_0202: ldloc.3
-		IL_0203: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
-		IL_0208: ldarg.1
-		IL_0209: ldstr "http"
-		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0213: stloc.3
-		IL_0214: ldloc.0
-		IL_0215: ldloc.3
-		IL_0216: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::http
-		IL_021b: ldarg.1
-		IL_021c: ldstr "path"
-		IL_0221: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0226: stloc.3
-		IL_0227: ldloc.0
-		IL_0228: ldloc.3
-		IL_0229: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
-		IL_022e: ldarg.1
-		IL_022f: ldstr "https"
-		IL_0234: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0239: stloc.3
-		IL_023a: ldloc.0
-		IL_023b: ldloc.3
-		IL_023c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::https
-		IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0246: dup
-		IL_0247: ldstr "main"
-		IL_024c: ldloc.2
-		IL_024d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0252: stloc.s 4
-		IL_0254: ldarg.2
-		IL_0255: ldstr "exports"
-		IL_025a: ldloc.s 4
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-		IL_0261: pop
-		IL_0262: ldarg.1
-		IL_0263: ldstr "main"
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026d: ldarg.2
-		IL_026e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0273: stloc.s 5
-		IL_0275: ldloc.s 5
-		IL_0277: brfalse IL_02bf
+		IL_012e: ldloc.2
+		IL_012f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+		IL_0134: ldarg.1
+		IL_0135: ldstr "node:https"
+		IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_013f: stloc.2
+		IL_0140: ldloc.0
+		IL_0141: ldloc.2
+		IL_0142: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+		IL_0147: ldarg.1
+		IL_0148: ldstr "path"
+		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0152: stloc.2
+		IL_0153: ldloc.0
+		IL_0154: ldloc.2
+		IL_0155: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+		IL_015a: ldarg.1
+		IL_015b: ldstr "node:url"
+		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0165: stloc.2
+		IL_0166: ldloc.2
+		IL_0167: brfalse IL_0177
 
-		IL_027c: ldc.i4.1
-		IL_027d: newarr [System.Runtime]System.Object
-		IL_0282: dup
-		IL_0283: ldc.i4.0
-		IL_0284: ldloc.0
-		IL_0285: stelem.ref
-		IL_0286: ldnull
-		IL_0287: ldnull
-		IL_0288: ldnull
-		IL_0289: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
-		IL_028e: stloc.3
-		IL_028f: ldnull
-		IL_0290: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/ArrowFunction_L573C16::__js_call__(object, object)
-		IL_0296: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_029b: ldc.i4.1
-		IL_029c: newarr [System.Runtime]System.Object
-		IL_02a1: dup
-		IL_02a2: ldc.i4.0
-		IL_02a3: ldloc.0
-		IL_02a4: stelem.ref
-		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02af: stloc.s 6
-		IL_02b1: ldloc.3
-		IL_02b2: ldstr "catch"
-		IL_02b7: ldloc.s 6
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02be: pop
+		IL_016c: ldloc.2
+		IL_016d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0172: brfalse IL_0187
 
-		IL_02bf: ret
-	} // end of method Compile_Scripts_ExtractEcma262SectionHtml::__js_module_init__
+		IL_0177: ldloc.2
+		IL_0178: ldstr ""
+		IL_017d: ldstr "URL"
+		IL_0182: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml
+		IL_0187: ldloc.2
+		IL_0188: ldstr "URL"
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0192: stloc.2
+		IL_0193: ldloc.0
+		IL_0194: ldloc.2
+		IL_0195: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+		IL_019a: ldarg.0
+		IL_019b: ldstr "runHarnessCli"
+		IL_01a0: ldloc.1
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_01a6: pop
+		IL_01a7: ret
+	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_TestHarness::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object
@@ -8519,7 +5003,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5c56
+		// Method begins at RVA 0x425f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8
@@ -8534,23 +5018,4 @@
 	} // end of method Program::Main
 
 } // end of class Program
-
-.class interface public auto ansi abstract Js2IL.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.ICompileScriptsExtractEcma262SectionHtmlExports
-	implements [System.Runtime]System.IDisposable
-{
-	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
-		01 00 29 43 6f 6d 70 69 6c 65 5f 53 63 72 69 70
-		74 73 5f 45 78 74 72 61 63 74 45 63 6d 61 32 36
-		32 53 65 63 74 69 6f 6e 48 74 6d 6c 00 00
-	)
-	// Methods
-	.method public hidebysig newslot abstract virtual 
-		instance class [System.Runtime]System.Threading.Tasks.Task Main (
-			object arg1,
-			object arg2
-		) cil managed 
-	{
-	} // end of method ICompileScriptsExtractEcma262SectionHtmlExports::Main
-
-} // end of class Js2IL.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.ICompileScriptsExtractEcma262SectionHtmlExports
 

--- a/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -1,0 +1,8556 @@
+﻿// IL code: Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit normalize
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L7C29
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x592c
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L7C29::.ctor
+
+			} // end of class Block_L7C29
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5923
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object text,
+				object outFile
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x23d4
+			// Header size: 12
+			// Code size: 249 (0xf9)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] bool,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: ldstr "includes"
+			IL_0006: ldstr " -> "
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: brfalse IL_0073
+
+			IL_001e: ldarg.1
+			IL_001f: ldstr "indexOf"
+			IL_0024: ldstr " -> "
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002e: stloc.0
+			IL_002f: ldloc.0
+			IL_0030: ldc.r8 4
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_003e: stloc.2
+			IL_003f: ldarg.1
+			IL_0040: ldstr "substring"
+			IL_0045: ldc.r8 0.0
+			IL_004e: box [System.Runtime]System.Double
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0059: stloc.0
+			IL_005a: ldloc.0
+			IL_005b: ldstr "<outFile>"
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0065: pop
+			IL_0066: ldloc.0
+			IL_0067: ldstr "<outFile>"
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0071: starg.s text
+
+			IL_0073: ldstr "[.*+?^${}()|[\\]\\\\]"
+			IL_0078: ldstr "g"
+			IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0082: stloc.3
+			IL_0083: ldarg.2
+			IL_0084: ldstr "replace"
+			IL_0089: ldloc.3
+			IL_008a: ldstr "\\$&"
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0094: stloc.0
+			IL_0095: ldloc.0
+			IL_0096: ldstr "g"
+			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00a0: stloc.3
+			IL_00a1: ldarg.1
+			IL_00a2: ldstr "replace"
+			IL_00a7: ldloc.3
+			IL_00a8: ldstr "<outFile>"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00b2: stloc.0
+			IL_00b3: ldstr "127\\.0\\.0\\.1:\\d+"
+			IL_00b8: ldstr "g"
+			IL_00bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00c2: stloc.3
+			IL_00c3: ldloc.0
+			IL_00c4: ldstr "replace"
+			IL_00c9: ldloc.3
+			IL_00ca: ldstr "127.0.0.1:<port>"
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d4: stloc.0
+			IL_00d5: ldstr "\\r\\n"
+			IL_00da: ldstr "g"
+			IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00e4: stloc.3
+			IL_00e5: ldloc.0
+			IL_00e6: ldstr "replace"
+			IL_00eb: ldloc.3
+			IL_00ec: ldstr "\n"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f6: stloc.0
+			IL_00f7: ldloc.0
+			IL_00f8: ret
+		} // end of method normalize::__js_call__
+
+	} // end of class normalize
+
+	.class nested public auto ansi abstract sealed beforefieldinit run
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L22C19
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+					01 00 13 53 63 6f 70 65 20 76 61 6c 75 65 3d 7b
+					76 61 6c 75 65 7d 00 00
+				)
+				// Fields
+				.field public object 'value'
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x593e
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget,
+					object 'value'
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x28d0
+				// Header size: 12
+				// Code size: 29 (0x1d)
+				.maxstack 8
+				.locals init (
+					[0] string
+				)
+
+				IL_0000: ldarg.2
+				IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0006: stloc.0
+				IL_0007: ldarg.0
+				IL_0008: ldc.i4.1
+				IL_0009: ldelem.ref
+				IL_000a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope
+				IL_000f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::lines
+				IL_0014: ldloc.0
+				IL_0015: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_001a: pop
+				IL_001b: ldnull
+				IL_001c: ret
+			} // end of method ArrowFunction_L22C19::__js_call__
+
+		} // end of class ArrowFunction_L22C19
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 13 53 63 6f 70 65 20 6c 69 6e 65 73 3d 7b
+				6c 69 6e 65 73 7d 00 00
+			)
+			// Fields
+			.field public class [JavaScriptRuntime]JavaScriptRuntime.Array lines
+			.field public object _awaited1
+			.field public object _awaited2
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5935
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L39C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L39C28
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5950
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L39C28::.ctor
+
+			} // end of class Block_L39C28
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5947
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L39C7::.ctor
+
+		} // end of class Scope_ForOf_L39C7
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x24dc
+			// Header size: 12
+			// Code size: 793 (0x319)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[6] bool,
+				[7] bool,
+				[8] object,
+				[9] object,
+				[10] object,
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[12] bool
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope
+			IL_0008: dup
+			IL_0009: brtrue IL_003b
+
+			IL_000e: pop
+			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::.ctor()
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: ldarg.0
+			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
+			IL_001c: starg.s scopes
+			IL_001e: ldloc.0
+			IL_001f: ldnull
+			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_002b: ldarg.0
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::Bind(object, object[])
+			IL_0031: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0036: br IL_003c
+
+			IL_003b: stloc.0
+
+			IL_003c: ldloc.0
+			IL_003d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0042: brtrue IL_0053
+
+			IL_0047: ldloc.0
+			IL_0048: ldc.i4.8
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+
+			IL_0053: ldloc.0
+			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0059: ldc.i4.0
+			IL_005a: ble.s IL_0097
+
+			IL_005c: ldloc.0
+			IL_005d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0062: dup
+			IL_0063: ldc.i4.0
+			IL_0064: ldelem.ref
+			IL_0065: stloc.1
+			IL_0066: dup
+			IL_0067: ldc.i4.1
+			IL_0068: ldelem.ref
+			IL_0069: stloc.2
+			IL_006a: dup
+			IL_006b: ldc.i4.2
+			IL_006c: ldelem.ref
+			IL_006d: stloc.3
+			IL_006e: dup
+			IL_006f: ldc.i4.3
+			IL_0070: ldelem.ref
+			IL_0071: stloc.s 4
+			IL_0073: dup
+			IL_0074: ldc.i4.4
+			IL_0075: ldelem.ref
+			IL_0076: castclass [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator
+			IL_007b: stloc.s 5
+			IL_007d: dup
+			IL_007e: ldc.i4.5
+			IL_007f: ldelem.ref
+			IL_0080: unbox.any [System.Runtime]System.Boolean
+			IL_0085: stloc.s 6
+			IL_0087: dup
+			IL_0088: ldc.i4.6
+			IL_0089: ldelem.ref
+			IL_008a: unbox.any [System.Runtime]System.Boolean
+			IL_008f: stloc.s 7
+			IL_0091: dup
+			IL_0092: ldc.i4.7
+			IL_0093: ldelem.ref
+			IL_0094: stloc.s 8
+			IL_0096: pop
+
+			IL_0097: ldloc.0
+			IL_0098: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_009d: switch (IL_00aa, IL_022d)
+
+			IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00af: ldstr "argv"
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b9: ldc.r8 2
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00c7: stloc.1
+			IL_00c8: ldarg.0
+			IL_00c9: ldc.i4.1
+			IL_00ca: ldelem.ref
+			IL_00cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
+			IL_00d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::path
+			IL_00d5: stloc.s 9
+			IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00dc: ldstr "cwd"
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00e6: stloc.s 10
+			IL_00e8: ldloc.s 9
+			IL_00ea: ldstr "join"
+			IL_00ef: ldloc.s 10
+			IL_00f1: ldstr "section-url.html"
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00fb: stloc.s 10
+			IL_00fd: ldloc.s 10
+			IL_00ff: stloc.2
+			IL_0100: ldarg.0
+			IL_0101: ldc.i4.1
+			IL_0102: ldelem.ref
+			IL_0103: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
+			IL_0108: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
+			IL_010d: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml"
+			IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0117: stloc.s 10
+			IL_0119: ldloc.s 10
+			IL_011b: stloc.3
+			IL_011c: ldloc.0
+			IL_011d: ldc.i4.0
+			IL_011e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0123: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::lines
+			IL_0128: ldnull
+			IL_0129: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/ArrowFunction_L22C19::__js_call__(object[], object, object)
+			IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0134: ldc.i4.2
+			IL_0135: newarr [System.Runtime]System.Object
+			IL_013a: dup
+			IL_013b: ldc.i4.0
+			IL_013c: ldarg.0
+			IL_013d: ldc.i4.1
+			IL_013e: ldelem.ref
+			IL_013f: stelem.ref
+			IL_0140: dup
+			IL_0141: ldc.i4.1
+			IL_0142: ldloc.0
+			IL_0143: stelem.ref
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_014e: stloc.s 10
+			IL_0150: ldloc.s 10
+			IL_0152: stloc.s 4
+			IL_0154: ldc.i4.s 10
+			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_015b: dup
+			IL_015c: ldstr "dotnet"
+			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0166: dup
+			IL_0167: ldstr "extractEcma262SectionHtml.js"
+			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0171: dup
+			IL_0172: ldstr "--section"
+			IL_0177: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_017c: dup
+			IL_017d: ldstr "27.3"
+			IL_0182: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0187: dup
+			IL_0188: ldstr "--url"
+			IL_018d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0192: dup
+			IL_0193: ldloc.1
+			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0199: dup
+			IL_019a: ldstr "--id"
+			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a4: dup
+			IL_01a5: ldstr "sec-generatorfunction-objects"
+			IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01af: dup
+			IL_01b0: ldstr "--out"
+			IL_01b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01ba: dup
+			IL_01bb: ldloc.2
+			IL_01bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01c1: stloc.s 11
+			IL_01c3: ldloc.3
+			IL_01c4: ldstr "main"
+			IL_01c9: ldloc.s 11
+			IL_01cb: ldloc.s 4
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01d2: stloc.s 10
+			IL_01d4: ldloc.0
+			IL_01d5: ldc.i4.1
+			IL_01d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01db: ldloc.0
+			IL_01dc: ldloc.s 10
+			IL_01de: ldarg.0
+			IL_01df: ldc.i4.1
+			IL_01e0: ldloc.0
+			IL_01e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01eb: ldloc.0
+			IL_01ec: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01f1: dup
+			IL_01f2: ldc.i4.0
+			IL_01f3: ldloc.1
+			IL_01f4: stelem.ref
+			IL_01f5: dup
+			IL_01f6: ldc.i4.1
+			IL_01f7: ldloc.2
+			IL_01f8: stelem.ref
+			IL_01f9: dup
+			IL_01fa: ldc.i4.2
+			IL_01fb: ldloc.3
+			IL_01fc: stelem.ref
+			IL_01fd: dup
+			IL_01fe: ldc.i4.3
+			IL_01ff: ldloc.s 4
+			IL_0201: stelem.ref
+			IL_0202: dup
+			IL_0203: ldc.i4.4
+			IL_0204: ldloc.s 5
+			IL_0206: stelem.ref
+			IL_0207: dup
+			IL_0208: ldc.i4.5
+			IL_0209: ldloc.s 6
+			IL_020b: box [System.Runtime]System.Boolean
+			IL_0210: stelem.ref
+			IL_0211: dup
+			IL_0212: ldc.i4.6
+			IL_0213: ldloc.s 7
+			IL_0215: box [System.Runtime]System.Boolean
+			IL_021a: stelem.ref
+			IL_021b: dup
+			IL_021c: ldc.i4.7
+			IL_021d: ldloc.s 8
+			IL_021f: stelem.ref
+			IL_0220: pop
+			IL_0221: ldloc.0
+			IL_0222: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0227: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_022c: ret
+
+			IL_022d: ldloc.0
+			IL_022e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::_awaited1
+			IL_0233: pop
+			IL_0234: ldloc.0
+			IL_0235: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::lines
+			IL_023a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_023f: stloc.s 5
+			IL_0241: ldc.i4.0
+			IL_0242: stloc.s 6
+			IL_0244: ldc.i4.0
+			IL_0245: stloc.s 7
+			.try
+			{
+				// loop start (head: IL_0247)
+					IL_0247: ldloc.s 5
+					IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_024e: stloc.s 10
+					IL_0250: ldloc.s 10
+					IL_0252: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_0257: stloc.s 12
+					IL_0259: ldloc.s 12
+					IL_025b: brtrue IL_0299
+
+					IL_0260: ldloc.s 10
+					IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_0267: stloc.s 10
+					IL_0269: ldloc.s 10
+					IL_026b: stloc.s 8
+					IL_026d: ldnull
+					IL_026e: ldloc.s 8
+					IL_0270: ldloc.2
+					IL_0271: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/normalize::__js_call__(object, object, object)
+					IL_0276: stloc.s 10
+					IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+					IL_027d: ldloc.s 10
+					IL_027f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+					IL_0284: pop
+					IL_0285: br IL_0247
+				// end loop
+				IL_028a: ldloc.s 5
+				IL_028c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0291: ldc.i4.1
+				IL_0292: stloc.s 7
+				IL_0294: leave IL_02b7
+
+				IL_0299: ldc.i4.1
+				IL_029a: stloc.s 6
+				IL_029c: leave IL_02b7
+			} // end .try
+			finally
+			{
+				IL_02a1: ldloc.s 6
+				IL_02a3: brtrue IL_02b6
+
+				IL_02a8: ldloc.s 7
+				IL_02aa: brtrue IL_02b6
+
+				IL_02af: ldloc.s 5
+				IL_02b1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+
+				IL_02b6: endfinally
+			} // end handler
+
+			IL_02b7: ldarg.0
+			IL_02b8: ldc.i4.1
+			IL_02b9: ldelem.ref
+			IL_02ba: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
+			IL_02bf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::fs
+			IL_02c4: ldstr "readFileSync"
+			IL_02c9: ldloc.2
+			IL_02ca: ldstr "utf8"
+			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02d4: stloc.s 10
+			IL_02d6: ldnull
+			IL_02d7: ldloc.s 10
+			IL_02d9: ldloc.2
+			IL_02da: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/normalize::__js_call__(object, object, object)
+			IL_02df: stloc.s 10
+			IL_02e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02e6: ldloc.s 10
+			IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02ed: pop
+			IL_02ee: ldloc.0
+			IL_02ef: ldc.i4.m1
+			IL_02f0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02f5: ldloc.0
+			IL_02f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0300: ldarg.0
+			IL_0301: ldc.i4.1
+			IL_0302: newarr [System.Runtime]System.Object
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_030c: pop
+			IL_030d: ldloc.0
+			IL_030e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0313: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0318: ret
+		} // end of method run::__js_call__
+
+	} // end of class run
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L46C13
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
+				72 7d 00 00
+			)
+			// Fields
+			.field public object err
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5959
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object err
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2814
+			// Header size: 12
+			// Code size: 175 (0xaf)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[3] bool,
+				[4] object,
+				[5] object,
+				[6] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: stloc.2
+			IL_0006: ldarg.1
+			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_000c: stloc.3
+			IL_000d: ldloc.3
+			IL_000e: brfalse IL_0025
+
+			IL_0013: ldarg.1
+			IL_0014: ldstr "stack"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001e: stloc.s 5
+			IL_0020: br IL_0028
+
+			IL_0025: ldarg.1
+			IL_0026: stloc.s 5
+
+			IL_0028: ldloc.s 5
+			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002f: stloc.3
+			IL_0030: ldloc.3
+			IL_0031: brfalse IL_0047
+
+			IL_0036: ldarg.1
+			IL_0037: ldstr "stack"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0041: stloc.0
+			IL_0042: br IL_008c
+
+			IL_0047: ldarg.1
+			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: brfalse IL_0066
+
+			IL_0054: ldarg.1
+			IL_0055: ldstr "message"
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005f: stloc.s 6
+			IL_0061: br IL_0069
+
+			IL_0066: ldarg.1
+			IL_0067: stloc.s 6
+
+			IL_0069: ldloc.s 6
+			IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: brfalse IL_0088
+
+			IL_0077: ldarg.1
+			IL_0078: ldstr "message"
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0082: stloc.1
+			IL_0083: br IL_008a
+
+			IL_0088: ldarg.1
+			IL_0089: stloc.1
+
+			IL_008a: ldloc.1
+			IL_008b: stloc.0
+
+			IL_008c: ldloc.2
+			IL_008d: ldloc.0
+			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0093: pop
+			IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0099: ldstr "exitCode"
+			IL_009e: ldc.r8 1
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_00ac: pop
+			IL_00ad: ldnull
+			IL_00ae: ret
+		} // end of method ArrowFunction_L46C13::__js_call__
+
+	} // end of class ArrowFunction_L46C13
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 4f 53 63 6f 70 65 20 72 65 71 75 69 72 65
+			3d 7b 72 65 71 75 69 72 65 7d 2c 20 66 73 3d 7b
+			66 73 7d 2c 20 70 61 74 68 3d 7b 70 61 74 68 7d
+			2c 20 6e 6f 72 6d 61 6c 69 7a 65 3d 7b 6e 6f 72
+			6d 61 6c 69 7a 65 7d 2c 20 72 75 6e 3d 7b 72 75
+			6e 7d 00 00
+		)
+		// Fields
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require
+		.field public object fs
+		.field public object path
+		.field public object normalize
+		.field public object run
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x591a
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 169 (0xa9)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope,
+			[1] object,
+			[2] object,
+			[3] object
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.1
+		IL_0008: stfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
+		IL_000d: ldnull
+		IL_000e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/normalize::__js_call__(object, object, object)
+		IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0019: stloc.2
+		IL_001a: ldloc.0
+		IL_001b: ldloc.2
+		IL_001c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::normalize
+		IL_0021: ldc.i4.1
+		IL_0022: newarr [System.Runtime]System.Object
+		IL_0027: dup
+		IL_0028: ldc.i4.0
+		IL_0029: ldloc.0
+		IL_002a: stelem.ref
+		IL_002b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
+		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0036: stloc.2
+		IL_0037: ldloc.2
+		IL_0038: stloc.1
+		IL_0039: ldloc.0
+		IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
+		IL_003f: ldstr "fs"
+		IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0049: stloc.2
+		IL_004a: ldloc.0
+		IL_004b: ldloc.2
+		IL_004c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::fs
+		IL_0051: ldloc.0
+		IL_0052: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
+		IL_0057: ldstr "path"
+		IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0061: stloc.2
+		IL_0062: ldloc.0
+		IL_0063: ldloc.2
+		IL_0064: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::path
+		IL_0069: ldc.i4.1
+		IL_006a: newarr [System.Runtime]System.Object
+		IL_006f: dup
+		IL_0070: ldc.i4.0
+		IL_0071: ldloc.0
+		IL_0072: stelem.ref
+		IL_0073: ldnull
+		IL_0074: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
+		IL_0079: stloc.2
+		IL_007a: ldnull
+		IL_007b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/ArrowFunction_L46C13::__js_call__(object, object)
+		IL_0081: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0086: ldc.i4.1
+		IL_0087: newarr [System.Runtime]System.Object
+		IL_008c: dup
+		IL_008d: ldc.i4.0
+		IL_008e: ldloc.0
+		IL_008f: stelem.ref
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_009a: stloc.3
+		IL_009b: ldloc.2
+		IL_009c: ldstr "catch"
+		IL_00a1: ldloc.3
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00a7: pop
+		IL_00a8: ret
+	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_UrlMode::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
+
+.class private auto ansi beforefieldinit Modules.Compile_Scripts_ExtractEcma262SectionHtml
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit parseArgs
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x596b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_For_L49C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L49C40
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L52C38
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5986
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L52C38::.ctor
+
+				} // end of class Block_L52C38
+
+				.class nested private auto ansi beforefieldinit Block_L57C41
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x598f
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L57C41::.ctor
+
+				} // end of class Block_L57C41
+
+				.class nested private auto ansi beforefieldinit Block_L63C36
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5998
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L63C36::.ctor
+
+				} // end of class Block_L63C36
+
+				.class nested private auto ansi beforefieldinit Block_L68C36
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59a1
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L68C36::.ctor
+
+				} // end of class Block_L68C36
+
+				.class nested private auto ansi beforefieldinit Block_L74C31
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59aa
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L74C31::.ctor
+
+				} // end of class Block_L74C31
+
+				.class nested private auto ansi beforefieldinit Block_L79C37
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59b3
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L79C37::.ctor
+
+				} // end of class Block_L79C37
+
+				.class nested private auto ansi beforefieldinit Block_L85C32
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59bc
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L85C32::.ctor
+
+				} // end of class Block_L85C32
+
+				.class nested private auto ansi beforefieldinit Block_L90C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59c5
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L90C24::.ctor
+
+				} // end of class Block_L90C24
+
+				.class nested private auto ansi beforefieldinit Block_L95C29
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59ce
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L95C29::.ctor
+
+				} // end of class Block_L95C29
+
+				.class nested private auto ansi beforefieldinit Block_L101C38
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59d7
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L101C38::.ctor
+
+				} // end of class Block_L101C38
+
+				.class nested private auto ansi beforefieldinit Block_L106C37
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59e0
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L106C37::.ctor
+
+				} // end of class Block_L106C37
+
+				.class nested private auto ansi beforefieldinit Block_L112C32
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59e9
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L112C32::.ctor
+
+				} // end of class Block_L112C32
+
+				.class nested private auto ansi beforefieldinit Block_L117C22
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59f2
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L117C22::.ctor
+
+				} // end of class Block_L117C22
+
+				.class nested private auto ansi beforefieldinit Block_L123C31
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x59fb
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L123C31::.ctor
+
+				} // end of class Block_L123C31
+
+				.class nested private auto ansi beforefieldinit Block_L128C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a04
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L128C24::.ctor
+
+				} // end of class Block_L128C24
+
+				.class nested private auto ansi beforefieldinit Block_L133C27
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a0d
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L133C27::.ctor
+
+				} // end of class Block_L133C27
+
+				.class nested private auto ansi beforefieldinit Block_L138C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a16
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L138C24::.ctor
+
+				} // end of class Block_L138C24
+
+				.class nested private auto ansi beforefieldinit Block_L144C33
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a1f
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L144C33::.ctor
+
+				} // end of class Block_L144C33
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x597d
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L49C40::.ctor
+
+			} // end of class Block_L49C40
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5974
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_For_L49C7::.ctor
+
+		} // end of class Scope_For_L49C7
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object argv
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x28fc
+			// Header size: 12
+			// Code size: 2463 (0x99f)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[2] float64,
+				[3] object,
+				[4] bool,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] object,
+				[11] object,
+				[12] object,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] object,
+				[18] object,
+				[19] object,
+				[20] object,
+				[21] object,
+				[22] object,
+				[23] object,
+				[24] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0005: dup
+			IL_0006: ldstr "section"
+			IL_000b: ldstr ""
+			IL_0010: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0015: dup
+			IL_0016: ldstr "inFile"
+			IL_001b: ldstr ""
+			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0025: dup
+			IL_0026: ldstr "url"
+			IL_002b: ldstr ""
+			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0035: dup
+			IL_0036: ldstr "auto"
+			IL_003b: ldc.i4.0
+			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0041: dup
+			IL_0042: ldstr "indexUrl"
+			IL_0047: ldstr "https://tc39.es/ecma262/multipage/"
+			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0051: dup
+			IL_0052: ldstr "outFile"
+			IL_0057: ldstr ""
+			IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0061: dup
+			IL_0062: ldstr "id"
+			IL_0067: ldstr ""
+			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0071: dup
+			IL_0072: ldstr "wrap"
+			IL_0077: ldc.i4.1
+			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_007d: dup
+			IL_007e: ldstr "baseHref"
+			IL_0083: ldstr ""
+			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_008d: dup
+			IL_008e: ldstr "help"
+			IL_0093: ldc.i4.0
+			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0099: stloc.0
+			IL_009a: ldc.i4.0
+			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00a0: stloc.1
+			IL_00a1: ldc.r8 2
+			IL_00aa: stloc.2
+			// loop start (head: IL_00ab)
+				IL_00ab: ldloc.2
+				IL_00ac: ldarg.2
+				IL_00ad: ldstr "length"
+				IL_00b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00b7: clt
+				IL_00b9: brfalse IL_07ec
+
+				IL_00be: ldarg.2
+				IL_00bf: ldloc.2
+				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00c5: stloc.3
+				IL_00c6: ldloc.3
+				IL_00c7: ldstr "--help"
+				IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00d1: stloc.s 4
+				IL_00d3: ldloc.s 4
+				IL_00d5: box [System.Runtime]System.Boolean
+				IL_00da: stloc.s 5
+				IL_00dc: ldloc.s 5
+				IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00e3: stloc.s 4
+				IL_00e5: ldloc.s 4
+				IL_00e7: brtrue IL_010b
+
+				IL_00ec: ldloc.3
+				IL_00ed: ldstr "-h"
+				IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00f7: stloc.s 4
+				IL_00f9: ldloc.s 4
+				IL_00fb: box [System.Runtime]System.Boolean
+				IL_0100: stloc.s 6
+				IL_0102: ldloc.s 6
+				IL_0104: stloc.s 8
+				IL_0106: br IL_010f
+
+				IL_010b: ldloc.s 5
+				IL_010d: stloc.s 8
+
+				IL_010f: ldloc.s 8
+				IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0116: stloc.s 4
+				IL_0118: ldloc.s 4
+				IL_011a: brfalse IL_0136
+
+				IL_011f: ldloc.0
+				IL_0120: ldstr "help"
+				IL_0125: ldc.i4.1
+				IL_0126: box [System.Runtime]System.Boolean
+				IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0130: pop
+				IL_0131: br IL_07db
+
+				IL_0136: ldloc.3
+				IL_0137: ldstr "--section"
+				IL_013c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0141: stloc.s 4
+				IL_0143: ldloc.s 4
+				IL_0145: box [System.Runtime]System.Boolean
+				IL_014a: stloc.s 5
+				IL_014c: ldloc.s 5
+				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0153: stloc.s 4
+				IL_0155: ldloc.s 4
+				IL_0157: brtrue IL_017b
+
+				IL_015c: ldloc.3
+				IL_015d: ldstr "-s"
+				IL_0162: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0167: stloc.s 4
+				IL_0169: ldloc.s 4
+				IL_016b: box [System.Runtime]System.Boolean
+				IL_0170: stloc.s 6
+				IL_0172: ldloc.s 6
+				IL_0174: stloc.s 9
+				IL_0176: br IL_017f
+
+				IL_017b: ldloc.s 5
+				IL_017d: stloc.s 9
+
+				IL_017f: ldloc.s 9
+				IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0186: stloc.s 4
+				IL_0188: ldloc.s 4
+				IL_018a: brfalse IL_01e1
+
+				IL_018f: ldarg.2
+				IL_0190: ldloc.2
+				IL_0191: ldc.r8 1
+				IL_019a: add
+				IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01a0: stloc.s 10
+				IL_01a2: ldloc.s 10
+				IL_01a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01a9: stloc.s 4
+				IL_01ab: ldloc.s 4
+				IL_01ad: brtrue IL_01be
+
+				IL_01b2: ldstr ""
+				IL_01b7: stloc.s 11
+				IL_01b9: br IL_01c2
+
+				IL_01be: ldloc.s 10
+				IL_01c0: stloc.s 11
+
+				IL_01c2: ldloc.0
+				IL_01c3: ldstr "section"
+				IL_01c8: ldloc.s 11
+				IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_01cf: pop
+				IL_01d0: ldloc.2
+				IL_01d1: ldc.r8 1
+				IL_01da: add
+				IL_01db: stloc.2
+				IL_01dc: br IL_07db
+
+				IL_01e1: ldloc.3
+				IL_01e2: ldstr "startsWith"
+				IL_01e7: ldstr "--section="
+				IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01f1: stloc.s 10
+				IL_01f3: ldloc.s 10
+				IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01fa: stloc.s 4
+				IL_01fc: ldloc.s 4
+				IL_01fe: brfalse IL_0233
+
+				IL_0203: ldloc.3
+				IL_0204: ldstr "substring"
+				IL_0209: ldstr "--section="
+				IL_020e: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_0213: conv.r8
+				IL_0214: box [System.Runtime]System.Double
+				IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_021e: stloc.s 10
+				IL_0220: ldloc.0
+				IL_0221: ldstr "section"
+				IL_0226: ldloc.s 10
+				IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_022d: pop
+				IL_022e: br IL_07db
+
+				IL_0233: ldloc.3
+				IL_0234: ldstr "--in"
+				IL_0239: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_023e: stloc.s 4
+				IL_0240: ldloc.s 4
+				IL_0242: box [System.Runtime]System.Boolean
+				IL_0247: stloc.s 5
+				IL_0249: ldloc.s 5
+				IL_024b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0250: stloc.s 4
+				IL_0252: ldloc.s 4
+				IL_0254: brtrue IL_0278
+
+				IL_0259: ldloc.3
+				IL_025a: ldstr "-i"
+				IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0264: stloc.s 4
+				IL_0266: ldloc.s 4
+				IL_0268: box [System.Runtime]System.Boolean
+				IL_026d: stloc.s 6
+				IL_026f: ldloc.s 6
+				IL_0271: stloc.s 12
+				IL_0273: br IL_027c
+
+				IL_0278: ldloc.s 5
+				IL_027a: stloc.s 12
+
+				IL_027c: ldloc.s 12
+				IL_027e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0283: stloc.s 4
+				IL_0285: ldloc.s 4
+				IL_0287: brfalse IL_02de
+
+				IL_028c: ldarg.2
+				IL_028d: ldloc.2
+				IL_028e: ldc.r8 1
+				IL_0297: add
+				IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_029d: stloc.s 10
+				IL_029f: ldloc.s 10
+				IL_02a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02a6: stloc.s 4
+				IL_02a8: ldloc.s 4
+				IL_02aa: brtrue IL_02bb
+
+				IL_02af: ldstr ""
+				IL_02b4: stloc.s 13
+				IL_02b6: br IL_02bf
+
+				IL_02bb: ldloc.s 10
+				IL_02bd: stloc.s 13
+
+				IL_02bf: ldloc.0
+				IL_02c0: ldstr "inFile"
+				IL_02c5: ldloc.s 13
+				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_02cc: pop
+				IL_02cd: ldloc.2
+				IL_02ce: ldc.r8 1
+				IL_02d7: add
+				IL_02d8: stloc.2
+				IL_02d9: br IL_07db
+
+				IL_02de: ldloc.3
+				IL_02df: ldstr "startsWith"
+				IL_02e4: ldstr "--in="
+				IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02ee: stloc.s 10
+				IL_02f0: ldloc.s 10
+				IL_02f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02f7: stloc.s 4
+				IL_02f9: ldloc.s 4
+				IL_02fb: brfalse IL_0330
+
+				IL_0300: ldloc.3
+				IL_0301: ldstr "substring"
+				IL_0306: ldstr "--in="
+				IL_030b: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_0310: conv.r8
+				IL_0311: box [System.Runtime]System.Double
+				IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_031b: stloc.s 10
+				IL_031d: ldloc.0
+				IL_031e: ldstr "inFile"
+				IL_0323: ldloc.s 10
+				IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_032a: pop
+				IL_032b: br IL_07db
+
+				IL_0330: ldloc.3
+				IL_0331: ldstr "--url"
+				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_033b: stloc.s 4
+				IL_033d: ldloc.s 4
+				IL_033f: box [System.Runtime]System.Boolean
+				IL_0344: stloc.s 5
+				IL_0346: ldloc.s 5
+				IL_0348: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_034d: stloc.s 4
+				IL_034f: ldloc.s 4
+				IL_0351: brtrue IL_0375
+
+				IL_0356: ldloc.3
+				IL_0357: ldstr "-u"
+				IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0361: stloc.s 4
+				IL_0363: ldloc.s 4
+				IL_0365: box [System.Runtime]System.Boolean
+				IL_036a: stloc.s 6
+				IL_036c: ldloc.s 6
+				IL_036e: stloc.s 14
+				IL_0370: br IL_0379
+
+				IL_0375: ldloc.s 5
+				IL_0377: stloc.s 14
+
+				IL_0379: ldloc.s 14
+				IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0380: stloc.s 4
+				IL_0382: ldloc.s 4
+				IL_0384: brfalse IL_03db
+
+				IL_0389: ldarg.2
+				IL_038a: ldloc.2
+				IL_038b: ldc.r8 1
+				IL_0394: add
+				IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_039a: stloc.s 10
+				IL_039c: ldloc.s 10
+				IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_03a3: stloc.s 4
+				IL_03a5: ldloc.s 4
+				IL_03a7: brtrue IL_03b8
+
+				IL_03ac: ldstr ""
+				IL_03b1: stloc.s 15
+				IL_03b3: br IL_03bc
+
+				IL_03b8: ldloc.s 10
+				IL_03ba: stloc.s 15
+
+				IL_03bc: ldloc.0
+				IL_03bd: ldstr "url"
+				IL_03c2: ldloc.s 15
+				IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_03c9: pop
+				IL_03ca: ldloc.2
+				IL_03cb: ldc.r8 1
+				IL_03d4: add
+				IL_03d5: stloc.2
+				IL_03d6: br IL_07db
+
+				IL_03db: ldloc.3
+				IL_03dc: ldstr "startsWith"
+				IL_03e1: ldstr "--url="
+				IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_03eb: stloc.s 10
+				IL_03ed: ldloc.s 10
+				IL_03ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_03f4: stloc.s 4
+				IL_03f6: ldloc.s 4
+				IL_03f8: brfalse IL_042d
+
+				IL_03fd: ldloc.3
+				IL_03fe: ldstr "substring"
+				IL_0403: ldstr "--url="
+				IL_0408: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_040d: conv.r8
+				IL_040e: box [System.Runtime]System.Double
+				IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0418: stloc.s 10
+				IL_041a: ldloc.0
+				IL_041b: ldstr "url"
+				IL_0420: ldloc.s 10
+				IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0427: pop
+				IL_0428: br IL_07db
+
+				IL_042d: ldloc.3
+				IL_042e: ldstr "--auto"
+				IL_0433: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0438: stloc.s 4
+				IL_043a: ldloc.s 4
+				IL_043c: brfalse IL_0458
+
+				IL_0441: ldloc.0
+				IL_0442: ldstr "auto"
+				IL_0447: ldc.i4.1
+				IL_0448: box [System.Runtime]System.Boolean
+				IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0452: pop
+				IL_0453: br IL_07db
+
+				IL_0458: ldloc.3
+				IL_0459: ldstr "--index-url"
+				IL_045e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0463: stloc.s 4
+				IL_0465: ldloc.s 4
+				IL_0467: brfalse IL_04be
+
+				IL_046c: ldarg.2
+				IL_046d: ldloc.2
+				IL_046e: ldc.r8 1
+				IL_0477: add
+				IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_047d: stloc.s 10
+				IL_047f: ldloc.s 10
+				IL_0481: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0486: stloc.s 4
+				IL_0488: ldloc.s 4
+				IL_048a: brtrue IL_049b
+
+				IL_048f: ldstr ""
+				IL_0494: stloc.s 16
+				IL_0496: br IL_049f
+
+				IL_049b: ldloc.s 10
+				IL_049d: stloc.s 16
+
+				IL_049f: ldloc.0
+				IL_04a0: ldstr "indexUrl"
+				IL_04a5: ldloc.s 16
+				IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_04ac: pop
+				IL_04ad: ldloc.2
+				IL_04ae: ldc.r8 1
+				IL_04b7: add
+				IL_04b8: stloc.2
+				IL_04b9: br IL_07db
+
+				IL_04be: ldloc.3
+				IL_04bf: ldstr "startsWith"
+				IL_04c4: ldstr "--index-url="
+				IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_04ce: stloc.s 10
+				IL_04d0: ldloc.s 10
+				IL_04d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_04d7: stloc.s 4
+				IL_04d9: ldloc.s 4
+				IL_04db: brfalse IL_0510
+
+				IL_04e0: ldloc.3
+				IL_04e1: ldstr "substring"
+				IL_04e6: ldstr "--index-url="
+				IL_04eb: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_04f0: conv.r8
+				IL_04f1: box [System.Runtime]System.Double
+				IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_04fb: stloc.s 10
+				IL_04fd: ldloc.0
+				IL_04fe: ldstr "indexUrl"
+				IL_0503: ldloc.s 10
+				IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_050a: pop
+				IL_050b: br IL_07db
+
+				IL_0510: ldloc.3
+				IL_0511: ldstr "--out"
+				IL_0516: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_051b: stloc.s 4
+				IL_051d: ldloc.s 4
+				IL_051f: box [System.Runtime]System.Boolean
+				IL_0524: stloc.s 5
+				IL_0526: ldloc.s 5
+				IL_0528: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_052d: stloc.s 4
+				IL_052f: ldloc.s 4
+				IL_0531: brtrue IL_0555
+
+				IL_0536: ldloc.3
+				IL_0537: ldstr "-o"
+				IL_053c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0541: stloc.s 4
+				IL_0543: ldloc.s 4
+				IL_0545: box [System.Runtime]System.Boolean
+				IL_054a: stloc.s 6
+				IL_054c: ldloc.s 6
+				IL_054e: stloc.s 17
+				IL_0550: br IL_0559
+
+				IL_0555: ldloc.s 5
+				IL_0557: stloc.s 17
+
+				IL_0559: ldloc.s 17
+				IL_055b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0560: stloc.s 4
+				IL_0562: ldloc.s 4
+				IL_0564: brfalse IL_05bb
+
+				IL_0569: ldarg.2
+				IL_056a: ldloc.2
+				IL_056b: ldc.r8 1
+				IL_0574: add
+				IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_057a: stloc.s 10
+				IL_057c: ldloc.s 10
+				IL_057e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0583: stloc.s 4
+				IL_0585: ldloc.s 4
+				IL_0587: brtrue IL_0598
+
+				IL_058c: ldstr ""
+				IL_0591: stloc.s 18
+				IL_0593: br IL_059c
+
+				IL_0598: ldloc.s 10
+				IL_059a: stloc.s 18
+
+				IL_059c: ldloc.0
+				IL_059d: ldstr "outFile"
+				IL_05a2: ldloc.s 18
+				IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_05a9: pop
+				IL_05aa: ldloc.2
+				IL_05ab: ldc.r8 1
+				IL_05b4: add
+				IL_05b5: stloc.2
+				IL_05b6: br IL_07db
+
+				IL_05bb: ldloc.3
+				IL_05bc: ldstr "startsWith"
+				IL_05c1: ldstr "--out="
+				IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_05cb: stloc.s 10
+				IL_05cd: ldloc.s 10
+				IL_05cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_05d4: stloc.s 4
+				IL_05d6: ldloc.s 4
+				IL_05d8: brfalse IL_060d
+
+				IL_05dd: ldloc.3
+				IL_05de: ldstr "substring"
+				IL_05e3: ldstr "--out="
+				IL_05e8: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_05ed: conv.r8
+				IL_05ee: box [System.Runtime]System.Double
+				IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_05f8: stloc.s 10
+				IL_05fa: ldloc.0
+				IL_05fb: ldstr "outFile"
+				IL_0600: ldloc.s 10
+				IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0607: pop
+				IL_0608: br IL_07db
+
+				IL_060d: ldloc.3
+				IL_060e: ldstr "--id"
+				IL_0613: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0618: stloc.s 4
+				IL_061a: ldloc.s 4
+				IL_061c: brfalse IL_0673
+
+				IL_0621: ldarg.2
+				IL_0622: ldloc.2
+				IL_0623: ldc.r8 1
+				IL_062c: add
+				IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0632: stloc.s 10
+				IL_0634: ldloc.s 10
+				IL_0636: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_063b: stloc.s 4
+				IL_063d: ldloc.s 4
+				IL_063f: brtrue IL_0650
+
+				IL_0644: ldstr ""
+				IL_0649: stloc.s 19
+				IL_064b: br IL_0654
+
+				IL_0650: ldloc.s 10
+				IL_0652: stloc.s 19
+
+				IL_0654: ldloc.0
+				IL_0655: ldstr "id"
+				IL_065a: ldloc.s 19
+				IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0661: pop
+				IL_0662: ldloc.2
+				IL_0663: ldc.r8 1
+				IL_066c: add
+				IL_066d: stloc.2
+				IL_066e: br IL_07db
+
+				IL_0673: ldloc.3
+				IL_0674: ldstr "startsWith"
+				IL_0679: ldstr "--id="
+				IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0683: stloc.s 10
+				IL_0685: ldloc.s 10
+				IL_0687: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_068c: stloc.s 4
+				IL_068e: ldloc.s 4
+				IL_0690: brfalse IL_06c5
+
+				IL_0695: ldloc.3
+				IL_0696: ldstr "substring"
+				IL_069b: ldstr "--id="
+				IL_06a0: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_06a5: conv.r8
+				IL_06a6: box [System.Runtime]System.Double
+				IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_06b0: stloc.s 10
+				IL_06b2: ldloc.0
+				IL_06b3: ldstr "id"
+				IL_06b8: ldloc.s 10
+				IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_06bf: pop
+				IL_06c0: br IL_07db
+
+				IL_06c5: ldloc.3
+				IL_06c6: ldstr "--wrap"
+				IL_06cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_06d0: stloc.s 4
+				IL_06d2: ldloc.s 4
+				IL_06d4: brfalse IL_06f0
+
+				IL_06d9: ldloc.0
+				IL_06da: ldstr "wrap"
+				IL_06df: ldc.i4.1
+				IL_06e0: box [System.Runtime]System.Boolean
+				IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_06ea: pop
+				IL_06eb: br IL_07db
+
+				IL_06f0: ldloc.3
+				IL_06f1: ldstr "--no-wrap"
+				IL_06f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_06fb: stloc.s 4
+				IL_06fd: ldloc.s 4
+				IL_06ff: brfalse IL_071b
+
+				IL_0704: ldloc.0
+				IL_0705: ldstr "wrap"
+				IL_070a: ldc.i4.0
+				IL_070b: box [System.Runtime]System.Boolean
+				IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0715: pop
+				IL_0716: br IL_07db
+
+				IL_071b: ldloc.3
+				IL_071c: ldstr "--base"
+				IL_0721: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0726: stloc.s 4
+				IL_0728: ldloc.s 4
+				IL_072a: brfalse IL_0781
+
+				IL_072f: ldarg.2
+				IL_0730: ldloc.2
+				IL_0731: ldc.r8 1
+				IL_073a: add
+				IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0740: stloc.s 10
+				IL_0742: ldloc.s 10
+				IL_0744: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0749: stloc.s 4
+				IL_074b: ldloc.s 4
+				IL_074d: brtrue IL_075e
+
+				IL_0752: ldstr ""
+				IL_0757: stloc.s 20
+				IL_0759: br IL_0762
+
+				IL_075e: ldloc.s 10
+				IL_0760: stloc.s 20
+
+				IL_0762: ldloc.0
+				IL_0763: ldstr "baseHref"
+				IL_0768: ldloc.s 20
+				IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_076f: pop
+				IL_0770: ldloc.2
+				IL_0771: ldc.r8 1
+				IL_077a: add
+				IL_077b: stloc.2
+				IL_077c: br IL_07db
+
+				IL_0781: ldloc.3
+				IL_0782: ldstr "startsWith"
+				IL_0787: ldstr "--base="
+				IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0791: stloc.s 10
+				IL_0793: ldloc.s 10
+				IL_0795: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_079a: stloc.s 4
+				IL_079c: ldloc.s 4
+				IL_079e: brfalse IL_07d3
+
+				IL_07a3: ldloc.3
+				IL_07a4: ldstr "substring"
+				IL_07a9: ldstr "--base="
+				IL_07ae: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_07b3: conv.r8
+				IL_07b4: box [System.Runtime]System.Double
+				IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_07be: stloc.s 10
+				IL_07c0: ldloc.0
+				IL_07c1: ldstr "baseHref"
+				IL_07c6: ldloc.s 10
+				IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_07cd: pop
+				IL_07ce: br IL_07db
+
+				IL_07d3: ldloc.1
+				IL_07d4: ldloc.3
+				IL_07d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_07da: pop
+
+				IL_07db: ldloc.2
+				IL_07dc: ldc.r8 1
+				IL_07e5: add
+				IL_07e6: stloc.2
+				IL_07e7: br IL_00ab
+			// end loop
+
+			IL_07ec: ldloc.0
+			IL_07ed: ldstr "section"
+			IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_07fc: ldc.i4.0
+			IL_07fd: ceq
+			IL_07ff: stloc.s 4
+			IL_0801: ldloc.s 4
+			IL_0803: box [System.Runtime]System.Boolean
+			IL_0808: stloc.s 5
+			IL_080a: ldloc.s 5
+			IL_080c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0811: stloc.s 4
+			IL_0813: ldloc.s 4
+			IL_0815: brfalse IL_083b
+
+			IL_081a: ldloc.1
+			IL_081b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0820: conv.r8
+			IL_0821: ldc.r8 1
+			IL_082a: clt
+			IL_082c: ldc.i4.0
+			IL_082d: ceq
+			IL_082f: box [System.Runtime]System.Boolean
+			IL_0834: stloc.s 21
+			IL_0836: br IL_083f
+
+			IL_083b: ldloc.s 5
+			IL_083d: stloc.s 21
+
+			IL_083f: ldloc.s 21
+			IL_0841: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0846: stloc.s 4
+			IL_0848: ldloc.s 4
+			IL_084a: brfalse IL_086a
+
+			IL_084f: ldloc.0
+			IL_0850: ldstr "section"
+			IL_0855: ldloc.1
+			IL_0856: ldc.r8 0.0
+			IL_085f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_0869: pop
+
+			IL_086a: ldloc.0
+			IL_086b: ldstr "inFile"
+			IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0875: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_087a: ldc.i4.0
+			IL_087b: ceq
+			IL_087d: stloc.s 4
+			IL_087f: ldloc.s 4
+			IL_0881: box [System.Runtime]System.Boolean
+			IL_0886: stloc.s 5
+			IL_0888: ldloc.s 5
+			IL_088a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_088f: stloc.s 4
+			IL_0891: ldloc.s 4
+			IL_0893: brfalse IL_08bf
+
+			IL_0898: ldloc.0
+			IL_0899: ldstr "url"
+			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08a3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08a8: ldc.i4.0
+			IL_08a9: ceq
+			IL_08ab: stloc.s 4
+			IL_08ad: ldloc.s 4
+			IL_08af: box [System.Runtime]System.Boolean
+			IL_08b4: stloc.s 6
+			IL_08b6: ldloc.s 6
+			IL_08b8: stloc.s 22
+			IL_08ba: br IL_08c3
+
+			IL_08bf: ldloc.s 5
+			IL_08c1: stloc.s 22
+
+			IL_08c3: ldloc.s 22
+			IL_08c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_08ca: stloc.s 4
+			IL_08cc: ldloc.s 4
+			IL_08ce: brfalse IL_08f4
+
+			IL_08d3: ldloc.1
+			IL_08d4: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_08d9: conv.r8
+			IL_08da: ldc.r8 2
+			IL_08e3: clt
+			IL_08e5: ldc.i4.0
+			IL_08e6: ceq
+			IL_08e8: box [System.Runtime]System.Boolean
+			IL_08ed: stloc.s 22
+			IL_08ef: br IL_08f4
+
+			IL_08f4: ldloc.s 22
+			IL_08f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_08fb: stloc.s 4
+			IL_08fd: ldloc.s 4
+			IL_08ff: brfalse IL_091f
+
+			IL_0904: ldloc.0
+			IL_0905: ldstr "inFile"
+			IL_090a: ldloc.1
+			IL_090b: ldc.r8 1
+			IL_0914: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0919: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_091e: pop
+
+			IL_091f: ldloc.0
+			IL_0920: ldstr "outFile"
+			IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_092a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_092f: ldc.i4.0
+			IL_0930: ceq
+			IL_0932: stloc.s 4
+			IL_0934: ldloc.s 4
+			IL_0936: box [System.Runtime]System.Boolean
+			IL_093b: stloc.s 5
+			IL_093d: ldloc.s 5
+			IL_093f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0944: stloc.s 4
+			IL_0946: ldloc.s 4
+			IL_0948: brfalse IL_096e
+
+			IL_094d: ldloc.1
+			IL_094e: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0953: conv.r8
+			IL_0954: ldc.r8 3
+			IL_095d: clt
+			IL_095f: ldc.i4.0
+			IL_0960: ceq
+			IL_0962: box [System.Runtime]System.Boolean
+			IL_0967: stloc.s 24
+			IL_0969: br IL_0972
+
+			IL_096e: ldloc.s 5
+			IL_0970: stloc.s 24
+
+			IL_0972: ldloc.s 24
+			IL_0974: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0979: stloc.s 4
+			IL_097b: ldloc.s 4
+			IL_097d: brfalse IL_099d
+
+			IL_0982: ldloc.0
+			IL_0983: ldstr "outFile"
+			IL_0988: ldloc.1
+			IL_0989: ldc.r8 2
+			IL_0992: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0997: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_099c: pop
+
+			IL_099d: ldloc.0
+			IL_099e: ret
+		} // end of method parseArgs::__js_call__
+
+	} // end of class parseArgs
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithHttp
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a28
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object urlString,
+				object maxRedirects
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x32a8
+			// Header size: 12
+			// Code size: 66 (0x42)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: brtrue IL_0016
+
+			IL_0006: ldc.r8 5
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: starg.s maxRedirects
+
+			IL_0016: ldc.i4.1
+			IL_0017: newarr [System.Runtime]System.Object
+			IL_001c: dup
+			IL_001d: ldc.i4.0
+			IL_001e: ldarg.0
+			IL_001f: stelem.ref
+			IL_0020: ldc.i4.0
+			IL_0021: ldelem.ref
+			IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0027: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
+			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0032: ldnull
+			IL_0033: ldstr "http"
+			IL_0038: ldarg.2
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_003f: stloc.0
+			IL_0040: ldloc.0
+			IL_0041: ret
+		} // end of method fetchTextWithHttp::__js_call__
+
+	} // end of class fetchTextWithHttp
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithHttps
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a31
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object urlString,
+				object maxRedirects
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x32f8
+			// Header size: 12
+			// Code size: 66 (0x42)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: brtrue IL_0016
+
+			IL_0006: ldc.r8 5
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: starg.s maxRedirects
+
+			IL_0016: ldc.i4.1
+			IL_0017: newarr [System.Runtime]System.Object
+			IL_001c: dup
+			IL_001d: ldc.i4.0
+			IL_001e: ldarg.0
+			IL_001f: stelem.ref
+			IL_0020: ldc.i4.0
+			IL_0021: ldelem.ref
+			IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0027: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
+			IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0032: ldnull
+			IL_0033: ldstr "https"
+			IL_0038: ldarg.2
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_003f: stloc.0
+			IL_0040: ldloc.0
+			IL_0041: ret
+		} // end of method fetchTextWithHttps::__js_call__
+
+	} // end of class fetchTextWithHttps
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithTransport
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L170C22
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L194C7
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L219C24
+					extends [System.Runtime]System.Object
+				{
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Scope
+						extends [System.Runtime]System.Object
+					{
+						.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+							01 00 13 53 63 6f 70 65 20 63 68 75 6e 6b 3d 7b
+							63 68 75 6e 6b 7d 00 00
+						)
+						// Fields
+						.field public object chunk
+
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5a8b
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Scope::.ctor
+
+					} // end of class Scope
+
+
+					// Methods
+					.method public hidebysig static 
+						object __js_call__ (
+							object[] scopes,
+							object newTarget,
+							object chunk
+						) cil managed 
+					{
+						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+							01 00 02 00 00 00 00 00
+						)
+						// Method begins at RVA 0x589c
+						// Header size: 12
+						// Code size: 36 (0x24)
+						.maxstack 8
+						.locals init (
+							[0] object
+						)
+
+						IL_0000: ldarg.0
+						IL_0001: ldc.i4.3
+						IL_0002: ldelem.ref
+						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
+						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_000d: ldarg.2
+						IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+						IL_0013: stloc.0
+						IL_0014: ldarg.0
+						IL_0015: ldc.i4.3
+						IL_0016: ldelem.ref
+						IL_0017: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
+						IL_001c: ldloc.0
+						IL_001d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_0022: ldnull
+						IL_0023: ret
+					} // end of method ArrowFunction_L219C24::__js_call__
+
+				} // end of class ArrowFunction_L219C24
+
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L222C23
+					extends [System.Runtime]System.Object
+				{
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Scope
+						extends [System.Runtime]System.Object
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5a94
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Scope::.ctor
+
+					} // end of class Scope
+
+
+					// Methods
+					.method public hidebysig static 
+						object __js_call__ (
+							object[] scopes,
+							object newTarget
+						) cil managed 
+					{
+						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+							01 00 02 00 00 00 00 00
+						)
+						// Method begins at RVA 0x58cc
+						// Header size: 12
+						// Code size: 66 (0x42)
+						.maxstack 8
+						.locals init (
+							[0] object[],
+							[1] object
+						)
+
+						IL_0000: ldc.i4.4
+						IL_0001: newarr [System.Runtime]System.Object
+						IL_0006: dup
+						IL_0007: ldc.i4.0
+						IL_0008: ldarg.0
+						IL_0009: ldc.i4.0
+						IL_000a: ldelem.ref
+						IL_000b: stelem.ref
+						IL_000c: dup
+						IL_000d: ldc.i4.1
+						IL_000e: ldarg.0
+						IL_000f: ldc.i4.1
+						IL_0010: ldelem.ref
+						IL_0011: stelem.ref
+						IL_0012: dup
+						IL_0013: ldc.i4.2
+						IL_0014: ldarg.0
+						IL_0015: ldc.i4.2
+						IL_0016: ldelem.ref
+						IL_0017: stelem.ref
+						IL_0018: dup
+						IL_0019: ldc.i4.3
+						IL_001a: ldarg.0
+						IL_001b: ldc.i4.3
+						IL_001c: ldelem.ref
+						IL_001d: stelem.ref
+						IL_001e: stloc.0
+						IL_001f: ldarg.0
+						IL_0020: ldc.i4.2
+						IL_0021: ldelem.ref
+						IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+						IL_0027: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+						IL_002c: ldloc.0
+						IL_002d: ldarg.0
+						IL_002e: ldc.i4.3
+						IL_002f: ldelem.ref
+						IL_0030: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope
+						IL_0035: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+						IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+						IL_003f: stloc.1
+						IL_0040: ldloc.1
+						IL_0041: ret
+					} // end of method ArrowFunction_L222C23::__js_call__
+
+				} // end of class ArrowFunction_L222C23
+
+				.class nested private auto ansi beforefieldinit Scope
+					extends [System.Runtime]System.Object
+				{
+					.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+						01 00 1c 53 63 6f 70 65 20 72 65 73 3d 7b 72 65
+						73 7d 2c 20 64 61 74 61 3d 7b 64 61 74 61 7d 00 00
+					)
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Block_L198C55
+						extends [System.Runtime]System.Object
+					{
+						// Nested Types
+						.class nested private auto ansi beforefieldinit Block_L199C33
+							extends [System.Runtime]System.Object
+						{
+							// Methods
+							.method public hidebysig specialname rtspecialname 
+								instance void .ctor () cil managed 
+							{
+								// Method begins at RVA 0x5a79
+								// Header size: 1
+								// Code size: 8 (0x8)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+								IL_0006: nop
+								IL_0007: ret
+							} // end of method Block_L199C33::.ctor
+
+						} // end of class Block_L199C33
+
+
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5a70
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Block_L198C55::.ctor
+
+					} // end of class Block_L198C55
+
+					.class nested private auto ansi beforefieldinit Block_L211C43
+						extends [System.Runtime]System.Object
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5a82
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Block_L211C43::.ctor
+
+					} // end of class Block_L211C43
+
+
+					// Fields
+					.field public object res
+					.field public object data
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a67
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Scope::.ctor
+
+				} // end of class Scope
+
+
+				// Methods
+				.method public hidebysig static 
+					object __js_call__ (
+						object[] scopes,
+						object newTarget,
+						object res
+					) cil managed 
+				{
+					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+						01 00 02 00 00 00 00 00
+					)
+					// Method begins at RVA 0x54a4
+					// Header size: 12
+					// Code size: 1001 (0x3e9)
+					.maxstack 8
+					.locals init (
+						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope,
+						[1] object,
+						[2] object,
+						[3] object,
+						[4] object,
+						[5] bool,
+						[6] object,
+						[7] object,
+						[8] float64,
+						[9] object,
+						[10] object,
+						[11] object,
+						[12] object,
+						[13] object[],
+						[14] string,
+						[15] object,
+						[16] class [System.Runtime]System.Delegate,
+						[17] object,
+						[18] object,
+						[19] string
+					)
+
+					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::.ctor()
+					IL_0005: stloc.0
+					IL_0006: ldarg.2
+					IL_0007: ldstr "statusCode"
+					IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0011: stloc.s 4
+					IL_0013: ldloc.s 4
+					IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_001a: stloc.s 5
+					IL_001c: ldloc.s 5
+					IL_001e: brtrue IL_0038
+
+					IL_0023: ldc.r8 0.0
+					IL_002c: box [System.Runtime]System.Double
+					IL_0031: stloc.s 7
+					IL_0033: br IL_003c
+
+					IL_0038: ldloc.s 4
+					IL_003a: stloc.s 7
+
+					IL_003c: ldloc.s 7
+					IL_003e: stloc.1
+					IL_003f: ldarg.2
+					IL_0040: ldstr "headers"
+					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_004a: ldstr "location"
+					IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0054: stloc.2
+					IL_0055: ldloc.1
+					IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_005b: stloc.s 8
+					IL_005d: ldloc.s 8
+					IL_005f: ldc.r8 300
+					IL_0068: clt
+					IL_006a: ldc.i4.0
+					IL_006b: ceq
+					IL_006d: stloc.s 5
+					IL_006f: ldloc.s 5
+					IL_0071: box [System.Runtime]System.Boolean
+					IL_0076: stloc.s 9
+					IL_0078: ldloc.s 9
+					IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_007f: stloc.s 5
+					IL_0081: ldloc.s 5
+					IL_0083: brfalse IL_00b1
+
+					IL_0088: ldloc.1
+					IL_0089: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_008e: stloc.s 8
+					IL_0090: ldloc.s 8
+					IL_0092: ldc.r8 400
+					IL_009b: clt
+					IL_009d: stloc.s 5
+					IL_009f: ldloc.s 5
+					IL_00a1: box [System.Runtime]System.Boolean
+					IL_00a6: stloc.s 10
+					IL_00a8: ldloc.s 10
+					IL_00aa: stloc.s 11
+					IL_00ac: br IL_00b5
+
+					IL_00b1: ldloc.s 9
+					IL_00b3: stloc.s 11
+
+					IL_00b5: ldloc.s 11
+					IL_00b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00bc: stloc.s 5
+					IL_00be: ldloc.s 5
+					IL_00c0: brfalse IL_00cd
+
+					IL_00c5: ldloc.2
+					IL_00c6: stloc.s 11
+					IL_00c8: br IL_00cd
+
+					IL_00cd: ldloc.s 11
+					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00d4: stloc.s 5
+					IL_00d6: ldloc.s 5
+					IL_00d8: brfalse IL_0239
+
+					IL_00dd: ldarg.0
+					IL_00de: ldc.i4.1
+					IL_00df: ldelem.ref
+					IL_00e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_00e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
+					IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00ef: ldc.r8 0.0
+					IL_00f8: cgt
+					IL_00fa: ldc.i4.0
+					IL_00fb: ceq
+					IL_00fd: brfalse IL_0175
+
+					IL_0102: ldarg.2
+					IL_0103: ldstr "resume"
+					IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_010d: pop
+					IL_010e: ldarg.0
+					IL_010f: ldc.i4.2
+					IL_0110: ldelem.ref
+					IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_011b: stloc.s 4
+					IL_011d: ldc.i4.3
+					IL_011e: newarr [System.Runtime]System.Object
+					IL_0123: dup
+					IL_0124: ldc.i4.0
+					IL_0125: ldarg.0
+					IL_0126: ldc.i4.0
+					IL_0127: ldelem.ref
+					IL_0128: stelem.ref
+					IL_0129: dup
+					IL_012a: ldc.i4.1
+					IL_012b: ldarg.0
+					IL_012c: ldc.i4.1
+					IL_012d: ldelem.ref
+					IL_012e: stelem.ref
+					IL_012f: dup
+					IL_0130: ldc.i4.2
+					IL_0131: ldarg.0
+					IL_0132: ldc.i4.2
+					IL_0133: ldelem.ref
+					IL_0134: stelem.ref
+					IL_0135: stloc.s 13
+					IL_0137: ldarg.0
+					IL_0138: ldc.i4.1
+					IL_0139: ldelem.ref
+					IL_013a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_013f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0149: stloc.s 14
+					IL_014b: ldstr "Too many redirects fetching "
+					IL_0150: ldloc.s 14
+					IL_0152: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0157: stloc.s 14
+					IL_0159: ldloc.s 14
+					IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0165: stloc.s 15
+					IL_0167: ldloc.s 4
+					IL_0169: ldloc.s 13
+					IL_016b: ldloc.s 15
+					IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_0172: pop
+					IL_0173: ldnull
+					IL_0174: ret
+
+					IL_0175: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
+					IL_017a: stloc.s 16
+					IL_017c: ldc.i4.2
+					IL_017d: newarr [System.Runtime]System.Object
+					IL_0182: dup
+					IL_0183: ldc.i4.0
+					IL_0184: ldloc.2
+					IL_0185: stelem.ref
+					IL_0186: dup
+					IL_0187: ldc.i4.1
+					IL_0188: ldarg.0
+					IL_0189: ldc.i4.2
+					IL_018a: ldelem.ref
+					IL_018b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_0190: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+					IL_0195: stelem.ref
+					IL_0196: stloc.s 13
+					IL_0198: ldloc.s 16
+					IL_019a: ldloc.s 13
+					IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01a1: stloc.s 15
+					IL_01a3: ldloc.s 15
+					IL_01a5: ldstr "toString"
+					IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01af: stloc.s 15
+					IL_01b1: ldloc.s 15
+					IL_01b3: stloc.3
+					IL_01b4: ldarg.2
+					IL_01b5: ldstr "resume"
+					IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01bf: pop
+					IL_01c0: ldarg.0
+					IL_01c1: ldc.i4.1
+					IL_01c2: ldelem.ref
+					IL_01c3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_01c8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
+					IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01d2: ldc.r8 1
+					IL_01db: sub
+					IL_01dc: box [System.Runtime]System.Double
+					IL_01e1: stloc.s 17
+					IL_01e3: ldc.i4.1
+					IL_01e4: newarr [System.Runtime]System.Object
+					IL_01e9: dup
+					IL_01ea: ldc.i4.0
+					IL_01eb: ldarg.0
+					IL_01ec: ldc.i4.0
+					IL_01ed: ldelem.ref
+					IL_01ee: stelem.ref
+					IL_01ef: ldc.i4.0
+					IL_01f0: ldelem.ref
+					IL_01f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+					IL_01f6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+					IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+					IL_0201: ldnull
+					IL_0202: ldloc.3
+					IL_0203: ldloc.s 17
+					IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+					IL_020a: stloc.s 15
+					IL_020c: ldarg.0
+					IL_020d: ldc.i4.2
+					IL_020e: ldelem.ref
+					IL_020f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_0214: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+					IL_0219: stloc.s 4
+					IL_021b: ldloc.s 15
+					IL_021d: ldstr "then"
+					IL_0222: ldloc.s 4
+					IL_0224: ldarg.0
+					IL_0225: ldc.i4.2
+					IL_0226: ldelem.ref
+					IL_0227: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_022c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0236: pop
+					IL_0237: ldnull
+					IL_0238: ret
+
+					IL_0239: ldloc.1
+					IL_023a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_023f: stloc.s 8
+					IL_0241: ldloc.s 8
+					IL_0243: ldc.r8 200
+					IL_024c: clt
+					IL_024e: stloc.s 5
+					IL_0250: ldloc.s 5
+					IL_0252: box [System.Runtime]System.Boolean
+					IL_0257: stloc.s 9
+					IL_0259: ldloc.s 9
+					IL_025b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0260: stloc.s 5
+					IL_0262: ldloc.s 5
+					IL_0264: brtrue IL_0295
+
+					IL_0269: ldloc.1
+					IL_026a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_026f: stloc.s 8
+					IL_0271: ldloc.s 8
+					IL_0273: ldc.r8 300
+					IL_027c: clt
+					IL_027e: ldc.i4.0
+					IL_027f: ceq
+					IL_0281: stloc.s 5
+					IL_0283: ldloc.s 5
+					IL_0285: box [System.Runtime]System.Boolean
+					IL_028a: stloc.s 10
+					IL_028c: ldloc.s 10
+					IL_028e: stloc.s 18
+					IL_0290: br IL_0299
+
+					IL_0295: ldloc.s 9
+					IL_0297: stloc.s 18
+
+					IL_0299: ldloc.s 18
+					IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a0: stloc.s 5
+					IL_02a2: ldloc.s 5
+					IL_02a4: brfalse IL_033d
+
+					IL_02a9: ldarg.2
+					IL_02aa: ldstr "resume"
+					IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02b4: pop
+					IL_02b5: ldarg.0
+					IL_02b6: ldc.i4.2
+					IL_02b7: ldelem.ref
+					IL_02b8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope
+					IL_02bd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_02c2: stloc.s 4
+					IL_02c4: ldc.i4.3
+					IL_02c5: newarr [System.Runtime]System.Object
+					IL_02ca: dup
+					IL_02cb: ldc.i4.0
+					IL_02cc: ldarg.0
+					IL_02cd: ldc.i4.0
+					IL_02ce: ldelem.ref
+					IL_02cf: stelem.ref
+					IL_02d0: dup
+					IL_02d1: ldc.i4.1
+					IL_02d2: ldarg.0
+					IL_02d3: ldc.i4.1
+					IL_02d4: ldelem.ref
+					IL_02d5: stelem.ref
+					IL_02d6: dup
+					IL_02d7: ldc.i4.2
+					IL_02d8: ldarg.0
+					IL_02d9: ldc.i4.2
+					IL_02da: ldelem.ref
+					IL_02db: stelem.ref
+					IL_02dc: stloc.s 13
+					IL_02de: ldloc.1
+					IL_02df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_02e4: stloc.s 14
+					IL_02e6: ldstr "HTTP "
+					IL_02eb: ldloc.s 14
+					IL_02ed: call string [System.Runtime]System.String::Concat(string, string)
+					IL_02f2: stloc.s 14
+					IL_02f4: ldloc.s 14
+					IL_02f6: ldstr " fetching "
+					IL_02fb: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0300: stloc.s 14
+					IL_0302: ldarg.0
+					IL_0303: ldc.i4.1
+					IL_0304: ldelem.ref
+					IL_0305: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_030a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_030f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0314: stloc.s 19
+					IL_0316: ldloc.s 14
+					IL_0318: ldloc.s 19
+					IL_031a: call string [System.Runtime]System.String::Concat(string, string)
+					IL_031f: stloc.s 19
+					IL_0321: ldloc.s 19
+					IL_0323: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0328: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_032d: stloc.s 15
+					IL_032f: ldloc.s 4
+					IL_0331: ldloc.s 13
+					IL_0333: ldloc.s 15
+					IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_033a: pop
+					IL_033b: ldnull
+					IL_033c: ret
+
+					IL_033d: ldarg.2
+					IL_033e: ldstr "setEncoding"
+					IL_0343: ldstr "utf8"
+					IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_034d: pop
+					IL_034e: ldloc.0
+					IL_034f: ldstr ""
+					IL_0354: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/Scope::data
+					IL_0359: ldnull
+					IL_035a: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/ArrowFunction_L219C24::__js_call__(object[], object, object)
+					IL_0360: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_0365: ldc.i4.4
+					IL_0366: newarr [System.Runtime]System.Object
+					IL_036b: dup
+					IL_036c: ldc.i4.0
+					IL_036d: ldarg.0
+					IL_036e: ldc.i4.0
+					IL_036f: ldelem.ref
+					IL_0370: stelem.ref
+					IL_0371: dup
+					IL_0372: ldc.i4.1
+					IL_0373: ldarg.0
+					IL_0374: ldc.i4.1
+					IL_0375: ldelem.ref
+					IL_0376: stelem.ref
+					IL_0377: dup
+					IL_0378: ldc.i4.2
+					IL_0379: ldarg.0
+					IL_037a: ldc.i4.2
+					IL_037b: ldelem.ref
+					IL_037c: stelem.ref
+					IL_037d: dup
+					IL_037e: ldc.i4.3
+					IL_037f: ldloc.0
+					IL_0380: stelem.ref
+					IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_038b: stloc.s 15
+					IL_038d: ldarg.2
+					IL_038e: ldstr "on"
+					IL_0393: ldstr "data"
+					IL_0398: ldloc.s 15
+					IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_039f: pop
+					IL_03a0: ldnull
+					IL_03a1: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7/ArrowFunction_L222C23::__js_call__(object[], object)
+					IL_03a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_03ac: ldc.i4.4
+					IL_03ad: newarr [System.Runtime]System.Object
+					IL_03b2: dup
+					IL_03b3: ldc.i4.0
+					IL_03b4: ldarg.0
+					IL_03b5: ldc.i4.0
+					IL_03b6: ldelem.ref
+					IL_03b7: stelem.ref
+					IL_03b8: dup
+					IL_03b9: ldc.i4.1
+					IL_03ba: ldarg.0
+					IL_03bb: ldc.i4.1
+					IL_03bc: ldelem.ref
+					IL_03bd: stelem.ref
+					IL_03be: dup
+					IL_03bf: ldc.i4.2
+					IL_03c0: ldarg.0
+					IL_03c1: ldc.i4.2
+					IL_03c2: ldelem.ref
+					IL_03c3: stelem.ref
+					IL_03c4: dup
+					IL_03c5: ldc.i4.3
+					IL_03c6: ldloc.0
+					IL_03c7: stelem.ref
+					IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03d2: stloc.s 15
+					IL_03d4: ldarg.2
+					IL_03d5: ldstr "on"
+					IL_03da: ldstr "end"
+					IL_03df: ldloc.s 15
+					IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03e6: pop
+					IL_03e7: ldnull
+					IL_03e8: ret
+				} // end of method ArrowFunction_L194C7::__js_call__
+
+			} // end of class ArrowFunction_L194C7
+
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+					01 00 39 53 63 6f 70 65 20 72 65 73 6f 6c 76 65
+					3d 7b 72 65 73 6f 6c 76 65 7d 2c 20 72 65 6a 65
+					63 74 3d 7b 72 65 6a 65 63 74 7d 2c 20 75 72 6c
+					4f 62 6a 3d 7b 75 72 6c 4f 62 6a 7d 00 00
+				)
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L172C8
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a4c
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L172C8::.ctor
+
+				} // end of class Block_L172C8
+
+				.class nested private auto ansi beforefieldinit Block_L174C12
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a55
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L174C12::.ctor
+
+				} // end of class Block_L174C12
+
+				.class nested private auto ansi beforefieldinit Block_L179C44
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5a5e
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L179C44::.ctor
+
+				} // end of class Block_L179C44
+
+
+				// Fields
+				.field public object resolve
+				.field public object reject
+				.field public object urlObj
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5a43
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget,
+					object resolve,
+					object reject
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x5154
+				// Header size: 12
+				// Code size: 674 (0x2a2)
+				.maxstack 8
+				.locals init (
+					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope,
+					[1] class [System.Runtime]System.Exception,
+					[2] object,
+					[3] object,
+					[4] object,
+					[5] class [System.Runtime]System.Delegate,
+					[6] object,
+					[7] object[],
+					[8] string,
+					[9] object,
+					[10] object,
+					[11] bool,
+					[12] string,
+					[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				)
+
+				IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::.ctor()
+				IL_0005: stloc.0
+				IL_0006: ldloc.0
+				IL_0007: ldarg.2
+				IL_0008: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::resolve
+				IL_000d: ldloc.0
+				IL_000e: ldarg.3
+				IL_000f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+				IL_0014: ldloc.0
+				IL_0015: ldnull
+				IL_0016: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+				.try
+				{
+					IL_001b: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
+					IL_0020: stloc.s 5
+					IL_0022: ldloc.s 5
+					IL_0024: ldc.i4.1
+					IL_0025: newarr [System.Runtime]System.Object
+					IL_002a: dup
+					IL_002b: ldc.i4.0
+					IL_002c: ldarg.0
+					IL_002d: ldc.i4.1
+					IL_002e: ldelem.ref
+					IL_002f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_0034: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_0039: stelem.ref
+					IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_003f: stloc.s 6
+					IL_0041: ldloc.0
+					IL_0042: ldloc.s 6
+					IL_0044: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+					IL_0049: leave IL_00b5
+				} // end .try
+				catch [System.Runtime]System.Exception
+				{
+					IL_004e: stloc.1
+					IL_004f: ldloc.0
+					IL_0050: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+					IL_0055: stloc.s 6
+					IL_0057: ldc.i4.2
+					IL_0058: newarr [System.Runtime]System.Object
+					IL_005d: dup
+					IL_005e: ldc.i4.0
+					IL_005f: ldarg.0
+					IL_0060: ldc.i4.0
+					IL_0061: ldelem.ref
+					IL_0062: stelem.ref
+					IL_0063: dup
+					IL_0064: ldc.i4.1
+					IL_0065: ldarg.0
+					IL_0066: ldc.i4.1
+					IL_0067: ldelem.ref
+					IL_0068: stelem.ref
+					IL_0069: stloc.s 7
+					IL_006b: ldarg.0
+					IL_006c: ldc.i4.1
+					IL_006d: ldelem.ref
+					IL_006e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+					IL_0073: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+					IL_0078: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_007d: stloc.s 8
+					IL_007f: ldstr "Invalid URL: "
+					IL_0084: ldloc.s 8
+					IL_0086: call string [System.Runtime]System.String::Concat(string, string)
+					IL_008b: stloc.s 8
+					IL_008d: ldloc.s 8
+					IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0099: stloc.s 9
+					IL_009b: ldloc.s 6
+					IL_009d: ldloc.s 7
+					IL_009f: ldloc.s 9
+					IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_00a6: pop
+					IL_00a7: ldnull
+					IL_00a8: stloc.2
+					IL_00a9: ldnull
+					IL_00aa: stloc.2
+					IL_00ab: leave IL_02a0
+
+					IL_00b0: leave IL_00b5
+				} // end handler
+
+				IL_00b5: ldloc.0
+				IL_00b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+				IL_00bb: ldstr "protocol"
+				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00c5: stloc.s 9
+				IL_00c7: ldarg.0
+				IL_00c8: ldc.i4.1
+				IL_00c9: ldelem.ref
+				IL_00ca: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_00cf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+				IL_00d4: ldstr ":"
+				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00de: stloc.s 10
+				IL_00e0: ldloc.s 9
+				IL_00e2: ldloc.s 10
+				IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_00e9: stloc.s 11
+				IL_00eb: ldloc.s 11
+				IL_00ed: brfalse IL_01a6
+
+				IL_00f2: ldloc.0
+				IL_00f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+				IL_00f8: stloc.s 9
+				IL_00fa: ldc.i4.2
+				IL_00fb: newarr [System.Runtime]System.Object
+				IL_0100: dup
+				IL_0101: ldc.i4.0
+				IL_0102: ldarg.0
+				IL_0103: ldc.i4.0
+				IL_0104: ldelem.ref
+				IL_0105: stelem.ref
+				IL_0106: dup
+				IL_0107: ldc.i4.1
+				IL_0108: ldarg.0
+				IL_0109: ldc.i4.1
+				IL_010a: ldelem.ref
+				IL_010b: stelem.ref
+				IL_010c: stloc.s 7
+				IL_010e: ldarg.0
+				IL_010f: ldc.i4.1
+				IL_0110: ldelem.ref
+				IL_0111: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+				IL_011b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0120: stloc.s 8
+				IL_0122: ldstr "Only "
+				IL_0127: ldloc.s 8
+				IL_0129: call string [System.Runtime]System.String::Concat(string, string)
+				IL_012e: stloc.s 8
+				IL_0130: ldloc.s 8
+				IL_0132: ldstr ":// URLs are supported by the "
+				IL_0137: call string [System.Runtime]System.String::Concat(string, string)
+				IL_013c: stloc.s 8
+				IL_013e: ldarg.0
+				IL_013f: ldc.i4.1
+				IL_0140: ldelem.ref
+				IL_0141: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_0146: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+				IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0150: stloc.s 12
+				IL_0152: ldloc.s 8
+				IL_0154: ldloc.s 12
+				IL_0156: call string [System.Runtime]System.String::Concat(string, string)
+				IL_015b: stloc.s 12
+				IL_015d: ldloc.s 12
+				IL_015f: ldstr " fallback. Got: "
+				IL_0164: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0169: stloc.s 12
+				IL_016b: ldarg.0
+				IL_016c: ldc.i4.1
+				IL_016d: ldelem.ref
+				IL_016e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_0173: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+				IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_017d: stloc.s 8
+				IL_017f: ldloc.s 12
+				IL_0181: ldloc.s 8
+				IL_0183: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0188: stloc.s 8
+				IL_018a: ldloc.s 8
+				IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0196: stloc.s 6
+				IL_0198: ldloc.s 9
+				IL_019a: ldloc.s 7
+				IL_019c: ldloc.s 6
+				IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+				IL_01a3: pop
+				IL_01a4: ldnull
+				IL_01a5: ret
+
+				IL_01a6: ldarg.0
+				IL_01a7: ldc.i4.1
+				IL_01a8: ldelem.ref
+				IL_01a9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope
+				IL_01ae: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+				IL_01b3: ldstr "http"
+				IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01bd: stloc.s 11
+				IL_01bf: ldloc.s 11
+				IL_01c1: brfalse IL_01d9
+
+				IL_01c6: ldarg.0
+				IL_01c7: ldc.i4.0
+				IL_01c8: ldelem.ref
+				IL_01c9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+				IL_01ce: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::http
+				IL_01d3: stloc.3
+				IL_01d4: br IL_01e7
+
+				IL_01d9: ldarg.0
+				IL_01da: ldc.i4.0
+				IL_01db: ldelem.ref
+				IL_01dc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+				IL_01e1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::https
+				IL_01e6: stloc.3
+
+				IL_01e7: ldloc.0
+				IL_01e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::urlObj
+				IL_01ed: stloc.s 6
+				IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_01f4: dup
+				IL_01f5: ldstr "method"
+				IL_01fa: ldstr "GET"
+				IL_01ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0204: dup
+				IL_0205: ldstr "headers"
+				IL_020a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_020f: dup
+				IL_0210: ldstr "Accept-Encoding"
+				IL_0215: ldstr "identity"
+				IL_021a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_021f: dup
+				IL_0220: ldstr "User-Agent"
+				IL_0225: ldstr "js2il-docs-script"
+				IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0234: stloc.s 13
+				IL_0236: ldnull
+				IL_0237: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/ArrowFunction_L194C7::__js_call__(object[], object, object)
+				IL_023d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0242: ldc.i4.3
+				IL_0243: newarr [System.Runtime]System.Object
+				IL_0248: dup
+				IL_0249: ldc.i4.0
+				IL_024a: ldarg.0
+				IL_024b: ldc.i4.0
+				IL_024c: ldelem.ref
+				IL_024d: stelem.ref
+				IL_024e: dup
+				IL_024f: ldc.i4.1
+				IL_0250: ldarg.0
+				IL_0251: ldc.i4.1
+				IL_0252: ldelem.ref
+				IL_0253: stelem.ref
+				IL_0254: dup
+				IL_0255: ldc.i4.2
+				IL_0256: ldloc.0
+				IL_0257: stelem.ref
+				IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0262: stloc.s 9
+				IL_0264: ldloc.3
+				IL_0265: ldstr "request"
+				IL_026a: ldloc.s 6
+				IL_026c: ldloc.s 13
+				IL_026e: ldloc.s 9
+				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0275: stloc.s 9
+				IL_0277: ldloc.s 9
+				IL_0279: stloc.s 4
+				IL_027b: ldloc.s 4
+				IL_027d: ldstr "on"
+				IL_0282: ldstr "error"
+				IL_0287: ldloc.0
+				IL_0288: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22/Scope::reject
+				IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0292: pop
+				IL_0293: ldloc.s 4
+				IL_0295: ldstr "end"
+				IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_029f: pop
+
+				IL_02a0: ldloc.2
+				IL_02a1: ret
+			} // end of method ArrowFunction_L170C22::__js_call__
+
+		} // end of class ArrowFunction_L170C22
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 4d 53 63 6f 70 65 20 70 72 6f 74 6f 63 6f
+				6c 3d 7b 70 72 6f 74 6f 63 6f 6c 7d 2c 20 75 72
+				6c 53 74 72 69 6e 67 3d 7b 75 72 6c 53 74 72 69
+				6e 67 7d 2c 20 6d 61 78 52 65 64 69 72 65 63 74
+				73 3d 7b 6d 61 78 52 65 64 69 72 65 63 74 73 7d
+				00 00
+			)
+			// Fields
+			.field public object protocol
+			.field public object urlString
+			.field public object maxRedirects
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a3a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object protocol,
+				object urlString,
+				object maxRedirects
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x3348
+			// Header size: 12
+			// Code size: 97 (0x61)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope,
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Promise
+			)
+
+			IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldarg.s maxRedirects
+			IL_0008: brtrue IL_001d
+
+			IL_000d: ldc.r8 5
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: starg.s maxRedirects
+
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::protocol
+			IL_0024: ldloc.0
+			IL_0025: ldarg.3
+			IL_0026: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::urlString
+			IL_002b: ldloc.0
+			IL_002c: ldarg.s maxRedirects
+			IL_002e: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/Scope::maxRedirects
+			IL_0033: ldnull
+			IL_0034: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport/ArrowFunction_L170C22::__js_call__(object[], object, object, object)
+			IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+			IL_003f: ldc.i4.2
+			IL_0040: newarr [System.Runtime]System.Object
+			IL_0045: dup
+			IL_0046: ldc.i4.0
+			IL_0047: ldarg.0
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.1
+			IL_004b: ldloc.0
+			IL_004c: stelem.ref
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0057: stloc.1
+			IL_0058: ldloc.1
+			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+			IL_005e: stloc.2
+			IL_005f: ldloc.2
+			IL_0060: ret
+		} // end of method fetchTextWithTransport::__js_call__
+
+	} // end of class fetchTextWithTransport
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchText
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5a9d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object urlString
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x33b8
+			// Header size: 12
+			// Code size: 39 (0x27)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: ldc.i4.0
+			IL_000b: ldelem.ref
+			IL_000c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0011: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_001c: ldnull
+			IL_001d: ldarg.2
+			IL_001e: ldnull
+			IL_001f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0024: stloc.0
+			IL_0025: ldloc.0
+			IL_0026: ret
+		} // end of method fetchText::__js_call__
+
+	} // end of class fetchText
+
+	.class nested public auto ansi abstract sealed beforefieldinit fetchTextWithNodeRequest
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L237C6
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5aaf
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L237C6::.ctor
+
+			} // end of class Block_L237C6
+
+			.class nested private auto ansi beforefieldinit Block_L239C10
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5ab8
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L239C10::.ctor
+
+			} // end of class Block_L239C10
+
+			.class nested private auto ansi beforefieldinit Block_L243C35
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5ac1
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L243C35::.ctor
+
+			} // end of class Block_L243C35
+
+			.class nested private auto ansi beforefieldinit Block_L247C36
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5aca
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L247C36::.ctor
+
+			} // end of class Block_L247C36
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5aa6
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object urlString,
+				object maxRedirects
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x33ec
+			// Header size: 12
+			// Code size: 309 (0x135)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [System.Runtime]System.Exception,
+				[2] object,
+				[3] class [System.Runtime]System.Delegate,
+				[4] object,
+				[5] string,
+				[6] bool
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: brtrue IL_0016
+
+			IL_0006: ldc.r8 5
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: starg.s maxRedirects
+
+			IL_0016: ldnull
+			IL_0017: stloc.0
+			.try
+			{
+				IL_0018: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
+				IL_001d: stloc.3
+				IL_001e: ldloc.3
+				IL_001f: ldc.i4.1
+				IL_0020: newarr [System.Runtime]System.Object
+				IL_0025: dup
+				IL_0026: ldc.i4.0
+				IL_0027: ldarg.2
+				IL_0028: stelem.ref
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+				IL_002e: stloc.s 4
+				IL_0030: ldloc.s 4
+				IL_0032: stloc.0
+				IL_0033: leave IL_0075
+			} // end .try
+			catch [System.Runtime]System.Exception
+			{
+				IL_0038: stloc.1
+				IL_0039: ldarg.2
+				IL_003a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_003f: stloc.s 5
+				IL_0041: ldstr "Invalid URL: "
+				IL_0046: ldloc.s 5
+				IL_0048: call string [System.Runtime]System.String::Concat(string, string)
+				IL_004d: stloc.s 5
+				IL_004f: ldloc.s 5
+				IL_0051: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0056: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_005b: stloc.s 4
+				IL_005d: ldloc.s 4
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+				IL_0064: stloc.s 4
+				IL_0066: ldnull
+				IL_0067: stloc.2
+				IL_0068: ldloc.s 4
+				IL_006a: stloc.2
+				IL_006b: leave IL_0133
+
+				IL_0070: leave IL_0075
+			} // end handler
+
+			IL_0075: ldloc.0
+			IL_0076: ldstr "protocol"
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0080: ldstr "http:"
+			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_008a: stloc.s 6
+			IL_008c: ldloc.s 6
+			IL_008e: brfalse IL_00bc
+
+			IL_0093: ldc.i4.1
+			IL_0094: newarr [System.Runtime]System.Object
+			IL_0099: dup
+			IL_009a: ldc.i4.0
+			IL_009b: ldarg.0
+			IL_009c: stelem.ref
+			IL_009d: ldc.i4.0
+			IL_009e: ldelem.ref
+			IL_009f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_00a4: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttp::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_00af: ldnull
+			IL_00b0: ldarg.2
+			IL_00b1: ldarg.3
+			IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_00b7: stloc.s 4
+			IL_00b9: ldloc.s 4
+			IL_00bb: ret
+
+			IL_00bc: ldloc.0
+			IL_00bd: ldstr "protocol"
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c7: ldstr "https:"
+			IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00d1: stloc.s 6
+			IL_00d3: ldloc.s 6
+			IL_00d5: brfalse IL_0103
+
+			IL_00da: ldc.i4.1
+			IL_00db: newarr [System.Runtime]System.Object
+			IL_00e0: dup
+			IL_00e1: ldc.i4.0
+			IL_00e2: ldarg.0
+			IL_00e3: stelem.ref
+			IL_00e4: ldc.i4.0
+			IL_00e5: ldelem.ref
+			IL_00e6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_00eb: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttps::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_00f6: ldnull
+			IL_00f7: ldarg.2
+			IL_00f8: ldarg.3
+			IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_00fe: stloc.s 4
+			IL_0100: ldloc.s 4
+			IL_0102: ret
+
+			IL_0103: ldarg.2
+			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0109: stloc.s 5
+			IL_010b: ldstr "Only http:// and https:// URLs are supported by the request fallback. Got: "
+			IL_0110: ldloc.s 5
+			IL_0112: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0117: stloc.s 5
+			IL_0119: ldloc.s 5
+			IL_011b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0125: stloc.s 4
+			IL_0127: ldloc.s 4
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+			IL_012e: stloc.s 4
+			IL_0130: ldloc.s 4
+			IL_0132: ret
+
+			IL_0133: ldloc.2
+			IL_0134: ret
+		} // end of method fetchTextWithNodeRequest::__js_call__
+
+	} // end of class fetchTextWithNodeRequest
+
+	.class nested public auto ansi abstract sealed beforefieldinit detectEol
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5ad3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object text
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x3540
+			// Header size: 12
+			// Code size: 49 (0x31)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] bool
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: ldstr "includes"
+			IL_0006: ldstr "\r\n"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0010: stloc.1
+			IL_0011: ldloc.1
+			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0017: stloc.2
+			IL_0018: ldloc.2
+			IL_0019: brfalse IL_0029
+
+			IL_001e: ldstr "\r\n"
+			IL_0023: stloc.0
+			IL_0024: br IL_002f
+
+			IL_0029: ldstr "\n"
+			IL_002e: stloc.0
+
+			IL_002f: ldloc.0
+			IL_0030: ret
+		} // end of method detectEol::__js_call__
+
+	} // end of class detectEol
+
+	.class nested public auto ansi abstract sealed beforefieldinit escapeRegExp
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5adc
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object text
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x3580
+			// Header size: 12
+			// Code size: 36 (0x24)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[1] object
+			)
+
+			IL_0000: ldstr "[.*+?^${}()|[\\]\\\\]"
+			IL_0005: ldstr "g"
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.1
+			IL_0011: ldstr "replace"
+			IL_0016: ldloc.0
+			IL_0017: ldstr "\\$&"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: ret
+		} // end of method escapeRegExp::__js_call__
+
+	} // end of class escapeRegExp
+
+	.class nested public auto ansi abstract sealed beforefieldinit writeTextPreserveEol
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L266C31
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5aee
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L266C31::.ctor
+
+			} // end of class Block_L266C31
+
+			.class nested private auto ansi beforefieldinit Block_L274C60
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5af7
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L274C60::.ctor
+
+			} // end of class Block_L274C60
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5ae5
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object filePath,
+				object text
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x35b0
+			// Header size: 12
+			// Code size: 286 (0x11e)
+			.maxstack 8
+			.locals init (
+				[0] string,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] bool,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] object
+			)
+
+			IL_0000: ldstr "\n"
+			IL_0005: stloc.0
+			IL_0006: ldc.i4.0
+			IL_0007: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_000c: stloc.1
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_0013: ldstr "existsSync"
+			IL_0018: ldarg.2
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001e: stloc.3
+			IL_001f: ldloc.3
+			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0025: stloc.s 4
+			IL_0027: ldloc.s 4
+			IL_0029: brfalse IL_0051
+
+			IL_002e: ldarg.0
+			IL_002f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_0034: ldstr "readFileSync"
+			IL_0039: ldarg.2
+			IL_003a: ldstr "utf8"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0044: stloc.3
+			IL_0045: ldloc.3
+			IL_0046: stloc.1
+			IL_0047: ldnull
+			IL_0048: ldloc.1
+			IL_0049: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/detectEol::__js_call__(object, object)
+			IL_004e: stloc.3
+			IL_004f: ldloc.3
+			IL_0050: stloc.0
+
+			IL_0051: ldstr "\\r\\n|\\n"
+			IL_0056: ldstr "g"
+			IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0060: stloc.s 5
+			IL_0062: ldarg.3
+			IL_0063: ldstr "replace"
+			IL_0068: ldloc.s 5
+			IL_006a: ldloc.0
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: stloc.2
+			IL_0073: ldloc.1
+			IL_0074: ldc.i4.0
+			IL_0075: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_007f: stloc.s 4
+			IL_0081: ldloc.s 4
+			IL_0083: box [System.Runtime]System.Boolean
+			IL_0088: stloc.s 6
+			IL_008a: ldloc.s 6
+			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0091: stloc.s 4
+			IL_0093: ldloc.s 4
+			IL_0095: brfalse IL_00b5
+
+			IL_009a: ldloc.1
+			IL_009b: ldloc.2
+			IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00a1: stloc.s 4
+			IL_00a3: ldloc.s 4
+			IL_00a5: box [System.Runtime]System.Boolean
+			IL_00aa: stloc.s 7
+			IL_00ac: ldloc.s 7
+			IL_00ae: stloc.s 9
+			IL_00b0: br IL_00b9
+
+			IL_00b5: ldloc.s 6
+			IL_00b7: stloc.s 9
+
+			IL_00b9: ldloc.s 9
+			IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00c0: stloc.s 4
+			IL_00c2: ldloc.s 4
+			IL_00c4: brfalse IL_00cb
+
+			IL_00c9: ldnull
+			IL_00ca: ret
+
+			IL_00cb: ldarg.0
+			IL_00cc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_00d1: stloc.3
+			IL_00d2: ldarg.0
+			IL_00d3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
+			IL_00d8: ldstr "dirname"
+			IL_00dd: ldarg.2
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e3: stloc.s 10
+			IL_00e5: ldloc.3
+			IL_00e6: ldstr "mkdirSync"
+			IL_00eb: ldloc.s 10
+			IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00f2: dup
+			IL_00f3: ldstr "recursive"
+			IL_00f8: ldc.i4.1
+			IL_00f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0103: pop
+			IL_0104: ldarg.0
+			IL_0105: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_010a: ldstr "writeFileSync"
+			IL_010f: ldarg.2
+			IL_0110: ldloc.2
+			IL_0111: ldstr "utf8"
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_011b: pop
+			IL_011c: ldnull
+			IL_011d: ret
+		} // end of method writeTextPreserveEol::__js_call__
+
+	} // end of class writeTextPreserveEol
+
+	.class nested public auto ansi abstract sealed beforefieldinit findTagNameAt
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L290C26
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L292C93
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5b12
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L292C93::.ctor
+
+				} // end of class Block_L292C93
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b09
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L290C26::.ctor
+
+			} // end of class Block_L290C26
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b00
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object html,
+				object tagStart
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x36dc
+			// Header size: 12
+			// Code size: 584 (0x248)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] bool,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] float64,
+				[7] object,
+				[8] bool,
+				[9] object,
+				[10] object,
+				[11] object,
+				[12] object,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] object,
+				[18] object
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: stloc.s 6
+			IL_0008: ldloc.s 6
+			IL_000a: ldc.r8 0.0
+			IL_0013: clt
+			IL_0015: box [System.Runtime]System.Boolean
+			IL_001a: stloc.s 7
+			IL_001c: ldloc.s 7
+			IL_001e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0023: stloc.s 8
+			IL_0025: ldloc.s 8
+			IL_0027: brtrue IL_0052
+
+			IL_002c: ldarg.2
+			IL_002d: ldloc.s 6
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0034: ldstr "<"
+			IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_003e: stloc.s 8
+			IL_0040: ldloc.s 8
+			IL_0042: box [System.Runtime]System.Boolean
+			IL_0047: stloc.s 9
+			IL_0049: ldloc.s 9
+			IL_004b: stloc.s 11
+			IL_004d: br IL_0056
+
+			IL_0052: ldloc.s 7
+			IL_0054: stloc.s 11
+
+			IL_0056: ldloc.s 11
+			IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005d: stloc.s 8
+			IL_005f: ldloc.s 8
+			IL_0061: brfalse IL_006c
+
+			IL_0066: ldstr ""
+			IL_006b: ret
+
+			IL_006c: ldarg.3
+			IL_006d: ldc.r8 1
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_007b: stloc.s 11
+			IL_007d: ldloc.s 11
+			IL_007f: stloc.0
+			IL_0080: ldarg.2
+			IL_0081: ldloc.0
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0087: ldstr "/"
+			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0091: stloc.s 8
+			IL_0093: ldloc.s 8
+			IL_0095: stloc.1
+			IL_0096: ldloc.1
+			IL_0097: brfalse IL_00b5
+
+			IL_009c: ldloc.0
+			IL_009d: ldc.r8 1
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00ab: stloc.s 11
+			IL_00ad: ldloc.s 11
+			IL_00af: stloc.2
+			IL_00b0: br IL_00b7
+
+			IL_00b5: ldloc.0
+			IL_00b6: stloc.2
+
+			IL_00b7: ldloc.2
+			IL_00b8: stloc.3
+			IL_00b9: ldloc.3
+			IL_00ba: stloc.s 4
+			// loop start (head: IL_00bc)
+				IL_00bc: ldarg.2
+				IL_00bd: ldstr "length"
+				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00c7: stloc.s 12
+				IL_00c9: ldloc.s 4
+				IL_00cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d0: stloc.s 6
+				IL_00d2: ldloc.s 6
+				IL_00d4: ldloc.s 12
+				IL_00d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00db: clt
+				IL_00dd: brfalse IL_0235
+
+				IL_00e2: ldarg.2
+				IL_00e3: ldloc.s 4
+				IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_00ea: stloc.s 5
+				IL_00ec: ldloc.s 5
+				IL_00ee: ldstr " "
+				IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00f8: stloc.s 8
+				IL_00fa: ldloc.s 8
+				IL_00fc: box [System.Runtime]System.Boolean
+				IL_0101: stloc.s 7
+				IL_0103: ldloc.s 7
+				IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_010a: stloc.s 8
+				IL_010c: ldloc.s 8
+				IL_010e: brtrue IL_0133
+
+				IL_0113: ldloc.s 5
+				IL_0115: ldstr "\t"
+				IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_011f: stloc.s 8
+				IL_0121: ldloc.s 8
+				IL_0123: box [System.Runtime]System.Boolean
+				IL_0128: stloc.s 9
+				IL_012a: ldloc.s 9
+				IL_012c: stloc.s 13
+				IL_012e: br IL_0137
+
+				IL_0133: ldloc.s 7
+				IL_0135: stloc.s 13
+
+				IL_0137: ldloc.s 13
+				IL_0139: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_013e: stloc.s 8
+				IL_0140: ldloc.s 8
+				IL_0142: brtrue IL_0167
+
+				IL_0147: ldloc.s 5
+				IL_0149: ldstr "\r"
+				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0153: stloc.s 8
+				IL_0155: ldloc.s 8
+				IL_0157: box [System.Runtime]System.Boolean
+				IL_015c: stloc.s 7
+				IL_015e: ldloc.s 7
+				IL_0160: stloc.s 13
+				IL_0162: br IL_0167
+
+				IL_0167: ldloc.s 13
+				IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_016e: stloc.s 8
+				IL_0170: ldloc.s 8
+				IL_0172: brtrue IL_0197
+
+				IL_0177: ldloc.s 5
+				IL_0179: ldstr "\n"
+				IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0183: stloc.s 8
+				IL_0185: ldloc.s 8
+				IL_0187: box [System.Runtime]System.Boolean
+				IL_018c: stloc.s 7
+				IL_018e: ldloc.s 7
+				IL_0190: stloc.s 13
+				IL_0192: br IL_0197
+
+				IL_0197: ldloc.s 13
+				IL_0199: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_019e: stloc.s 8
+				IL_01a0: ldloc.s 8
+				IL_01a2: brtrue IL_01c7
+
+				IL_01a7: ldloc.s 5
+				IL_01a9: ldstr ">"
+				IL_01ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01b3: stloc.s 8
+				IL_01b5: ldloc.s 8
+				IL_01b7: box [System.Runtime]System.Boolean
+				IL_01bc: stloc.s 7
+				IL_01be: ldloc.s 7
+				IL_01c0: stloc.s 13
+				IL_01c2: br IL_01c7
+
+				IL_01c7: ldloc.s 13
+				IL_01c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01ce: stloc.s 8
+				IL_01d0: ldloc.s 8
+				IL_01d2: brtrue IL_01f7
+
+				IL_01d7: ldloc.s 5
+				IL_01d9: ldstr "/"
+				IL_01de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01e3: stloc.s 8
+				IL_01e5: ldloc.s 8
+				IL_01e7: box [System.Runtime]System.Boolean
+				IL_01ec: stloc.s 7
+				IL_01ee: ldloc.s 7
+				IL_01f0: stloc.s 13
+				IL_01f2: br IL_01f7
+
+				IL_01f7: ldloc.s 13
+				IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01fe: stloc.s 8
+				IL_0200: ldloc.s 8
+				IL_0202: brfalse IL_020c
+
+				IL_0207: br IL_0235
+
+				IL_020c: ldloc.s 4
+				IL_020e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0213: stloc.s 6
+				IL_0215: ldloc.s 6
+				IL_0217: ldc.r8 1
+				IL_0220: add
+				IL_0221: stloc.s 6
+				IL_0223: ldloc.s 6
+				IL_0225: box [System.Runtime]System.Double
+				IL_022a: stloc.s 18
+				IL_022c: ldloc.s 18
+				IL_022e: stloc.s 4
+				IL_0230: br IL_00bc
+			// end loop
+
+			IL_0235: ldarg.2
+			IL_0236: ldstr "substring"
+			IL_023b: ldloc.3
+			IL_023c: ldloc.s 4
+			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0243: stloc.s 12
+			IL_0245: ldloc.s 12
+			IL_0247: ret
+		} // end of method findTagNameAt::__js_call__
+
+	} // end of class findTagNameAt
+
+	.class nested public auto ansi abstract sealed beforefieldinit extractElementById
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L307C19
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b24
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L307C19::.ctor
+
+			} // end of class Block_L307C19
+
+			.class nested private auto ansi beforefieldinit Block_L312C20
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b2d
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L312C20::.ctor
+
+			} // end of class Block_L312C20
+
+			.class nested private auto ansi beforefieldinit Block_L317C16
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b36
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L317C16::.ctor
+
+			} // end of class Block_L317C16
+
+			.class nested private auto ansi beforefieldinit Block_L328C15
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L334C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5b48
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L334C24::.ctor
+
+				} // end of class Block_L334C24
+
+				.class nested private auto ansi beforefieldinit Block_L339C17
+					extends [System.Runtime]System.Object
+				{
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Block_L341C23
+						extends [System.Runtime]System.Object
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x5b5a
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Block_L341C23::.ctor
+
+					} // end of class Block_L341C23
+
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5b51
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L339C17::.ctor
+
+				} // end of class Block_L339C17
+
+				.class nested private auto ansi beforefieldinit Block_L348C11
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5b63
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L348C11::.ctor
+
+				} // end of class Block_L348C11
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b3f
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L328C15::.ctor
+
+			} // end of class Block_L328C15
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b1b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object html,
+				object elementId
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x3930
+			// Header size: 12
+			// Code size: 966 (0x3c6)
+			.maxstack 8
+			.locals init (
+				[0] string,
+				[1] string,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[6] float64,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] object,
+				[11] object,
+				[12] string,
+				[13] object,
+				[14] float64,
+				[15] bool,
+				[16] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] string
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0006: stloc.s 12
+			IL_0008: ldstr "id=\""
+			IL_000d: ldloc.s 12
+			IL_000f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0014: stloc.s 12
+			IL_0016: ldloc.s 12
+			IL_0018: ldstr "\""
+			IL_001d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0022: stloc.s 12
+			IL_0024: ldloc.s 12
+			IL_0026: stloc.0
+			IL_0027: ldarg.3
+			IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002d: stloc.s 12
+			IL_002f: ldstr "id='"
+			IL_0034: ldloc.s 12
+			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
+			IL_003b: stloc.s 12
+			IL_003d: ldloc.s 12
+			IL_003f: ldstr "'"
+			IL_0044: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0049: stloc.s 12
+			IL_004b: ldloc.s 12
+			IL_004d: stloc.1
+			IL_004e: ldarg.2
+			IL_004f: ldstr "indexOf"
+			IL_0054: ldloc.0
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_005a: stloc.s 13
+			IL_005c: ldloc.s 13
+			IL_005e: stloc.2
+			IL_005f: ldloc.2
+			IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0065: stloc.s 14
+			IL_0067: ldloc.s 14
+			IL_0069: ldc.r8 0.0
+			IL_0072: clt
+			IL_0074: brfalse IL_008a
+
+			IL_0079: ldarg.2
+			IL_007a: ldstr "indexOf"
+			IL_007f: ldloc.1
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0085: stloc.s 13
+			IL_0087: ldloc.s 13
+			IL_0089: stloc.2
+
+			IL_008a: ldloc.2
+			IL_008b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0090: stloc.s 14
+			IL_0092: ldloc.s 14
+			IL_0094: ldc.r8 0.0
+			IL_009d: clt
+			IL_009f: brfalse IL_00e9
+
+			IL_00a4: ldarg.3
+			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00aa: stloc.s 12
+			IL_00ac: ldstr "Could not find id '"
+			IL_00b1: ldloc.s 12
+			IL_00b3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b8: stloc.s 12
+			IL_00ba: ldloc.s 12
+			IL_00bc: ldstr "' in input HTML."
+			IL_00c1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00c6: stloc.s 12
+			IL_00c8: ldloc.s 12
+			IL_00ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00d4: dup
+			IL_00d5: isinst [System.Runtime]System.Exception
+			IL_00da: dup
+			IL_00db: brtrue IL_00e7
+
+			IL_00e0: pop
+			IL_00e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00e6: throw
+
+			IL_00e7: pop
+			IL_00e8: throw
+
+			IL_00e9: ldarg.2
+			IL_00ea: ldstr "lastIndexOf"
+			IL_00ef: ldstr "<"
+			IL_00f4: ldloc.2
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00fa: stloc.s 13
+			IL_00fc: ldloc.s 13
+			IL_00fe: stloc.3
+			IL_00ff: ldloc.3
+			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0105: stloc.s 14
+			IL_0107: ldloc.s 14
+			IL_0109: ldc.r8 0.0
+			IL_0112: clt
+			IL_0114: brfalse IL_015e
+
+			IL_0119: ldarg.3
+			IL_011a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_011f: stloc.s 12
+			IL_0121: ldstr "Could not locate tag start for id '"
+			IL_0126: ldloc.s 12
+			IL_0128: call string [System.Runtime]System.String::Concat(string, string)
+			IL_012d: stloc.s 12
+			IL_012f: ldloc.s 12
+			IL_0131: ldstr "'."
+			IL_0136: call string [System.Runtime]System.String::Concat(string, string)
+			IL_013b: stloc.s 12
+			IL_013d: ldloc.s 12
+			IL_013f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0149: dup
+			IL_014a: isinst [System.Runtime]System.Exception
+			IL_014f: dup
+			IL_0150: brtrue IL_015c
+
+			IL_0155: pop
+			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_015b: throw
+
+			IL_015c: pop
+			IL_015d: throw
+
+			IL_015e: ldc.i4.1
+			IL_015f: newarr [System.Runtime]System.Object
+			IL_0164: dup
+			IL_0165: ldc.i4.0
+			IL_0166: ldarg.0
+			IL_0167: stelem.ref
+			IL_0168: ldc.i4.0
+			IL_0169: ldelem.ref
+			IL_016a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_016f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_017a: ldnull
+			IL_017b: ldarg.2
+			IL_017c: ldloc.3
+			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0182: stloc.s 13
+			IL_0184: ldloc.s 13
+			IL_0186: stloc.s 4
+			IL_0188: ldloc.s 4
+			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_018f: ldc.i4.0
+			IL_0190: ceq
+			IL_0192: stloc.s 15
+			IL_0194: ldloc.s 15
+			IL_0196: brfalse IL_01e0
+
+			IL_019b: ldarg.3
+			IL_019c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01a1: stloc.s 12
+			IL_01a3: ldstr "Could not determine tag name for id '"
+			IL_01a8: ldloc.s 12
+			IL_01aa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01af: stloc.s 12
+			IL_01b1: ldloc.s 12
+			IL_01b3: ldstr "'."
+			IL_01b8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01bd: stloc.s 12
+			IL_01bf: ldloc.s 12
+			IL_01c1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01cb: dup
+			IL_01cc: isinst [System.Runtime]System.Exception
+			IL_01d1: dup
+			IL_01d2: brtrue IL_01de
+
+			IL_01d7: pop
+			IL_01d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_01dd: throw
+
+			IL_01de: pop
+			IL_01df: throw
+
+			IL_01e0: ldnull
+			IL_01e1: ldloc.s 4
+			IL_01e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+			IL_01e8: stloc.s 13
+			IL_01ea: ldloc.s 13
+			IL_01ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01f1: stloc.s 12
+			IL_01f3: ldstr "<\\/?"
+			IL_01f8: ldloc.s 12
+			IL_01fa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ff: stloc.s 12
+			IL_0201: ldloc.s 12
+			IL_0203: ldstr "\\b[^>]*>"
+			IL_0208: call string [System.Runtime]System.String::Concat(string, string)
+			IL_020d: stloc.s 12
+			IL_020f: ldloc.s 12
+			IL_0211: ldstr "gi"
+			IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_021b: stloc.s 16
+			IL_021d: ldloc.s 16
+			IL_021f: stloc.s 5
+			IL_0221: ldloc.s 5
+			IL_0223: ldstr "lastIndex"
+			IL_0228: ldloc.3
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_022e: pop
+			IL_022f: ldc.r8 0.0
+			IL_0238: stloc.s 6
+			IL_023a: ldc.r8 1
+			IL_0243: neg
+			IL_0244: box [System.Runtime]System.Double
+			IL_0249: stloc.s 7
+			// loop start (head: IL_024b)
+				IL_024b: ldc.i4.1
+				IL_024c: brfalse IL_035d
+
+				IL_0251: ldloc.s 5
+				IL_0253: ldstr "exec"
+				IL_0258: ldarg.2
+				IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_025e: stloc.s 13
+				IL_0260: ldloc.s 13
+				IL_0262: stloc.s 8
+				IL_0264: ldloc.s 8
+				IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_026b: ldc.i4.0
+				IL_026c: ceq
+				IL_026e: stloc.s 15
+				IL_0270: ldloc.s 15
+				IL_0272: brfalse IL_027c
+
+				IL_0277: br IL_035d
+
+				IL_027c: ldloc.s 8
+				IL_027e: ldc.r8 0.0
+				IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_028c: stloc.s 9
+				IL_028e: ldloc.s 7
+				IL_0290: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0295: stloc.s 14
+				IL_0297: ldloc.s 14
+				IL_0299: ldc.r8 0.0
+				IL_02a2: clt
+				IL_02a4: brfalse IL_02bb
+
+				IL_02a9: ldloc.s 8
+				IL_02ab: ldstr "index"
+				IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02b5: stloc.s 13
+				IL_02b7: ldloc.s 13
+				IL_02b9: stloc.s 7
+
+				IL_02bb: ldloc.s 9
+				IL_02bd: ldstr "startsWith"
+				IL_02c2: ldstr "</"
+				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02cc: stloc.s 13
+				IL_02ce: ldloc.s 13
+				IL_02d0: stloc.s 10
+				IL_02d2: ldloc.s 10
+				IL_02d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d9: stloc.s 15
+				IL_02db: ldloc.s 15
+				IL_02dd: brfalse IL_034a
+
+				IL_02e2: ldloc.s 6
+				IL_02e4: ldc.r8 1
+				IL_02ed: sub
+				IL_02ee: stloc.s 6
+				IL_02f0: ldloc.s 6
+				IL_02f2: ldc.r8 0.0
+				IL_02fb: ceq
+				IL_02fd: brfalse IL_0345
+
+				IL_0302: ldloc.s 5
+				IL_0304: ldstr "lastIndex"
+				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_030e: stloc.s 11
+				IL_0310: ldarg.2
+				IL_0311: ldstr "substring"
+				IL_0316: ldloc.s 7
+				IL_0318: ldloc.s 11
+				IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_031f: stloc.s 13
+				IL_0321: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0326: dup
+				IL_0327: ldstr "tagName"
+				IL_032c: ldloc.s 4
+				IL_032e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0333: dup
+				IL_0334: ldstr "html"
+				IL_0339: ldloc.s 13
+				IL_033b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0340: stloc.s 17
+				IL_0342: ldloc.s 17
+				IL_0344: ret
+
+				IL_0345: br IL_0358
+
+				IL_034a: ldloc.s 6
+				IL_034c: ldc.r8 1
+				IL_0355: add
+				IL_0356: stloc.s 6
+
+				IL_0358: br IL_024b
+			// end loop
+
+			IL_035d: ldloc.s 4
+			IL_035f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0364: stloc.s 12
+			IL_0366: ldstr "Could not find a matching closing </"
+			IL_036b: ldloc.s 12
+			IL_036d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0372: stloc.s 12
+			IL_0374: ldloc.s 12
+			IL_0376: ldstr "> for id '"
+			IL_037b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0380: stloc.s 12
+			IL_0382: ldarg.3
+			IL_0383: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0388: stloc.s 18
+			IL_038a: ldloc.s 12
+			IL_038c: ldloc.s 18
+			IL_038e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0393: stloc.s 18
+			IL_0395: ldloc.s 18
+			IL_0397: ldstr "'."
+			IL_039c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03a1: stloc.s 18
+			IL_03a3: ldloc.s 18
+			IL_03a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03af: dup
+			IL_03b0: isinst [System.Runtime]System.Exception
+			IL_03b5: dup
+			IL_03b6: brtrue IL_03c2
+
+			IL_03bb: pop
+			IL_03bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03c1: throw
+
+			IL_03c2: pop
+			IL_03c3: throw
+
+			IL_03c4: ldnull
+			IL_03c5: ret
+		} // end of method extractElementById::__js_call__
+
+	} // end of class extractElementById
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolveSectionLinkFromMultipageIndexHtml
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b6c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object indexHtml,
+				object section
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x3d04
+			// Header size: 12
+			// Code size: 452 (0x1c4)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] string,
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[12] bool,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] float64,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldarg.3
+			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+			IL_0007: stloc.s 9
+			IL_0009: ldloc.s 9
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0012: stloc.s 10
+			IL_0014: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_0019: ldloc.s 10
+			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0020: stloc.s 10
+			IL_0022: ldloc.s 10
+			IL_0024: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_0029: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002e: stloc.s 10
+			IL_0030: ldloc.s 10
+			IL_0032: ldstr "i"
+			IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_003c: stloc.s 11
+			IL_003e: ldloc.s 11
+			IL_0040: stloc.1
+			IL_0041: ldloc.1
+			IL_0042: ldstr "exec"
+			IL_0047: ldarg.2
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004d: stloc.s 9
+			IL_004f: ldloc.s 9
+			IL_0051: stloc.2
+			IL_0052: ldloc.2
+			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0058: stloc.s 12
+			IL_005a: ldloc.s 12
+			IL_005c: brfalse IL_00a5
+
+			IL_0061: ldloc.2
+			IL_0062: ldc.r8 1
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0070: stloc.s 9
+			IL_0072: ldloc.s 9
+			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0079: stloc.s 12
+			IL_007b: ldloc.s 12
+			IL_007d: brtrue IL_0098
+
+			IL_0082: ldloc.2
+			IL_0083: ldc.r8 2
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0091: stloc.s 14
+			IL_0093: br IL_009c
+
+			IL_0098: ldloc.s 9
+			IL_009a: stloc.s 14
+
+			IL_009c: ldloc.s 14
+			IL_009e: stloc.s 15
+			IL_00a0: br IL_00a8
+
+			IL_00a5: ldloc.2
+			IL_00a6: stloc.s 15
+
+			IL_00a8: ldloc.s 15
+			IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00af: stloc.s 12
+			IL_00b1: ldloc.s 12
+			IL_00b3: brtrue IL_00c4
+
+			IL_00b8: ldstr ""
+			IL_00bd: stloc.s 15
+			IL_00bf: br IL_00c4
+
+			IL_00c4: ldloc.s 15
+			IL_00c6: stloc.3
+			IL_00c7: ldloc.3
+			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00cd: ldc.i4.0
+			IL_00ce: ceq
+			IL_00d0: stloc.s 12
+			IL_00d2: ldloc.s 12
+			IL_00d4: brfalse IL_00e0
+
+			IL_00d9: ldc.i4.0
+			IL_00da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00df: ret
+
+			IL_00e0: ldloc.3
+			IL_00e1: ldstr "indexOf"
+			IL_00e6: ldstr "#"
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f0: stloc.s 9
+			IL_00f2: ldloc.s 9
+			IL_00f4: stloc.s 4
+			IL_00f6: ldloc.s 4
+			IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00fd: stloc.s 17
+			IL_00ff: ldloc.s 17
+			IL_0101: ldc.r8 0.0
+			IL_010a: clt
+			IL_010c: ldc.i4.0
+			IL_010d: ceq
+			IL_010f: brfalse IL_013a
+
+			IL_0114: ldloc.3
+			IL_0115: castclass [System.Runtime]System.String
+			IL_011a: ldc.r8 0.0
+			IL_0123: box [System.Runtime]System.Double
+			IL_0128: ldloc.s 4
+			IL_012a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_012f: stloc.s 10
+			IL_0131: ldloc.s 10
+			IL_0133: stloc.s 5
+			IL_0135: br IL_013d
+
+			IL_013a: ldloc.3
+			IL_013b: stloc.s 5
+
+			IL_013d: ldloc.s 5
+			IL_013f: stloc.s 6
+			IL_0141: ldloc.s 4
+			IL_0143: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0148: stloc.s 17
+			IL_014a: ldloc.s 17
+			IL_014c: ldc.r8 0.0
+			IL_0155: clt
+			IL_0157: ldc.i4.0
+			IL_0158: ceq
+			IL_015a: brfalse IL_0189
+
+			IL_015f: ldloc.s 4
+			IL_0161: ldc.r8 1
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_016f: stloc.s 15
+			IL_0171: ldloc.3
+			IL_0172: castclass [System.Runtime]System.String
+			IL_0177: ldloc.s 15
+			IL_0179: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_017e: stloc.s 10
+			IL_0180: ldloc.s 10
+			IL_0182: stloc.s 7
+			IL_0184: br IL_0190
+
+			IL_0189: ldstr ""
+			IL_018e: stloc.s 7
+
+			IL_0190: ldloc.s 7
+			IL_0192: stloc.s 8
+			IL_0194: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0199: dup
+			IL_019a: ldstr "href"
+			IL_019f: ldloc.3
+			IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01a5: dup
+			IL_01a6: ldstr "filePart"
+			IL_01ab: ldloc.s 6
+			IL_01ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01b2: dup
+			IL_01b3: ldstr "fragment"
+			IL_01b8: ldloc.s 8
+			IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01bf: stloc.s 18
+			IL_01c1: ldloc.s 18
+			IL_01c3: ret
+		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
+
+	} // end of class resolveSectionLinkFromMultipageIndexHtml
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolveSectionIdFromHtml
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L387C2
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b7e
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L387C2::.ctor
+
+			} // end of class Block_L387C2
+
+			.class nested private auto ansi beforefieldinit Block_L398C2
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b87
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L398C2::.ctor
+
+			} // end of class Block_L398C2
+
+			.class nested private auto ansi beforefieldinit Block_L408C2
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b90
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L408C2::.ctor
+
+			} // end of class Block_L408C2
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b75
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope scope,
+				object newTarget,
+				object html,
+				object section
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 26 00 00 02
+			)
+			// Method begins at RVA 0x3ed4
+			// Header size: 12
+			// Code size: 586 (0x24a)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[6] object,
+				[7] object,
+				[8] string,
+				[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[10] bool,
+				[11] object,
+				[12] object,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] string,
+				[17] object,
+				[18] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldarg.3
+			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+			IL_0007: stloc.s 7
+			IL_0009: ldloc.s 7
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0012: stloc.s 8
+			IL_0014: ldstr "<a\\b[^>]*href=(?:\"[^\"]*#([^\"#]+)\"|'[^']*#([^'#]+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_0019: ldloc.s 8
+			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0020: stloc.s 8
+			IL_0022: ldloc.s 8
+			IL_0024: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_0029: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002e: stloc.s 8
+			IL_0030: ldloc.s 8
+			IL_0032: ldstr "i"
+			IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_003c: stloc.s 9
+			IL_003e: ldloc.s 9
+			IL_0040: stloc.1
+			IL_0041: ldloc.1
+			IL_0042: ldstr "exec"
+			IL_0047: ldarg.2
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
+			IL_0051: stloc.2
+			IL_0052: ldloc.2
+			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0058: stloc.s 10
+			IL_005a: ldloc.s 10
+			IL_005c: brfalse IL_00bb
+
+			IL_0061: ldloc.2
+			IL_0062: ldc.r8 1
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0070: stloc.s 7
+			IL_0072: ldloc.s 7
+			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0079: stloc.s 10
+			IL_007b: ldloc.s 10
+			IL_007d: brtrue IL_0098
+
+			IL_0082: ldloc.2
+			IL_0083: ldc.r8 2
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0091: stloc.s 12
+			IL_0093: br IL_009c
+
+			IL_0098: ldloc.s 7
+			IL_009a: stloc.s 12
+
+			IL_009c: ldloc.s 12
+			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00a3: stloc.s 10
+			IL_00a5: ldloc.s 10
+			IL_00a7: brtrue IL_00b8
+
+			IL_00ac: ldstr ""
+			IL_00b1: stloc.s 12
+			IL_00b3: br IL_00b8
+
+			IL_00b8: ldloc.s 12
+			IL_00ba: ret
+
+			IL_00bb: ldloc.0
+			IL_00bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c1: stloc.s 8
+			IL_00c3: ldstr "<emu-clause\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,8000}?<h[1-6]\\b[^>]*>[\\s\\S]{0,1200}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_00c8: ldloc.s 8
+			IL_00ca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00cf: stloc.s 8
+			IL_00d1: ldloc.s 8
+			IL_00d3: ldstr "\\s*<\\/span>[\\s\\S]{0,1200}?<\\/h[1-6]>"
+			IL_00d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00dd: stloc.s 8
+			IL_00df: ldloc.s 8
+			IL_00e1: ldstr "i"
+			IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00eb: stloc.s 9
+			IL_00ed: ldloc.s 9
+			IL_00ef: stloc.3
+			IL_00f0: ldloc.3
+			IL_00f1: ldstr "exec"
+			IL_00f6: ldarg.2
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00fc: stloc.s 7
+			IL_00fe: ldloc.s 7
+			IL_0100: stloc.s 4
+			IL_0102: ldloc.s 4
+			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0109: stloc.s 10
+			IL_010b: ldloc.s 10
+			IL_010d: brfalse IL_016e
+
+			IL_0112: ldloc.s 4
+			IL_0114: ldc.r8 1
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0122: stloc.s 7
+			IL_0124: ldloc.s 7
+			IL_0126: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_012b: stloc.s 10
+			IL_012d: ldloc.s 10
+			IL_012f: brtrue IL_014b
+
+			IL_0134: ldloc.s 4
+			IL_0136: ldc.r8 2
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0144: stloc.s 14
+			IL_0146: br IL_014f
+
+			IL_014b: ldloc.s 7
+			IL_014d: stloc.s 14
+
+			IL_014f: ldloc.s 14
+			IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0156: stloc.s 10
+			IL_0158: ldloc.s 10
+			IL_015a: brtrue IL_016b
+
+			IL_015f: ldstr ""
+			IL_0164: stloc.s 14
+			IL_0166: br IL_016b
+
+			IL_016b: ldloc.s 14
+			IL_016d: ret
+
+			IL_016e: ldloc.0
+			IL_016f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0174: stloc.s 8
+			IL_0176: ldstr "<h[1-6]\\b[^>]*id=(?:\"([^\"]+)\"|'([^']+)')[^>]*>[\\s\\S]{0,1200}?(?:\\s*"
+			IL_017b: ldloc.s 8
+			IL_017d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0182: stloc.s 8
+			IL_0184: ldloc.s 8
+			IL_0186: ldstr "\\b|<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_018b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0190: stloc.s 8
+			IL_0192: ldloc.0
+			IL_0193: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0198: stloc.s 16
+			IL_019a: ldloc.s 8
+			IL_019c: ldloc.s 16
+			IL_019e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a3: stloc.s 16
+			IL_01a5: ldloc.s 16
+			IL_01a7: ldstr "\\s*<\\/span>)"
+			IL_01ac: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01b1: stloc.s 16
+			IL_01b3: ldloc.s 16
+			IL_01b5: ldstr "i"
+			IL_01ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01bf: stloc.s 9
+			IL_01c1: ldloc.s 9
+			IL_01c3: stloc.s 5
+			IL_01c5: ldloc.s 5
+			IL_01c7: ldstr "exec"
+			IL_01cc: ldarg.2
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01d2: stloc.s 7
+			IL_01d4: ldloc.s 7
+			IL_01d6: stloc.s 6
+			IL_01d8: ldloc.s 6
+			IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01df: stloc.s 10
+			IL_01e1: ldloc.s 10
+			IL_01e3: brfalse IL_0244
+
+			IL_01e8: ldloc.s 6
+			IL_01ea: ldc.r8 1
+			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01f8: stloc.s 7
+			IL_01fa: ldloc.s 7
+			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0201: stloc.s 10
+			IL_0203: ldloc.s 10
+			IL_0205: brtrue IL_0221
+
+			IL_020a: ldloc.s 6
+			IL_020c: ldc.r8 2
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_021a: stloc.s 17
+			IL_021c: br IL_0225
+
+			IL_0221: ldloc.s 7
+			IL_0223: stloc.s 17
+
+			IL_0225: ldloc.s 17
+			IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_022c: stloc.s 10
+			IL_022e: ldloc.s 10
+			IL_0230: brtrue IL_0241
+
+			IL_0235: ldstr ""
+			IL_023a: stloc.s 17
+			IL_023c: br IL_0241
+
+			IL_0241: ldloc.s 17
+			IL_0243: ret
+
+			IL_0244: ldstr ""
+			IL_0249: ret
+		} // end of method resolveSectionIdFromHtml::__js_call__
+
+	} // end of class resolveSectionIdFromHtml
+
+	.class nested public auto ansi abstract sealed beforefieldinit wrapAsStandaloneHtml
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5b99
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object extractedHtml,
+				object options
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x412c
+			// Header size: 12
+			// Code size: 295 (0x127)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] string,
+				[5] object,
+				[6] bool,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] string,
+				[11] string
+			)
+
+			IL_0000: ldarg.2
+			IL_0001: ldstr "title"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000b: stloc.s 5
+			IL_000d: ldloc.s 5
+			IL_000f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0014: stloc.s 6
+			IL_0016: ldloc.s 6
+			IL_0018: brtrue IL_0029
+
+			IL_001d: ldstr "ECMA-262 Section Extract"
+			IL_0022: stloc.s 8
+			IL_0024: br IL_002d
+
+			IL_0029: ldloc.s 5
+			IL_002b: stloc.s 8
+
+			IL_002d: ldloc.s 8
+			IL_002f: stloc.0
+			IL_0030: ldarg.2
+			IL_0031: ldstr "baseHref"
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003b: stloc.s 5
+			IL_003d: ldloc.s 5
+			IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0044: stloc.s 6
+			IL_0046: ldloc.s 6
+			IL_0048: brtrue IL_0059
+
+			IL_004d: ldstr ""
+			IL_0052: stloc.s 9
+			IL_0054: br IL_005d
+
+			IL_0059: ldloc.s 5
+			IL_005b: stloc.s 9
+
+			IL_005d: ldloc.s 9
+			IL_005f: stloc.1
+			IL_0060: ldloc.1
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0066: stloc.s 6
+			IL_0068: ldloc.s 6
+			IL_006a: brfalse IL_009b
+
+			IL_006f: ldloc.1
+			IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0075: stloc.s 10
+			IL_0077: ldstr "  <base href=\""
+			IL_007c: ldloc.s 10
+			IL_007e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0083: stloc.s 10
+			IL_0085: ldloc.s 10
+			IL_0087: ldstr "\">\n"
+			IL_008c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0091: stloc.s 10
+			IL_0093: ldloc.s 10
+			IL_0095: stloc.2
+			IL_0096: br IL_00a1
+
+			IL_009b: ldstr ""
+			IL_00a0: stloc.2
+
+			IL_00a1: ldloc.2
+			IL_00a2: stloc.3
+			IL_00a3: ldstr "  <style>\n    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; line-height: 1.35; }\n    emu-clause, emu-intro, emu-annex, emu-section, emu-subsection, emu-table, emu-figure, emu-note, emu-example, emu-alg, emu-grammar, emu-prodref, emu-xref { display: block; }\n    emu-note { border-left: 4px solid #ccc; padding-left: 1rem; margin-left: 0; }\n    table { border-collapse: collapse; }\n    th, td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; vertical-align: top; }\n    pre { background: #f6f8fa; padding: 0.75rem; overflow: auto; }\n    code { background: #f6f8fa; padding: 0 0.25rem; border-radius: 3px; }\n  </style>\n"
+			IL_00a8: stloc.s 4
+			IL_00aa: ldloc.3
+			IL_00ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b0: stloc.s 10
+			IL_00b2: ldstr "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+			IL_00b7: ldloc.s 10
+			IL_00b9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00be: stloc.s 10
+			IL_00c0: ldloc.s 4
+			IL_00c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c7: stloc.s 11
+			IL_00c9: ldloc.s 10
+			IL_00cb: ldloc.s 11
+			IL_00cd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00d2: stloc.s 11
+			IL_00d4: ldloc.s 11
+			IL_00d6: ldstr "  <title>"
+			IL_00db: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00e0: stloc.s 11
+			IL_00e2: ldloc.0
+			IL_00e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e8: stloc.s 10
+			IL_00ea: ldloc.s 11
+			IL_00ec: ldloc.s 10
+			IL_00ee: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00f3: stloc.s 10
+			IL_00f5: ldloc.s 10
+			IL_00f7: ldstr "</title>\n</head>\n<body>\n"
+			IL_00fc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0101: stloc.s 10
+			IL_0103: ldarg.1
+			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0109: stloc.s 11
+			IL_010b: ldloc.s 10
+			IL_010d: ldloc.s 11
+			IL_010f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0114: stloc.s 11
+			IL_0116: ldloc.s 11
+			IL_0118: ldstr "\n</body>\n</html>\n"
+			IL_011d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0122: stloc.s 11
+			IL_0124: ldloc.s 11
+			IL_0126: ret
+		} // end of method wrapAsStandaloneHtml::__js_call__
+
+	} // end of class wrapAsStandaloneHtml
+
+	.class nested public auto ansi abstract sealed beforefieldinit printHelp
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5ba2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x4260
+			// Header size: 12
+			// Code size: 322 (0x142)
+			.maxstack 8
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: ldstr "Extract a section's HTML from a locally saved ECMA-262 multipage HTML file."
+			IL_000a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_000f: pop
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0015: ldstr "You can also fetch the input HTML from the web using Node's built-in fetch/https."
+			IL_001a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_001f: pop
+			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0025: ldstr ""
+			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_002f: pop
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0035: ldstr "Usage:"
+			IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_003f: pop
+			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0045: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --in <input.html> --out <output.html>"
+			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_004f: pop
+			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0055: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --url <https://...> --out <output.html>"
+			IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_005f: pop
+			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0065: ldstr "  node scripts/ECMA262/extractEcma262SectionHtml.js --section 27.3 --auto --out <output.html>"
+			IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_006f: pop
+			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0075: ldstr ""
+			IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_007f: pop
+			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0085: ldstr "Options:"
+			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_008f: pop
+			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0095: ldstr "  --section, -s   Section number to extract (e.g. 27.3)"
+			IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_009f: pop
+			IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00a5: ldstr "  --in, -i        Input HTML file path"
+			IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00af: pop
+			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00b5: ldstr "  --url, -u       Fetch input HTML from URL instead of --in"
+			IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00bf: pop
+			IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00c5: ldstr "  --auto          Auto-discover the correct multipage URL from the multipage index"
+			IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00cf: pop
+			IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00d5: ldstr "  --index-url     Multipage index URL used by --auto (default: https://tc39.es/ecma262/multipage/)"
+			IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00df: pop
+			IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00e5: ldstr "  --out, -o       Output file path"
+			IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00ef: pop
+			IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00f5: ldstr "  --id            Explicit element id to extract (e.g. sec-generatorfunction-objects)"
+			IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00ff: pop
+			IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0105: ldstr "  --wrap          Wrap output as standalone HTML (default)"
+			IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_010f: pop
+			IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0115: ldstr "  --no-wrap       Output only the extracted element HTML"
+			IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_011f: pop
+			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0125: ldstr "  --base          Optional <base href=\"...\"> to inject when wrapping"
+			IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_012f: pop
+			IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0135: ldstr "  --help, -h      Show help"
+			IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_013f: pop
+			IL_0140: ldnull
+			IL_0141: ret
+		} // end of method printHelp::__js_call__
+
+	} // end of class printHelp
+
+	.class nested public auto ansi abstract sealed beforefieldinit main
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L492C92
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+					01 00 12 53 63 6f 70 65 20 61 3d 7b 61 7d 2c 20
+					62 3d 7b 62 7d 00 00
+				)
+				// Fields
+				.field public object a
+				.field public object b
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bcf
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					object a,
+					object b
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+					01 00 00 00 00 00 00 00
+				)
+				// Method begins at RVA 0x5414
+				// Header size: 12
+				// Code size: 10 (0xa)
+				.maxstack 8
+				.locals init (
+					[0] object
+				)
+
+				IL_0000: ldarg.1
+				IL_0001: ldarg.2
+				IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0007: stloc.0
+				IL_0008: ldloc.0
+				IL_0009: ret
+			} // end of method ArrowFunction_L492C92::__js_call__
+
+		} // end of class ArrowFunction_L492C92
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 80 c1 53 63 6f 70 65 20 5f 61 77 61 69 74
+				65 64 31 3d 7b 5f 61 77 61 69 74 65 64 31 7d 2c
+				20 5f 61 77 61 69 74 65 64 32 3d 7b 5f 61 77 61
+				69 74 65 64 32 7d 2c 20 5f 61 77 61 69 74 65 64
+				33 3d 7b 5f 61 77 61 69 74 65 64 33 7d 2c 20 5f
+				61 77 61 69 74 65 64 34 3d 7b 5f 61 77 61 69 74
+				65 64 34 7d 2c 20 5f 61 77 61 69 74 65 64 35 3d
+				7b 5f 61 77 61 69 74 65 64 35 7d 2c 20 5f 61 77
+				61 69 74 65 64 36 3d 7b 5f 61 77 61 69 74 65 64
+				36 7d 2c 20 5f 61 77 61 69 74 65 64 37 3d 7b 5f
+				61 77 61 69 74 65 64 37 7d 2c 20 5f 61 77 61 69
+				74 65 64 38 3d 7b 5f 61 77 61 69 74 65 64 38 7d
+				2c 20 e2 80 a6 00 00
+			)
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L478C17
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bb4
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L478C17::.ctor
+
+			} // end of class Block_L478C17
+
+			.class nested private auto ansi beforefieldinit Block_L483C21
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bbd
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L483C21::.ctor
+
+			} // end of class Block_L483C21
+
+			.class nested private auto ansi beforefieldinit Block_L488C33
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bc6
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L488C33::.ctor
+
+			} // end of class Block_L488C33
+
+			.class nested private auto ansi beforefieldinit Block_L493C28
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bd8
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L493C28::.ctor
+
+			} // end of class Block_L493C28
+
+			.class nested private auto ansi beforefieldinit Block_L497C21
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5be1
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L497C21::.ctor
+
+			} // end of class Block_L497C21
+
+			.class nested private auto ansi beforefieldinit Block_L507C17
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L509C19
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5bf3
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L509C19::.ctor
+
+				} // end of class Block_L509C19
+
+				.class nested private auto ansi beforefieldinit Block_L515C15
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5bfc
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L515C15::.ctor
+
+				} // end of class Block_L515C15
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5bea
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L507C17::.ctor
+
+			} // end of class Block_L507C17
+
+			.class nested private auto ansi beforefieldinit Block_L524C23
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c05
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L524C23::.ctor
+
+			} // end of class Block_L524C23
+
+			.class nested private auto ansi beforefieldinit Block_L528C9
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L530C35
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x5c17
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L530C35::.ctor
+
+				} // end of class Block_L530C35
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c0e
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L528C9::.ctor
+
+			} // end of class Block_L528C9
+
+			.class nested private auto ansi beforefieldinit Block_L537C48
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c20
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L537C48::.ctor
+
+			} // end of class Block_L537C48
+
+			.class nested private auto ansi beforefieldinit Block_L541C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c29
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L541C18::.ctor
+
+			} // end of class Block_L541C18
+
+			.class nested private auto ansi beforefieldinit Block_L545C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c32
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L545C18::.ctor
+
+			} // end of class Block_L545C18
+
+			.class nested private auto ansi beforefieldinit Block_L554C17
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5c3b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L554C17::.ctor
+
+			} // end of class Block_L554C17
+
+
+			// Fields
+			.field public object _awaited1
+			.field public object _awaited2
+			.field public object _awaited3
+			.field public object _awaited4
+			.field public object _awaited5
+			.field public object _awaited6
+			.field public object _awaited7
+			.field public object _awaited8
+			.field public object _awaited9
+			.field public object _awaited10
+			.field public object _awaited11
+			.field public object _awaited12
+			.field public object _awaited13
+			.field public object _awaited14
+			.field public object _awaited15
+			.field public object _awaited16
+			.field public object _awaited17
+			.field public object _awaited18
+			.field public object _awaited19
+			.field public object _awaited20
+			.field public object _awaited21
+			.field public object _awaited22
+			.field public object _awaited23
+			.field public object _awaited24
+			.field public object _awaited25
+			.field public object _awaited26
+			.field public object _awaited27
+			.field public object _awaited28
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5bab
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget,
+				object argv,
+				object logger
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x43b0
+			// Header size: 12
+			// Code size: 3479 (0xd97)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] string,
+				[9] string,
+				[10] object,
+				[11] object,
+				[12] object,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] object,
+				[18] object,
+				[19] object,
+				[20] object,
+				[21] bool,
+				[22] object,
+				[23] object,
+				[24] object,
+				[25] object,
+				[26] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[27] object,
+				[28] object,
+				[29] string,
+				[30] string,
+				[31] class [System.Runtime]System.Delegate,
+				[32] object,
+				[33] object[],
+				[34] object,
+				[35] object,
+				[36] object,
+				[37] object,
+				[38] object,
+				[39] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: isinst Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope
+			IL_0008: dup
+			IL_0009: brtrue IL_0049
+
+			IL_000e: pop
+			IL_000f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::.ctor()
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: ldarg.0
+			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
+			IL_001c: starg.s scopes
+			IL_001e: ldloc.0
+			IL_001f: ldnull
+			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
+			IL_002b: ldarg.0
+			IL_002c: ldc.i4.2
+			IL_002d: newarr [System.Runtime]System.Object
+			IL_0032: dup
+			IL_0033: ldc.i4.0
+			IL_0034: ldarg.2
+			IL_0035: stelem.ref
+			IL_0036: dup
+			IL_0037: ldc.i4.1
+			IL_0038: ldarg.3
+			IL_0039: stelem.ref
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindMoveNext(object, object[], object[])
+			IL_003f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0044: br IL_004a
+
+			IL_0049: stloc.0
+
+			IL_004a: ldloc.0
+			IL_004b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0050: brtrue IL_0062
+
+			IL_0055: ldloc.0
+			IL_0056: ldc.i4.s 19
+			IL_0058: newarr [System.Runtime]System.Object
+			IL_005d: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+
+			IL_0062: ldloc.0
+			IL_0063: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0068: ldc.i4.0
+			IL_0069: ble.s IL_00e2
+
+			IL_006b: ldloc.0
+			IL_006c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0071: dup
+			IL_0072: ldc.i4.0
+			IL_0073: ldelem.ref
+			IL_0074: stloc.1
+			IL_0075: dup
+			IL_0076: ldc.i4.1
+			IL_0077: ldelem.ref
+			IL_0078: stloc.2
+			IL_0079: dup
+			IL_007a: ldc.i4.2
+			IL_007b: ldelem.ref
+			IL_007c: stloc.3
+			IL_007d: dup
+			IL_007e: ldc.i4.3
+			IL_007f: ldelem.ref
+			IL_0080: stloc.s 4
+			IL_0082: dup
+			IL_0083: ldc.i4.4
+			IL_0084: ldelem.ref
+			IL_0085: stloc.s 5
+			IL_0087: dup
+			IL_0088: ldc.i4.5
+			IL_0089: ldelem.ref
+			IL_008a: stloc.s 6
+			IL_008c: dup
+			IL_008d: ldc.i4.6
+			IL_008e: ldelem.ref
+			IL_008f: stloc.s 7
+			IL_0091: dup
+			IL_0092: ldc.i4.7
+			IL_0093: ldelem.ref
+			IL_0094: castclass [System.Runtime]System.String
+			IL_0099: stloc.s 8
+			IL_009b: dup
+			IL_009c: ldc.i4.8
+			IL_009d: ldelem.ref
+			IL_009e: castclass [System.Runtime]System.String
+			IL_00a3: stloc.s 9
+			IL_00a5: dup
+			IL_00a6: ldc.i4.s 9
+			IL_00a8: ldelem.ref
+			IL_00a9: stloc.s 10
+			IL_00ab: dup
+			IL_00ac: ldc.i4.s 10
+			IL_00ae: ldelem.ref
+			IL_00af: stloc.s 11
+			IL_00b1: dup
+			IL_00b2: ldc.i4.s 11
+			IL_00b4: ldelem.ref
+			IL_00b5: stloc.s 12
+			IL_00b7: dup
+			IL_00b8: ldc.i4.s 12
+			IL_00ba: ldelem.ref
+			IL_00bb: stloc.s 13
+			IL_00bd: dup
+			IL_00be: ldc.i4.s 13
+			IL_00c0: ldelem.ref
+			IL_00c1: stloc.s 14
+			IL_00c3: dup
+			IL_00c4: ldc.i4.s 14
+			IL_00c6: ldelem.ref
+			IL_00c7: stloc.s 15
+			IL_00c9: dup
+			IL_00ca: ldc.i4.s 15
+			IL_00cc: ldelem.ref
+			IL_00cd: stloc.s 16
+			IL_00cf: dup
+			IL_00d0: ldc.i4.s 16
+			IL_00d2: ldelem.ref
+			IL_00d3: stloc.s 17
+			IL_00d5: dup
+			IL_00d6: ldc.i4.s 17
+			IL_00d8: ldelem.ref
+			IL_00d9: stloc.s 18
+			IL_00db: dup
+			IL_00dc: ldc.i4.s 18
+			IL_00de: ldelem.ref
+			IL_00df: stloc.s 19
+			IL_00e1: pop
+
+			IL_00e2: ldloc.0
+			IL_00e3: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00e8: switch (IL_00fd, IL_060d, IL_0846, IL_094b)
+
+			IL_00fd: ldarg.2
+			IL_00fe: brtrue IL_0114
+
+			IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0108: ldstr "argv"
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0112: starg.s argv
+
+			IL_0114: ldarg.3
+			IL_0115: brtrue IL_012b
+
+			IL_011a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_011f: ldstr "log"
+			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0129: starg.s logger
+
+			IL_012b: ldc.i4.1
+			IL_012c: newarr [System.Runtime]System.Object
+			IL_0131: dup
+			IL_0132: ldc.i4.0
+			IL_0133: ldarg.0
+			IL_0134: ldc.i4.1
+			IL_0135: ldelem.ref
+			IL_0136: stelem.ref
+			IL_0137: ldc.i4.0
+			IL_0138: ldelem.ref
+			IL_0139: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_013e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0149: ldnull
+			IL_014a: ldarg.2
+			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0150: stloc.s 20
+			IL_0152: ldloc.s 20
+			IL_0154: stloc.1
+			IL_0155: ldloc.1
+			IL_0156: ldstr "help"
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0165: stloc.s 21
+			IL_0167: ldloc.s 21
+			IL_0169: brfalse IL_01a4
+
+			IL_016e: ldnull
+			IL_016f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/printHelp::__js_call__(object)
+			IL_0174: pop
+			IL_0175: ldloc.0
+			IL_0176: ldc.i4.m1
+			IL_0177: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_017c: ldloc.0
+			IL_017d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0187: ldarg.0
+			IL_0188: ldc.i4.1
+			IL_0189: newarr [System.Runtime]System.Object
+			IL_018e: dup
+			IL_018f: ldc.i4.0
+			IL_0190: ldnull
+			IL_0191: stelem.ref
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0197: pop
+			IL_0198: ldloc.0
+			IL_0199: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_019e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01a3: ret
+
+			IL_01a4: ldloc.1
+			IL_01a5: ldstr "section"
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01b4: ldc.i4.0
+			IL_01b5: ceq
+			IL_01b7: stloc.s 21
+			IL_01b9: ldloc.s 21
+			IL_01bb: brfalse IL_0201
+
+			IL_01c0: ldstr "Missing required --section (e.g. 27.3)."
+			IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01cf: stloc.s 20
+			IL_01d1: ldloc.0
+			IL_01d2: ldc.i4.m1
+			IL_01d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01d8: ldloc.0
+			IL_01d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01e3: ldarg.0
+			IL_01e4: ldc.i4.1
+			IL_01e5: newarr [System.Runtime]System.Object
+			IL_01ea: dup
+			IL_01eb: ldc.i4.0
+			IL_01ec: ldloc.s 20
+			IL_01ee: stelem.ref
+			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01f4: pop
+			IL_01f5: ldloc.0
+			IL_01f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0200: ret
+
+			IL_0201: ldloc.1
+			IL_0202: ldstr "inFile"
+			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0211: ldc.i4.0
+			IL_0212: ceq
+			IL_0214: stloc.s 21
+			IL_0216: ldloc.s 21
+			IL_0218: box [System.Runtime]System.Boolean
+			IL_021d: stloc.s 22
+			IL_021f: ldloc.s 22
+			IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0226: stloc.s 21
+			IL_0228: ldloc.s 21
+			IL_022a: brfalse IL_0256
+
+			IL_022f: ldloc.1
+			IL_0230: ldstr "url"
+			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_023f: ldc.i4.0
+			IL_0240: ceq
+			IL_0242: stloc.s 21
+			IL_0244: ldloc.s 21
+			IL_0246: box [System.Runtime]System.Boolean
+			IL_024b: stloc.s 23
+			IL_024d: ldloc.s 23
+			IL_024f: stloc.s 25
+			IL_0251: br IL_025a
+
+			IL_0256: ldloc.s 22
+			IL_0258: stloc.s 25
+
+			IL_025a: ldloc.s 25
+			IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0261: stloc.s 21
+			IL_0263: ldloc.s 21
+			IL_0265: brfalse IL_027c
+
+			IL_026a: ldloc.1
+			IL_026b: ldstr "auto"
+			IL_0270: ldc.i4.1
+			IL_0271: box [System.Runtime]System.Boolean
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_027b: pop
+
+			IL_027c: ldloc.1
+			IL_027d: ldstr "inFile"
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_028c: stloc.s 21
+			IL_028e: ldloc.s 21
+			IL_0290: brfalse IL_02a9
+
+			IL_0295: ldc.r8 1
+			IL_029e: box [System.Runtime]System.Double
+			IL_02a3: stloc.2
+			IL_02a4: br IL_02b8
+
+			IL_02a9: ldc.r8 0.0
+			IL_02b2: box [System.Runtime]System.Double
+			IL_02b7: stloc.2
+
+			IL_02b8: ldloc.1
+			IL_02b9: ldstr "url"
+			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02c8: stloc.s 21
+			IL_02ca: ldloc.s 21
+			IL_02cc: brfalse IL_02e5
+
+			IL_02d1: ldc.r8 1
+			IL_02da: box [System.Runtime]System.Double
+			IL_02df: stloc.3
+			IL_02e0: br IL_02f4
+
+			IL_02e5: ldc.r8 0.0
+			IL_02ee: box [System.Runtime]System.Double
+			IL_02f3: stloc.3
+
+			IL_02f4: ldloc.1
+			IL_02f5: ldstr "auto"
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0304: stloc.s 21
+			IL_0306: ldloc.s 21
+			IL_0308: brfalse IL_0322
+
+			IL_030d: ldc.r8 1
+			IL_0316: box [System.Runtime]System.Double
+			IL_031b: stloc.s 4
+			IL_031d: br IL_0332
+
+			IL_0322: ldc.r8 0.0
+			IL_032b: box [System.Runtime]System.Double
+			IL_0330: stloc.s 4
+
+			IL_0332: ldc.i4.3
+			IL_0333: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0338: dup
+			IL_0339: ldloc.2
+			IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_033f: dup
+			IL_0340: ldloc.3
+			IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0346: dup
+			IL_0347: ldloc.s 4
+			IL_0349: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_034e: stloc.s 26
+			IL_0350: ldnull
+			IL_0351: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/ArrowFunction_L492C92::__js_call__(object, object, object)
+			IL_0357: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_035c: ldc.i4.1
+			IL_035d: newarr [System.Runtime]System.Object
+			IL_0362: dup
+			IL_0363: ldc.i4.0
+			IL_0364: ldarg.0
+			IL_0365: ldc.i4.1
+			IL_0366: ldelem.ref
+			IL_0367: stelem.ref
+			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0372: stloc.s 20
+			IL_0374: ldloc.s 26
+			IL_0376: ldc.i4.2
+			IL_0377: newarr [System.Runtime]System.Object
+			IL_037c: dup
+			IL_037d: ldc.i4.0
+			IL_037e: ldloc.s 20
+			IL_0380: stelem.ref
+			IL_0381: dup
+			IL_0382: ldc.i4.1
+			IL_0383: ldc.r8 0.0
+			IL_038c: box [System.Runtime]System.Double
+			IL_0391: stelem.ref
+			IL_0392: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::reduce(object[])
+			IL_0397: stloc.s 20
+			IL_0399: ldloc.s 20
+			IL_039b: stloc.s 5
+			IL_039d: ldloc.s 5
+			IL_039f: ldc.r8 1
+			IL_03a8: box [System.Runtime]System.Double
+			IL_03ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03b2: stloc.s 21
+			IL_03b4: ldloc.s 21
+			IL_03b6: brfalse IL_03fc
+
+			IL_03bb: ldstr "Provide exactly one input mode: --in, --url, or --auto."
+			IL_03c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03ca: stloc.s 20
+			IL_03cc: ldloc.0
+			IL_03cd: ldc.i4.m1
+			IL_03ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03d3: ldloc.0
+			IL_03d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_03de: ldarg.0
+			IL_03df: ldc.i4.1
+			IL_03e0: newarr [System.Runtime]System.Object
+			IL_03e5: dup
+			IL_03e6: ldc.i4.0
+			IL_03e7: ldloc.s 20
+			IL_03e9: stelem.ref
+			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03ef: pop
+			IL_03f0: ldloc.0
+			IL_03f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03fb: ret
+
+			IL_03fc: ldloc.1
+			IL_03fd: ldstr "outFile"
+			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0407: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_040c: ldc.i4.0
+			IL_040d: ceq
+			IL_040f: stloc.s 21
+			IL_0411: ldloc.s 21
+			IL_0413: brfalse IL_0459
+
+			IL_0418: ldstr "Missing required --out <output.html>."
+			IL_041d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0422: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0427: stloc.s 20
+			IL_0429: ldloc.0
+			IL_042a: ldc.i4.m1
+			IL_042b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0430: ldloc.0
+			IL_0431: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0436: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_043b: ldarg.0
+			IL_043c: ldc.i4.1
+			IL_043d: newarr [System.Runtime]System.Object
+			IL_0442: dup
+			IL_0443: ldc.i4.0
+			IL_0444: ldloc.s 20
+			IL_0446: stelem.ref
+			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_044c: pop
+			IL_044d: ldloc.0
+			IL_044e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0453: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0458: ret
+
+			IL_0459: ldarg.0
+			IL_045a: ldc.i4.1
+			IL_045b: ldelem.ref
+			IL_045c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0461: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
+			IL_0466: stloc.s 20
+			IL_0468: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_046d: ldstr "cwd"
+			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0477: stloc.s 27
+			IL_0479: ldloc.s 20
+			IL_047b: ldstr "resolve"
+			IL_0480: ldloc.s 27
+			IL_0482: ldloc.1
+			IL_0483: ldstr "outFile"
+			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0492: stloc.s 27
+			IL_0494: ldloc.s 27
+			IL_0496: stloc.s 6
+			IL_0498: ldnull
+			IL_0499: stloc.s 7
+			IL_049b: ldstr ""
+			IL_04a0: stloc.s 8
+			IL_04a2: ldstr ""
+			IL_04a7: stloc.s 9
+			IL_04a9: ldloc.1
+			IL_04aa: ldstr "auto"
+			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04b9: stloc.s 21
+			IL_04bb: ldloc.s 21
+			IL_04bd: brfalse IL_085f
+
+			IL_04c2: ldloc.1
+			IL_04c3: ldstr "indexUrl"
+			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04cd: stloc.s 27
+			IL_04cf: ldloc.s 27
+			IL_04d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04d6: stloc.s 21
+			IL_04d8: ldloc.s 21
+			IL_04da: brtrue IL_04eb
+
+			IL_04df: ldstr "https://tc39.es/ecma262/multipage/"
+			IL_04e4: stloc.s 28
+			IL_04e6: br IL_04ef
+
+			IL_04eb: ldloc.s 27
+			IL_04ed: stloc.s 28
+
+			IL_04ef: ldloc.s 28
+			IL_04f1: castclass [System.Runtime]System.String
+			IL_04f6: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_04fb: stloc.s 29
+			IL_04fd: ldloc.s 29
+			IL_04ff: stloc.s 10
+			IL_0501: ldloc.s 10
+			IL_0503: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0508: ldc.i4.0
+			IL_0509: ceq
+			IL_050b: stloc.s 21
+			IL_050d: ldloc.s 21
+			IL_050f: brfalse IL_0555
+
+			IL_0514: ldstr "Missing --index-url value."
+			IL_0519: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_051e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0523: stloc.s 27
+			IL_0525: ldloc.0
+			IL_0526: ldc.i4.m1
+			IL_0527: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_052c: ldloc.0
+			IL_052d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0532: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0537: ldarg.0
+			IL_0538: ldc.i4.1
+			IL_0539: newarr [System.Runtime]System.Object
+			IL_053e: dup
+			IL_053f: ldc.i4.0
+			IL_0540: ldloc.s 27
+			IL_0542: stelem.ref
+			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0548: pop
+			IL_0549: ldloc.0
+			IL_054a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_054f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0554: ret
+
+			IL_0555: ldc.i4.1
+			IL_0556: newarr [System.Runtime]System.Object
+			IL_055b: dup
+			IL_055c: ldc.i4.0
+			IL_055d: ldarg.0
+			IL_055e: ldc.i4.1
+			IL_055f: ldelem.ref
+			IL_0560: stelem.ref
+			IL_0561: ldc.i4.0
+			IL_0562: ldelem.ref
+			IL_0563: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0568: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+			IL_056e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0573: ldnull
+			IL_0574: ldloc.s 10
+			IL_0576: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_057b: stloc.s 27
+			IL_057d: ldloc.0
+			IL_057e: ldc.i4.1
+			IL_057f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0584: ldloc.0
+			IL_0585: ldloc.s 27
+			IL_0587: ldarg.0
+			IL_0588: ldc.i4.1
+			IL_0589: ldloc.0
+			IL_058a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_058f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0594: ldloc.0
+			IL_0595: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_059a: dup
+			IL_059b: ldc.i4.0
+			IL_059c: ldloc.1
+			IL_059d: stelem.ref
+			IL_059e: dup
+			IL_059f: ldc.i4.1
+			IL_05a0: ldloc.2
+			IL_05a1: stelem.ref
+			IL_05a2: dup
+			IL_05a3: ldc.i4.2
+			IL_05a4: ldloc.3
+			IL_05a5: stelem.ref
+			IL_05a6: dup
+			IL_05a7: ldc.i4.3
+			IL_05a8: ldloc.s 4
+			IL_05aa: stelem.ref
+			IL_05ab: dup
+			IL_05ac: ldc.i4.4
+			IL_05ad: ldloc.s 5
+			IL_05af: stelem.ref
+			IL_05b0: dup
+			IL_05b1: ldc.i4.5
+			IL_05b2: ldloc.s 6
+			IL_05b4: stelem.ref
+			IL_05b5: dup
+			IL_05b6: ldc.i4.6
+			IL_05b7: ldloc.s 7
+			IL_05b9: stelem.ref
+			IL_05ba: dup
+			IL_05bb: ldc.i4.7
+			IL_05bc: ldloc.s 8
+			IL_05be: stelem.ref
+			IL_05bf: dup
+			IL_05c0: ldc.i4.8
+			IL_05c1: ldloc.s 9
+			IL_05c3: stelem.ref
+			IL_05c4: dup
+			IL_05c5: ldc.i4.s 9
+			IL_05c7: ldloc.s 10
+			IL_05c9: stelem.ref
+			IL_05ca: dup
+			IL_05cb: ldc.i4.s 10
+			IL_05cd: ldloc.s 11
+			IL_05cf: stelem.ref
+			IL_05d0: dup
+			IL_05d1: ldc.i4.s 11
+			IL_05d3: ldloc.s 12
+			IL_05d5: stelem.ref
+			IL_05d6: dup
+			IL_05d7: ldc.i4.s 12
+			IL_05d9: ldloc.s 13
+			IL_05db: stelem.ref
+			IL_05dc: dup
+			IL_05dd: ldc.i4.s 13
+			IL_05df: ldloc.s 14
+			IL_05e1: stelem.ref
+			IL_05e2: dup
+			IL_05e3: ldc.i4.s 14
+			IL_05e5: ldloc.s 15
+			IL_05e7: stelem.ref
+			IL_05e8: dup
+			IL_05e9: ldc.i4.s 15
+			IL_05eb: ldloc.s 16
+			IL_05ed: stelem.ref
+			IL_05ee: dup
+			IL_05ef: ldc.i4.s 16
+			IL_05f1: ldloc.s 17
+			IL_05f3: stelem.ref
+			IL_05f4: dup
+			IL_05f5: ldc.i4.s 17
+			IL_05f7: ldloc.s 18
+			IL_05f9: stelem.ref
+			IL_05fa: dup
+			IL_05fb: ldc.i4.s 18
+			IL_05fd: ldloc.s 19
+			IL_05ff: stelem.ref
+			IL_0600: pop
+			IL_0601: ldloc.0
+			IL_0602: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0607: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_060c: ret
+
+			IL_060d: ldloc.0
+			IL_060e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited1
+			IL_0613: stloc.s 27
+			IL_0615: ldloc.s 27
+			IL_0617: stloc.s 11
+			IL_0619: ldloc.1
+			IL_061a: ldstr "section"
+			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0624: ldstr "trim"
+			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_062e: stloc.s 27
+			IL_0630: ldc.i4.1
+			IL_0631: newarr [System.Runtime]System.Object
+			IL_0636: dup
+			IL_0637: ldc.i4.0
+			IL_0638: ldarg.0
+			IL_0639: ldc.i4.1
+			IL_063a: ldelem.ref
+			IL_063b: stelem.ref
+			IL_063c: ldc.i4.0
+			IL_063d: ldelem.ref
+			IL_063e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0643: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0649: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_064e: ldnull
+			IL_064f: ldloc.s 11
+			IL_0651: ldloc.s 27
+			IL_0653: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0658: stloc.s 27
+			IL_065a: ldloc.s 27
+			IL_065c: stloc.s 12
+			IL_065e: ldloc.s 12
+			IL_0660: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0665: ldc.i4.0
+			IL_0666: ceq
+			IL_0668: stloc.s 21
+			IL_066a: ldloc.s 21
+			IL_066c: brfalse IL_06f1
+
+			IL_0671: ldloc.1
+			IL_0672: ldstr "section"
+			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_067c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0681: stloc.s 29
+			IL_0683: ldstr "Could not find section '"
+			IL_0688: ldloc.s 29
+			IL_068a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_068f: stloc.s 29
+			IL_0691: ldloc.s 29
+			IL_0693: ldstr "' in multipage index: "
+			IL_0698: call string [System.Runtime]System.String::Concat(string, string)
+			IL_069d: stloc.s 29
+			IL_069f: ldloc.s 10
+			IL_06a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06a6: stloc.s 30
+			IL_06a8: ldloc.s 29
+			IL_06aa: ldloc.s 30
+			IL_06ac: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06b1: stloc.s 30
+			IL_06b3: ldloc.s 30
+			IL_06b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_06bf: stloc.s 27
+			IL_06c1: ldloc.0
+			IL_06c2: ldc.i4.m1
+			IL_06c3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06c8: ldloc.0
+			IL_06c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_06d3: ldarg.0
+			IL_06d4: ldc.i4.1
+			IL_06d5: newarr [System.Runtime]System.Object
+			IL_06da: dup
+			IL_06db: ldc.i4.0
+			IL_06dc: ldloc.s 27
+			IL_06de: stelem.ref
+			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06e4: pop
+			IL_06e5: ldloc.0
+			IL_06e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06f0: ret
+
+			IL_06f1: call class [System.Runtime]System.Delegate [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_URL()
+			IL_06f6: stloc.s 31
+			IL_06f8: ldloc.s 12
+			IL_06fa: ldstr "filePart"
+			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0704: stloc.s 27
+			IL_0706: ldloc.s 27
+			IL_0708: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_070d: stloc.s 21
+			IL_070f: ldloc.s 21
+			IL_0711: brtrue IL_0729
+
+			IL_0716: ldloc.s 12
+			IL_0718: ldstr "href"
+			IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0722: stloc.s 32
+			IL_0724: br IL_072d
+
+			IL_0729: ldloc.s 27
+			IL_072b: stloc.s 32
+
+			IL_072d: ldc.i4.2
+			IL_072e: newarr [System.Runtime]System.Object
+			IL_0733: dup
+			IL_0734: ldc.i4.0
+			IL_0735: ldloc.s 32
+			IL_0737: stelem.ref
+			IL_0738: dup
+			IL_0739: ldc.i4.1
+			IL_073a: ldloc.s 10
+			IL_073c: stelem.ref
+			IL_073d: stloc.s 33
+			IL_073f: ldloc.s 31
+			IL_0741: ldloc.s 33
+			IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0748: stloc.s 27
+			IL_074a: ldloc.s 27
+			IL_074c: ldstr "toString"
+			IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0756: stloc.s 27
+			IL_0758: ldloc.s 27
+			IL_075a: stloc.s 13
+			IL_075c: ldloc.s 12
+			IL_075e: ldstr "fragment"
+			IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0768: stloc.s 27
+			IL_076a: ldloc.s 27
+			IL_076c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0771: stloc.s 21
+			IL_0773: ldloc.s 21
+			IL_0775: brtrue IL_0786
+
+			IL_077a: ldstr ""
+			IL_077f: stloc.s 34
+			IL_0781: br IL_078a
+
+			IL_0786: ldloc.s 27
+			IL_0788: stloc.s 34
+
+			IL_078a: ldloc.s 34
+			IL_078c: stloc.s 9
+			IL_078e: ldc.i4.1
+			IL_078f: newarr [System.Runtime]System.Object
+			IL_0794: dup
+			IL_0795: ldc.i4.0
+			IL_0796: ldarg.0
+			IL_0797: ldc.i4.1
+			IL_0798: ldelem.ref
+			IL_0799: stelem.ref
+			IL_079a: ldc.i4.0
+			IL_079b: ldelem.ref
+			IL_079c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_07a1: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+			IL_07a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_07ac: ldnull
+			IL_07ad: ldloc.s 13
+			IL_07af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_07b4: stloc.s 27
+			IL_07b6: ldloc.0
+			IL_07b7: ldc.i4.2
+			IL_07b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07bd: ldloc.0
+			IL_07be: ldloc.s 27
+			IL_07c0: ldarg.0
+			IL_07c1: ldc.i4.2
+			IL_07c2: ldloc.0
+			IL_07c3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07cd: ldloc.0
+			IL_07ce: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07d3: dup
+			IL_07d4: ldc.i4.0
+			IL_07d5: ldloc.1
+			IL_07d6: stelem.ref
+			IL_07d7: dup
+			IL_07d8: ldc.i4.1
+			IL_07d9: ldloc.2
+			IL_07da: stelem.ref
+			IL_07db: dup
+			IL_07dc: ldc.i4.2
+			IL_07dd: ldloc.3
+			IL_07de: stelem.ref
+			IL_07df: dup
+			IL_07e0: ldc.i4.3
+			IL_07e1: ldloc.s 4
+			IL_07e3: stelem.ref
+			IL_07e4: dup
+			IL_07e5: ldc.i4.4
+			IL_07e6: ldloc.s 5
+			IL_07e8: stelem.ref
+			IL_07e9: dup
+			IL_07ea: ldc.i4.5
+			IL_07eb: ldloc.s 6
+			IL_07ed: stelem.ref
+			IL_07ee: dup
+			IL_07ef: ldc.i4.6
+			IL_07f0: ldloc.s 7
+			IL_07f2: stelem.ref
+			IL_07f3: dup
+			IL_07f4: ldc.i4.7
+			IL_07f5: ldloc.s 8
+			IL_07f7: stelem.ref
+			IL_07f8: dup
+			IL_07f9: ldc.i4.8
+			IL_07fa: ldloc.s 9
+			IL_07fc: stelem.ref
+			IL_07fd: dup
+			IL_07fe: ldc.i4.s 9
+			IL_0800: ldloc.s 10
+			IL_0802: stelem.ref
+			IL_0803: dup
+			IL_0804: ldc.i4.s 10
+			IL_0806: ldloc.s 11
+			IL_0808: stelem.ref
+			IL_0809: dup
+			IL_080a: ldc.i4.s 11
+			IL_080c: ldloc.s 12
+			IL_080e: stelem.ref
+			IL_080f: dup
+			IL_0810: ldc.i4.s 12
+			IL_0812: ldloc.s 13
+			IL_0814: stelem.ref
+			IL_0815: dup
+			IL_0816: ldc.i4.s 13
+			IL_0818: ldloc.s 14
+			IL_081a: stelem.ref
+			IL_081b: dup
+			IL_081c: ldc.i4.s 14
+			IL_081e: ldloc.s 15
+			IL_0820: stelem.ref
+			IL_0821: dup
+			IL_0822: ldc.i4.s 15
+			IL_0824: ldloc.s 16
+			IL_0826: stelem.ref
+			IL_0827: dup
+			IL_0828: ldc.i4.s 16
+			IL_082a: ldloc.s 17
+			IL_082c: stelem.ref
+			IL_082d: dup
+			IL_082e: ldc.i4.s 17
+			IL_0830: ldloc.s 18
+			IL_0832: stelem.ref
+			IL_0833: dup
+			IL_0834: ldc.i4.s 18
+			IL_0836: ldloc.s 19
+			IL_0838: stelem.ref
+			IL_0839: pop
+			IL_083a: ldloc.0
+			IL_083b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0840: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0845: ret
+
+			IL_0846: ldloc.0
+			IL_0847: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited2
+			IL_084c: stloc.s 27
+			IL_084e: ldloc.s 27
+			IL_0850: stloc.s 7
+			IL_0852: ldloc.s 13
+			IL_0854: stloc.s 27
+			IL_0856: ldloc.s 27
+			IL_0858: stloc.s 8
+			IL_085a: br IL_0a4a
+
+			IL_085f: ldloc.1
+			IL_0860: ldstr "url"
+			IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_086a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_086f: stloc.s 21
+			IL_0871: ldloc.s 21
+			IL_0873: brfalse IL_0964
+
+			IL_0878: ldloc.1
+			IL_0879: ldstr "url"
+			IL_087e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0883: ldstr "trim"
+			IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_088d: stloc.s 27
+			IL_088f: ldloc.s 27
+			IL_0891: stloc.s 14
+			IL_0893: ldc.i4.1
+			IL_0894: newarr [System.Runtime]System.Object
+			IL_0899: dup
+			IL_089a: ldc.i4.0
+			IL_089b: ldarg.0
+			IL_089c: ldc.i4.1
+			IL_089d: ldelem.ref
+			IL_089e: stelem.ref
+			IL_089f: ldc.i4.0
+			IL_08a0: ldelem.ref
+			IL_08a1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_08a6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+			IL_08ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_08b1: ldnull
+			IL_08b2: ldloc.s 14
+			IL_08b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_08b9: stloc.s 27
+			IL_08bb: ldloc.0
+			IL_08bc: ldc.i4.3
+			IL_08bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08c2: ldloc.0
+			IL_08c3: ldloc.s 27
+			IL_08c5: ldarg.0
+			IL_08c6: ldc.i4.3
+			IL_08c7: ldloc.0
+			IL_08c8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_08d2: ldloc.0
+			IL_08d3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08d8: dup
+			IL_08d9: ldc.i4.0
+			IL_08da: ldloc.1
+			IL_08db: stelem.ref
+			IL_08dc: dup
+			IL_08dd: ldc.i4.1
+			IL_08de: ldloc.2
+			IL_08df: stelem.ref
+			IL_08e0: dup
+			IL_08e1: ldc.i4.2
+			IL_08e2: ldloc.3
+			IL_08e3: stelem.ref
+			IL_08e4: dup
+			IL_08e5: ldc.i4.3
+			IL_08e6: ldloc.s 4
+			IL_08e8: stelem.ref
+			IL_08e9: dup
+			IL_08ea: ldc.i4.4
+			IL_08eb: ldloc.s 5
+			IL_08ed: stelem.ref
+			IL_08ee: dup
+			IL_08ef: ldc.i4.5
+			IL_08f0: ldloc.s 6
+			IL_08f2: stelem.ref
+			IL_08f3: dup
+			IL_08f4: ldc.i4.6
+			IL_08f5: ldloc.s 7
+			IL_08f7: stelem.ref
+			IL_08f8: dup
+			IL_08f9: ldc.i4.7
+			IL_08fa: ldloc.s 8
+			IL_08fc: stelem.ref
+			IL_08fd: dup
+			IL_08fe: ldc.i4.8
+			IL_08ff: ldloc.s 9
+			IL_0901: stelem.ref
+			IL_0902: dup
+			IL_0903: ldc.i4.s 9
+			IL_0905: ldloc.s 10
+			IL_0907: stelem.ref
+			IL_0908: dup
+			IL_0909: ldc.i4.s 10
+			IL_090b: ldloc.s 11
+			IL_090d: stelem.ref
+			IL_090e: dup
+			IL_090f: ldc.i4.s 11
+			IL_0911: ldloc.s 12
+			IL_0913: stelem.ref
+			IL_0914: dup
+			IL_0915: ldc.i4.s 12
+			IL_0917: ldloc.s 13
+			IL_0919: stelem.ref
+			IL_091a: dup
+			IL_091b: ldc.i4.s 13
+			IL_091d: ldloc.s 14
+			IL_091f: stelem.ref
+			IL_0920: dup
+			IL_0921: ldc.i4.s 14
+			IL_0923: ldloc.s 15
+			IL_0925: stelem.ref
+			IL_0926: dup
+			IL_0927: ldc.i4.s 15
+			IL_0929: ldloc.s 16
+			IL_092b: stelem.ref
+			IL_092c: dup
+			IL_092d: ldc.i4.s 16
+			IL_092f: ldloc.s 17
+			IL_0931: stelem.ref
+			IL_0932: dup
+			IL_0933: ldc.i4.s 17
+			IL_0935: ldloc.s 18
+			IL_0937: stelem.ref
+			IL_0938: dup
+			IL_0939: ldc.i4.s 18
+			IL_093b: ldloc.s 19
+			IL_093d: stelem.ref
+			IL_093e: pop
+			IL_093f: ldloc.0
+			IL_0940: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0945: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_094a: ret
+
+			IL_094b: ldloc.0
+			IL_094c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main/Scope::_awaited3
+			IL_0951: stloc.s 27
+			IL_0953: ldloc.s 27
+			IL_0955: stloc.s 7
+			IL_0957: ldloc.s 14
+			IL_0959: stloc.s 27
+			IL_095b: ldloc.s 27
+			IL_095d: stloc.s 8
+			IL_095f: br IL_0a4a
+
+			IL_0964: ldarg.0
+			IL_0965: ldc.i4.1
+			IL_0966: ldelem.ref
+			IL_0967: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_096c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
+			IL_0971: stloc.s 27
+			IL_0973: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0978: ldstr "cwd"
+			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0982: stloc.s 20
+			IL_0984: ldloc.s 27
+			IL_0986: ldstr "resolve"
+			IL_098b: ldloc.s 20
+			IL_098d: ldloc.1
+			IL_098e: ldstr "inFile"
+			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_099d: stloc.s 20
+			IL_099f: ldloc.s 20
+			IL_09a1: stloc.s 15
+			IL_09a3: ldarg.0
+			IL_09a4: ldc.i4.1
+			IL_09a5: ldelem.ref
+			IL_09a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_09ab: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_09b0: ldstr "existsSync"
+			IL_09b5: ldloc.s 15
+			IL_09b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_09bc: stloc.s 20
+			IL_09be: ldloc.s 20
+			IL_09c0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09c5: ldc.i4.0
+			IL_09c6: ceq
+			IL_09c8: stloc.s 21
+			IL_09ca: ldloc.s 21
+			IL_09cc: brfalse IL_0a26
+
+			IL_09d1: ldloc.s 15
+			IL_09d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09d8: stloc.s 30
+			IL_09da: ldstr "Input file not found: "
+			IL_09df: ldloc.s 30
+			IL_09e1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09e6: stloc.s 30
+			IL_09e8: ldloc.s 30
+			IL_09ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_09f4: stloc.s 20
+			IL_09f6: ldloc.0
+			IL_09f7: ldc.i4.m1
+			IL_09f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09fd: ldloc.0
+			IL_09fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a03: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0a08: ldarg.0
+			IL_0a09: ldc.i4.1
+			IL_0a0a: newarr [System.Runtime]System.Object
+			IL_0a0f: dup
+			IL_0a10: ldc.i4.0
+			IL_0a11: ldloc.s 20
+			IL_0a13: stelem.ref
+			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a19: pop
+			IL_0a1a: ldloc.0
+			IL_0a1b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a20: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a25: ret
+
+			IL_0a26: ldarg.0
+			IL_0a27: ldc.i4.1
+			IL_0a28: ldelem.ref
+			IL_0a29: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0a2e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+			IL_0a33: ldstr "readFileSync"
+			IL_0a38: ldloc.s 15
+			IL_0a3a: ldstr "utf8"
+			IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a44: stloc.s 20
+			IL_0a46: ldloc.s 20
+			IL_0a48: stloc.s 7
+
+			IL_0a4a: ldloc.1
+			IL_0a4b: ldstr "id"
+			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a55: stloc.s 20
+			IL_0a57: ldloc.s 20
+			IL_0a59: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0a5e: stloc.s 21
+			IL_0a60: ldloc.s 21
+			IL_0a62: brtrue IL_0a73
+
+			IL_0a67: ldstr ""
+			IL_0a6c: stloc.s 35
+			IL_0a6e: br IL_0a77
+
+			IL_0a73: ldloc.s 20
+			IL_0a75: stloc.s 35
+
+			IL_0a77: ldloc.s 35
+			IL_0a79: castclass [System.Runtime]System.String
+			IL_0a7e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0a83: stloc.s 30
+			IL_0a85: ldloc.s 30
+			IL_0a87: stloc.s 16
+			IL_0a89: ldloc.s 16
+			IL_0a8b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0a90: ldc.i4.0
+			IL_0a91: ceq
+			IL_0a93: stloc.s 21
+			IL_0a95: ldloc.s 21
+			IL_0a97: box [System.Runtime]System.Boolean
+			IL_0a9c: stloc.s 22
+			IL_0a9e: ldloc.s 22
+			IL_0aa0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0aa5: stloc.s 21
+			IL_0aa7: ldloc.s 21
+			IL_0aa9: brfalse IL_0ab7
+
+			IL_0aae: ldloc.s 9
+			IL_0ab0: stloc.s 36
+			IL_0ab2: br IL_0abb
+
+			IL_0ab7: ldloc.s 22
+			IL_0ab9: stloc.s 36
+
+			IL_0abb: ldloc.s 36
+			IL_0abd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0ac2: stloc.s 21
+			IL_0ac4: ldloc.s 21
+			IL_0ac6: brfalse IL_0ad3
+
+			IL_0acb: ldloc.s 9
+			IL_0acd: stloc.s 36
+			IL_0acf: ldloc.s 36
+			IL_0ad1: stloc.s 16
+
+			IL_0ad3: ldloc.s 16
+			IL_0ad5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0ada: ldc.i4.0
+			IL_0adb: ceq
+			IL_0add: stloc.s 21
+			IL_0adf: ldloc.s 21
+			IL_0ae1: brfalse IL_0b2b
+
+			IL_0ae6: ldloc.1
+			IL_0ae7: ldstr "section"
+			IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0af1: ldstr "trim"
+			IL_0af6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0afb: stloc.s 20
+			IL_0afd: ldc.i4.1
+			IL_0afe: newarr [System.Runtime]System.Object
+			IL_0b03: dup
+			IL_0b04: ldc.i4.0
+			IL_0b05: ldarg.0
+			IL_0b06: ldc.i4.1
+			IL_0b07: ldelem.ref
+			IL_0b08: stelem.ref
+			IL_0b09: ldc.i4.0
+			IL_0b0a: ldelem.ref
+			IL_0b0b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0b10: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionIdFromHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0b16: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0b1b: ldnull
+			IL_0b1c: ldloc.s 7
+			IL_0b1e: ldloc.s 20
+			IL_0b20: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0b25: stloc.s 20
+			IL_0b27: ldloc.s 20
+			IL_0b29: stloc.s 16
+
+			IL_0b2b: ldloc.s 16
+			IL_0b2d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0b32: ldc.i4.0
+			IL_0b33: ceq
+			IL_0b35: stloc.s 21
+			IL_0b37: ldloc.s 21
+			IL_0b39: brfalse IL_0baa
+
+			IL_0b3e: ldloc.1
+			IL_0b3f: ldstr "section"
+			IL_0b44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b49: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b4e: stloc.s 30
+			IL_0b50: ldstr "Could not infer an element id for section '"
+			IL_0b55: ldloc.s 30
+			IL_0b57: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b5c: stloc.s 30
+			IL_0b5e: ldloc.s 30
+			IL_0b60: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0b65: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b6a: stloc.s 30
+			IL_0b6c: ldloc.s 30
+			IL_0b6e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b73: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0b78: stloc.s 20
+			IL_0b7a: ldloc.0
+			IL_0b7b: ldc.i4.m1
+			IL_0b7c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b81: ldloc.0
+			IL_0b82: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b87: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0b8c: ldarg.0
+			IL_0b8d: ldc.i4.1
+			IL_0b8e: newarr [System.Runtime]System.Object
+			IL_0b93: dup
+			IL_0b94: ldc.i4.0
+			IL_0b95: ldloc.s 20
+			IL_0b97: stelem.ref
+			IL_0b98: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0b9d: pop
+			IL_0b9e: ldloc.0
+			IL_0b9f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0ba9: ret
+
+			IL_0baa: ldc.i4.1
+			IL_0bab: newarr [System.Runtime]System.Object
+			IL_0bb0: dup
+			IL_0bb1: ldc.i4.0
+			IL_0bb2: ldarg.0
+			IL_0bb3: ldc.i4.1
+			IL_0bb4: ldelem.ref
+			IL_0bb5: stelem.ref
+			IL_0bb6: ldc.i4.0
+			IL_0bb7: ldelem.ref
+			IL_0bb8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0bbd: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0bc3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0bc8: ldnull
+			IL_0bc9: ldloc.s 7
+			IL_0bcb: ldloc.s 16
+			IL_0bcd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0bd2: stloc.s 20
+			IL_0bd4: ldloc.s 20
+			IL_0bd6: stloc.s 17
+			IL_0bd8: ldloc.s 17
+			IL_0bda: ldstr "html"
+			IL_0bdf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0be4: stloc.s 18
+			IL_0be6: ldloc.1
+			IL_0be7: ldstr "wrap"
+			IL_0bec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bf1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0bf6: stloc.s 21
+			IL_0bf8: ldloc.s 21
+			IL_0bfa: brfalse IL_0c9a
+
+			IL_0bff: ldloc.1
+			IL_0c00: ldstr "baseHref"
+			IL_0c05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c0a: stloc.s 20
+			IL_0c0c: ldloc.s 20
+			IL_0c0e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0c13: stloc.s 21
+			IL_0c15: ldloc.s 21
+			IL_0c17: brtrue IL_0c25
+
+			IL_0c1c: ldloc.s 8
+			IL_0c1e: stloc.s 37
+			IL_0c20: br IL_0c29
+
+			IL_0c25: ldloc.s 20
+			IL_0c27: stloc.s 37
+
+			IL_0c29: ldloc.s 37
+			IL_0c2b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0c30: stloc.s 21
+			IL_0c32: ldloc.s 21
+			IL_0c34: brtrue IL_0c45
+
+			IL_0c39: ldstr ""
+			IL_0c3e: stloc.s 37
+			IL_0c40: br IL_0c45
+
+			IL_0c45: ldloc.s 37
+			IL_0c47: stloc.s 19
+			IL_0c49: ldloc.1
+			IL_0c4a: ldstr "section"
+			IL_0c4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c54: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0c59: stloc.s 30
+			IL_0c5b: ldstr "ECMA-262 "
+			IL_0c60: ldloc.s 30
+			IL_0c62: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c67: stloc.s 30
+			IL_0c69: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0c6e: dup
+			IL_0c6f: ldstr "title"
+			IL_0c74: ldloc.s 30
+			IL_0c76: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0c7b: dup
+			IL_0c7c: ldstr "baseHref"
+			IL_0c81: ldloc.s 19
+			IL_0c83: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0c88: stloc.s 39
+			IL_0c8a: ldnull
+			IL_0c8b: ldloc.s 18
+			IL_0c8d: ldloc.s 39
+			IL_0c8f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/wrapAsStandaloneHtml::__js_call__(object, object, object)
+			IL_0c94: stloc.s 20
+			IL_0c96: ldloc.s 20
+			IL_0c98: stloc.s 18
+
+			IL_0c9a: ldc.i4.1
+			IL_0c9b: newarr [System.Runtime]System.Object
+			IL_0ca0: dup
+			IL_0ca1: ldc.i4.0
+			IL_0ca2: ldarg.0
+			IL_0ca3: ldc.i4.1
+			IL_0ca4: ldelem.ref
+			IL_0ca5: stelem.ref
+			IL_0ca6: ldc.i4.0
+			IL_0ca7: ldelem.ref
+			IL_0ca8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+			IL_0cad: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/writeTextPreserveEol::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+			IL_0cb3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0cb8: ldnull
+			IL_0cb9: ldloc.s 6
+			IL_0cbb: ldloc.s 18
+			IL_0cbd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0cc2: pop
+			IL_0cc3: ldc.i4.1
+			IL_0cc4: newarr [System.Runtime]System.Object
+			IL_0cc9: dup
+			IL_0cca: ldc.i4.0
+			IL_0ccb: ldarg.0
+			IL_0ccc: ldc.i4.1
+			IL_0ccd: ldelem.ref
+			IL_0cce: stelem.ref
+			IL_0ccf: stloc.s 33
+			IL_0cd1: ldloc.1
+			IL_0cd2: ldstr "section"
+			IL_0cd7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0cdc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ce1: stloc.s 30
+			IL_0ce3: ldstr "Extracted section "
+			IL_0ce8: ldloc.s 30
+			IL_0cea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0cef: stloc.s 30
+			IL_0cf1: ldloc.s 30
+			IL_0cf3: ldstr " (id="
+			IL_0cf8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0cfd: stloc.s 30
+			IL_0cff: ldloc.s 16
+			IL_0d01: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0d06: stloc.s 29
+			IL_0d08: ldloc.s 30
+			IL_0d0a: ldloc.s 29
+			IL_0d0c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d11: stloc.s 29
+			IL_0d13: ldloc.s 29
+			IL_0d15: ldstr ", tag="
+			IL_0d1a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d1f: stloc.s 29
+			IL_0d21: ldloc.s 17
+			IL_0d23: ldstr "tagName"
+			IL_0d28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0d32: stloc.s 30
+			IL_0d34: ldloc.s 29
+			IL_0d36: ldloc.s 30
+			IL_0d38: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d3d: stloc.s 30
+			IL_0d3f: ldloc.s 30
+			IL_0d41: ldstr ") -> "
+			IL_0d46: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d4b: stloc.s 30
+			IL_0d4d: ldloc.s 6
+			IL_0d4f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0d54: stloc.s 29
+			IL_0d56: ldloc.s 30
+			IL_0d58: ldloc.s 29
+			IL_0d5a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0d5f: stloc.s 29
+			IL_0d61: ldarg.3
+			IL_0d62: ldloc.s 33
+			IL_0d64: ldloc.s 29
+			IL_0d66: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+			IL_0d6b: pop
+			IL_0d6c: ldloc.0
+			IL_0d6d: ldc.i4.m1
+			IL_0d6e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0d73: ldloc.0
+			IL_0d74: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0d79: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0d7e: ldarg.0
+			IL_0d7f: ldc.i4.1
+			IL_0d80: newarr [System.Runtime]System.Object
+			IL_0d85: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0d8a: pop
+			IL_0d8b: ldloc.0
+			IL_0d8c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0d91: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0d96: ret
+		} // end of method main::__js_call__
+
+	} // end of class main
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L573C16
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 0f 53 63 6f 70 65 20 65 72 72 3d 7b 65 72
+				72 7d 00 00
+			)
+			// Fields
+			.field public object err
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5c4d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object err
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x542c
+			// Header size: 12
+			// Code size: 108 (0x6c)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[2] bool,
+				[3] object,
+				[4] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: stloc.1
+			IL_0006: ldarg.1
+			IL_0007: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_000c: stloc.2
+			IL_000d: ldloc.2
+			IL_000e: brfalse IL_0025
+
+			IL_0013: ldarg.1
+			IL_0014: ldstr "message"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001e: stloc.s 4
+			IL_0020: br IL_0028
+
+			IL_0025: ldarg.1
+			IL_0026: stloc.s 4
+
+			IL_0028: ldloc.s 4
+			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002f: stloc.2
+			IL_0030: ldloc.2
+			IL_0031: brfalse IL_0047
+
+			IL_0036: ldarg.1
+			IL_0037: ldstr "message"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0041: stloc.0
+			IL_0042: br IL_0049
+
+			IL_0047: ldarg.1
+			IL_0048: stloc.0
+
+			IL_0049: ldloc.1
+			IL_004a: ldloc.0
+			IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0050: pop
+			IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0056: ldstr "exitCode"
+			IL_005b: ldc.r8 1
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_0069: pop
+			IL_006a: ldnull
+			IL_006b: ret
+		} // end of method ArrowFunction_L573C16::__js_call__
+
+	} // end of class ArrowFunction_L573C16
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 80 d3 53 63 6f 70 65 20 66 73 3d 7b 66 73
+			7d 2c 20 68 74 74 70 3d 7b 68 74 74 70 7d 2c 20
+			70 61 74 68 3d 7b 70 61 74 68 7d 2c 20 68 74 74
+			70 73 3d 7b 68 74 74 70 73 7d 2c 20 70 61 72 73
+			65 41 72 67 73 3d 7b 70 61 72 73 65 41 72 67 73
+			7d 2c 20 66 65 74 63 68 54 65 78 74 57 69 74 68
+			48 74 74 70 3d 7b 66 65 74 63 68 54 65 78 74 57
+			69 74 68 48 74 74 70 7d 2c 20 66 65 74 63 68 54
+			65 78 74 57 69 74 68 48 74 74 70 73 3d 7b 66 65
+			74 63 68 54 65 78 74 57 69 74 68 48 74 74 70 73
+			7d 2c 20 66 65 74 63 68 54 65 78 74 57 69 74 68
+			54 72 61 6e 73 70 6f 72 74 3d 7b 66 65 74 63 68
+			54 65 78 74 57 69 74 68 54 72 61 6e 73 70 6f 72
+			74 7d 2c 20 e2 80 a6 00 00
+		)
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Block_L572C29
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5c44
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L572C29::.ctor
+
+		} // end of class Block_L572C29
+
+
+		// Fields
+		.field public object fs
+		.field public object http
+		.field public object path
+		.field public object https
+		.field public object parseArgs
+		.field public object fetchTextWithHttp
+		.field public object fetchTextWithHttps
+		.field public object fetchTextWithTransport
+		.field public object fetchText
+		.field public object fetchTextWithNodeRequest
+		.field public object detectEol
+		.field public object escapeRegExp
+		.field public object writeTextPreserveEol
+		.field public object findTagNameAt
+		.field public object extractElementById
+		.field public object resolveSectionLinkFromMultipageIndexHtml
+		.field public object resolveSectionIdFromHtml
+		.field public object wrapAsStandaloneHtml
+		.field public object printHelp
+		.field public object main
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x5962
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2108
+		// Header size: 12
+		// Code size: 704 (0x2c0)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[5] bool,
+			[6] object
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldloc.0
+		IL_000f: stelem.ref
+		IL_0010: ldc.i4.0
+		IL_0011: ldelem.ref
+		IL_0012: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_0017: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0022: stloc.3
+		IL_0023: ldloc.0
+		IL_0024: ldloc.3
+		IL_0025: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::parseArgs
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.0
+		IL_0033: stelem.ref
+		IL_0034: ldc.i4.0
+		IL_0035: ldelem.ref
+		IL_0036: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_003b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttp::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0046: stloc.3
+		IL_0047: ldloc.0
+		IL_0048: ldloc.3
+		IL_0049: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithHttp
+		IL_004e: ldc.i4.1
+		IL_004f: newarr [System.Runtime]System.Object
+		IL_0054: dup
+		IL_0055: ldc.i4.0
+		IL_0056: ldloc.0
+		IL_0057: stelem.ref
+		IL_0058: ldc.i4.0
+		IL_0059: ldelem.ref
+		IL_005a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_005f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithHttps::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_006a: stloc.3
+		IL_006b: ldloc.0
+		IL_006c: ldloc.3
+		IL_006d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithHttps
+		IL_0072: ldc.i4.1
+		IL_0073: newarr [System.Runtime]System.Object
+		IL_0078: dup
+		IL_0079: ldc.i4.0
+		IL_007a: ldloc.0
+		IL_007b: stelem.ref
+		IL_007c: ldc.i4.0
+		IL_007d: ldelem.ref
+		IL_007e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_0083: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithTransport::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object, object)
+		IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_008e: stloc.3
+		IL_008f: ldloc.0
+		IL_0090: ldloc.3
+		IL_0091: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithTransport
+		IL_0096: ldc.i4.1
+		IL_0097: newarr [System.Runtime]System.Object
+		IL_009c: dup
+		IL_009d: ldc.i4.0
+		IL_009e: ldloc.0
+		IL_009f: stelem.ref
+		IL_00a0: ldc.i4.0
+		IL_00a1: ldelem.ref
+		IL_00a2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_00a7: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object)
+		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00b2: stloc.3
+		IL_00b3: ldloc.3
+		IL_00b4: stloc.1
+		IL_00b5: ldc.i4.1
+		IL_00b6: newarr [System.Runtime]System.Object
+		IL_00bb: dup
+		IL_00bc: ldc.i4.0
+		IL_00bd: ldloc.0
+		IL_00be: stelem.ref
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldelem.ref
+		IL_00c1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_00c6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/fetchTextWithNodeRequest::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00d1: stloc.3
+		IL_00d2: ldloc.0
+		IL_00d3: ldloc.3
+		IL_00d4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fetchTextWithNodeRequest
+		IL_00d9: ldnull
+		IL_00da: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/detectEol::__js_call__(object, object)
+		IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00e5: stloc.3
+		IL_00e6: ldloc.0
+		IL_00e7: ldloc.3
+		IL_00e8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::detectEol
+		IL_00ed: ldnull
+		IL_00ee: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/escapeRegExp::__js_call__(object, object)
+		IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f9: stloc.3
+		IL_00fa: ldloc.0
+		IL_00fb: ldloc.3
+		IL_00fc: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::escapeRegExp
+		IL_0101: ldc.i4.1
+		IL_0102: newarr [System.Runtime]System.Object
+		IL_0107: dup
+		IL_0108: ldc.i4.0
+		IL_0109: ldloc.0
+		IL_010a: stelem.ref
+		IL_010b: ldc.i4.0
+		IL_010c: ldelem.ref
+		IL_010d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_0112: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/writeTextPreserveEol::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_011d: stloc.3
+		IL_011e: ldloc.0
+		IL_011f: ldloc.3
+		IL_0120: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::writeTextPreserveEol
+		IL_0125: ldc.i4.1
+		IL_0126: newarr [System.Runtime]System.Object
+		IL_012b: dup
+		IL_012c: ldc.i4.0
+		IL_012d: ldloc.0
+		IL_012e: stelem.ref
+		IL_012f: ldc.i4.0
+		IL_0130: ldelem.ref
+		IL_0131: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_0136: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_013c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0141: stloc.3
+		IL_0142: ldloc.0
+		IL_0143: ldloc.3
+		IL_0144: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::findTagNameAt
+		IL_0149: ldc.i4.1
+		IL_014a: newarr [System.Runtime]System.Object
+		IL_014f: dup
+		IL_0150: ldc.i4.0
+		IL_0151: ldloc.0
+		IL_0152: stelem.ref
+		IL_0153: ldc.i4.0
+		IL_0154: ldelem.ref
+		IL_0155: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_015a: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0165: stloc.3
+		IL_0166: ldloc.0
+		IL_0167: ldloc.3
+		IL_0168: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::extractElementById
+		IL_016d: ldc.i4.1
+		IL_016e: newarr [System.Runtime]System.Object
+		IL_0173: dup
+		IL_0174: ldc.i4.0
+		IL_0175: ldloc.0
+		IL_0176: stelem.ref
+		IL_0177: ldc.i4.0
+		IL_0178: ldelem.ref
+		IL_0179: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_017e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0189: stloc.3
+		IL_018a: ldloc.0
+		IL_018b: ldloc.3
+		IL_018c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::resolveSectionLinkFromMultipageIndexHtml
+		IL_0191: ldc.i4.1
+		IL_0192: newarr [System.Runtime]System.Object
+		IL_0197: dup
+		IL_0198: ldc.i4.0
+		IL_0199: ldloc.0
+		IL_019a: stelem.ref
+		IL_019b: ldc.i4.0
+		IL_019c: ldelem.ref
+		IL_019d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope
+		IL_01a2: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/resolveSectionIdFromHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope, object, object, object)
+		IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01ad: stloc.3
+		IL_01ae: ldloc.0
+		IL_01af: ldloc.3
+		IL_01b0: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::resolveSectionIdFromHtml
+		IL_01b5: ldnull
+		IL_01b6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/wrapAsStandaloneHtml::__js_call__(object, object, object)
+		IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01c1: stloc.3
+		IL_01c2: ldloc.0
+		IL_01c3: ldloc.3
+		IL_01c4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::wrapAsStandaloneHtml
+		IL_01c9: ldnull
+		IL_01ca: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/printHelp::__js_call__(object)
+		IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01d5: stloc.3
+		IL_01d6: ldloc.0
+		IL_01d7: ldloc.3
+		IL_01d8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::printHelp
+		IL_01dd: ldc.i4.1
+		IL_01de: newarr [System.Runtime]System.Object
+		IL_01e3: dup
+		IL_01e4: ldc.i4.0
+		IL_01e5: ldloc.0
+		IL_01e6: stelem.ref
+		IL_01e7: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
+		IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01f2: stloc.3
+		IL_01f3: ldloc.3
+		IL_01f4: stloc.2
+		IL_01f5: ldarg.1
+		IL_01f6: ldstr "fs"
+		IL_01fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0200: stloc.3
+		IL_0201: ldloc.0
+		IL_0202: ldloc.3
+		IL_0203: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::fs
+		IL_0208: ldarg.1
+		IL_0209: ldstr "http"
+		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0213: stloc.3
+		IL_0214: ldloc.0
+		IL_0215: ldloc.3
+		IL_0216: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::http
+		IL_021b: ldarg.1
+		IL_021c: ldstr "path"
+		IL_0221: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0226: stloc.3
+		IL_0227: ldloc.0
+		IL_0228: ldloc.3
+		IL_0229: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::path
+		IL_022e: ldarg.1
+		IL_022f: ldstr "https"
+		IL_0234: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0239: stloc.3
+		IL_023a: ldloc.0
+		IL_023b: ldloc.3
+		IL_023c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml/Scope::https
+		IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0246: dup
+		IL_0247: ldstr "main"
+		IL_024c: ldloc.2
+		IL_024d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0252: stloc.s 4
+		IL_0254: ldarg.2
+		IL_0255: ldstr "exports"
+		IL_025a: ldloc.s 4
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_0261: pop
+		IL_0262: ldarg.1
+		IL_0263: ldstr "main"
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026d: ldarg.2
+		IL_026e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0273: stloc.s 5
+		IL_0275: ldloc.s 5
+		IL_0277: brfalse IL_02bf
+
+		IL_027c: ldc.i4.1
+		IL_027d: newarr [System.Runtime]System.Object
+		IL_0282: dup
+		IL_0283: ldc.i4.0
+		IL_0284: ldloc.0
+		IL_0285: stelem.ref
+		IL_0286: ldnull
+		IL_0287: ldnull
+		IL_0288: ldnull
+		IL_0289: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml/main::__js_call__(object[], object, object, object)
+		IL_028e: stloc.3
+		IL_028f: ldnull
+		IL_0290: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml/ArrowFunction_L573C16::__js_call__(object, object)
+		IL_0296: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_029b: ldc.i4.1
+		IL_029c: newarr [System.Runtime]System.Object
+		IL_02a1: dup
+		IL_02a2: ldc.i4.0
+		IL_02a3: ldloc.0
+		IL_02a4: stelem.ref
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02af: stloc.s 6
+		IL_02b1: ldloc.3
+		IL_02b2: ldstr "catch"
+		IL_02b7: ldloc.s 6
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02be: pop
+
+		IL_02bf: ret
+	} // end of method Compile_Scripts_ExtractEcma262SectionHtml::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x5c56
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class interface public auto ansi abstract Js2IL.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.ICompileScriptsExtractEcma262SectionHtmlExports
+	implements [System.Runtime]System.IDisposable
+{
+	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
+		01 00 29 43 6f 6d 70 69 6c 65 5f 53 63 72 69 70
+		74 73 5f 45 78 74 72 61 63 74 45 63 6d 61 32 36
+		32 53 65 63 74 69 6f 6e 48 74 6d 6c 00 00
+	)
+	// Methods
+	.method public hidebysig newslot abstract virtual 
+		instance class [System.Runtime]System.Threading.Tasks.Task Main (
+			object arg1,
+			object arg2
+		) cil managed 
+	{
+	} // end of method ICompileScriptsExtractEcma262SectionHtmlExports::Main
+
+} // end of class Js2IL.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.ICompileScriptsExtractEcma262SectionHtmlExports
+

--- a/Js2IL.Tests/Js2IL.Tests.csproj
+++ b/Js2IL.Tests/Js2IL.Tests.csproj
@@ -44,6 +44,9 @@
     <EmbeddedResource Include="Integration\Resources\extractEcma262SectionHtml_autoMode.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.js</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Integration\Resources\extractEcma262SectionHtml_testHarness.js">
+      <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness.js</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Integration\Resources\turndown_index.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.node_modules.turndown.index.js</LogicalName>
     </EmbeddedResource>

--- a/Js2IL.Tests/Js2IL.Tests.csproj
+++ b/Js2IL.Tests/Js2IL.Tests.csproj
@@ -29,11 +29,20 @@
     <EmbeddedResource Include="..\scripts\bumpVersion.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_BumpVersion.js</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\scripts\ECMA262\extractEcma262SectionHtml.js">
+      <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_ExtractEcma262SectionHtml.js</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\scripts\ECMA262\convertEcmaExtractHtmlToMarkdown.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.js</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="..\scripts\decompileGeneratorTest.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_DecompileGeneratorTest.js</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Integration\Resources\extractEcma262SectionHtml_urlMode.js">
+      <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.js</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Integration\Resources\extractEcma262SectionHtml_autoMode.js">
+      <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.js</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="Integration\Resources\turndown_index.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.node_modules.turndown.index.js</LogicalName>

--- a/Js2IL.Tests/Node/Https/ExecutionTests.cs
+++ b/Js2IL.Tests/Node/Https/ExecutionTests.cs
@@ -25,5 +25,9 @@ namespace Js2IL.Tests.Node.Https
         [Fact]
         public Task Https_Request_Post_Basic()
             => ExecutionTest(nameof(Https_Request_Post_Basic));
+
+        [Fact]
+        public Task Https_Request_UrlObject_WithOptions()
+            => ExecutionTest(nameof(Https_Request_UrlObject_WithOptions));
     }
 }

--- a/Js2IL.Tests/Node/Https/GeneratorTests.cs
+++ b/Js2IL.Tests/Node/Https/GeneratorTests.cs
@@ -25,5 +25,9 @@ namespace Js2IL.Tests.Node.Https
         [Fact]
         public Task Https_Request_Post_Basic()
             => GenerateTest(nameof(Https_Request_Post_Basic));
+
+        [Fact]
+        public Task Https_Request_UrlObject_WithOptions()
+            => GenerateTest(nameof(Https_Request_UrlObject_WithOptions));
     }
 }

--- a/Js2IL.Tests/Node/Https/JavaScript/Https_Request_UrlObject_WithOptions.js
+++ b/Js2IL.Tests/Node/Https/JavaScript/Https_Request_UrlObject_WithOptions.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const https = require('node:https');
+const { URL: NodeUrl } = require('node:url');
+const { certPem, keyPem } = require('./Tls_TestCertificates');
+
+const server = https.createServer({ key: keyPem, cert: certPem }, (req, res) => {
+  console.log('req:' + req.method + ':' + req.url + ':' + req.headers['accept-encoding']);
+  res.statusCode = 200;
+  res.end('url-object-ok');
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  const target = new NodeUrl('https://127.0.0.1:' + address.port + '/spec?section=27.3');
+  const req = https.request(
+    target,
+    {
+      method: 'GET',
+      headers: {
+        'Accept-Encoding': 'identity',
+      },
+      rejectUnauthorized: false,
+    },
+    (res) => {
+      res.setEncoding('utf8');
+      console.log('status:' + res.statusCode);
+
+      let body = '';
+      res.on('data', (chunk) => {
+        body += chunk;
+      });
+      res.on('end', () => {
+        console.log('body:' + body);
+        server.close(() => {
+          console.log('closed');
+        });
+      });
+    }
+  );
+
+  req.end();
+});

--- a/Js2IL.Tests/Node/Https/Snapshots/ExecutionTests.Https_Request_UrlObject_WithOptions.verified.txt
+++ b/Js2IL.Tests/Node/Https/Snapshots/ExecutionTests.Https_Request_UrlObject_WithOptions.verified.txt
@@ -1,0 +1,4 @@
+﻿req:GET:/spec?section=27.3:identity
+status:200
+body:url-object-ok
+closed

--- a/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
+++ b/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
@@ -1,0 +1,900 @@
+﻿// IL code: Https_Request_UrlObject_WithOptions
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Https_Request_UrlObject_WithOptions
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L7C67
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 1a 53 63 6f 70 65 20 72 65 71 3d 7b 72 65
+				71 7d 2c 20 72 65 73 3d 7b 72 65 73 7d 00 00
+			)
+			// Fields
+			.field public object req
+			.field public object res
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2530
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object req,
+				object res
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x21fc
+			// Header size: 12
+			// Code size: 144 (0x90)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "req:"
+			IL_0005: ldarg.1
+			IL_0006: ldstr "method"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ldstr ":"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0021: stloc.0
+			IL_0022: ldloc.0
+			IL_0023: ldarg.1
+			IL_0024: ldstr "url"
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0033: stloc.0
+			IL_0034: ldloc.0
+			IL_0035: ldstr ":"
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_003f: stloc.0
+			IL_0040: ldloc.0
+			IL_0041: ldarg.1
+			IL_0042: ldstr "headers"
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004c: ldstr "accept-encoding"
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_005b: stloc.0
+			IL_005c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0061: ldloc.0
+			IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0067: pop
+			IL_0068: ldarg.2
+			IL_0069: ldstr "statusCode"
+			IL_006e: ldc.r8 200
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_007c: pop
+			IL_007d: ldarg.2
+			IL_007e: ldstr "end"
+			IL_0083: ldstr "url-object-ok"
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_008d: pop
+			IL_008e: ldnull
+			IL_008f: ret
+		} // end of method ArrowFunction_L7C67::__js_call__
+
+	} // end of class ArrowFunction_L7C67
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L13C31
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L25C5
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L30C22
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Scope
+					extends [System.Runtime]System.Object
+				{
+					.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+						01 00 13 53 63 6f 70 65 20 63 68 75 6e 6b 3d 7b
+						63 68 75 6e 6b 7d 00 00
+					)
+					// Fields
+					.field public object chunk
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x254b
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Scope::.ctor
+
+				} // end of class Scope
+
+
+				// Methods
+				.method public hidebysig static 
+					object __js_call__ (
+						object[] scopes,
+						object newTarget,
+						object chunk
+					) cil managed 
+				{
+					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+						01 00 02 00 00 00 00 00
+					)
+					// Method begins at RVA 0x2470
+					// Header size: 12
+					// Code size: 36 (0x24)
+					.maxstack 8
+					.locals init (
+						[0] object
+					)
+
+					IL_0000: ldarg.0
+					IL_0001: ldc.i4.2
+					IL_0002: ldelem.ref
+					IL_0003: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
+					IL_0008: ldfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
+					IL_000d: ldarg.2
+					IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0013: stloc.0
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
+					IL_001c: ldloc.0
+					IL_001d: stfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
+					IL_0022: ldnull
+					IL_0023: ret
+				} // end of method ArrowFunction_L30C22::__js_call__
+
+			} // end of class ArrowFunction_L30C22
+
+			.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L33C21
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L35C22
+					extends [System.Runtime]System.Object
+				{
+					// Nested Types
+					.class nested private auto ansi beforefieldinit Scope
+						extends [System.Runtime]System.Object
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x255d
+							// Header size: 1
+							// Code size: 8 (0x8)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+							IL_0006: nop
+							IL_0007: ret
+						} // end of method Scope::.ctor
+
+					} // end of class Scope
+
+
+					// Methods
+					.method public hidebysig static 
+						object __js_call__ (
+							object newTarget
+						) cil managed 
+					{
+						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+							01 00 00 00 00 00 00 00
+						)
+						// Method begins at RVA 0x2514
+						// Header size: 1
+						// Code size: 18 (0x12)
+						.maxstack 8
+
+						IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+						IL_0005: ldstr "closed"
+						IL_000a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+						IL_000f: pop
+						IL_0010: ldnull
+						IL_0011: ret
+					} // end of method ArrowFunction_L35C22::__js_call__
+
+				} // end of class ArrowFunction_L35C22
+
+				.class nested private auto ansi beforefieldinit Scope
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x2554
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Scope::.ctor
+
+				} // end of class Scope
+
+
+				// Methods
+				.method public hidebysig static 
+					object __js_call__ (
+						object[] scopes,
+						object newTarget
+					) cil managed 
+				{
+					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+						01 00 02 00 00 00 00 00
+					)
+					// Method begins at RVA 0x24a0
+					// Header size: 12
+					// Code size: 104 (0x68)
+					.maxstack 8
+					.locals init (
+						[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/Scope,
+						[1] object,
+						[2] object
+					)
+
+					IL_0000: newobj instance void Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/Scope::.ctor()
+					IL_0005: stloc.0
+					IL_0006: ldstr "body:"
+					IL_000b: ldarg.0
+					IL_000c: ldc.i4.2
+					IL_000d: ldelem.ref
+					IL_000e: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
+					IL_0013: ldfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_001d: stloc.1
+					IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+					IL_0023: ldloc.1
+					IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+					IL_0029: pop
+					IL_002a: ldnull
+					IL_002b: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/ArrowFunction_L35C22::__js_call__(object)
+					IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0036: ldc.i4.1
+					IL_0037: newarr [System.Runtime]System.Object
+					IL_003c: dup
+					IL_003d: ldc.i4.0
+					IL_003e: ldarg.0
+					IL_003f: ldc.i4.0
+					IL_0040: ldelem.ref
+					IL_0041: stelem.ref
+					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_004c: stloc.2
+					IL_004d: ldarg.0
+					IL_004e: ldc.i4.0
+					IL_004f: ldelem.ref
+					IL_0050: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
+					IL_0055: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+					IL_005a: ldstr "close"
+					IL_005f: ldloc.2
+					IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0065: pop
+					IL_0066: ldnull
+					IL_0067: ret
+				} // end of method ArrowFunction_L33C21::__js_call__
+
+			} // end of class ArrowFunction_L33C21
+
+			.class nested private auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+					01 00 1c 53 63 6f 70 65 20 72 65 73 3d 7b 72 65
+					73 7d 2c 20 62 6f 64 79 3d 7b 62 6f 64 79 7d 00 00
+				)
+				// Fields
+				.field public object res
+				.field public object body
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2542
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget,
+					object res
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x23a0
+				// Header size: 12
+				// Code size: 196 (0xc4)
+				.maxstack 8
+				.locals init (
+					[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope,
+					[1] object,
+					[2] object
+				)
+
+				IL_0000: newobj instance void Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::.ctor()
+				IL_0005: stloc.0
+				IL_0006: ldarg.2
+				IL_0007: ldstr "setEncoding"
+				IL_000c: ldstr "utf8"
+				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0016: pop
+				IL_0017: ldstr "status:"
+				IL_001c: ldarg.2
+				IL_001d: ldstr "statusCode"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_002c: stloc.1
+				IL_002d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0032: ldloc.1
+				IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0038: pop
+				IL_0039: ldloc.0
+				IL_003a: ldstr ""
+				IL_003f: stfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
+				IL_0044: ldnull
+				IL_0045: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L30C22::__js_call__(object[], object, object)
+				IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0050: ldc.i4.3
+				IL_0051: newarr [System.Runtime]System.Object
+				IL_0056: dup
+				IL_0057: ldc.i4.0
+				IL_0058: ldarg.0
+				IL_0059: ldc.i4.0
+				IL_005a: ldelem.ref
+				IL_005b: stelem.ref
+				IL_005c: dup
+				IL_005d: ldc.i4.1
+				IL_005e: ldarg.0
+				IL_005f: ldc.i4.1
+				IL_0060: ldelem.ref
+				IL_0061: stelem.ref
+				IL_0062: dup
+				IL_0063: ldc.i4.2
+				IL_0064: ldloc.0
+				IL_0065: stelem.ref
+				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0070: stloc.2
+				IL_0071: ldarg.2
+				IL_0072: ldstr "on"
+				IL_0077: ldstr "data"
+				IL_007c: ldloc.2
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0082: pop
+				IL_0083: ldnull
+				IL_0084: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21::__js_call__(object[], object)
+				IL_008a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+				IL_008f: ldc.i4.3
+				IL_0090: newarr [System.Runtime]System.Object
+				IL_0095: dup
+				IL_0096: ldc.i4.0
+				IL_0097: ldarg.0
+				IL_0098: ldc.i4.0
+				IL_0099: ldelem.ref
+				IL_009a: stelem.ref
+				IL_009b: dup
+				IL_009c: ldc.i4.1
+				IL_009d: ldarg.0
+				IL_009e: ldc.i4.1
+				IL_009f: ldelem.ref
+				IL_00a0: stelem.ref
+				IL_00a1: dup
+				IL_00a2: ldc.i4.2
+				IL_00a3: ldloc.0
+				IL_00a4: stelem.ref
+				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_00af: stloc.2
+				IL_00b0: ldarg.2
+				IL_00b1: ldstr "on"
+				IL_00b6: ldstr "end"
+				IL_00bb: ldloc.2
+				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00c1: pop
+				IL_00c2: ldnull
+				IL_00c3: ret
+			} // end of method ArrowFunction_L25C5::__js_call__
+
+		} // end of class ArrowFunction_L25C5
+
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2539
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Https_Request_UrlObject_WithOptions/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0a 00 00 02
+			)
+			// Method begins at RVA 0x2298
+			// Header size: 12
+			// Code size: 252 (0xfc)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/Scope,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] object[],
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[8] object
+			)
+
+			IL_0000: newobj instance void Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldarg.0
+			IL_0007: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0016: stloc.s 4
+			IL_0018: ldloc.s 4
+			IL_001a: stloc.1
+			IL_001b: ldarg.0
+			IL_001c: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::NodeUrl
+			IL_0021: stloc.s 4
+			IL_0023: ldstr "https://127.0.0.1:"
+			IL_0028: ldloc.1
+			IL_0029: ldstr "port"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0038: stloc.s 5
+			IL_003a: ldloc.s 5
+			IL_003c: ldstr "/spec?section=27.3"
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0046: stloc.s 5
+			IL_0048: ldc.i4.1
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: dup
+			IL_004f: ldc.i4.0
+			IL_0050: ldloc.s 5
+			IL_0052: stelem.ref
+			IL_0053: stloc.s 6
+			IL_0055: ldloc.s 4
+			IL_0057: ldloc.s 6
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_005e: stloc.s 4
+			IL_0060: ldloc.s 4
+			IL_0062: stloc.2
+			IL_0063: ldarg.0
+			IL_0064: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
+			IL_0069: stloc.s 4
+			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0070: dup
+			IL_0071: ldstr "Accept-Encoding"
+			IL_0076: ldstr "identity"
+			IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0080: stloc.s 7
+			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0087: dup
+			IL_0088: ldstr "method"
+			IL_008d: ldstr "GET"
+			IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0097: dup
+			IL_0098: ldstr "headers"
+			IL_009d: ldloc.s 7
+			IL_009f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a4: dup
+			IL_00a5: ldstr "rejectUnauthorized"
+			IL_00aa: ldc.i4.0
+			IL_00ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00b0: stloc.s 7
+			IL_00b2: ldnull
+			IL_00b3: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5::__js_call__(object[], object, object)
+			IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00be: ldc.i4.2
+			IL_00bf: newarr [System.Runtime]System.Object
+			IL_00c4: dup
+			IL_00c5: ldc.i4.0
+			IL_00c6: ldarg.0
+			IL_00c7: stelem.ref
+			IL_00c8: dup
+			IL_00c9: ldc.i4.1
+			IL_00ca: ldloc.0
+			IL_00cb: stelem.ref
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00d6: stloc.s 8
+			IL_00d8: ldloc.s 4
+			IL_00da: ldstr "request"
+			IL_00df: ldloc.2
+			IL_00e0: ldloc.s 7
+			IL_00e2: ldloc.s 8
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00e9: stloc.s 8
+			IL_00eb: ldloc.s 8
+			IL_00ed: stloc.3
+			IL_00ee: ldloc.3
+			IL_00ef: ldstr "end"
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00f9: pop
+			IL_00fa: ldnull
+			IL_00fb: ret
+		} // end of method ArrowFunction_L13C31::__js_call__
+
+	} // end of class ArrowFunction_L13C31
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 37 53 63 6f 70 65 20 68 74 74 70 73 3d 7b
+			68 74 74 70 73 7d 2c 20 4e 6f 64 65 55 72 6c 3d
+			7b 4e 6f 64 65 55 72 6c 7d 2c 20 73 65 72 76 65
+			72 3d 7b 73 65 72 76 65 72 7d 00 00
+		)
+		// Fields
+		.field public object https
+		.field public object NodeUrl
+		.field public object server
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2527
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 346 (0x15a)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Https_Request_UrlObject_WithOptions/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[5] object
+		)
+
+		IL_0000: newobj instance void Modules.Https_Request_UrlObject_WithOptions/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.1
+		IL_0007: ldstr "node:https"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.3
+		IL_0012: ldloc.0
+		IL_0013: ldloc.3
+		IL_0014: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
+		IL_0019: ldarg.1
+		IL_001a: ldstr "node:url"
+		IL_001f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0024: stloc.3
+		IL_0025: ldloc.3
+		IL_0026: brfalse IL_0036
+
+		IL_002b: ldloc.3
+		IL_002c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0031: brfalse IL_0046
+
+		IL_0036: ldloc.3
+		IL_0037: ldstr ""
+		IL_003c: ldstr "URL"
+		IL_0041: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+
+		IL_0046: ldloc.3
+		IL_0047: ldstr "URL"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0051: stloc.3
+		IL_0052: ldloc.0
+		IL_0053: ldloc.3
+		IL_0054: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::NodeUrl
+		IL_0059: ldarg.1
+		IL_005a: ldstr "./Tls_TestCertificates"
+		IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0064: stloc.3
+		IL_0065: ldloc.3
+		IL_0066: brfalse IL_0076
+
+		IL_006b: ldloc.3
+		IL_006c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0071: brfalse IL_0086
+
+		IL_0076: ldloc.3
+		IL_0077: ldstr ""
+		IL_007c: ldstr "certPem"
+		IL_0081: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+
+		IL_0086: ldloc.3
+		IL_0087: ldstr "certPem"
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0091: stloc.1
+		IL_0092: ldloc.3
+		IL_0093: ldstr "keyPem"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009d: stloc.2
+		IL_009e: ldloc.0
+		IL_009f: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
+		IL_00a4: stloc.3
+		IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00aa: dup
+		IL_00ab: ldstr "key"
+		IL_00b0: ldloc.2
+		IL_00b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00b6: dup
+		IL_00b7: ldstr "cert"
+		IL_00bc: ldloc.1
+		IL_00bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00c2: stloc.s 4
+		IL_00c4: ldnull
+		IL_00c5: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L7C67::__js_call__(object, object, object)
+		IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00d0: ldc.i4.1
+		IL_00d1: newarr [System.Runtime]System.Object
+		IL_00d6: dup
+		IL_00d7: ldc.i4.0
+		IL_00d8: ldloc.0
+		IL_00d9: stelem.ref
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00e4: stloc.s 5
+		IL_00e6: ldloc.3
+		IL_00e7: ldstr "createServer"
+		IL_00ec: ldloc.s 4
+		IL_00ee: ldloc.s 5
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00f5: stloc.s 5
+		IL_00f7: ldloc.0
+		IL_00f8: ldloc.s 5
+		IL_00fa: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+		IL_00ff: ldloc.0
+		IL_0100: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+		IL_0105: stloc.s 5
+		IL_0107: ldc.i4.1
+		IL_0108: newarr [System.Runtime]System.Object
+		IL_010d: dup
+		IL_010e: ldc.i4.0
+		IL_010f: ldloc.0
+		IL_0110: stelem.ref
+		IL_0111: ldc.i4.0
+		IL_0112: ldelem.ref
+		IL_0113: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
+		IL_0118: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31::__js_call__(class Modules.Https_Request_UrlObject_WithOptions/Scope, object)
+		IL_011e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0123: ldc.i4.1
+		IL_0124: newarr [System.Runtime]System.Object
+		IL_0129: dup
+		IL_012a: ldc.i4.0
+		IL_012b: ldloc.0
+		IL_012c: stelem.ref
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0137: stloc.3
+		IL_0138: ldloc.s 5
+		IL_013a: ldstr "listen"
+		IL_013f: ldc.r8 0.0
+		IL_0148: box [System.Runtime]System.Double
+		IL_014d: ldstr "127.0.0.1"
+		IL_0152: ldloc.3
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0158: pop
+		IL_0159: ret
+	} // end of method Https_Request_UrlObject_WithOptions::__js_module_init__
+
+} // end of class Modules.Https_Request_UrlObject_WithOptions
+
+.class private auto ansi beforefieldinit Modules.Tls_TestCertificates
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2566
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x21b8
+		// Header size: 12
+		// Code size: 56 (0x38)
+		.maxstack 8
+		.locals (
+			[0] class Modules.Tls_TestCertificates/Scope
+		)
+
+		IL_0000: newobj instance void Modules.Tls_TestCertificates/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.2
+		IL_0007: ldstr "exports"
+		IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0011: dup
+		IL_0012: ldstr "certPem"
+		IL_0017: ldstr "-----BEGIN CERTIFICATE-----\nMIIC+TCCAeGgAwIBAgIIaUAevC7krmQwDQYJKoZIhvcNAQELBQAwFjEUMBIGA1UE\nAxMLanMyaWwtbG9jYWwwHhcNMjYwMzE0MjAwODM0WhcNMjcwMzE1MjAwODM0WjAW\nMRQwEgYDVQQDEwtqczJpbC1sb2NhbDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC\nAQoCggEBANP5G6yPJfJHP9xJsjN4DzzfGc3OahHJ9HkJuoicHjTd0m5l9kLBs1dE\nnES1ZZAnHC3StoD5iABtyS4yYtiL5Gv7UvgqR/9YL5XvyyYj8p9h51rVQn4xaU8p\nM7ngRaBciAqwpH8+JbnCA0RA9RC5rpEJtcUGNGPGwwQ7xuBUdQrWEFTnQ/PCrvpg\nP9wlJqQF+5pGorCV3rH5P5dOYR4AVO68ulqXcjwbM3OCAInONzth8xNjWNKFWwou\nR77IBF7/oboZFGJhKPqhWP9I974M69lGA1HrUMX9AmU+tVmgjo63XvzhWIhhmCZy\nWmP9FPfUipGpBQXSCTDILxXY+6jFu1UCAwEAAaNLMEkwGgYDVR0RBBMwEYIJbG9j\nYWxob3N0hwR/AAABMAkGA1UdEwQCMAAwCwYDVR0PBAQDAgeAMBMGA1UdJQQMMAoG\nCCsGAQUFBwMBMA0GCSqGSIb3DQEBCwUAA4IBAQC2gZkmvzdlk0JLBjRr8qtbtrMy\nd/CnwDprOe9k+BeHIdlGzzpm7vvr63DacVo7znnH7Lp/O1FYiqJRhBWdm4weZj7c\nlHy9KNC/Eyv7ieGMPb4R0BGOvEmA8kp55ohaWsySGd2MQohNzYVDVntJ8xBvt2+Y\n5eHfYDfoBYG1lJTbTv0E3UWEpR8itnTsDEtA/FBvn/Do1TvYvyB7uUPFcCt4BWom\nTJdsb+Cl9CRe8yStfbsgjkzAdgJh74xYtmk+rSbYx8DLlp++Xfdgfj7eAKZ0Rm83\ng0+a+SMF6xucjCIRjG0R9AEgL7K2vppinB2/MusGrmD0HFUhAta7miSlnymn\n-----END CERTIFICATE-----"
+		IL_001c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0021: dup
+		IL_0022: ldstr "keyPem"
+		IL_0027: ldstr "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDT+RusjyXyRz/c\nSbIzeA883xnNzmoRyfR5CbqInB403dJuZfZCwbNXRJxEtWWQJxwt0raA+YgAbcku\nMmLYi+Rr+1L4Kkf/WC+V78smI/KfYeda1UJ+MWlPKTO54EWgXIgKsKR/PiW5wgNE\nQPUQua6RCbXFBjRjxsMEO8bgVHUK1hBU50Pzwq76YD/cJSakBfuaRqKwld6x+T+X\nTmEeAFTuvLpal3I8GzNzggCJzjc7YfMTY1jShVsKLke+yARe/6G6GRRiYSj6oVj/\nSPe+DOvZRgNR61DF/QJlPrVZoI6Ot1784ViIYZgmclpj/RT31IqRqQUF0gkwyC8V\n2PuoxbtVAgMBAAECggEAYNaJIggzmb+bGRRB6OmMbI6vxynpoz7UBQfAw/AujJBa\nNj02h8DeIZwil/EW+QglA3okDj/xNeDx67zxE2S1ce9bNCx8v9aVxrXJ5R6/FLkx\nbHnI6sXACn4UN3KR3HTpYZjZTZgiu/46Z9AVJRLvASuicuQmwv5m0WRNsuZiohPc\nel2rXFnX7RLY8Few3FrqZhLV+nDGSBWSnd3TGLOi4rxcRL+V+2AITP5Aj88+FWne\ni/MS50lrNtwIsOSx0Af8gNc4KNNgwlSFfVs+BsUj45pmsgzdYC0pVs6mVdH954U0\nELEoWLSeWYS/fyo6tVmdKtz8jhQsCid2N6jJDxpQcQKBgQDs4nc3wjOUjVCi/Oka\nUqn8v2o9gTdUwjb5aIruUU5Mw6PGjP47mxhxSWUpOt8o4c5spkccTVv8wodSIoLz\nbAQjCYKuVq2yzJR3jwhnJVRaYtn/Zv1Iwwok6UwOKt23FX8f31NUB2k9HmoudZGE\n59pMo7D5wlqNK2cCM7t4pG5ptwKBgQDlFAXEoFQAENRS703Snnx2sHly/dsYaeUA\nAWh/bsEMzKxEiz+U3RYETUjPqel/yp0IlRzLHwhO2j9MPEmxyzC+DvyVuPiR3mIu\naRkIbBhGsPSqcSzmJJTdp8tp9SDdV+FyMlbF3U570ARmloqIk2l6h+09wNgWFHeB\ngYD/nWYzUwKBgQCMR4hGEtEs1Yq9GnyIRA+6RziI965mmSSpCgnMG4X825ZvDCu5\n7JzK6aXohp6EvUPa/5T4467nveMY9qsJsBu7C/TBfT8btR7utltJicesRwHFx52S\nqz2koiuR8DygITDJFR1pk4H02cAThzgHtq2F2SICpd+t3dgAa9ZHGUjxfQKBgQCO\nP7i1OLnwsIKoXWF+AFxZd4xzE6ARsPA66KTzPNs0D4SJq853qjIZycQE8AXHDRIm\nWjHfEA4gqPXVaTp55SsHWlcOwiXYrrdZCno4+Ka6fvfvPwgagWzPl3qA+W7HA+NC\n/m9TvvEVgT66VZEA7kj5hZ6UUkPcsijjin+IOz1TcQKBgHGpSDuMjSskmvnVFMtc\nD2IODSKFhbXGhvNrQk8eyTUWSOA6xmtjv1qC8m2QSL+FTIHRn5lWlH3kntL8BO1S\nKdvFqYmZ/n0gIBGimF2WI8DAVUuAxDGQgnjqWotBaiCE6cEvwy7c3JS1156zMWic\nnodqo8mDXzbUbIenGwelECRH\n-----END PRIVATE KEY-----"
+		IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_0036: pop
+		IL_0037: ret
+	} // end of method Tls_TestCertificates::__js_module_init__
+
+} // end of class Modules.Tls_TestCertificates
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x256f
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Https_Request_UrlObject_WithOptions::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class interface public auto ansi abstract Js2IL.Https_Request_UrlObject_WithOptions.ITlsTestCertificatesExports
+	implements [System.Runtime]System.IDisposable
+{
+	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
+		01 00 14 54 6c 73 5f 54 65 73 74 43 65 72 74 69
+		66 69 63 61 74 65 73 00 00
+	)
+	// Methods
+	.method public hidebysig specialname newslot abstract virtual 
+		instance object get_CertPem () cil managed 
+	{
+	} // end of method ITlsTestCertificatesExports::get_CertPem
+
+	.method public hidebysig specialname newslot abstract virtual 
+		instance object get_KeyPem () cil managed 
+	{
+	} // end of method ITlsTestCertificatesExports::get_KeyPem
+
+	// Properties
+	.property instance object CertPem()
+	{
+		.get instance object Js2IL.Https_Request_UrlObject_WithOptions.ITlsTestCertificatesExports::get_CertPem()
+	}
+	.property instance object KeyPem()
+	{
+		.get instance object Js2IL.Https_Request_UrlObject_WithOptions.ITlsTestCertificatesExports::get_KeyPem()
+	}
+
+} // end of class Js2IL.Https_Request_UrlObject_WithOptions.ITlsTestCertificatesExports
+

--- a/docs/nodejs/https.json
+++ b/docs/nodejs/https.json
@@ -38,7 +38,7 @@
       "name": "request(...)",
       "kind": "function",
       "status": "partial",
-      "notes": "Issues HTTPS client requests on port 443 by default, preserving the existing node:http ClientRequest/IncomingMessage object model. The current baseline supports object or https:// URL inputs plus rejectUnauthorized: false for local self-signed test scenarios; custom CA trust, secureContext on the client side, and https.Agent pooling are not yet implemented.",
+      "notes": "Issues HTTPS client requests on port 443 by default, preserving the existing node:http ClientRequest/IncomingMessage object model. The current baseline supports object or https:// / WHATWG URL inputs, including URL-plus-options call shapes where second-argument overrides still control headers, path, and rejectUnauthorized: false for local self-signed test scenarios; custom CA trust, secureContext on the client side, and https.Agent pooling are not yet implemented.",
       "docs": "https://nodejs.org/api/https.html#httpsrequestoptions-callback",
       "tests": [
         {
@@ -47,6 +47,14 @@
         },
         {
           "name": "Js2IL.Tests.Node.Https.GeneratorTests.Https_Request_Post_Basic",
+          "file": "Js2IL.Tests/Node/Https/GeneratorTests.cs"
+        },
+        {
+          "name": "Js2IL.Tests.Node.Https.ExecutionTests.Https_Request_UrlObject_WithOptions",
+          "file": "Js2IL.Tests/Node/Https/ExecutionTests.cs"
+        },
+        {
+          "name": "Js2IL.Tests.Node.Https.GeneratorTests.Https_Request_UrlObject_WithOptions",
           "file": "Js2IL.Tests/Node/Https/GeneratorTests.cs"
         }
       ]

--- a/docs/nodejs/https.md
+++ b/docs/nodejs/https.md
@@ -40,11 +40,13 @@ Creates an HTTPS server that reuses the node:http request/response lifecycle ove
 
 ### request(...)
 
-Issues HTTPS client requests on port 443 by default, preserving the existing node:http ClientRequest/IncomingMessage object model. The current baseline supports object or https:// URL inputs plus rejectUnauthorized: false for local self-signed test scenarios; custom CA trust, secureContext on the client side, and https.Agent pooling are not yet implemented.
+Issues HTTPS client requests on port 443 by default, preserving the existing node:http ClientRequest/IncomingMessage object model. The current baseline supports object or https:// / WHATWG URL inputs, including URL-plus-options call shapes where second-argument overrides still control headers, path, and rejectUnauthorized: false for local self-signed test scenarios; custom CA trust, secureContext on the client side, and https.Agent pooling are not yet implemented.
 
 **Tests:**
 - `Js2IL.Tests.Node.Https.ExecutionTests.Https_Request_Post_Basic` (`Js2IL.Tests/Node/Https/ExecutionTests.cs`)
 - `Js2IL.Tests.Node.Https.GeneratorTests.Https_Request_Post_Basic` (`Js2IL.Tests/Node/Https/GeneratorTests.cs`)
+- `Js2IL.Tests.Node.Https.ExecutionTests.Https_Request_UrlObject_WithOptions` (`Js2IL.Tests/Node/Https/ExecutionTests.cs`)
+- `Js2IL.Tests.Node.Https.GeneratorTests.Https_Request_UrlObject_WithOptions` (`Js2IL.Tests/Node/Https/GeneratorTests.cs`)
 
 ### get(...)
 

--- a/scripts/ECMA262/extractEcma262SectionHtml.js
+++ b/scripts/ECMA262/extractEcma262SectionHtml.js
@@ -26,6 +26,7 @@
 'use strict';
 
 const fs = require('fs');
+const http = require('http');
 const path = require('path');
 const https = require('https');
 
@@ -157,7 +158,15 @@ function parseArgs(argv) {
   return args;
 }
 
+function fetchTextWithHttp(urlString, maxRedirects = 5) {
+  return fetchTextWithTransport('http', urlString, maxRedirects);
+}
+
 function fetchTextWithHttps(urlString, maxRedirects = 5) {
+  return fetchTextWithTransport('https', urlString, maxRedirects);
+}
+
+function fetchTextWithTransport(protocol, urlString, maxRedirects = 5) {
   return new Promise((resolve, reject) => {
     let urlObj;
     try {
@@ -167,12 +176,12 @@ function fetchTextWithHttps(urlString, maxRedirects = 5) {
       return;
     }
 
-    if (urlObj.protocol !== 'https:') {
-      reject(new Error(`Only https:// URLs are supported by the https fallback. Got: ${urlString}`));
+    if (urlObj.protocol !== protocol + ':') {
+      reject(new Error(`Only ${protocol}:// URLs are supported by the ${protocol} fallback. Got: ${urlString}`));
       return;
     }
 
-    const req = https.request(
+    const req = (protocol === 'http' ? http : https).request(
       urlObj,
       {
         method: 'GET',
@@ -195,7 +204,7 @@ function fetchTextWithHttps(urlString, maxRedirects = 5) {
 
           const nextUrl = new URL(location, urlObj).toString();
           res.resume();
-          fetchTextWithHttps(nextUrl, maxRedirects - 1).then(resolve, reject);
+          fetchTextWithNodeRequest(nextUrl, maxRedirects - 1).then(resolve, reject);
           return;
         }
 
@@ -219,24 +228,27 @@ function fetchTextWithHttps(urlString, maxRedirects = 5) {
   });
 }
 
-async function fetchText(urlString) {
-  // Prefer the built-in fetch (Node 18+). Fall back to https for older Node.
-  if (typeof fetch === 'function') {
-    const res = await fetch(urlString, {
-      redirect: 'follow',
-      headers: {
-        'User-Agent': 'js2il-docs-script',
-      },
-    });
+function fetchText(urlString) {
+  return fetchTextWithNodeRequest(urlString);
+}
 
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status} fetching ${urlString}`);
-    }
-
-    return await res.text();
+function fetchTextWithNodeRequest(urlString, maxRedirects = 5) {
+  let urlObj;
+  try {
+    urlObj = new URL(urlString);
+  } catch {
+    return Promise.reject(new Error(`Invalid URL: ${urlString}`));
   }
 
-  return await fetchTextWithHttps(urlString);
+  if (urlObj.protocol === 'http:') {
+    return fetchTextWithHttp(urlString, maxRedirects);
+  }
+
+  if (urlObj.protocol === 'https:') {
+    return fetchTextWithHttps(urlString, maxRedirects);
+  }
+
+  return Promise.reject(new Error(`Only http:// and https:// URLs are supported by the request fallback. Got: ${urlString}`));
 }
 
 function detectEol(text) {
@@ -460,8 +472,8 @@ function printHelp() {
   console.log('  --help, -h      Show help');
 }
 
-async function main() {
-  const args = parseArgs(process.argv);
+async function main(argv = process.argv, logger = console.log) {
+  const args = parseArgs(argv);
 
   if (args.help) {
     printHelp();
@@ -550,8 +562,12 @@ async function main() {
   writeTextPreserveEol(outPath, outText);
 
   // eslint-disable-next-line no-console
-  console.log(`Extracted section ${args.section} (id=${elementId}, tag=${extracted.tagName}) -> ${outPath}`);
+  logger(`Extracted section ${args.section} (id=${elementId}, tag=${extracted.tagName}) -> ${outPath}`);
 }
+
+module.exports = {
+  main,
+};
 
 if (require.main === module) {
   main().catch((err) => {

--- a/scripts/ECMA262/extractEcma262SectionHtml.js
+++ b/scripts/ECMA262/extractEcma262SectionHtml.js
@@ -26,7 +26,6 @@
 'use strict';
 
 const fs = require('fs');
-const http = require('http');
 const path = require('path');
 const https = require('https');
 
@@ -158,15 +157,7 @@ function parseArgs(argv) {
   return args;
 }
 
-function fetchTextWithHttp(urlString, maxRedirects = 5) {
-  return fetchTextWithTransport('http', urlString, maxRedirects);
-}
-
 function fetchTextWithHttps(urlString, maxRedirects = 5) {
-  return fetchTextWithTransport('https', urlString, maxRedirects);
-}
-
-function fetchTextWithTransport(protocol, urlString, maxRedirects = 5) {
   return new Promise((resolve, reject) => {
     let urlObj;
     try {
@@ -176,12 +167,12 @@ function fetchTextWithTransport(protocol, urlString, maxRedirects = 5) {
       return;
     }
 
-    if (urlObj.protocol !== protocol + ':') {
-      reject(new Error(`Only ${protocol}:// URLs are supported by the ${protocol} fallback. Got: ${urlString}`));
+    if (urlObj.protocol !== 'https:') {
+      reject(new Error(`Only https:// URLs are supported by the https fallback. Got: ${urlString}`));
       return;
     }
 
-    const req = (protocol === 'http' ? http : https).request(
+    const req = https.request(
       urlObj,
       {
         method: 'GET',
@@ -204,7 +195,7 @@ function fetchTextWithTransport(protocol, urlString, maxRedirects = 5) {
 
           const nextUrl = new URL(location, urlObj).toString();
           res.resume();
-          fetchTextWithNodeRequest(nextUrl, maxRedirects - 1).then(resolve, reject);
+          fetchTextWithHttps(nextUrl, maxRedirects - 1).then(resolve, reject);
           return;
         }
 
@@ -228,27 +219,24 @@ function fetchTextWithTransport(protocol, urlString, maxRedirects = 5) {
   });
 }
 
-function fetchText(urlString) {
-  return fetchTextWithNodeRequest(urlString);
-}
+async function fetchText(urlString) {
+  // Prefer the built-in fetch (Node 18+). Fall back to https for older Node.
+  if (typeof fetch === 'function') {
+    const res = await fetch(urlString, {
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'js2il-docs-script',
+      },
+    });
 
-function fetchTextWithNodeRequest(urlString, maxRedirects = 5) {
-  let urlObj;
-  try {
-    urlObj = new URL(urlString);
-  } catch {
-    return Promise.reject(new Error(`Invalid URL: ${urlString}`));
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} fetching ${urlString}`);
+    }
+
+    return await res.text();
   }
 
-  if (urlObj.protocol === 'http:') {
-    return fetchTextWithHttp(urlString, maxRedirects);
-  }
-
-  if (urlObj.protocol === 'https:') {
-    return fetchTextWithHttps(urlString, maxRedirects);
-  }
-
-  return Promise.reject(new Error(`Only http:// and https:// URLs are supported by the request fallback. Got: ${urlString}`));
+  return await fetchTextWithHttps(urlString);
 }
 
 function detectEol(text) {
@@ -472,8 +460,8 @@ function printHelp() {
   console.log('  --help, -h      Show help');
 }
 
-async function main(argv = process.argv, logger = console.log) {
-  const args = parseArgs(argv);
+async function main() {
+  const args = parseArgs(process.argv);
 
   if (args.help) {
     printHelp();
@@ -562,12 +550,8 @@ async function main(argv = process.argv, logger = console.log) {
   writeTextPreserveEol(outPath, outText);
 
   // eslint-disable-next-line no-console
-  logger(`Extracted section ${args.section} (id=${elementId}, tag=${extracted.tagName}) -> ${outPath}`);
+  console.log(`Extracted section ${args.section} (id=${elementId}, tag=${extracted.tagName}) -> ${outPath}`);
 }
-
-module.exports = {
-  main,
-};
 
 if (require.main === module) {
   main().catch((err) => {

--- a/src/JavaScriptRuntime/Node/Http.cs
+++ b/src/JavaScriptRuntime/Node/Http.cs
@@ -1322,6 +1322,15 @@ namespace JavaScriptRuntime.Node
 
                 result.Callback = tertiary as Delegate ?? secondary as Delegate;
             }
+            else if (TryApplyUrlObject(result, primary, scheme, defaultPort, moduleName))
+            {
+                if (secondary != null && secondary is not JsNull && secondary is not Delegate)
+                {
+                    ApplyObjectOptions(result, secondary);
+                }
+
+                result.Callback = tertiary as Delegate ?? secondary as Delegate;
+            }
             else if (primary is Delegate callbackOnly)
             {
                 result.Callback = callbackOnly;
@@ -1342,6 +1351,17 @@ namespace JavaScriptRuntime.Node
             }
 
             return result;
+        }
+
+        private static bool TryApplyUrlObject(HttpRequestOptions options, object? value, string scheme, int defaultPort, string moduleName)
+        {
+            if (value is not URL url)
+            {
+                return false;
+            }
+
+            ApplyUrl(options, url.href, scheme, defaultPort, moduleName);
+            return true;
         }
 
         internal static bool TryGetUnsupportedFeatureMessage(string method, IDictionary<string, string> headers, string moduleName, out string message)

--- a/src/JavaScriptRuntime/Node/Https.cs
+++ b/src/JavaScriptRuntime/Node/Https.cs
@@ -682,9 +682,11 @@ namespace JavaScriptRuntime.Node
             }
 
             var first = sourceArgs[0];
-            if (first is string)
+            if (first is string || first is URL)
             {
-                if (sourceArgs.Length > 1 && NodeNetworkingCommon.LooksLikeOptionsObject(sourceArgs[1]))
+                if (sourceArgs.Length > 1
+                    && sourceArgs[1] is not URL
+                    && NodeNetworkingCommon.LooksLikeOptionsObject(sourceArgs[1]))
                 {
                     return sourceArgs[1];
                 }


### PR DESCRIPTION
Closes #947.

## Summary
- fix `http.request(...)` / `https.request(...)` WHATWG URL + second-argument option interop so URL-derived path/query and TLS overrides survive the extractor's call shape
- run the ECMA-262 extractor through the Node request path directly, broaden its request fallback to loopback-friendly `http://` as well as `https://`, and keep the real CLI behavior testable through `main(...)`
- add focused HTTPS regression coverage plus end-to-end `--url` / `--auto` integration smokes for the checked-in extractor, and refresh the HTTPS docs/changelog

## Validation
- `dotnet test .\Js2IL.Tests\Js2IL.Tests.csproj -c Release --filter "FullyQualifiedName~Js2IL.Tests.Node.Https.|FullyQualifiedName=Js2IL.Tests.Integration.ExecutionTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode|FullyQualifiedName=Js2IL.Tests.Integration.ExecutionTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode|FullyQualifiedName=Js2IL.Tests.Integration.GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode|FullyQualifiedName=Js2IL.Tests.Integration.GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode" --nologo`
- manual loopback CLI smoke for `scripts\ECMA262\extractEcma262SectionHtml.js` in `--url` and `--auto` modes against a controlled local server