### PR TITLE
feat(test262): add pinned intake bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- tooling/tests/docs: close issue #928 by adopting a pinned sparse-checkout intake model for upstream `tc39/test262`, adding the bootstrap CLI + pin metadata used by local/CI acquisition, recording the licensing/update policy in a new ADR, and adding focused integration coverage for the bootstrap describe flow.
 - node/http/https/tests/docs: fix WHATWG `URL` + second-argument request-option interop for `http.request(...)` / `https.request(...)` so URL-derived path/query and TLS/client overrides stay aligned with Node call shapes, add focused HTTPS regression coverage plus end-to-end `--url` / `--auto` smoke tests for the ECMA-262 extractor network workflow, and refresh the HTTPS docs.
 
 ## v0.9.7 - 2026-04-07

--- a/docs/adr/0005-test262-intake-and-sync-model.md
+++ b/docs/adr/0005-test262-intake-and-sync-model.md
@@ -1,0 +1,134 @@
+# ADR 0005: test262 Intake and Sync Model
+
+- Date: 2026-04-11
+- Status: Accepted
+
+## Context
+
+Issue #927 introduces a phased test262 conformance program, and Issue #928 is the first dependency because every later runner/reporting decision depends on how JS2IL acquires and pins upstream `tc39/test262`.
+
+We need one canonical intake model that keeps:
+
+- contributor setup low-friction
+- CI reproducible
+- repository churn manageable
+- licensing and attribution explicit
+- Windows line-ending behavior safe for upstream tests
+
+The candidate models were:
+
+1. a sibling checkout outside the repository
+2. a vendored snapshot committed into this repository
+3. a scripted fetch flow pinned to an exact upstream commit
+
+## Decision
+
+JS2IL uses a **scripted fetch + pinned commit** model for test262 intake.
+
+- The canonical pin lives in `tests/test262/test262.pin.json`.
+- Local bootstrap and CI both use `node scripts/test262/bootstrap.js`.
+- The managed checkout lives outside source control under `artifacts/test262/cache/<sha>`.
+- Developers may override the managed checkout with `JS2IL_TEST262_ROOT` (or `--root`) for local experimentation, but that override is not the canonical path and must not become the required workflow.
+- The managed checkout is materialized as a sparse git checkout with `core.autocrlf=false` and `core.eol=lf` so Windows does not rewrite upstream files to CRLF.
+
+## MVP Intake Scope
+
+The pinned intake keeps only the minimum upstream content needed for the first plain synchronous-script phase:
+
+- root metadata files:
+  - `LICENSE`
+  - `INTERPRETING.md`
+  - `features.txt`
+  - `package.json`
+- harness content:
+  - `harness/**`
+- first-wave test roots:
+  - `test/language/**`
+  - `test/built-ins/**`
+
+The MVP intentionally excludes:
+
+- `test/annexB/**`
+- `test/intl402/**`
+- `test/staging/**`
+- module-flagged tests
+- async-flagged tests
+- agent/broadcast-heavy tests
+- async-harness-dependent cases
+
+The file-level exclusions inside `test/language/**` and `test/built-ins/**` are enforced later by the metadata parser and runner work (#929-#931); Issue #928 only defines the canonical upstream intake boundary.
+
+## Local Flow
+
+The default local workflow is:
+
+1. run `npm run test262:bootstrap`
+2. let the script materialize or reuse `artifacts/test262/cache/<sha>`
+3. point later tooling at that resolved root (or call `npm run test262:root`)
+
+For local-only experimentation, a developer may point `JS2IL_TEST262_ROOT` at a sibling checkout or another prepared test262 directory. The bootstrap script still validates the expected root files, harness files, and pinned `package.json` version before accepting the override.
+
+## CI Flow
+
+CI is allowed to fetch the pinned commit from GitHub and cache by SHA.
+
+The expected pattern is:
+
+1. restore `artifacts/test262/cache` with a cache key derived from `tests/test262/test262.pin.json`
+2. run `npm run test262:bootstrap`
+3. let downstream runner/reporting jobs consume the resolved root
+
+This keeps the repository small while still making CI deterministic.
+
+## Licensing and Attribution
+
+JS2IL does not vendor the upstream suite into the repository for this phase, but the managed checkout still preserves upstream attribution material.
+
+- The sparse checkout always includes `LICENSE` and `INTERPRETING.md`.
+- Any later generated baselines, mirrored files, or exported reports that copy upstream content must preserve the relevant upstream notices.
+- The pinned `package.json` version is recorded alongside the commit SHA so interpretation-shift changes in upstream test262 remain visible during pin bumps.
+
+## Update Policy
+
+Pin bumps are **manual**.
+
+- Update `tests/test262/test262.pin.json` with a new commit SHA and matching upstream `package.json` version.
+- Re-run `npm run test262:bootstrap`.
+- Summarize the upstream commit, package version, and any material harness/interpretation changes in the PR description.
+
+This keeps test262 updates explicit and reviewable instead of introducing silent scheduled drift before the runner/reporting pipeline exists.
+
+## Consequences
+
+### Positive
+
+- Reproducible local and CI intake without committing a large third-party tree.
+- Cache-by-SHA works naturally once CI is wired in.
+- Later issues can build on a real pinned root path instead of inventing one ad hoc.
+- Windows line endings are controlled in the managed checkout instead of depending on contributor git settings.
+
+### Negative
+
+- First bootstrap requires git network access.
+- There is one more small piece of repo configuration (`test262.pin.json`) to maintain.
+- Local override roots can drift from the canonical pin if used casually.
+
+### Mitigations
+
+- Keep the canonical path script-first and validate override roots before use.
+- Keep pin bumps manual and reviewable until the later reporting workflow exists.
+- Store the pin in-repo so runner and CI changes can key from one source of truth.
+
+## Alternatives Considered
+
+### 1) Vendored snapshot committed into JS2IL
+
+Rejected because upstream test262 is large, would create noisy update PRs, and is unnecessary now that CI may fetch and cache by SHA.
+
+### 2) Sibling checkout as the primary workflow
+
+Rejected because it makes CI and contributor onboarding less reproducible and would force every later tool to guess where the suite lives.
+
+### 3) Git submodule
+
+Rejected because the repository does not currently use submodules, and a scripted pinned fetch gives the same reproducibility with less contributor friction.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "diff:test:canary": "node scripts/differential-test/runCanarySuites.js --suite pr --timeout 20 --compile-timeout 60",
     "diff:test:canary:nightly": "node scripts/differential-test/runCanarySuites.js --suite nightly --timeout 20 --compile-timeout 60",
     "diff:test:canary:packed": "node scripts/differential-test/runPackedCanarySuites.js --suite pr --timeout 20 --compile-timeout 60",
-    "diff:test:canary:nightly:packed": "node scripts/differential-test/runPackedCanarySuites.js --suite nightly --timeout 20 --compile-timeout 60"
+    "diff:test:canary:nightly:packed": "node scripts/differential-test/runPackedCanarySuites.js --suite nightly --timeout 20 --compile-timeout 60",
+    "test262:bootstrap": "node scripts/test262/bootstrap.js",
+    "test262:describe": "node scripts/test262/bootstrap.js --describe",
+    "test262:root": "node scripts/test262/bootstrap.js --print-root"
   },
   "dependencies": {
     "turndown": "^7.2.2"

--- a/scripts/test262/bootstrap.js
+++ b/scripts/test262/bootstrap.js
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+'use strict';
+
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseArgs(argv) {
+  const args = {
+    pin: null,
+    root: null,
+    describe: false,
+    force: false,
+    printRoot: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === '--pin' && argv[i + 1]) {
+      args.pin = argv[++i];
+      continue;
+    }
+
+    if (arg === '--root' && argv[i + 1]) {
+      args.root = argv[++i];
+      continue;
+    }
+
+    if (arg === '--describe') {
+      args.describe = true;
+      continue;
+    }
+
+    if (arg === '--force') {
+      args.force = true;
+      continue;
+    }
+
+    if (arg === '--print-root') {
+      args.printRoot = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(
+    [
+      'node scripts/test262/bootstrap.js',
+      '',
+      'Materializes the pinned upstream test262 MVP slice into a managed local cache,',
+      'or reuses a developer-provided checkout via JS2IL_TEST262_ROOT / --root.',
+      '',
+      'Options:',
+      '  --pin <path>      Pin/config file (default: tests/test262/test262.pin.json)',
+      '  --root <path>     Developer override root (same effect as JS2IL_TEST262_ROOT)',
+      '  --describe        Print the configured intake/update policy without fetching',
+      '  --print-root      Print only the resolved test262 root after validation/bootstrap',
+      '  --force           Recreate the managed checkout even if it already looks valid',
+      '  --help, -h        Show this help text',
+      '',
+    ].join('\n')
+  );
+}
+
+function defaultPinPath() {
+  return path.resolve(__dirname, '..', '..', 'tests', 'test262', 'test262.pin.json');
+}
+
+function resolvePathFromCwd(value) {
+  if (!value) {
+    return '';
+  }
+
+  return path.isAbsolute(value) ? value : path.resolve(process.cwd(), value);
+}
+
+function toPortablePath(value) {
+  return value.replace(/\\/g, '/');
+}
+
+function normalizeSpecPath(value) {
+  return toPortablePath(value).replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+function ensureString(value, label) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Invalid pin file: expected non-empty string for '${label}'.`);
+  }
+}
+
+function ensureStringArray(value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`Invalid pin file: expected non-empty string array for '${label}'.`);
+  }
+
+  for (const entry of value) {
+    if (typeof entry !== 'string' || entry.trim() === '') {
+      throw new Error(`Invalid pin file: '${label}' entries must be non-empty strings.`);
+    }
+  }
+}
+
+function validatePin(pin) {
+  if (!pin || typeof pin !== 'object') {
+    throw new Error('Invalid pin file: expected a JSON object.');
+  }
+
+  if (!pin.upstream || typeof pin.upstream !== 'object') {
+    throw new Error("Invalid pin file: expected object for 'upstream'.");
+  }
+
+  ensureString(pin.upstream.owner, 'upstream.owner');
+  ensureString(pin.upstream.repo, 'upstream.repo');
+  ensureString(pin.upstream.cloneUrl, 'upstream.cloneUrl');
+  ensureString(pin.upstream.commit, 'upstream.commit');
+  ensureString(pin.upstream.packageVersion, 'upstream.packageVersion');
+  ensureString(pin.localOverrideEnvVar, 'localOverrideEnvVar');
+  ensureString(pin.managedRoot, 'managedRoot');
+  ensureString(pin.lineEndings, 'lineEndings');
+  ensureString(pin.updateStrategy, 'updateStrategy');
+  ensureStringArray(pin.includeFiles, 'includeFiles');
+  ensureStringArray(pin.includeDirectories, 'includeDirectories');
+  ensureStringArray(pin.requiredFiles, 'requiredFiles');
+  ensureStringArray(pin.requiredDirectories, 'requiredDirectories');
+  ensureStringArray(pin.defaultHarnessFiles, 'defaultHarnessFiles');
+  ensureStringArray(pin.excludedFromMvp, 'excludedFromMvp');
+  ensureStringArray(pin.attributionFiles, 'attributionFiles');
+
+  if (!/^[0-9a-f]{40}$/i.test(pin.upstream.commit)) {
+    throw new Error("Invalid pin file: 'upstream.commit' must be a 40-character git SHA.");
+  }
+}
+
+function loadPin(pinPath) {
+  const raw = fs.readFileSync(pinPath, 'utf8');
+  const pin = JSON.parse(raw);
+  validatePin(pin);
+  return pin;
+}
+
+function resolveManagedCheckoutRoot(pinPath, pin) {
+  const pinDirectory = path.dirname(pinPath);
+  return path.resolve(pinDirectory, pin.managedRoot, pin.upstream.commit);
+}
+
+function resolveManagedCheckoutLabel(pin) {
+  return toPortablePath(path.posix.join(normalizeSpecPath(pin.managedRoot), pin.upstream.commit));
+}
+
+function resolveOverrideRoot(args, pin) {
+  const overrideValue = args.root || process.env[pin.localOverrideEnvVar] || '';
+  if (!overrideValue) {
+    return null;
+  }
+
+  return {
+    source: args.root ? '--root' : pin.localOverrideEnvVar,
+    rootPath: resolvePathFromCwd(overrideValue),
+  };
+}
+
+function describePlan(pin, override) {
+  const lines = [
+    `source ${override ? 'override' : 'managed'}`,
+    `cloneUrl ${pin.upstream.cloneUrl}`,
+    `commit ${pin.upstream.commit}`,
+    `packageVersion ${pin.upstream.packageVersion}`,
+    `managedRoot ${toPortablePath(pin.managedRoot)}`,
+    `checkoutDir ${resolveManagedCheckoutLabel(pin)}`,
+    `overrideEnv ${pin.localOverrideEnvVar}`,
+    `lineEndings ${pin.lineEndings}`,
+    `updateStrategy ${pin.updateStrategy}`,
+    `includeFiles ${pin.includeFiles.join(', ')}`,
+    `includeDirectories ${pin.includeDirectories.join(', ')}`,
+    `requiredFiles ${pin.requiredFiles.join(', ')}`,
+    `requiredDirectories ${pin.requiredDirectories.join(', ')}`,
+    `defaultHarnessFiles ${pin.defaultHarnessFiles.join(', ')}`,
+    `excludedFromMvp ${pin.excludedFromMvp.join('; ')}`,
+    `attributionFiles ${pin.attributionFiles.join(', ')}`,
+  ];
+
+  if (override) {
+    lines.push(`overrideSource ${override.source}`);
+    lines.push(`overrideRoot ${toPortablePath(override.rootPath)}`);
+  }
+
+  return lines.join('\n');
+}
+
+function ensureDir(directoryPath) {
+  fs.mkdirSync(directoryPath, { recursive: true });
+}
+
+function removeDir(directoryPath) {
+  if (!fs.existsSync(directoryPath)) {
+    return;
+  }
+
+  fs.rmSync(directoryPath, { recursive: true, force: true });
+}
+
+function runGit(args, cwd) {
+  const result = childProcess.spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+    shell: false,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    const stdout = (result.stdout || '').trim();
+    const details = [stderr, stdout].filter(Boolean).join('\n');
+    throw new Error(`git ${args.join(' ')} failed${details ? `:\n${details}` : '.'}`);
+  }
+
+  return result.stdout || '';
+}
+
+function buildSparsePatterns(pin) {
+  const patterns = [];
+
+  for (const filePath of pin.includeFiles) {
+    patterns.push(`/${normalizeSpecPath(filePath)}`);
+  }
+
+  for (const directoryPath of pin.includeDirectories) {
+    const normalized = normalizeSpecPath(directoryPath);
+    patterns.push(`/${normalized}/`);
+    patterns.push(`/${normalized}/**`);
+  }
+
+  return patterns;
+}
+
+function validateResolvedRoot(rootPath, pin) {
+  const missingFiles = [];
+  const missingDirectories = [];
+
+  for (const filePath of pin.requiredFiles) {
+    const fullPath = path.join(rootPath, ...normalizeSpecPath(filePath).split('/'));
+    if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isFile()) {
+      missingFiles.push(filePath);
+    }
+  }
+
+  for (const directoryPath of pin.requiredDirectories) {
+    const fullPath = path.join(rootPath, ...normalizeSpecPath(directoryPath).split('/'));
+    if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isDirectory()) {
+      missingDirectories.push(directoryPath);
+    }
+  }
+
+  if (missingFiles.length > 0 || missingDirectories.length > 0) {
+    const parts = [];
+    if (missingFiles.length > 0) {
+      parts.push(`missing files: ${missingFiles.join(', ')}`);
+    }
+    if (missingDirectories.length > 0) {
+      parts.push(`missing directories: ${missingDirectories.join(', ')}`);
+    }
+    return { ok: false, message: parts.join('; ') };
+  }
+
+  const packageJsonPath = path.join(rootPath, 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  if (!packageJson || packageJson.version !== pin.upstream.packageVersion) {
+    return {
+      ok: false,
+      message: `package.json version mismatch: expected ${pin.upstream.packageVersion}, got ${packageJson && packageJson.version ? packageJson.version : '<missing>'}`,
+    };
+  }
+
+  return { ok: true, message: '' };
+}
+
+function ensureManagedCheckout(rootPath, pin, force) {
+  if (!force) {
+    const current = validateResolvedRoot(rootPath, pin);
+    if (current.ok) {
+      return { source: 'managed-cache', rootPath, reused: true };
+    }
+  }
+
+  removeDir(rootPath);
+  ensureDir(rootPath);
+
+  runGit(['init'], rootPath);
+  runGit(['config', 'core.autocrlf', 'false'], rootPath);
+  runGit(['config', 'core.eol', 'lf'], rootPath);
+  runGit(['remote', 'add', 'origin', pin.upstream.cloneUrl], rootPath);
+  runGit(['sparse-checkout', 'init', '--no-cone'], rootPath);
+  runGit(['sparse-checkout', 'set', '--no-cone'].concat(buildSparsePatterns(pin)), rootPath);
+  runGit(['fetch', '--depth', '1', 'origin', pin.upstream.commit], rootPath);
+  runGit(['checkout', '--detach', 'FETCH_HEAD'], rootPath);
+
+  const validation = validateResolvedRoot(rootPath, pin);
+  if (!validation.ok) {
+    throw new Error(`Pinned test262 checkout is incomplete after bootstrap: ${validation.message}`);
+  }
+
+  return { source: 'managed-cache', rootPath, reused: false };
+}
+
+function resolveBootstrapRoot(pinPath, pin, args) {
+  const override = resolveOverrideRoot(args, pin);
+  if (override) {
+    const validation = validateResolvedRoot(override.rootPath, pin);
+    if (!validation.ok) {
+      throw new Error(`Override test262 root '${override.rootPath}' is invalid: ${validation.message}`);
+    }
+
+    return { source: override.source, rootPath: override.rootPath, reused: true };
+  }
+
+  return ensureManagedCheckout(resolveManagedCheckoutRoot(pinPath, pin), pin, args.force);
+}
+
+function printResolvedRoot(result, pin, printRootOnly) {
+  if (printRootOnly) {
+    console.log(result.rootPath);
+    return;
+  }
+
+  const reusedText = result.reused ? 'reused' : 'fetched';
+  console.log(
+    [
+      `source ${result.source}`,
+      `root ${toPortablePath(result.rootPath)}`,
+      `commit ${pin.upstream.commit}`,
+      `packageVersion ${pin.upstream.packageVersion}`,
+      `status ${reusedText}`,
+    ].join('\n')
+  );
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const pinPath = resolvePathFromCwd(args.pin || defaultPinPath());
+  const pin = loadPin(pinPath);
+  const override = resolveOverrideRoot(args, pin);
+
+  if (args.describe) {
+    console.log(describePlan(pin, override));
+    return;
+  }
+
+  const result = resolveBootstrapRoot(pinPath, pin, args);
+  printResolvedRoot(result, pin, args.printRoot);
+}
+
+module.exports = {
+  buildSparsePatterns,
+  defaultPinPath,
+  describePlan,
+  ensureManagedCheckout,
+  loadPin,
+  parseArgs,
+  resolveBootstrapRoot,
+  resolveManagedCheckoutLabel,
+  resolveManagedCheckoutRoot,
+  validateResolvedRoot,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    console.error(message);
+    process.exitCode = 1;
+  }
+}

--- a/tests/Js2IL.Tests/Integration/ExecutionTests.cs
+++ b/tests/Js2IL.Tests/Integration/ExecutionTests.cs
@@ -15,6 +15,82 @@ namespace Js2IL.Tests.Integration
         public Task Compile_Performance_Dromaeo_Object_Regexp() => ExecutionTest(nameof(Compile_Performance_Dromaeo_Object_Regexp));
 
         [Fact]
+        public async Task Compile_Scripts_Test262Bootstrap()
+        {
+            using var currentDirectory = new TemporaryCurrentDirectory();
+            var pinPath = System.IO.Path.Combine(currentDirectory.Path, "test262.pin.json");
+
+            System.IO.File.WriteAllText(
+                pinPath,
+                """
+                {
+                  "upstream": {
+                    "owner": "tc39",
+                    "repo": "test262",
+                    "cloneUrl": "https://github.com/tc39/test262.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "packageVersion": "5.0.0"
+                  },
+                  "localOverrideEnvVar": "JS2IL_TEST262_ROOT",
+                  "managedRoot": "./managed-cache",
+                  "lineEndings": "lf",
+                  "updateStrategy": "manual-pinned-sha",
+                  "includeFiles": [
+                    "LICENSE",
+                    "INTERPRETING.md",
+                    "features.txt",
+                    "package.json"
+                  ],
+                  "includeDirectories": [
+                    "harness",
+                    "test/language",
+                    "test/built-ins"
+                  ],
+                  "requiredFiles": [
+                    "LICENSE",
+                    "INTERPRETING.md",
+                    "features.txt",
+                    "package.json",
+                    "harness/assert.js",
+                    "harness/sta.js"
+                  ],
+                  "requiredDirectories": [
+                    "harness",
+                    "test/language",
+                    "test/built-ins"
+                  ],
+                  "defaultHarnessFiles": [
+                    "assert.js",
+                    "sta.js"
+                  ],
+                  "excludedFromMvp": [
+                    "test/annexB/**",
+                    "test/intl402/**",
+                    "test/staging/**",
+                    "frontmatter:flags=module",
+                    "frontmatter:flags=async",
+                    "frontmatter:requires-agent-or-broadcast",
+                    "frontmatter:requires-async-harness"
+                  ],
+                  "attributionFiles": [
+                    "LICENSE",
+                    "INTERPRETING.md"
+                  ]
+                }
+                """.ReplaceLineEndings("\n"));
+
+            await ExecutionTest(
+                nameof(Compile_Scripts_Test262Bootstrap),
+                addMocks: services => services.RegisterInstance<IEnvironment>(
+                    new FixedCommandLineEnvironment(
+                        "dotnet",
+                        "test262-bootstrap.dll",
+                        "--describe",
+                        "--pin",
+                        pinPath)));
+        }
+
+        [Fact]
         public async Task Compile_Scripts_ExtractEcma262SectionHtml_UrlMode()
         {
             await using var server = await LoopbackEcma262Server.StartAsync();

--- a/tests/Js2IL.Tests/Integration/GeneratorTests.cs
+++ b/tests/Js2IL.Tests/Integration/GeneratorTests.cs
@@ -16,6 +16,9 @@ namespace Js2IL.Tests.Integration
         public Task Compile_Scripts_DecompileGeneratorTest() => GenerateTest(nameof(Compile_Scripts_DecompileGeneratorTest));
 
         [Fact]
+        public Task Compile_Scripts_Test262Bootstrap() => GenerateTest(nameof(Compile_Scripts_Test262Bootstrap));
+
+        [Fact]
         public Task Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown()
             => GenerateTest(nameof(Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown), ["node_modules/turndown/index"]);
 

--- a/tests/Js2IL.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -1,0 +1,16 @@
+﻿source managed
+cloneUrl https://github.com/tc39/test262.git
+commit 0123456789abcdef0123456789abcdef01234567
+packageVersion 5.0.0
+managedRoot ./managed-cache
+checkoutDir managed-cache/0123456789abcdef0123456789abcdef01234567
+overrideEnv JS2IL_TEST262_ROOT
+lineEndings lf
+updateStrategy manual-pinned-sha
+includeFiles LICENSE, INTERPRETING.md, features.txt, package.json
+includeDirectories harness, test/language, test/built-ins
+requiredFiles LICENSE, INTERPRETING.md, features.txt, package.json, harness/assert.js, harness/sta.js
+requiredDirectories harness, test/language, test/built-ins
+defaultHarnessFiles assert.js, sta.js
+excludedFromMvp test/annexB/**; test/intl402/**; test/staging/**; frontmatter:flags=module; frontmatter:flags=async; frontmatter:requires-agent-or-broadcast; frontmatter:requires-async-harness
+attributionFiles LICENSE, INTERPRETING.md

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -1,0 +1,6389 @@
+﻿// IL code: Compile_Scripts_Test262Bootstrap
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Compile_Scripts_Test262Bootstrap
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit parseArgs
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4ab9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_For_L18C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L18C40
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L21C40
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4ad4
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L21C40::.ctor
+
+				} // end of class Block_L21C40
+
+				.class nested private auto ansi beforefieldinit Block_L26C41
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4add
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L26C41::.ctor
+
+				} // end of class Block_L26C41
+
+				.class nested private auto ansi beforefieldinit Block_L31C30
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4ae6
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L31C30::.ctor
+
+				} // end of class Block_L31C30
+
+				.class nested private auto ansi beforefieldinit Block_L36C27
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4aef
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L36C27::.ctor
+
+				} // end of class Block_L36C27
+
+				.class nested private auto ansi beforefieldinit Block_L41C32
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4af8
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L41C32::.ctor
+
+				} // end of class Block_L41C32
+
+				.class nested private auto ansi beforefieldinit Block_L46C42
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4b01
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L46C42::.ctor
+
+				} // end of class Block_L46C42
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4acb
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L18C40::.ctor
+
+			} // end of class Block_L18C40
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4ac2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_For_L18C7::.ctor
+
+		} // end of class Scope_For_L18C7
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object argv
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x25b8
+			// Header size: 12
+			// Code size: 621 (0x26d)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[1] float64,
+				[2] object,
+				[3] bool,
+				[4] object,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] object,
+				[11] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0005: dup
+			IL_0006: ldstr "pin"
+			IL_000b: ldc.i4.0
+			IL_000c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0016: dup
+			IL_0017: ldstr "root"
+			IL_001c: ldc.i4.0
+			IL_001d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0027: dup
+			IL_0028: ldstr "describe"
+			IL_002d: ldc.i4.0
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "force"
+			IL_0039: ldc.i4.0
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003f: dup
+			IL_0040: ldstr "printRoot"
+			IL_0045: ldc.i4.0
+			IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_004b: dup
+			IL_004c: ldstr "help"
+			IL_0051: ldc.i4.0
+			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0057: stloc.0
+			IL_0058: ldc.r8 0.0
+			IL_0061: stloc.1
+			// loop start (head: IL_0062)
+				IL_0062: ldloc.1
+				IL_0063: ldarg.2
+				IL_0064: ldstr "length"
+				IL_0069: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_006e: clt
+				IL_0070: brfalse IL_026b
+
+				IL_0075: ldarg.2
+				IL_0076: ldloc.1
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_007c: stloc.2
+				IL_007d: ldloc.2
+				IL_007e: ldstr "--pin"
+				IL_0083: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0088: stloc.3
+				IL_0089: ldloc.3
+				IL_008a: box [System.Runtime]System.Boolean
+				IL_008f: stloc.s 4
+				IL_0091: ldloc.s 4
+				IL_0093: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0098: stloc.3
+				IL_0099: ldloc.3
+				IL_009a: brfalse IL_00b7
+
+				IL_009f: ldarg.2
+				IL_00a0: ldloc.1
+				IL_00a1: ldc.r8 1
+				IL_00aa: add
+				IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00b0: stloc.s 6
+				IL_00b2: br IL_00bb
+
+				IL_00b7: ldloc.s 4
+				IL_00b9: stloc.s 6
+
+				IL_00bb: ldloc.s 6
+				IL_00bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00c2: stloc.3
+				IL_00c3: ldloc.3
+				IL_00c4: brfalse IL_00fa
+
+				IL_00c9: ldloc.1
+				IL_00ca: ldc.r8 1
+				IL_00d3: add
+				IL_00d4: stloc.1
+				IL_00d5: ldloc.1
+				IL_00d6: box [System.Runtime]System.Double
+				IL_00db: stloc.s 7
+				IL_00dd: ldarg.2
+				IL_00de: ldloc.s 7
+				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_00e5: stloc.s 8
+				IL_00e7: ldloc.0
+				IL_00e8: ldstr "pin"
+				IL_00ed: ldloc.s 8
+				IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_00f4: pop
+				IL_00f5: br IL_025a
+
+				IL_00fa: ldloc.2
+				IL_00fb: ldstr "--root"
+				IL_0100: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0105: stloc.3
+				IL_0106: ldloc.3
+				IL_0107: box [System.Runtime]System.Boolean
+				IL_010c: stloc.s 4
+				IL_010e: ldloc.s 4
+				IL_0110: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0115: stloc.3
+				IL_0116: ldloc.3
+				IL_0117: brfalse IL_0134
+
+				IL_011c: ldarg.2
+				IL_011d: ldloc.1
+				IL_011e: ldc.r8 1
+				IL_0127: add
+				IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_012d: stloc.s 9
+				IL_012f: br IL_0138
+
+				IL_0134: ldloc.s 4
+				IL_0136: stloc.s 9
+
+				IL_0138: ldloc.s 9
+				IL_013a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_013f: stloc.3
+				IL_0140: ldloc.3
+				IL_0141: brfalse IL_0177
+
+				IL_0146: ldloc.1
+				IL_0147: ldc.r8 1
+				IL_0150: add
+				IL_0151: stloc.1
+				IL_0152: ldloc.1
+				IL_0153: box [System.Runtime]System.Double
+				IL_0158: stloc.s 7
+				IL_015a: ldarg.2
+				IL_015b: ldloc.s 7
+				IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0162: stloc.s 8
+				IL_0164: ldloc.0
+				IL_0165: ldstr "root"
+				IL_016a: ldloc.s 8
+				IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0171: pop
+				IL_0172: br IL_025a
+
+				IL_0177: ldloc.2
+				IL_0178: ldstr "--describe"
+				IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0182: stloc.3
+				IL_0183: ldloc.3
+				IL_0184: brfalse IL_01a0
+
+				IL_0189: ldloc.0
+				IL_018a: ldstr "describe"
+				IL_018f: ldc.i4.1
+				IL_0190: box [System.Runtime]System.Boolean
+				IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_019a: pop
+				IL_019b: br IL_025a
+
+				IL_01a0: ldloc.2
+				IL_01a1: ldstr "--force"
+				IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01ab: stloc.3
+				IL_01ac: ldloc.3
+				IL_01ad: brfalse IL_01c9
+
+				IL_01b2: ldloc.0
+				IL_01b3: ldstr "force"
+				IL_01b8: ldc.i4.1
+				IL_01b9: box [System.Runtime]System.Boolean
+				IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_01c3: pop
+				IL_01c4: br IL_025a
+
+				IL_01c9: ldloc.2
+				IL_01ca: ldstr "--print-root"
+				IL_01cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01d4: stloc.3
+				IL_01d5: ldloc.3
+				IL_01d6: brfalse IL_01f2
+
+				IL_01db: ldloc.0
+				IL_01dc: ldstr "printRoot"
+				IL_01e1: ldc.i4.1
+				IL_01e2: box [System.Runtime]System.Boolean
+				IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_01ec: pop
+				IL_01ed: br IL_025a
+
+				IL_01f2: ldloc.2
+				IL_01f3: ldstr "--help"
+				IL_01f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01fd: stloc.3
+				IL_01fe: ldloc.3
+				IL_01ff: box [System.Runtime]System.Boolean
+				IL_0204: stloc.s 4
+				IL_0206: ldloc.s 4
+				IL_0208: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_020d: stloc.3
+				IL_020e: ldloc.3
+				IL_020f: brtrue IL_0231
+
+				IL_0214: ldloc.2
+				IL_0215: ldstr "-h"
+				IL_021a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_021f: stloc.3
+				IL_0220: ldloc.3
+				IL_0221: box [System.Runtime]System.Boolean
+				IL_0226: stloc.s 10
+				IL_0228: ldloc.s 10
+				IL_022a: stloc.s 11
+				IL_022c: br IL_0235
+
+				IL_0231: ldloc.s 4
+				IL_0233: stloc.s 11
+
+				IL_0235: ldloc.s 11
+				IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_023c: stloc.3
+				IL_023d: ldloc.3
+				IL_023e: brfalse IL_025a
+
+				IL_0243: ldloc.0
+				IL_0244: ldstr "help"
+				IL_0249: ldc.i4.1
+				IL_024a: box [System.Runtime]System.Boolean
+				IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+				IL_0254: pop
+				IL_0255: br IL_025a
+
+				IL_025a: ldloc.1
+				IL_025b: ldc.r8 1
+				IL_0264: add
+				IL_0265: stloc.1
+				IL_0266: br IL_0062
+			// end loop
+
+			IL_026b: ldloc.0
+			IL_026c: ret
+		} // end of method parseArgs::__js_call__
+
+	} // end of class parseArgs
+
+	.class nested public auto ansi abstract sealed beforefieldinit printHelp
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b0a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2834
+			// Header size: 12
+			// Code size: 184 (0xb8)
+			.maxstack 8
+			.locals init (
+				[0] string
+			)
+
+			IL_0000: ldc.i4.s 13
+			IL_0002: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0007: dup
+			IL_0008: ldstr "node scripts/test262/bootstrap.js"
+			IL_000d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0012: dup
+			IL_0013: ldstr ""
+			IL_0018: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_001d: dup
+			IL_001e: ldstr "Materializes the pinned upstream test262 MVP slice into a managed local cache,"
+			IL_0023: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0028: dup
+			IL_0029: ldstr "or reuses a developer-provided checkout via JS2IL_TEST262_ROOT / --root."
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0033: dup
+			IL_0034: ldstr ""
+			IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_003e: dup
+			IL_003f: ldstr "Options:"
+			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0049: dup
+			IL_004a: ldstr "  --pin <path>      Pin/config file (default: tests/test262/test262.pin.json)"
+			IL_004f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0054: dup
+			IL_0055: ldstr "  --root <path>     Developer override root (same effect as JS2IL_TEST262_ROOT)"
+			IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_005f: dup
+			IL_0060: ldstr "  --describe        Print the configured intake/update policy without fetching"
+			IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_006a: dup
+			IL_006b: ldstr "  --print-root      Print only the resolved test262 root after validation/bootstrap"
+			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0075: dup
+			IL_0076: ldstr "  --force           Recreate the managed checkout even if it already looks valid"
+			IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0080: dup
+			IL_0081: ldstr "  --help, -h        Show this help text"
+			IL_0086: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_008b: dup
+			IL_008c: ldstr ""
+			IL_0091: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0096: ldc.i4.1
+			IL_0097: newarr [System.Runtime]System.Object
+			IL_009c: dup
+			IL_009d: ldc.i4.0
+			IL_009e: ldstr "\n"
+			IL_00a3: stelem.ref
+			IL_00a4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_00a9: stloc.0
+			IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00af: ldloc.0
+			IL_00b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00b5: pop
+			IL_00b6: ldnull
+			IL_00b7: ret
+		} // end of method printHelp::__js_call__
+
+	} // end of class printHelp
+
+	.class nested public auto ansi abstract sealed beforefieldinit defaultPinPath
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b13
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x28f8
+			// Header size: 12
+			// Code size: 76 (0x4c)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "resolve"
+			IL_000d: ldc.i4.6
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::__dirname
+			IL_001b: stelem.ref
+			IL_001c: dup
+			IL_001d: ldc.i4.1
+			IL_001e: ldstr ".."
+			IL_0023: stelem.ref
+			IL_0024: dup
+			IL_0025: ldc.i4.2
+			IL_0026: ldstr ".."
+			IL_002b: stelem.ref
+			IL_002c: dup
+			IL_002d: ldc.i4.3
+			IL_002e: ldstr "tests"
+			IL_0033: stelem.ref
+			IL_0034: dup
+			IL_0035: ldc.i4.4
+			IL_0036: ldstr "test262"
+			IL_003b: stelem.ref
+			IL_003c: dup
+			IL_003d: ldc.i4.5
+			IL_003e: ldstr "test262.pin.json"
+			IL_0043: stelem.ref
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0049: stloc.0
+			IL_004a: ldloc.0
+			IL_004b: ret
+		} // end of method defaultPinPath::__js_call__
+
+	} // end of class defaultPinPath
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolvePathFromCwd
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L80C14
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4b25
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L80C14::.ctor
+
+			} // end of class Block_L80C14
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b1c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x2950
+			// Header size: 12
+			// Code size: 101 (0x65)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] bool,
+				[2] object,
+				[3] object
+			)
+
+			IL_0000: ldarg.2
+			IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0006: ldc.i4.0
+			IL_0007: ceq
+			IL_0009: stloc.1
+			IL_000a: ldloc.1
+			IL_000b: brfalse IL_0016
+
+			IL_0010: ldstr ""
+			IL_0015: ret
+
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_001c: ldstr "isAbsolute"
+			IL_0021: ldarg.2
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0027: stloc.2
+			IL_0028: ldloc.2
+			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002e: stloc.1
+			IL_002f: ldloc.1
+			IL_0030: brfalse IL_003c
+
+			IL_0035: ldarg.2
+			IL_0036: stloc.0
+			IL_0037: br IL_0063
+
+			IL_003c: ldarg.0
+			IL_003d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0042: stloc.2
+			IL_0043: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0048: ldstr "cwd"
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0052: stloc.3
+			IL_0053: ldloc.2
+			IL_0054: ldstr "resolve"
+			IL_0059: ldloc.3
+			IL_005a: ldarg.2
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0060: stloc.3
+			IL_0061: ldloc.3
+			IL_0062: stloc.0
+
+			IL_0063: ldloc.0
+			IL_0064: ret
+		} // end of method resolvePathFromCwd::__js_call__
+
+	} // end of class resolvePathFromCwd
+
+	.class nested public auto ansi abstract sealed beforefieldinit toPortablePath
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b2e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x29c4
+			// Header size: 12
+			// Code size: 36 (0x24)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[1] object
+			)
+
+			IL_0000: ldstr "\\\\"
+			IL_0005: ldstr "g"
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.1
+			IL_0011: ldstr "replace"
+			IL_0016: ldloc.0
+			IL_0017: ldstr "/"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: ret
+		} // end of method toPortablePath::__js_call__
+
+	} // end of class toPortablePath
+
+	.class nested public auto ansi abstract sealed beforefieldinit normalizeSpecPath
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b37
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x29f4
+			// Header size: 12
+			// Code size: 78 (0x4e)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldarg.2
+			IL_0002: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_0007: stloc.0
+			IL_0008: ldstr "^\\/+"
+			IL_000d: ldstr ""
+			IL_0012: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: ldstr "replace"
+			IL_001e: ldloc.1
+			IL_001f: ldstr ""
+			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0029: stloc.0
+			IL_002a: ldstr "\\/+$"
+			IL_002f: ldstr ""
+			IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0039: stloc.1
+			IL_003a: ldloc.0
+			IL_003b: ldstr "replace"
+			IL_0040: ldloc.1
+			IL_0041: ldstr ""
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_004b: stloc.0
+			IL_004c: ldloc.0
+			IL_004d: ret
+		} // end of method normalizeSpecPath::__js_call__
+
+	} // end of class normalizeSpecPath
+
+	.class nested public auto ansi abstract sealed beforefieldinit ensureString
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L96C56
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4b49
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L96C56::.ctor
+
+			} // end of class Block_L96C56
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b40
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value',
+				object label
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a50
+			// Header size: 12
+			// Code size: 164 (0xa4)
+			.maxstack 8
+			.locals init (
+				[0] bool,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] string
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0006: ldstr "string"
+			IL_000b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Boolean
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: brtrue IL_004c
+
+			IL_0025: ldarg.1
+			IL_0026: ldstr "trim"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0030: stloc.2
+			IL_0031: ldloc.2
+			IL_0032: ldstr ""
+			IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_003c: stloc.0
+			IL_003d: ldloc.0
+			IL_003e: box [System.Runtime]System.Boolean
+			IL_0043: stloc.3
+			IL_0044: ldloc.3
+			IL_0045: stloc.s 5
+			IL_0047: br IL_004f
+
+			IL_004c: ldloc.1
+			IL_004d: stloc.s 5
+
+			IL_004f: ldloc.s 5
+			IL_0051: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0056: stloc.0
+			IL_0057: ldloc.0
+			IL_0058: brfalse IL_00a2
+
+			IL_005d: ldarg.2
+			IL_005e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0063: stloc.s 6
+			IL_0065: ldstr "Invalid pin file: expected non-empty string for '"
+			IL_006a: ldloc.s 6
+			IL_006c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0071: stloc.s 6
+			IL_0073: ldloc.s 6
+			IL_0075: ldstr "'."
+			IL_007a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_007f: stloc.s 6
+			IL_0081: ldloc.s 6
+			IL_0083: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_008d: dup
+			IL_008e: isinst [System.Runtime]System.Exception
+			IL_0093: dup
+			IL_0094: brtrue IL_00a0
+
+			IL_0099: pop
+			IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_009f: throw
+
+			IL_00a0: pop
+			IL_00a1: throw
+
+			IL_00a2: ldnull
+			IL_00a3: ret
+		} // end of method ensureString::__js_call__
+
+	} // end of class ensureString
+
+	.class nested public auto ansi abstract sealed beforefieldinit ensureStringArray
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L102C51
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4b5b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L102C51::.ctor
+
+			} // end of class Block_L102C51
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b52
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L106C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L106C29
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L107C58
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4b76
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L107C58::.ctor
+
+				} // end of class Block_L107C58
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4b6d
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L106C29::.ctor
+
+			} // end of class Block_L106C29
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b64
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L106C7::.ctor
+
+		} // end of class Scope_ForOf_L106C7
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value',
+				object label
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2b00
+			// Header size: 12
+			// Code size: 453 (0x1c5)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[1] bool,
+				[2] bool,
+				[3] object,
+				[4] bool,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] string,
+				[11] object
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.Array::isArray(object)
+			IL_0006: stloc.s 4
+			IL_0008: ldloc.s 4
+			IL_000a: ldc.i4.0
+			IL_000b: ceq
+			IL_000d: stloc.s 4
+			IL_000f: ldloc.s 4
+			IL_0011: box [System.Runtime]System.Boolean
+			IL_0016: stloc.s 5
+			IL_0018: ldloc.s 5
+			IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_001f: stloc.s 4
+			IL_0021: ldloc.s 4
+			IL_0023: brtrue IL_005e
+
+			IL_0028: ldarg.1
+			IL_0029: ldstr "length"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0033: stloc.s 6
+			IL_0035: ldloc.s 6
+			IL_0037: ldc.r8 0.0
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_004a: stloc.s 4
+			IL_004c: ldloc.s 4
+			IL_004e: box [System.Runtime]System.Boolean
+			IL_0053: stloc.s 7
+			IL_0055: ldloc.s 7
+			IL_0057: stloc.s 9
+			IL_0059: br IL_0062
+
+			IL_005e: ldloc.s 5
+			IL_0060: stloc.s 9
+
+			IL_0062: ldloc.s 9
+			IL_0064: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0069: stloc.s 4
+			IL_006b: ldloc.s 4
+			IL_006d: brfalse IL_00b7
+
+			IL_0072: ldarg.2
+			IL_0073: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0078: stloc.s 10
+			IL_007a: ldstr "Invalid pin file: expected non-empty string array for '"
+			IL_007f: ldloc.s 10
+			IL_0081: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0086: stloc.s 10
+			IL_0088: ldloc.s 10
+			IL_008a: ldstr "'."
+			IL_008f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0094: stloc.s 10
+			IL_0096: ldloc.s 10
+			IL_0098: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_009d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00a2: dup
+			IL_00a3: isinst [System.Runtime]System.Exception
+			IL_00a8: dup
+			IL_00a9: brtrue IL_00b5
+
+			IL_00ae: pop
+			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00b4: throw
+
+			IL_00b5: pop
+			IL_00b6: throw
+
+			IL_00b7: ldarg.1
+			IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00bd: stloc.0
+			IL_00be: ldc.i4.0
+			IL_00bf: stloc.1
+			IL_00c0: ldc.i4.0
+			IL_00c1: stloc.2
+			.try
+			{
+				// loop start (head: IL_00c2)
+					IL_00c2: ldloc.0
+					IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_00c8: stloc.s 6
+					IL_00ca: ldloc.s 6
+					IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_00d1: stloc.s 4
+					IL_00d3: ldloc.s 4
+					IL_00d5: brtrue IL_01a9
+
+					IL_00da: ldloc.s 6
+					IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_00e1: stloc.s 6
+					IL_00e3: ldloc.s 6
+					IL_00e5: stloc.3
+					IL_00e6: ldloc.3
+					IL_00e7: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+					IL_00ec: ldstr "string"
+					IL_00f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+					IL_00f6: stloc.s 4
+					IL_00f8: ldloc.s 4
+					IL_00fa: box [System.Runtime]System.Boolean
+					IL_00ff: stloc.s 5
+					IL_0101: ldloc.s 5
+					IL_0103: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0108: stloc.s 4
+					IL_010a: ldloc.s 4
+					IL_010c: brtrue IL_013e
+
+					IL_0111: ldloc.3
+					IL_0112: ldstr "trim"
+					IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_011c: stloc.s 6
+					IL_011e: ldloc.s 6
+					IL_0120: ldstr ""
+					IL_0125: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+					IL_012a: stloc.s 4
+					IL_012c: ldloc.s 4
+					IL_012e: box [System.Runtime]System.Boolean
+					IL_0133: stloc.s 7
+					IL_0135: ldloc.s 7
+					IL_0137: stloc.s 11
+					IL_0139: br IL_0142
+
+					IL_013e: ldloc.s 5
+					IL_0140: stloc.s 11
+
+					IL_0142: ldloc.s 11
+					IL_0144: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0149: stloc.s 4
+					IL_014b: ldloc.s 4
+					IL_014d: brfalse IL_0197
+
+					IL_0152: ldarg.2
+					IL_0153: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0158: stloc.s 10
+					IL_015a: ldstr "Invalid pin file: '"
+					IL_015f: ldloc.s 10
+					IL_0161: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0166: stloc.s 10
+					IL_0168: ldloc.s 10
+					IL_016a: ldstr "' entries must be non-empty strings."
+					IL_016f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0174: stloc.s 10
+					IL_0176: ldloc.s 10
+					IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0182: dup
+					IL_0183: isinst [System.Runtime]System.Exception
+					IL_0188: dup
+					IL_0189: brtrue IL_0195
+
+					IL_018e: pop
+					IL_018f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_0194: throw
+
+					IL_0195: pop
+					IL_0196: throw
+
+					IL_0197: br IL_00c2
+				// end loop
+				IL_019c: ldloc.0
+				IL_019d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_01a2: ldc.i4.1
+				IL_01a3: stloc.2
+				IL_01a4: leave IL_01c3
+
+				IL_01a9: ldc.i4.1
+				IL_01aa: stloc.1
+				IL_01ab: leave IL_01c3
+			} // end .try
+			finally
+			{
+				IL_01b0: ldloc.1
+				IL_01b1: brtrue IL_01c2
+
+				IL_01b6: ldloc.2
+				IL_01b7: brtrue IL_01c2
+
+				IL_01bc: ldloc.0
+				IL_01bd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+
+				IL_01c2: endfinally
+			} // end handler
+
+			IL_01c3: ldnull
+			IL_01c4: ret
+		} // end of method ensureStringArray::__js_call__
+
+	} // end of class ensureStringArray
+
+	.class nested public auto ansi abstract sealed beforefieldinit validatePin
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L114C39
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4b88
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L114C39::.ctor
+
+			} // end of class Block_L114C39
+
+			.class nested private auto ansi beforefieldinit Block_L118C57
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4b91
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L118C57::.ctor
+
+			} // end of class Block_L118C57
+
+			.class nested private auto ansi beforefieldinit Block_L139C52
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4b9a
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L139C52::.ctor
+
+			} // end of class Block_L139C52
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4b7f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object pin
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x2ce4
+			// Header size: 12
+			// Code size: 834 (0x342)
+			.maxstack 8
+			.locals init (
+				[0] bool,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] object,
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			)
+
+			IL_0000: ldarg.2
+			IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0006: ldc.i4.0
+			IL_0007: ceq
+			IL_0009: stloc.0
+			IL_000a: ldloc.0
+			IL_000b: box [System.Runtime]System.Boolean
+			IL_0010: stloc.1
+			IL_0011: ldloc.1
+			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0017: stloc.0
+			IL_0018: ldloc.0
+			IL_0019: brtrue IL_003e
+
+			IL_001e: ldarg.2
+			IL_001f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0024: ldstr "object"
+			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_002e: stloc.0
+			IL_002f: ldloc.0
+			IL_0030: box [System.Runtime]System.Boolean
+			IL_0035: stloc.2
+			IL_0036: ldloc.2
+			IL_0037: stloc.s 4
+			IL_0039: br IL_0041
+
+			IL_003e: ldloc.1
+			IL_003f: stloc.s 4
+
+			IL_0041: ldloc.s 4
+			IL_0043: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0048: stloc.0
+			IL_0049: ldloc.0
+			IL_004a: brfalse IL_0073
+
+			IL_004f: ldstr "Invalid pin file: expected a JSON object."
+			IL_0054: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_005e: dup
+			IL_005f: isinst [System.Runtime]System.Exception
+			IL_0064: dup
+			IL_0065: brtrue IL_0071
+
+			IL_006a: pop
+			IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0070: throw
+
+			IL_0071: pop
+			IL_0072: throw
+
+			IL_0073: ldarg.2
+			IL_0074: ldstr "upstream"
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0083: ldc.i4.0
+			IL_0084: ceq
+			IL_0086: stloc.0
+			IL_0087: ldloc.0
+			IL_0088: box [System.Runtime]System.Boolean
+			IL_008d: stloc.1
+			IL_008e: ldloc.1
+			IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0094: stloc.0
+			IL_0095: ldloc.0
+			IL_0096: brtrue IL_00c5
+
+			IL_009b: ldarg.2
+			IL_009c: ldstr "upstream"
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a6: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_00ab: ldstr "object"
+			IL_00b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00b5: stloc.0
+			IL_00b6: ldloc.0
+			IL_00b7: box [System.Runtime]System.Boolean
+			IL_00bc: stloc.2
+			IL_00bd: ldloc.2
+			IL_00be: stloc.s 5
+			IL_00c0: br IL_00c8
+
+			IL_00c5: ldloc.1
+			IL_00c6: stloc.s 5
+
+			IL_00c8: ldloc.s 5
+			IL_00ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00cf: stloc.0
+			IL_00d0: ldloc.0
+			IL_00d1: brfalse IL_00fa
+
+			IL_00d6: ldstr "Invalid pin file: expected object for 'upstream'."
+			IL_00db: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00e5: dup
+			IL_00e6: isinst [System.Runtime]System.Exception
+			IL_00eb: dup
+			IL_00ec: brtrue IL_00f8
+
+			IL_00f1: pop
+			IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00f7: throw
+
+			IL_00f8: pop
+			IL_00f9: throw
+
+			IL_00fa: ldarg.2
+			IL_00fb: ldstr "upstream"
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0105: ldstr "owner"
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_010f: stloc.s 6
+			IL_0111: ldnull
+			IL_0112: ldloc.s 6
+			IL_0114: ldstr "upstream.owner"
+			IL_0119: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_011e: pop
+			IL_011f: ldarg.2
+			IL_0120: ldstr "upstream"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012a: ldstr "repo"
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0134: stloc.s 6
+			IL_0136: ldnull
+			IL_0137: ldloc.s 6
+			IL_0139: ldstr "upstream.repo"
+			IL_013e: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_0143: pop
+			IL_0144: ldarg.2
+			IL_0145: ldstr "upstream"
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014f: ldstr "cloneUrl"
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0159: stloc.s 6
+			IL_015b: ldnull
+			IL_015c: ldloc.s 6
+			IL_015e: ldstr "upstream.cloneUrl"
+			IL_0163: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_0168: pop
+			IL_0169: ldarg.2
+			IL_016a: ldstr "upstream"
+			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0174: ldstr "commit"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017e: stloc.s 6
+			IL_0180: ldnull
+			IL_0181: ldloc.s 6
+			IL_0183: ldstr "upstream.commit"
+			IL_0188: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_018d: pop
+			IL_018e: ldarg.2
+			IL_018f: ldstr "upstream"
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0199: ldstr "packageVersion"
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a3: stloc.s 6
+			IL_01a5: ldnull
+			IL_01a6: ldloc.s 6
+			IL_01a8: ldstr "upstream.packageVersion"
+			IL_01ad: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_01b2: pop
+			IL_01b3: ldarg.2
+			IL_01b4: ldstr "localOverrideEnvVar"
+			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01be: stloc.s 6
+			IL_01c0: ldnull
+			IL_01c1: ldloc.s 6
+			IL_01c3: ldstr "localOverrideEnvVar"
+			IL_01c8: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_01cd: pop
+			IL_01ce: ldarg.2
+			IL_01cf: ldstr "managedRoot"
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d9: stloc.s 6
+			IL_01db: ldnull
+			IL_01dc: ldloc.s 6
+			IL_01de: ldstr "managedRoot"
+			IL_01e3: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_01e8: pop
+			IL_01e9: ldarg.2
+			IL_01ea: ldstr "lineEndings"
+			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f4: stloc.s 6
+			IL_01f6: ldnull
+			IL_01f7: ldloc.s 6
+			IL_01f9: ldstr "lineEndings"
+			IL_01fe: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_0203: pop
+			IL_0204: ldarg.2
+			IL_0205: ldstr "updateStrategy"
+			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020f: stloc.s 6
+			IL_0211: ldnull
+			IL_0212: ldloc.s 6
+			IL_0214: ldstr "updateStrategy"
+			IL_0219: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+			IL_021e: pop
+			IL_021f: ldarg.2
+			IL_0220: ldstr "includeFiles"
+			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_022a: stloc.s 6
+			IL_022c: ldnull
+			IL_022d: ldloc.s 6
+			IL_022f: ldstr "includeFiles"
+			IL_0234: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_0239: pop
+			IL_023a: ldarg.2
+			IL_023b: ldstr "includeDirectories"
+			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0245: stloc.s 6
+			IL_0247: ldnull
+			IL_0248: ldloc.s 6
+			IL_024a: ldstr "includeDirectories"
+			IL_024f: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_0254: pop
+			IL_0255: ldarg.2
+			IL_0256: ldstr "requiredFiles"
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0260: stloc.s 6
+			IL_0262: ldnull
+			IL_0263: ldloc.s 6
+			IL_0265: ldstr "requiredFiles"
+			IL_026a: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_026f: pop
+			IL_0270: ldarg.2
+			IL_0271: ldstr "requiredDirectories"
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027b: stloc.s 6
+			IL_027d: ldnull
+			IL_027e: ldloc.s 6
+			IL_0280: ldstr "requiredDirectories"
+			IL_0285: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_028a: pop
+			IL_028b: ldarg.2
+			IL_028c: ldstr "defaultHarnessFiles"
+			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0296: stloc.s 6
+			IL_0298: ldnull
+			IL_0299: ldloc.s 6
+			IL_029b: ldstr "defaultHarnessFiles"
+			IL_02a0: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_02a5: pop
+			IL_02a6: ldarg.2
+			IL_02a7: ldstr "excludedFromMvp"
+			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02b1: stloc.s 6
+			IL_02b3: ldnull
+			IL_02b4: ldloc.s 6
+			IL_02b6: ldstr "excludedFromMvp"
+			IL_02bb: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_02c0: pop
+			IL_02c1: ldarg.2
+			IL_02c2: ldstr "attributionFiles"
+			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02cc: stloc.s 6
+			IL_02ce: ldnull
+			IL_02cf: ldloc.s 6
+			IL_02d1: ldstr "attributionFiles"
+			IL_02d6: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_02db: pop
+			IL_02dc: ldstr "^[0-9a-f]{40}$"
+			IL_02e1: ldstr "i"
+			IL_02e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_02eb: stloc.s 7
+			IL_02ed: ldloc.s 7
+			IL_02ef: ldarg.2
+			IL_02f0: ldstr "upstream"
+			IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fa: ldstr "commit"
+			IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0304: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0309: stloc.s 6
+			IL_030b: ldloc.s 6
+			IL_030d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0312: ldc.i4.0
+			IL_0313: ceq
+			IL_0315: stloc.0
+			IL_0316: ldloc.0
+			IL_0317: brfalse IL_0340
+
+			IL_031c: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_0321: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0326: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_032b: dup
+			IL_032c: isinst [System.Runtime]System.Exception
+			IL_0331: dup
+			IL_0332: brtrue IL_033e
+
+			IL_0337: pop
+			IL_0338: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_033d: throw
+
+			IL_033e: pop
+			IL_033f: throw
+
+			IL_0340: ldnull
+			IL_0341: ret
+		} // end of method validatePin::__js_call__
+
+	} // end of class validatePin
+
+	.class nested public auto ansi abstract sealed beforefieldinit loadPin
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4ba3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object pinPath
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x3034
+			// Header size: 12
+			// Code size: 72 (0x48)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0006: ldstr "readFileSync"
+			IL_000b: ldarg.2
+			IL_000c: ldstr "utf8"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: stloc.0
+			IL_0019: ldloc.0
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_001f: stloc.2
+			IL_0020: ldloc.2
+			IL_0021: stloc.1
+			IL_0022: ldc.i4.1
+			IL_0023: newarr [System.Runtime]System.Object
+			IL_0028: dup
+			IL_0029: ldc.i4.0
+			IL_002a: ldarg.0
+			IL_002b: stelem.ref
+			IL_002c: ldc.i4.0
+			IL_002d: ldelem.ref
+			IL_002e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0033: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0039: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_003e: ldnull
+			IL_003f: ldloc.1
+			IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0045: pop
+			IL_0046: ldloc.1
+			IL_0047: ret
+		} // end of method loadPin::__js_call__
+
+	} // end of class loadPin
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolveManagedCheckoutRoot
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4bac
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object pinPath,
+				object pin
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x3088
+			// Header size: 12
+			// Code size: 76 (0x4c)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0006: ldstr "dirname"
+			IL_000b: ldarg.2
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0011: stloc.1
+			IL_0012: ldloc.1
+			IL_0013: stloc.0
+			IL_0014: ldarg.0
+			IL_0015: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_001a: stloc.1
+			IL_001b: ldarg.3
+			IL_001c: ldstr "managedRoot"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0026: stloc.2
+			IL_0027: ldloc.1
+			IL_0028: ldstr "resolve"
+			IL_002d: ldloc.0
+			IL_002e: ldloc.2
+			IL_002f: ldarg.3
+			IL_0030: ldstr "upstream"
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003a: ldstr "commit"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0049: stloc.2
+			IL_004a: ldloc.2
+			IL_004b: ret
+		} // end of method resolveManagedCheckoutRoot::__js_call__
+
+	} // end of class resolveManagedCheckoutRoot
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolveManagedCheckoutLabel
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4bb5
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object pin
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x30e0
+			// Header size: 12
+			// Code size: 109 (0x6d)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0006: ldstr "posix"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: stloc.0
+			IL_0011: ldarg.2
+			IL_0012: ldstr "managedRoot"
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001c: stloc.1
+			IL_001d: ldc.i4.1
+			IL_001e: newarr [System.Runtime]System.Object
+			IL_0023: dup
+			IL_0024: ldc.i4.0
+			IL_0025: ldarg.0
+			IL_0026: stelem.ref
+			IL_0027: ldc.i4.0
+			IL_0028: ldelem.ref
+			IL_0029: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_002e: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0039: ldnull
+			IL_003a: ldloc.1
+			IL_003b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0040: stloc.1
+			IL_0041: ldloc.0
+			IL_0042: ldstr "join"
+			IL_0047: ldloc.1
+			IL_0048: ldarg.2
+			IL_0049: ldstr "upstream"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0053: ldstr "commit"
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0062: stloc.1
+			IL_0063: ldnull
+			IL_0064: ldloc.1
+			IL_0065: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_006a: stloc.1
+			IL_006b: ldloc.1
+			IL_006c: ret
+		} // end of method resolveManagedCheckoutLabel::__js_call__
+
+	} // end of class resolveManagedCheckoutLabel
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolveOverrideRoot
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L162C22
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4bc7
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L162C22::.ctor
+
+			} // end of class Block_L162C22
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4bbe
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object args,
+				object pin
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x315c
+			// Header size: 12
+			// Code size: 238 (0xee)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object,
+				[3] bool,
+				[4] object,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			)
+
+			IL_0000: ldarg.2
+			IL_0001: ldstr "root"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000b: stloc.2
+			IL_000c: ldloc.2
+			IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0012: stloc.3
+			IL_0013: ldloc.3
+			IL_0014: brtrue IL_0043
+
+			IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_001e: ldstr "env"
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0028: stloc.s 4
+			IL_002a: ldloc.s 4
+			IL_002c: ldarg.3
+			IL_002d: ldstr "localOverrideEnvVar"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_003c: stloc.s 6
+			IL_003e: br IL_0046
+
+			IL_0043: ldloc.2
+			IL_0044: stloc.s 6
+
+			IL_0046: ldloc.s 6
+			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: brtrue IL_0060
+
+			IL_0054: ldstr ""
+			IL_0059: stloc.s 6
+			IL_005b: br IL_0060
+
+			IL_0060: ldloc.s 6
+			IL_0062: stloc.0
+			IL_0063: ldloc.0
+			IL_0064: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0069: ldc.i4.0
+			IL_006a: ceq
+			IL_006c: stloc.3
+			IL_006d: ldloc.3
+			IL_006e: brfalse IL_007a
+
+			IL_0073: ldc.i4.0
+			IL_0074: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0079: ret
+
+			IL_007a: ldarg.2
+			IL_007b: ldstr "root"
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_008a: stloc.3
+			IL_008b: ldloc.3
+			IL_008c: brfalse IL_009c
+
+			IL_0091: ldstr "--root"
+			IL_0096: stloc.1
+			IL_0097: br IL_00a8
+
+			IL_009c: ldarg.3
+			IL_009d: ldstr "localOverrideEnvVar"
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a7: stloc.1
+
+			IL_00a8: ldc.i4.1
+			IL_00a9: newarr [System.Runtime]System.Object
+			IL_00ae: dup
+			IL_00af: ldc.i4.0
+			IL_00b0: ldarg.0
+			IL_00b1: stelem.ref
+			IL_00b2: ldc.i4.0
+			IL_00b3: ldelem.ref
+			IL_00b4: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00b9: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00c4: ldnull
+			IL_00c5: ldloc.0
+			IL_00c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_00cb: stloc.2
+			IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00d1: dup
+			IL_00d2: ldstr "source"
+			IL_00d7: ldloc.1
+			IL_00d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00dd: dup
+			IL_00de: ldstr "rootPath"
+			IL_00e3: ldloc.2
+			IL_00e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00e9: stloc.s 8
+			IL_00eb: ldloc.s 8
+			IL_00ed: ret
+		} // end of method resolveOverrideRoot::__js_call__
+
+	} // end of class resolveOverrideRoot
+
+	.class nested public auto ansi abstract sealed beforefieldinit describePlan
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L192C16
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4bd9
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L192C16::.ctor
+
+			} // end of class Block_L192C16
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4bd0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object pin,
+				object override
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x3258
+			// Header size: 12
+			// Code size: 1007 (0x3ef)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[2] bool,
+				[3] string,
+				[4] string,
+				[5] string,
+				[6] string,
+				[7] object,
+				[8] string,
+				[9] string,
+				[10] string,
+				[11] string,
+				[12] string,
+				[13] string,
+				[14] string,
+				[15] string,
+				[16] string,
+				[17] string,
+				[18] string,
+				[19] string,
+				[20] class [JavaScriptRuntime]JavaScriptRuntime.Array
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0006: stloc.2
+			IL_0007: ldloc.2
+			IL_0008: brfalse IL_0018
+
+			IL_000d: ldstr "override"
+			IL_0012: stloc.0
+			IL_0013: br IL_001e
+
+			IL_0018: ldstr "managed"
+			IL_001d: stloc.0
+
+			IL_001e: ldloc.0
+			IL_001f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0024: stloc.3
+			IL_0025: ldstr "source "
+			IL_002a: ldloc.3
+			IL_002b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0030: stloc.3
+			IL_0031: ldarg.2
+			IL_0032: ldstr "upstream"
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003c: ldstr "cloneUrl"
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0046: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_004b: stloc.s 4
+			IL_004d: ldstr "cloneUrl "
+			IL_0052: ldloc.s 4
+			IL_0054: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0059: stloc.s 4
+			IL_005b: ldarg.2
+			IL_005c: ldstr "upstream"
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0066: ldstr "commit"
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0075: stloc.s 5
+			IL_0077: ldstr "commit "
+			IL_007c: ldloc.s 5
+			IL_007e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0083: stloc.s 5
+			IL_0085: ldarg.2
+			IL_0086: ldstr "upstream"
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0090: ldstr "packageVersion"
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_009f: stloc.s 6
+			IL_00a1: ldstr "packageVersion "
+			IL_00a6: ldloc.s 6
+			IL_00a8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ad: stloc.s 6
+			IL_00af: ldarg.2
+			IL_00b0: ldstr "managedRoot"
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ba: stloc.s 7
+			IL_00bc: ldnull
+			IL_00bd: ldloc.s 7
+			IL_00bf: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_00c4: stloc.s 7
+			IL_00c6: ldloc.s 7
+			IL_00c8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00cd: stloc.s 8
+			IL_00cf: ldstr "managedRoot "
+			IL_00d4: ldloc.s 8
+			IL_00d6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00db: stloc.s 8
+			IL_00dd: ldc.i4.1
+			IL_00de: newarr [System.Runtime]System.Object
+			IL_00e3: dup
+			IL_00e4: ldc.i4.0
+			IL_00e5: ldarg.0
+			IL_00e6: stelem.ref
+			IL_00e7: ldc.i4.0
+			IL_00e8: ldelem.ref
+			IL_00e9: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00ee: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00f9: ldnull
+			IL_00fa: ldarg.2
+			IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0100: stloc.s 7
+			IL_0102: ldloc.s 7
+			IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0109: stloc.s 9
+			IL_010b: ldstr "checkoutDir "
+			IL_0110: ldloc.s 9
+			IL_0112: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0117: stloc.s 9
+			IL_0119: ldarg.2
+			IL_011a: ldstr "localOverrideEnvVar"
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0124: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0129: stloc.s 10
+			IL_012b: ldstr "overrideEnv "
+			IL_0130: ldloc.s 10
+			IL_0132: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0137: stloc.s 10
+			IL_0139: ldarg.2
+			IL_013a: ldstr "lineEndings"
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0149: stloc.s 11
+			IL_014b: ldstr "lineEndings "
+			IL_0150: ldloc.s 11
+			IL_0152: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0157: stloc.s 11
+			IL_0159: ldarg.2
+			IL_015a: ldstr "updateStrategy"
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0164: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0169: stloc.s 12
+			IL_016b: ldstr "updateStrategy "
+			IL_0170: ldloc.s 12
+			IL_0172: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0177: stloc.s 12
+			IL_0179: ldarg.2
+			IL_017a: ldstr "includeFiles"
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0184: ldstr "join"
+			IL_0189: ldstr ", "
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0193: stloc.s 7
+			IL_0195: ldloc.s 7
+			IL_0197: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_019c: stloc.s 13
+			IL_019e: ldstr "includeFiles "
+			IL_01a3: ldloc.s 13
+			IL_01a5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01aa: stloc.s 13
+			IL_01ac: ldarg.2
+			IL_01ad: ldstr "includeDirectories"
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b7: ldstr "join"
+			IL_01bc: ldstr ", "
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01c6: stloc.s 7
+			IL_01c8: ldloc.s 7
+			IL_01ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01cf: stloc.s 14
+			IL_01d1: ldstr "includeDirectories "
+			IL_01d6: ldloc.s 14
+			IL_01d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01dd: stloc.s 14
+			IL_01df: ldarg.2
+			IL_01e0: ldstr "requiredFiles"
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ea: ldstr "join"
+			IL_01ef: ldstr ", "
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01f9: stloc.s 7
+			IL_01fb: ldloc.s 7
+			IL_01fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0202: stloc.s 15
+			IL_0204: ldstr "requiredFiles "
+			IL_0209: ldloc.s 15
+			IL_020b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0210: stloc.s 15
+			IL_0212: ldarg.2
+			IL_0213: ldstr "requiredDirectories"
+			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_021d: ldstr "join"
+			IL_0222: ldstr ", "
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_022c: stloc.s 7
+			IL_022e: ldloc.s 7
+			IL_0230: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0235: stloc.s 16
+			IL_0237: ldstr "requiredDirectories "
+			IL_023c: ldloc.s 16
+			IL_023e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0243: stloc.s 16
+			IL_0245: ldarg.2
+			IL_0246: ldstr "defaultHarnessFiles"
+			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0250: ldstr "join"
+			IL_0255: ldstr ", "
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_025f: stloc.s 7
+			IL_0261: ldloc.s 7
+			IL_0263: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0268: stloc.s 17
+			IL_026a: ldstr "defaultHarnessFiles "
+			IL_026f: ldloc.s 17
+			IL_0271: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0276: stloc.s 17
+			IL_0278: ldarg.2
+			IL_0279: ldstr "excludedFromMvp"
+			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0283: ldstr "join"
+			IL_0288: ldstr "; "
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0292: stloc.s 7
+			IL_0294: ldloc.s 7
+			IL_0296: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_029b: stloc.s 18
+			IL_029d: ldstr "excludedFromMvp "
+			IL_02a2: ldloc.s 18
+			IL_02a4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a9: stloc.s 18
+			IL_02ab: ldarg.2
+			IL_02ac: ldstr "attributionFiles"
+			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02b6: ldstr "join"
+			IL_02bb: ldstr ", "
+			IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02c5: stloc.s 7
+			IL_02c7: ldloc.s 7
+			IL_02c9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02ce: stloc.s 19
+			IL_02d0: ldstr "attributionFiles "
+			IL_02d5: ldloc.s 19
+			IL_02d7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02dc: stloc.s 19
+			IL_02de: ldc.i4.s 16
+			IL_02e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02e5: dup
+			IL_02e6: ldloc.3
+			IL_02e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02ec: dup
+			IL_02ed: ldloc.s 4
+			IL_02ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f4: dup
+			IL_02f5: ldloc.s 5
+			IL_02f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02fc: dup
+			IL_02fd: ldloc.s 6
+			IL_02ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0304: dup
+			IL_0305: ldloc.s 8
+			IL_0307: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_030c: dup
+			IL_030d: ldloc.s 9
+			IL_030f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0314: dup
+			IL_0315: ldloc.s 10
+			IL_0317: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_031c: dup
+			IL_031d: ldloc.s 11
+			IL_031f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0324: dup
+			IL_0325: ldloc.s 12
+			IL_0327: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_032c: dup
+			IL_032d: ldloc.s 13
+			IL_032f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0334: dup
+			IL_0335: ldloc.s 14
+			IL_0337: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_033c: dup
+			IL_033d: ldloc.s 15
+			IL_033f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0344: dup
+			IL_0345: ldloc.s 16
+			IL_0347: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_034c: dup
+			IL_034d: ldloc.s 17
+			IL_034f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0354: dup
+			IL_0355: ldloc.s 18
+			IL_0357: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_035c: dup
+			IL_035d: ldloc.s 19
+			IL_035f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0364: stloc.s 20
+			IL_0366: ldloc.s 20
+			IL_0368: stloc.1
+			IL_0369: ldarg.3
+			IL_036a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_036f: stloc.2
+			IL_0370: ldloc.2
+			IL_0371: brfalse IL_03d6
+
+			IL_0376: ldarg.3
+			IL_0377: ldstr "source"
+			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0381: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0386: stloc.s 19
+			IL_0388: ldstr "overrideSource "
+			IL_038d: ldloc.s 19
+			IL_038f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0394: stloc.s 19
+			IL_0396: ldloc.1
+			IL_0397: ldloc.s 19
+			IL_0399: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_039e: pop
+			IL_039f: ldarg.3
+			IL_03a0: ldstr "rootPath"
+			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03aa: stloc.s 7
+			IL_03ac: ldnull
+			IL_03ad: ldloc.s 7
+			IL_03af: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_03b4: stloc.s 7
+			IL_03b6: ldloc.s 7
+			IL_03b8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03bd: stloc.s 19
+			IL_03bf: ldstr "overrideRoot "
+			IL_03c4: ldloc.s 19
+			IL_03c6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03cb: stloc.s 19
+			IL_03cd: ldloc.1
+			IL_03ce: ldloc.s 19
+			IL_03d0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03d5: pop
+
+			IL_03d6: ldloc.1
+			IL_03d7: ldc.i4.1
+			IL_03d8: newarr [System.Runtime]System.Object
+			IL_03dd: dup
+			IL_03de: ldc.i4.0
+			IL_03df: ldstr "\n"
+			IL_03e4: stelem.ref
+			IL_03e5: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03ea: stloc.s 19
+			IL_03ec: ldloc.s 19
+			IL_03ee: ret
+		} // end of method describePlan::__js_call__
+
+	} // end of class describePlan
+
+	.class nested public auto ansi abstract sealed beforefieldinit ensureDir
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4be2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object directoryPath
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x3654
+			// Header size: 12
+			// Code size: 39 (0x27)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "mkdirSync"
+			IL_000d: ldarg.2
+			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0013: dup
+			IL_0014: ldstr "recursive"
+			IL_0019: ldc.i4.1
+			IL_001a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0024: pop
+			IL_0025: ldnull
+			IL_0026: ret
+		} // end of method ensureDir::__js_call__
+
+	} // end of class ensureDir
+
+	.class nested public auto ansi abstract sealed beforefieldinit removeDir
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L205C37
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4bf4
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L205C37::.ctor
+
+			} // end of class Block_L205C37
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4beb
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object directoryPath
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x3688
+			// Header size: 12
+			// Code size: 87 (0x57)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] bool
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0006: ldstr "existsSync"
+			IL_000b: ldarg.2
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0011: stloc.0
+			IL_0012: ldloc.0
+			IL_0013: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0018: ldc.i4.0
+			IL_0019: ceq
+			IL_001b: stloc.1
+			IL_001c: ldloc.1
+			IL_001d: brfalse IL_0024
+
+			IL_0022: ldnull
+			IL_0023: ret
+
+			IL_0024: ldarg.0
+			IL_0025: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_002a: stloc.0
+			IL_002b: ldloc.0
+			IL_002c: ldstr "rmSync"
+			IL_0031: ldarg.2
+			IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0037: dup
+			IL_0038: ldstr "recursive"
+			IL_003d: ldc.i4.1
+			IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0043: dup
+			IL_0044: ldstr "force"
+			IL_0049: ldc.i4.1
+			IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0054: pop
+			IL_0055: ldnull
+			IL_0056: ret
+		} // end of method removeDir::__js_call__
+
+	} // end of class removeDir
+
+	.class nested public auto ansi abstract sealed beforefieldinit runGit
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L220C20
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c06
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L220C20::.ctor
+
+			} // end of class Block_L220C20
+
+			.class nested private auto ansi beforefieldinit Block_L224C27
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c0f
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L224C27::.ctor
+
+			} // end of class Block_L224C27
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4bfd
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object args,
+				object cwd
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x36ec
+			// Header size: 12
+			// Code size: 628 (0x274)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object,
+				[3] string,
+				[4] object,
+				[5] object,
+				[6] float64,
+				[7] bool,
+				[8] object,
+				[9] object,
+				[10] string,
+				[11] object,
+				[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[13] string,
+				[14] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
+			IL_0006: stloc.s 5
+			IL_0008: ldc.r8 4
+			IL_0011: ldc.r8 1024
+			IL_001a: mul
+			IL_001b: stloc.s 6
+			IL_001d: ldloc.s 6
+			IL_001f: ldc.r8 1024
+			IL_0028: mul
+			IL_0029: stloc.s 6
+			IL_002b: ldloc.s 5
+			IL_002d: ldstr "spawnSync"
+			IL_0032: ldstr "git"
+			IL_0037: ldarg.2
+			IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003d: dup
+			IL_003e: ldstr "cwd"
+			IL_0043: ldarg.3
+			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0049: dup
+			IL_004a: ldstr "encoding"
+			IL_004f: ldstr "utf8"
+			IL_0054: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0059: dup
+			IL_005a: ldstr "maxBuffer"
+			IL_005f: ldloc.s 6
+			IL_0061: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0066: dup
+			IL_0067: ldstr "shell"
+			IL_006c: ldc.i4.0
+			IL_006d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0077: stloc.s 5
+			IL_0079: ldloc.s 5
+			IL_007b: stloc.0
+			IL_007c: ldloc.0
+			IL_007d: ldstr "error"
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_008c: stloc.s 7
+			IL_008e: ldloc.s 7
+			IL_0090: brfalse IL_00b5
+
+			IL_0095: ldloc.0
+			IL_0096: ldstr "error"
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a0: dup
+			IL_00a1: isinst [System.Runtime]System.Exception
+			IL_00a6: dup
+			IL_00a7: brtrue IL_00b3
+
+			IL_00ac: pop
+			IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00b2: throw
+
+			IL_00b3: pop
+			IL_00b4: throw
+
+			IL_00b5: ldloc.0
+			IL_00b6: ldstr "status"
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c0: stloc.s 5
+			IL_00c2: ldloc.s 5
+			IL_00c4: ldc.r8 0.0
+			IL_00cd: box [System.Runtime]System.Double
+			IL_00d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00d7: stloc.s 7
+			IL_00d9: ldloc.s 7
+			IL_00db: brfalse IL_0244
+
+			IL_00e0: ldloc.0
+			IL_00e1: ldstr "stderr"
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00eb: stloc.s 5
+			IL_00ed: ldloc.s 5
+			IL_00ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00f4: stloc.s 7
+			IL_00f6: ldloc.s 7
+			IL_00f8: brtrue IL_0109
+
+			IL_00fd: ldstr ""
+			IL_0102: stloc.s 9
+			IL_0104: br IL_010d
+
+			IL_0109: ldloc.s 5
+			IL_010b: stloc.s 9
+
+			IL_010d: ldloc.s 9
+			IL_010f: castclass [System.Runtime]System.String
+			IL_0114: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0119: stloc.s 10
+			IL_011b: ldloc.s 10
+			IL_011d: stloc.1
+			IL_011e: ldloc.0
+			IL_011f: ldstr "stdout"
+			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0129: stloc.s 5
+			IL_012b: ldloc.s 5
+			IL_012d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0132: stloc.s 7
+			IL_0134: ldloc.s 7
+			IL_0136: brtrue IL_0147
+
+			IL_013b: ldstr ""
+			IL_0140: stloc.s 11
+			IL_0142: br IL_014b
+
+			IL_0147: ldloc.s 5
+			IL_0149: stloc.s 11
+
+			IL_014b: ldloc.s 11
+			IL_014d: castclass [System.Runtime]System.String
+			IL_0152: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0157: stloc.s 10
+			IL_0159: ldloc.s 10
+			IL_015b: stloc.2
+			IL_015c: ldc.i4.2
+			IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0162: dup
+			IL_0163: ldloc.1
+			IL_0164: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0169: dup
+			IL_016a: ldloc.2
+			IL_016b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0170: stloc.s 12
+			IL_0172: ldloc.s 12
+			IL_0174: ldc.i4.1
+			IL_0175: newarr [System.Runtime]System.Object
+			IL_017a: dup
+			IL_017b: ldc.i4.0
+			IL_017c: call class [System.Runtime]System.Func`3<object[], object, bool> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Boolean()
+			IL_0181: stelem.ref
+			IL_0182: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
+			IL_0187: stloc.s 12
+			IL_0189: ldloc.s 12
+			IL_018b: ldc.i4.1
+			IL_018c: newarr [System.Runtime]System.Object
+			IL_0191: dup
+			IL_0192: ldc.i4.0
+			IL_0193: ldstr "\n"
+			IL_0198: stelem.ref
+			IL_0199: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_019e: stloc.s 10
+			IL_01a0: ldloc.s 10
+			IL_01a2: stloc.3
+			IL_01a3: ldarg.2
+			IL_01a4: ldstr "join"
+			IL_01a9: ldstr " "
+			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01b3: stloc.s 5
+			IL_01b5: ldloc.s 5
+			IL_01b7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01bc: stloc.s 10
+			IL_01be: ldstr "git "
+			IL_01c3: ldloc.s 10
+			IL_01c5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ca: stloc.s 10
+			IL_01cc: ldloc.s 10
+			IL_01ce: ldstr " failed"
+			IL_01d3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d8: stloc.s 10
+			IL_01da: ldloc.3
+			IL_01db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01e0: stloc.s 7
+			IL_01e2: ldloc.s 7
+			IL_01e4: brfalse IL_0208
+
+			IL_01e9: ldloc.3
+			IL_01ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ef: stloc.s 13
+			IL_01f1: ldstr ":\n"
+			IL_01f6: ldloc.s 13
+			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fd: stloc.s 13
+			IL_01ff: ldloc.s 13
+			IL_0201: stloc.s 4
+			IL_0203: br IL_020f
+
+			IL_0208: ldstr "."
+			IL_020d: stloc.s 4
+
+			IL_020f: ldloc.s 4
+			IL_0211: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0216: stloc.s 13
+			IL_0218: ldloc.s 10
+			IL_021a: ldloc.s 13
+			IL_021c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0221: stloc.s 13
+			IL_0223: ldloc.s 13
+			IL_0225: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_022f: dup
+			IL_0230: isinst [System.Runtime]System.Exception
+			IL_0235: dup
+			IL_0236: brtrue IL_0242
+
+			IL_023b: pop
+			IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0241: throw
+
+			IL_0242: pop
+			IL_0243: throw
+
+			IL_0244: ldloc.0
+			IL_0245: ldstr "stdout"
+			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024f: stloc.s 5
+			IL_0251: ldloc.s 5
+			IL_0253: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0258: stloc.s 7
+			IL_025a: ldloc.s 7
+			IL_025c: brtrue IL_026d
+
+			IL_0261: ldstr ""
+			IL_0266: stloc.s 14
+			IL_0268: br IL_0271
+
+			IL_026d: ldloc.s 5
+			IL_026f: stloc.s 14
+
+			IL_0271: ldloc.s 14
+			IL_0273: ret
+		} // end of method runGit::__js_call__
+
+	} // end of class runGit
+
+	.class nested public auto ansi abstract sealed beforefieldinit buildSparsePatterns
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4c18
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L237C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L237C43
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c2a
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L237C43::.ctor
+
+			} // end of class Block_L237C43
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4c21
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L237C7::.ctor
+
+		} // end of class Scope_ForOf_L237C7
+
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L241C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L241C54
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c3c
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L241C54::.ctor
+
+			} // end of class Block_L241C54
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4c33
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L241C7::.ctor
+
+		} // end of class Scope_ForOf_L241C7
+
+
+		// Methods
+		.method public hidebysig static 
+			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object pin
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x396c
+			// Header size: 12
+			// Code size: 427 (0x1ab)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[2] bool,
+				[3] bool,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[6] bool,
+				[7] bool,
+				[8] object,
+				[9] object,
+				[10] object,
+				[11] bool,
+				[12] string
+			)
+
+			IL_0000: ldc.i4.0
+			IL_0001: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0006: stloc.0
+			IL_0007: ldarg.2
+			IL_0008: ldstr "includeFiles"
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0017: stloc.1
+			IL_0018: ldc.i4.0
+			IL_0019: stloc.2
+			IL_001a: ldc.i4.0
+			IL_001b: stloc.3
+			.try
+			{
+				// loop start (head: IL_001c)
+					IL_001c: ldloc.1
+					IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_0022: stloc.s 10
+					IL_0024: ldloc.s 10
+					IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_002b: stloc.s 11
+					IL_002d: ldloc.s 11
+					IL_002f: brtrue IL_0099
+
+					IL_0034: ldloc.s 10
+					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_003b: stloc.s 10
+					IL_003d: ldloc.s 10
+					IL_003f: stloc.s 4
+					IL_0041: ldc.i4.1
+					IL_0042: newarr [System.Runtime]System.Object
+					IL_0047: dup
+					IL_0048: ldc.i4.0
+					IL_0049: ldarg.0
+					IL_004a: stelem.ref
+					IL_004b: ldc.i4.0
+					IL_004c: ldelem.ref
+					IL_004d: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_0052: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_0058: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_005d: ldnull
+					IL_005e: ldloc.s 4
+					IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+					IL_0065: stloc.s 10
+					IL_0067: ldloc.s 10
+					IL_0069: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_006e: stloc.s 12
+					IL_0070: ldstr "/"
+					IL_0075: ldloc.s 12
+					IL_0077: call string [System.Runtime]System.String::Concat(string, string)
+					IL_007c: stloc.s 12
+					IL_007e: ldloc.0
+					IL_007f: ldloc.s 12
+					IL_0081: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0086: pop
+					IL_0087: br IL_001c
+				// end loop
+				IL_008c: ldloc.1
+				IL_008d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0092: ldc.i4.1
+				IL_0093: stloc.3
+				IL_0094: leave IL_00b3
+
+				IL_0099: ldc.i4.1
+				IL_009a: stloc.2
+				IL_009b: leave IL_00b3
+			} // end .try
+			finally
+			{
+				IL_00a0: ldloc.2
+				IL_00a1: brtrue IL_00b2
+
+				IL_00a6: ldloc.3
+				IL_00a7: brtrue IL_00b2
+
+				IL_00ac: ldloc.1
+				IL_00ad: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+
+				IL_00b2: endfinally
+			} // end handler
+
+			IL_00b3: ldarg.2
+			IL_00b4: ldstr "includeDirectories"
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00be: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00c3: stloc.s 5
+			IL_00c5: ldc.i4.0
+			IL_00c6: stloc.s 6
+			IL_00c8: ldc.i4.0
+			IL_00c9: stloc.s 7
+			.try
+			{
+				// loop start (head: IL_00cb)
+					IL_00cb: ldloc.s 5
+					IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_00d2: stloc.s 10
+					IL_00d4: ldloc.s 10
+					IL_00d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_00db: stloc.s 11
+					IL_00dd: ldloc.s 11
+					IL_00df: brtrue IL_018b
+
+					IL_00e4: ldloc.s 10
+					IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_00eb: stloc.s 10
+					IL_00ed: ldloc.s 10
+					IL_00ef: stloc.s 8
+					IL_00f1: ldc.i4.1
+					IL_00f2: newarr [System.Runtime]System.Object
+					IL_00f7: dup
+					IL_00f8: ldc.i4.0
+					IL_00f9: ldarg.0
+					IL_00fa: stelem.ref
+					IL_00fb: ldc.i4.0
+					IL_00fc: ldelem.ref
+					IL_00fd: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_0102: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_010d: ldnull
+					IL_010e: ldloc.s 8
+					IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+					IL_0115: stloc.s 10
+					IL_0117: ldloc.s 10
+					IL_0119: stloc.s 9
+					IL_011b: ldloc.s 9
+					IL_011d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0122: stloc.s 12
+					IL_0124: ldstr "/"
+					IL_0129: ldloc.s 12
+					IL_012b: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0130: stloc.s 12
+					IL_0132: ldloc.s 12
+					IL_0134: ldstr "/"
+					IL_0139: call string [System.Runtime]System.String::Concat(string, string)
+					IL_013e: stloc.s 12
+					IL_0140: ldloc.0
+					IL_0141: ldloc.s 12
+					IL_0143: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0148: pop
+					IL_0149: ldloc.s 9
+					IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0150: stloc.s 12
+					IL_0152: ldstr "/"
+					IL_0157: ldloc.s 12
+					IL_0159: call string [System.Runtime]System.String::Concat(string, string)
+					IL_015e: stloc.s 12
+					IL_0160: ldloc.s 12
+					IL_0162: ldstr "/**"
+					IL_0167: call string [System.Runtime]System.String::Concat(string, string)
+					IL_016c: stloc.s 12
+					IL_016e: ldloc.0
+					IL_016f: ldloc.s 12
+					IL_0171: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0176: pop
+					IL_0177: br IL_00cb
+				// end loop
+				IL_017c: ldloc.s 5
+				IL_017e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0183: ldc.i4.1
+				IL_0184: stloc.s 7
+				IL_0186: leave IL_01a9
+
+				IL_018b: ldc.i4.1
+				IL_018c: stloc.s 6
+				IL_018e: leave IL_01a9
+			} // end .try
+			finally
+			{
+				IL_0193: ldloc.s 6
+				IL_0195: brtrue IL_01a8
+
+				IL_019a: ldloc.s 7
+				IL_019c: brtrue IL_01a8
+
+				IL_01a1: ldloc.s 5
+				IL_01a3: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+
+				IL_01a8: endfinally
+			} // end handler
+
+			IL_01a9: ldloc.0
+			IL_01aa: ret
+		} // end of method buildSparsePatterns::__js_call__
+
+	} // end of class buildSparsePatterns
+
+	.class nested public auto ansi abstract sealed beforefieldinit validateResolvedRoot
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L268C64
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L270C33
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4c8d
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L270C33::.ctor
+
+				} // end of class Block_L270C33
+
+				.class nested private auto ansi beforefieldinit Block_L273C39
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4c96
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L273C39::.ctor
+
+				} // end of class Block_L273C39
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c84
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L268C64::.ctor
+
+			} // end of class Block_L268C64
+
+			.class nested private auto ansi beforefieldinit Block_L281C75
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c9f
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L281C75::.ctor
+
+			} // end of class Block_L281C75
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4c45
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L254C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L254C44
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L256C69
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4c60
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L256C69::.ctor
+
+				} // end of class Block_L256C69
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c57
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L254C44::.ctor
+
+			} // end of class Block_L254C44
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4c4e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L254C7::.ctor
+
+		} // end of class Scope_ForOf_L254C7
+
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L261C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L261C55
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L263C74
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4c7b
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L263C74::.ctor
+
+				} // end of class Block_L263C74
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c72
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L261C55::.ctor
+
+			} // end of class Block_L261C55
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4c69
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L261C7::.ctor
+
+		} // end of class Scope_ForOf_L261C7
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object rootPath,
+				object pin
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x3b40
+			// Header size: 12
+			// Code size: 1491 (0x5d3)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[3] bool,
+				[4] bool,
+				[5] object,
+				[6] object,
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[8] bool,
+				[9] bool,
+				[10] object,
+				[11] object,
+				[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[13] object,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] bool,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[19] object,
+				[20] object[],
+				[21] object,
+				[22] object,
+				[23] object,
+				[24] object,
+				[25] object,
+				[26] object,
+				[27] string,
+				[28] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[29] object,
+				[30] object,
+				[31] string
+			)
+
+			IL_0000: ldc.i4.0
+			IL_0001: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.0
+			IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_000d: stloc.1
+			IL_000e: ldarg.3
+			IL_000f: ldstr "requiredFiles"
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_001e: stloc.2
+			IL_001f: ldc.i4.0
+			IL_0020: stloc.3
+			IL_0021: ldc.i4.0
+			IL_0022: stloc.s 4
+			.try
+			{
+				// loop start (head: IL_0024)
+					IL_0024: ldloc.2
+					IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_002a: stloc.s 16
+					IL_002c: ldloc.s 16
+					IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_0033: stloc.s 17
+					IL_0035: ldloc.s 17
+					IL_0037: brtrue IL_0168
+
+					IL_003c: ldloc.s 16
+					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_0043: stloc.s 16
+					IL_0045: ldloc.s 16
+					IL_0047: stloc.s 5
+					IL_0049: ldarg.0
+					IL_004a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_004f: stloc.s 16
+					IL_0051: ldc.i4.1
+					IL_0052: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0057: dup
+					IL_0058: ldarg.2
+					IL_0059: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_005e: stloc.s 18
+					IL_0060: ldc.i4.1
+					IL_0061: newarr [System.Runtime]System.Object
+					IL_0066: dup
+					IL_0067: ldc.i4.0
+					IL_0068: ldarg.0
+					IL_0069: stelem.ref
+					IL_006a: ldc.i4.0
+					IL_006b: ldelem.ref
+					IL_006c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_0071: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_007c: ldnull
+					IL_007d: ldloc.s 5
+					IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+					IL_0084: stloc.s 19
+					IL_0086: ldloc.s 19
+					IL_0088: ldstr "split"
+					IL_008d: ldstr "/"
+					IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0097: stloc.s 19
+					IL_0099: ldloc.s 18
+					IL_009b: ldloc.s 19
+					IL_009d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00a2: ldloc.s 18
+					IL_00a4: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00a9: stloc.s 20
+					IL_00ab: ldloc.s 16
+					IL_00ad: ldstr "join"
+					IL_00b2: ldloc.s 20
+					IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_00b9: stloc.s 16
+					IL_00bb: ldloc.s 16
+					IL_00bd: stloc.s 6
+					IL_00bf: ldarg.0
+					IL_00c0: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00c5: ldstr "existsSync"
+					IL_00ca: ldloc.s 6
+					IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00d1: stloc.s 16
+					IL_00d3: ldloc.s 16
+					IL_00d5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_00da: ldc.i4.0
+					IL_00db: ceq
+					IL_00dd: stloc.s 17
+					IL_00df: ldloc.s 17
+					IL_00e1: box [System.Runtime]System.Boolean
+					IL_00e6: stloc.s 21
+					IL_00e8: ldloc.s 21
+					IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00ef: stloc.s 17
+					IL_00f1: ldloc.s 17
+					IL_00f3: brtrue IL_0138
+
+					IL_00f8: ldarg.0
+					IL_00f9: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00fe: ldstr "statSync"
+					IL_0103: ldloc.s 6
+					IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_010a: stloc.s 16
+					IL_010c: ldloc.s 16
+					IL_010e: ldstr "isFile"
+					IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0118: stloc.s 16
+					IL_011a: ldloc.s 16
+					IL_011c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0121: ldc.i4.0
+					IL_0122: ceq
+					IL_0124: stloc.s 17
+					IL_0126: ldloc.s 17
+					IL_0128: box [System.Runtime]System.Boolean
+					IL_012d: stloc.s 22
+					IL_012f: ldloc.s 22
+					IL_0131: stloc.s 24
+					IL_0133: br IL_013c
+
+					IL_0138: ldloc.s 21
+					IL_013a: stloc.s 24
+
+					IL_013c: ldloc.s 24
+					IL_013e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0143: stloc.s 17
+					IL_0145: ldloc.s 17
+					IL_0147: brfalse IL_0155
+
+					IL_014c: ldloc.0
+					IL_014d: ldloc.s 5
+					IL_014f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0154: pop
+
+					IL_0155: br IL_0024
+				// end loop
+				IL_015a: ldloc.2
+				IL_015b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0160: ldc.i4.1
+				IL_0161: stloc.s 4
+				IL_0163: leave IL_0183
+
+				IL_0168: ldc.i4.1
+				IL_0169: stloc.3
+				IL_016a: leave IL_0183
+			} // end .try
+			finally
+			{
+				IL_016f: ldloc.3
+				IL_0170: brtrue IL_0182
+
+				IL_0175: ldloc.s 4
+				IL_0177: brtrue IL_0182
+
+				IL_017c: ldloc.2
+				IL_017d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+
+				IL_0182: endfinally
+			} // end handler
+
+			IL_0183: ldarg.3
+			IL_0184: ldstr "requiredDirectories"
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0193: stloc.s 7
+			IL_0195: ldc.i4.0
+			IL_0196: stloc.s 8
+			IL_0198: ldc.i4.0
+			IL_0199: stloc.s 9
+			.try
+			{
+				// loop start (head: IL_019b)
+					IL_019b: ldloc.s 7
+					IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_01a2: stloc.s 16
+					IL_01a4: ldloc.s 16
+					IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_01ab: stloc.s 17
+					IL_01ad: ldloc.s 17
+					IL_01af: brtrue IL_02e1
+
+					IL_01b4: ldloc.s 16
+					IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_01bb: stloc.s 16
+					IL_01bd: ldloc.s 16
+					IL_01bf: stloc.s 10
+					IL_01c1: ldarg.0
+					IL_01c2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_01c7: stloc.s 16
+					IL_01c9: ldc.i4.1
+					IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_01cf: dup
+					IL_01d0: ldarg.2
+					IL_01d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_01d6: stloc.s 18
+					IL_01d8: ldc.i4.1
+					IL_01d9: newarr [System.Runtime]System.Object
+					IL_01de: dup
+					IL_01df: ldc.i4.0
+					IL_01e0: ldarg.0
+					IL_01e1: stelem.ref
+					IL_01e2: ldc.i4.0
+					IL_01e3: ldelem.ref
+					IL_01e4: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_01e9: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_01ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_01f4: ldnull
+					IL_01f5: ldloc.s 10
+					IL_01f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+					IL_01fc: stloc.s 19
+					IL_01fe: ldloc.s 19
+					IL_0200: ldstr "split"
+					IL_0205: ldstr "/"
+					IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_020f: stloc.s 19
+					IL_0211: ldloc.s 18
+					IL_0213: ldloc.s 19
+					IL_0215: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_021a: ldloc.s 18
+					IL_021c: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_0221: stloc.s 20
+					IL_0223: ldloc.s 16
+					IL_0225: ldstr "join"
+					IL_022a: ldloc.s 20
+					IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_0231: stloc.s 16
+					IL_0233: ldloc.s 16
+					IL_0235: stloc.s 11
+					IL_0237: ldarg.0
+					IL_0238: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_023d: ldstr "existsSync"
+					IL_0242: ldloc.s 11
+					IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0249: stloc.s 16
+					IL_024b: ldloc.s 16
+					IL_024d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0252: ldc.i4.0
+					IL_0253: ceq
+					IL_0255: stloc.s 17
+					IL_0257: ldloc.s 17
+					IL_0259: box [System.Runtime]System.Boolean
+					IL_025e: stloc.s 21
+					IL_0260: ldloc.s 21
+					IL_0262: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0267: stloc.s 17
+					IL_0269: ldloc.s 17
+					IL_026b: brtrue IL_02b0
+
+					IL_0270: ldarg.0
+					IL_0271: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0276: ldstr "statSync"
+					IL_027b: ldloc.s 11
+					IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0282: stloc.s 16
+					IL_0284: ldloc.s 16
+					IL_0286: ldstr "isDirectory"
+					IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0290: stloc.s 16
+					IL_0292: ldloc.s 16
+					IL_0294: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0299: ldc.i4.0
+					IL_029a: ceq
+					IL_029c: stloc.s 17
+					IL_029e: ldloc.s 17
+					IL_02a0: box [System.Runtime]System.Boolean
+					IL_02a5: stloc.s 22
+					IL_02a7: ldloc.s 22
+					IL_02a9: stloc.s 25
+					IL_02ab: br IL_02b4
+
+					IL_02b0: ldloc.s 21
+					IL_02b2: stloc.s 25
+
+					IL_02b4: ldloc.s 25
+					IL_02b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02bb: stloc.s 17
+					IL_02bd: ldloc.s 17
+					IL_02bf: brfalse IL_02cd
+
+					IL_02c4: ldloc.1
+					IL_02c5: ldloc.s 10
+					IL_02c7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02cc: pop
+
+					IL_02cd: br IL_019b
+				// end loop
+				IL_02d2: ldloc.s 7
+				IL_02d4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_02d9: ldc.i4.1
+				IL_02da: stloc.s 9
+				IL_02dc: leave IL_02ff
+
+				IL_02e1: ldc.i4.1
+				IL_02e2: stloc.s 8
+				IL_02e4: leave IL_02ff
+			} // end .try
+			finally
+			{
+				IL_02e9: ldloc.s 8
+				IL_02eb: brtrue IL_02fe
+
+				IL_02f0: ldloc.s 9
+				IL_02f2: brtrue IL_02fe
+
+				IL_02f7: ldloc.s 7
+				IL_02f9: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+
+				IL_02fe: endfinally
+			} // end handler
+
+			IL_02ff: ldloc.0
+			IL_0300: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0305: conv.r8
+			IL_0306: ldc.r8 0.0
+			IL_030f: cgt
+			IL_0311: box [System.Runtime]System.Boolean
+			IL_0316: stloc.s 21
+			IL_0318: ldloc.s 21
+			IL_031a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_031f: stloc.s 17
+			IL_0321: ldloc.s 17
+			IL_0323: brtrue IL_0346
+
+			IL_0328: ldloc.1
+			IL_0329: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_032e: conv.r8
+			IL_032f: ldc.r8 0.0
+			IL_0338: cgt
+			IL_033a: box [System.Runtime]System.Boolean
+			IL_033f: stloc.s 26
+			IL_0341: br IL_034a
+
+			IL_0346: ldloc.s 21
+			IL_0348: stloc.s 26
+
+			IL_034a: ldloc.s 26
+			IL_034c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0351: stloc.s 17
+			IL_0353: ldloc.s 17
+			IL_0355: brfalse IL_0438
+
+			IL_035a: ldc.i4.0
+			IL_035b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0360: stloc.s 12
+			IL_0362: ldloc.0
+			IL_0363: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0368: conv.r8
+			IL_0369: ldc.r8 0.0
+			IL_0372: cgt
+			IL_0374: brfalse IL_03b0
+
+			IL_0379: ldloc.0
+			IL_037a: ldc.i4.1
+			IL_037b: newarr [System.Runtime]System.Object
+			IL_0380: dup
+			IL_0381: ldc.i4.0
+			IL_0382: ldstr ", "
+			IL_0387: stelem.ref
+			IL_0388: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_038d: stloc.s 27
+			IL_038f: ldloc.s 27
+			IL_0391: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0396: stloc.s 27
+			IL_0398: ldstr "missing files: "
+			IL_039d: ldloc.s 27
+			IL_039f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03a4: stloc.s 27
+			IL_03a6: ldloc.s 12
+			IL_03a8: ldloc.s 27
+			IL_03aa: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03af: pop
+
+			IL_03b0: ldloc.1
+			IL_03b1: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_03b6: conv.r8
+			IL_03b7: ldc.r8 0.0
+			IL_03c0: cgt
+			IL_03c2: brfalse IL_03fe
+
+			IL_03c7: ldloc.1
+			IL_03c8: ldc.i4.1
+			IL_03c9: newarr [System.Runtime]System.Object
+			IL_03ce: dup
+			IL_03cf: ldc.i4.0
+			IL_03d0: ldstr ", "
+			IL_03d5: stelem.ref
+			IL_03d6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03db: stloc.s 27
+			IL_03dd: ldloc.s 27
+			IL_03df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03e4: stloc.s 27
+			IL_03e6: ldstr "missing directories: "
+			IL_03eb: ldloc.s 27
+			IL_03ed: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03f2: stloc.s 27
+			IL_03f4: ldloc.s 12
+			IL_03f6: ldloc.s 27
+			IL_03f8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03fd: pop
+
+			IL_03fe: ldloc.s 12
+			IL_0400: ldc.i4.1
+			IL_0401: newarr [System.Runtime]System.Object
+			IL_0406: dup
+			IL_0407: ldc.i4.0
+			IL_0408: ldstr "; "
+			IL_040d: stelem.ref
+			IL_040e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0413: stloc.s 27
+			IL_0415: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_041a: dup
+			IL_041b: ldstr "ok"
+			IL_0420: ldc.i4.0
+			IL_0421: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0426: dup
+			IL_0427: ldstr "message"
+			IL_042c: ldloc.s 27
+			IL_042e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0433: stloc.s 28
+			IL_0435: ldloc.s 28
+			IL_0437: ret
+
+			IL_0438: ldarg.0
+			IL_0439: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_043e: ldstr "join"
+			IL_0443: ldarg.2
+			IL_0444: ldstr "package.json"
+			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_044e: stloc.s 16
+			IL_0450: ldloc.s 16
+			IL_0452: stloc.s 13
+			IL_0454: ldarg.0
+			IL_0455: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_045a: ldstr "readFileSync"
+			IL_045f: ldloc.s 13
+			IL_0461: ldstr "utf8"
+			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_046b: stloc.s 16
+			IL_046d: ldloc.s 16
+			IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_0474: stloc.s 16
+			IL_0476: ldloc.s 16
+			IL_0478: stloc.s 14
+			IL_047a: ldloc.s 14
+			IL_047c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0481: ldc.i4.0
+			IL_0482: ceq
+			IL_0484: stloc.s 17
+			IL_0486: ldloc.s 17
+			IL_0488: box [System.Runtime]System.Boolean
+			IL_048d: stloc.s 21
+			IL_048f: ldloc.s 21
+			IL_0491: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0496: stloc.s 17
+			IL_0498: ldloc.s 17
+			IL_049a: brtrue IL_04dd
+
+			IL_049f: ldloc.s 14
+			IL_04a1: ldstr "version"
+			IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04ab: stloc.s 16
+			IL_04ad: ldloc.s 16
+			IL_04af: ldarg.3
+			IL_04b0: ldstr "upstream"
+			IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04ba: ldstr "packageVersion"
+			IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_04c9: stloc.s 17
+			IL_04cb: ldloc.s 17
+			IL_04cd: box [System.Runtime]System.Boolean
+			IL_04d2: stloc.s 22
+			IL_04d4: ldloc.s 22
+			IL_04d6: stloc.s 29
+			IL_04d8: br IL_04e1
+
+			IL_04dd: ldloc.s 21
+			IL_04df: stloc.s 29
+
+			IL_04e1: ldloc.s 29
+			IL_04e3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04e8: stloc.s 17
+			IL_04ea: ldloc.s 17
+			IL_04ec: brfalse IL_05b1
+
+			IL_04f1: ldarg.3
+			IL_04f2: ldstr "upstream"
+			IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fc: ldstr "packageVersion"
+			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0506: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_050b: stloc.s 27
+			IL_050d: ldstr "package.json version mismatch: expected "
+			IL_0512: ldloc.s 27
+			IL_0514: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0519: stloc.s 27
+			IL_051b: ldloc.s 27
+			IL_051d: ldstr ", got "
+			IL_0522: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0527: stloc.s 27
+			IL_0529: ldloc.s 14
+			IL_052b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0530: stloc.s 17
+			IL_0532: ldloc.s 17
+			IL_0534: brfalse IL_054c
+
+			IL_0539: ldloc.s 14
+			IL_053b: ldstr "version"
+			IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0545: stloc.s 30
+			IL_0547: br IL_0550
+
+			IL_054c: ldloc.s 14
+			IL_054e: stloc.s 30
+
+			IL_0550: ldloc.s 30
+			IL_0552: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0557: stloc.s 17
+			IL_0559: ldloc.s 17
+			IL_055b: brfalse IL_0573
+
+			IL_0560: ldloc.s 14
+			IL_0562: ldstr "version"
+			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056c: stloc.s 15
+			IL_056e: br IL_057a
+
+			IL_0573: ldstr "<missing>"
+			IL_0578: stloc.s 15
+
+			IL_057a: ldloc.s 15
+			IL_057c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0581: stloc.s 31
+			IL_0583: ldloc.s 27
+			IL_0585: ldloc.s 31
+			IL_0587: call string [System.Runtime]System.String::Concat(string, string)
+			IL_058c: stloc.s 31
+			IL_058e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0593: dup
+			IL_0594: ldstr "ok"
+			IL_0599: ldc.i4.0
+			IL_059a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_059f: dup
+			IL_05a0: ldstr "message"
+			IL_05a5: ldloc.s 31
+			IL_05a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05ac: stloc.s 28
+			IL_05ae: ldloc.s 28
+			IL_05b0: ret
+
+			IL_05b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05b6: dup
+			IL_05b7: ldstr "ok"
+			IL_05bc: ldc.i4.1
+			IL_05bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05c2: dup
+			IL_05c3: ldstr "message"
+			IL_05c8: ldstr ""
+			IL_05cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05d2: ret
+		} // end of method validateResolvedRoot::__js_call__
+
+	} // end of class validateResolvedRoot
+
+	.class nested public auto ansi abstract sealed beforefieldinit ensureManagedCheckout
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L292C14
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L294C20
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4cba
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L294C20::.ctor
+
+				} // end of class Block_L294C20
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4cb1
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L292C14::.ctor
+
+			} // end of class Block_L292C14
+
+			.class nested private auto ansi beforefieldinit Block_L312C22
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4cc3
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L312C22::.ctor
+
+			} // end of class Block_L312C22
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4ca8
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object rootPath,
+				object pin,
+				object force
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x4154
+			// Header size: 12
+			// Code size: 1103 (0x44f)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] bool,
+				[3] object,
+				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[5] string
+			)
+
+			IL_0000: ldarg.s force
+			IL_0002: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0007: ldc.i4.0
+			IL_0008: ceq
+			IL_000a: stloc.2
+			IL_000b: ldloc.2
+			IL_000c: brfalse IL_007d
+
+			IL_0011: ldc.i4.1
+			IL_0012: newarr [System.Runtime]System.Object
+			IL_0017: dup
+			IL_0018: ldc.i4.0
+			IL_0019: ldarg.0
+			IL_001a: stelem.ref
+			IL_001b: ldc.i4.0
+			IL_001c: ldelem.ref
+			IL_001d: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0022: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_002d: ldnull
+			IL_002e: ldarg.2
+			IL_002f: ldarg.3
+			IL_0030: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0035: stloc.3
+			IL_0036: ldloc.3
+			IL_0037: stloc.0
+			IL_0038: ldloc.0
+			IL_0039: ldstr "ok"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0043: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0048: stloc.2
+			IL_0049: ldloc.2
+			IL_004a: brfalse IL_007d
+
+			IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0054: dup
+			IL_0055: ldstr "source"
+			IL_005a: ldstr "managed-cache"
+			IL_005f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0064: dup
+			IL_0065: ldstr "rootPath"
+			IL_006a: ldarg.2
+			IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0070: dup
+			IL_0071: ldstr "reused"
+			IL_0076: ldc.i4.1
+			IL_0077: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_007c: ret
+
+			IL_007d: ldc.i4.1
+			IL_007e: newarr [System.Runtime]System.Object
+			IL_0083: dup
+			IL_0084: ldc.i4.0
+			IL_0085: ldarg.0
+			IL_0086: stelem.ref
+			IL_0087: ldc.i4.0
+			IL_0088: ldelem.ref
+			IL_0089: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_008e: ldftn object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0099: ldnull
+			IL_009a: ldarg.2
+			IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_00a0: pop
+			IL_00a1: ldc.i4.1
+			IL_00a2: newarr [System.Runtime]System.Object
+			IL_00a7: dup
+			IL_00a8: ldc.i4.0
+			IL_00a9: ldarg.0
+			IL_00aa: stelem.ref
+			IL_00ab: ldc.i4.0
+			IL_00ac: ldelem.ref
+			IL_00ad: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00b2: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00bd: ldnull
+			IL_00be: ldarg.2
+			IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_00c4: pop
+			IL_00c5: ldc.i4.1
+			IL_00c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00cb: dup
+			IL_00cc: ldstr "init"
+			IL_00d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00d6: stloc.s 4
+			IL_00d8: ldc.i4.1
+			IL_00d9: newarr [System.Runtime]System.Object
+			IL_00de: dup
+			IL_00df: ldc.i4.0
+			IL_00e0: ldarg.0
+			IL_00e1: stelem.ref
+			IL_00e2: ldc.i4.0
+			IL_00e3: ldelem.ref
+			IL_00e4: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00e9: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_00f4: ldnull
+			IL_00f5: ldloc.s 4
+			IL_00f7: ldarg.2
+			IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_00fd: pop
+			IL_00fe: ldc.i4.3
+			IL_00ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0104: dup
+			IL_0105: ldstr "config"
+			IL_010a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_010f: dup
+			IL_0110: ldstr "core.autocrlf"
+			IL_0115: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011a: dup
+			IL_011b: ldstr "false"
+			IL_0120: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0125: stloc.s 4
+			IL_0127: ldc.i4.1
+			IL_0128: newarr [System.Runtime]System.Object
+			IL_012d: dup
+			IL_012e: ldc.i4.0
+			IL_012f: ldarg.0
+			IL_0130: stelem.ref
+			IL_0131: ldc.i4.0
+			IL_0132: ldelem.ref
+			IL_0133: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0138: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_013e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0143: ldnull
+			IL_0144: ldloc.s 4
+			IL_0146: ldarg.2
+			IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_014c: pop
+			IL_014d: ldc.i4.3
+			IL_014e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0153: dup
+			IL_0154: ldstr "config"
+			IL_0159: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_015e: dup
+			IL_015f: ldstr "core.eol"
+			IL_0164: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0169: dup
+			IL_016a: ldstr "lf"
+			IL_016f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0174: stloc.s 4
+			IL_0176: ldc.i4.1
+			IL_0177: newarr [System.Runtime]System.Object
+			IL_017c: dup
+			IL_017d: ldc.i4.0
+			IL_017e: ldarg.0
+			IL_017f: stelem.ref
+			IL_0180: ldc.i4.0
+			IL_0181: ldelem.ref
+			IL_0182: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0187: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_018d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0192: ldnull
+			IL_0193: ldloc.s 4
+			IL_0195: ldarg.2
+			IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_019b: pop
+			IL_019c: ldc.i4.4
+			IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01a2: dup
+			IL_01a3: ldstr "remote"
+			IL_01a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01ad: dup
+			IL_01ae: ldstr "add"
+			IL_01b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b8: dup
+			IL_01b9: ldstr "origin"
+			IL_01be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01c3: dup
+			IL_01c4: ldarg.3
+			IL_01c5: ldstr "upstream"
+			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cf: ldstr "cloneUrl"
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01de: stloc.s 4
+			IL_01e0: ldc.i4.1
+			IL_01e1: newarr [System.Runtime]System.Object
+			IL_01e6: dup
+			IL_01e7: ldc.i4.0
+			IL_01e8: ldarg.0
+			IL_01e9: stelem.ref
+			IL_01ea: ldc.i4.0
+			IL_01eb: ldelem.ref
+			IL_01ec: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_01f1: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_01f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_01fc: ldnull
+			IL_01fd: ldloc.s 4
+			IL_01ff: ldarg.2
+			IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0205: pop
+			IL_0206: ldc.i4.3
+			IL_0207: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_020c: dup
+			IL_020d: ldstr "sparse-checkout"
+			IL_0212: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0217: dup
+			IL_0218: ldstr "init"
+			IL_021d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0222: dup
+			IL_0223: ldstr "--no-cone"
+			IL_0228: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_022d: stloc.s 4
+			IL_022f: ldc.i4.1
+			IL_0230: newarr [System.Runtime]System.Object
+			IL_0235: dup
+			IL_0236: ldc.i4.0
+			IL_0237: ldarg.0
+			IL_0238: stelem.ref
+			IL_0239: ldc.i4.0
+			IL_023a: ldelem.ref
+			IL_023b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0240: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0246: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_024b: ldnull
+			IL_024c: ldloc.s 4
+			IL_024e: ldarg.2
+			IL_024f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0254: pop
+			IL_0255: ldc.i4.3
+			IL_0256: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_025b: dup
+			IL_025c: ldstr "sparse-checkout"
+			IL_0261: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0266: dup
+			IL_0267: ldstr "set"
+			IL_026c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0271: dup
+			IL_0272: ldstr "--no-cone"
+			IL_0277: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_027c: stloc.s 4
+			IL_027e: ldc.i4.1
+			IL_027f: newarr [System.Runtime]System.Object
+			IL_0284: dup
+			IL_0285: ldc.i4.0
+			IL_0286: ldarg.0
+			IL_0287: stelem.ref
+			IL_0288: ldc.i4.0
+			IL_0289: ldelem.ref
+			IL_028a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_028f: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0295: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_029a: ldnull
+			IL_029b: ldarg.3
+			IL_029c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_02a1: stloc.3
+			IL_02a2: ldloc.s 4
+			IL_02a4: ldc.i4.1
+			IL_02a5: newarr [System.Runtime]System.Object
+			IL_02aa: dup
+			IL_02ab: ldc.i4.0
+			IL_02ac: ldloc.3
+			IL_02ad: stelem.ref
+			IL_02ae: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
+			IL_02b3: stloc.s 4
+			IL_02b5: ldc.i4.1
+			IL_02b6: newarr [System.Runtime]System.Object
+			IL_02bb: dup
+			IL_02bc: ldc.i4.0
+			IL_02bd: ldarg.0
+			IL_02be: stelem.ref
+			IL_02bf: ldc.i4.0
+			IL_02c0: ldelem.ref
+			IL_02c1: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_02c6: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_02cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_02d1: ldnull
+			IL_02d2: ldloc.s 4
+			IL_02d4: ldarg.2
+			IL_02d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_02da: pop
+			IL_02db: ldc.i4.5
+			IL_02dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02e1: dup
+			IL_02e2: ldstr "fetch"
+			IL_02e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02ec: dup
+			IL_02ed: ldstr "--depth"
+			IL_02f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f7: dup
+			IL_02f8: ldstr "1"
+			IL_02fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0302: dup
+			IL_0303: ldstr "origin"
+			IL_0308: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_030d: dup
+			IL_030e: ldarg.3
+			IL_030f: ldstr "upstream"
+			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0319: ldstr "commit"
+			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0323: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0328: stloc.s 4
+			IL_032a: ldc.i4.1
+			IL_032b: newarr [System.Runtime]System.Object
+			IL_0330: dup
+			IL_0331: ldc.i4.0
+			IL_0332: ldarg.0
+			IL_0333: stelem.ref
+			IL_0334: ldc.i4.0
+			IL_0335: ldelem.ref
+			IL_0336: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_033b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0341: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0346: ldnull
+			IL_0347: ldloc.s 4
+			IL_0349: ldarg.2
+			IL_034a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_034f: pop
+			IL_0350: ldc.i4.3
+			IL_0351: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0356: dup
+			IL_0357: ldstr "checkout"
+			IL_035c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0361: dup
+			IL_0362: ldstr "--detach"
+			IL_0367: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_036c: dup
+			IL_036d: ldstr "FETCH_HEAD"
+			IL_0372: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0377: stloc.s 4
+			IL_0379: ldc.i4.1
+			IL_037a: newarr [System.Runtime]System.Object
+			IL_037f: dup
+			IL_0380: ldc.i4.0
+			IL_0381: ldarg.0
+			IL_0382: stelem.ref
+			IL_0383: ldc.i4.0
+			IL_0384: ldelem.ref
+			IL_0385: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_038a: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0390: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0395: ldnull
+			IL_0396: ldloc.s 4
+			IL_0398: ldarg.2
+			IL_0399: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_039e: pop
+			IL_039f: ldc.i4.1
+			IL_03a0: newarr [System.Runtime]System.Object
+			IL_03a5: dup
+			IL_03a6: ldc.i4.0
+			IL_03a7: ldarg.0
+			IL_03a8: stelem.ref
+			IL_03a9: ldc.i4.0
+			IL_03aa: ldelem.ref
+			IL_03ab: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_03b0: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_03b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_03bb: ldnull
+			IL_03bc: ldarg.2
+			IL_03bd: ldarg.3
+			IL_03be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_03c3: stloc.3
+			IL_03c4: ldloc.3
+			IL_03c5: stloc.1
+			IL_03c6: ldloc.1
+			IL_03c7: ldstr "ok"
+			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03d6: ldc.i4.0
+			IL_03d7: ceq
+			IL_03d9: stloc.2
+			IL_03da: ldloc.2
+			IL_03db: brfalse IL_0421
+
+			IL_03e0: ldloc.1
+			IL_03e1: ldstr "message"
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03eb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03f0: stloc.s 5
+			IL_03f2: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
+			IL_03f7: ldloc.s 5
+			IL_03f9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03fe: stloc.s 5
+			IL_0400: ldloc.s 5
+			IL_0402: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0407: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_040c: dup
+			IL_040d: isinst [System.Runtime]System.Exception
+			IL_0412: dup
+			IL_0413: brtrue IL_041f
+
+			IL_0418: pop
+			IL_0419: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_041e: throw
+
+			IL_041f: pop
+			IL_0420: throw
+
+			IL_0421: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0426: dup
+			IL_0427: ldstr "source"
+			IL_042c: ldstr "managed-cache"
+			IL_0431: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0436: dup
+			IL_0437: ldstr "rootPath"
+			IL_043c: ldarg.2
+			IL_043d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0442: dup
+			IL_0443: ldstr "reused"
+			IL_0448: ldc.i4.0
+			IL_0449: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_044e: ret
+		} // end of method ensureManagedCheckout::__js_call__
+
+	} // end of class ensureManagedCheckout
+
+	.class nested public auto ansi abstract sealed beforefieldinit resolveBootstrapRoot
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L321C16
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L323C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4cde
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L323C24::.ctor
+
+				} // end of class Block_L323C24
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4cd5
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L321C16::.ctor
+
+			} // end of class Block_L321C16
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4ccc
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object pinPath,
+				object pin,
+				object args
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x45b0
+			// Header size: 12
+			// Code size: 398 (0x18e)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object,
+				[3] bool,
+				[4] string,
+				[5] string,
+				[6] object
+			)
+
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: ldc.i4.0
+			IL_000b: ldelem.ref
+			IL_000c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0011: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_001c: ldnull
+			IL_001d: ldarg.s args
+			IL_001f: ldarg.3
+			IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0025: stloc.2
+			IL_0026: ldloc.2
+			IL_0027: stloc.0
+			IL_0028: ldloc.0
+			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002e: stloc.3
+			IL_002f: ldloc.3
+			IL_0030: brfalse IL_0132
+
+			IL_0035: ldloc.0
+			IL_0036: ldstr "rootPath"
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0040: stloc.2
+			IL_0041: ldc.i4.1
+			IL_0042: newarr [System.Runtime]System.Object
+			IL_0047: dup
+			IL_0048: ldc.i4.0
+			IL_0049: ldarg.0
+			IL_004a: stelem.ref
+			IL_004b: ldc.i4.0
+			IL_004c: ldelem.ref
+			IL_004d: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0052: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0058: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_005d: ldnull
+			IL_005e: ldloc.2
+			IL_005f: ldarg.3
+			IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0065: stloc.2
+			IL_0066: ldloc.2
+			IL_0067: stloc.1
+			IL_0068: ldloc.1
+			IL_0069: ldstr "ok"
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0078: ldc.i4.0
+			IL_0079: ceq
+			IL_007b: stloc.3
+			IL_007c: ldloc.3
+			IL_007d: brfalse IL_00ee
+
+			IL_0082: ldloc.0
+			IL_0083: ldstr "rootPath"
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0092: stloc.s 4
+			IL_0094: ldstr "Override test262 root '"
+			IL_0099: ldloc.s 4
+			IL_009b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00a0: stloc.s 4
+			IL_00a2: ldloc.s 4
+			IL_00a4: ldstr "' is invalid: "
+			IL_00a9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ae: stloc.s 4
+			IL_00b0: ldloc.1
+			IL_00b1: ldstr "message"
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c0: stloc.s 5
+			IL_00c2: ldloc.s 4
+			IL_00c4: ldloc.s 5
+			IL_00c6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00cb: stloc.s 5
+			IL_00cd: ldloc.s 5
+			IL_00cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00d9: dup
+			IL_00da: isinst [System.Runtime]System.Exception
+			IL_00df: dup
+			IL_00e0: brtrue IL_00ec
+
+			IL_00e5: pop
+			IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00eb: throw
+
+			IL_00ec: pop
+			IL_00ed: throw
+
+			IL_00ee: ldloc.0
+			IL_00ef: ldstr "source"
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f9: stloc.2
+			IL_00fa: ldloc.0
+			IL_00fb: ldstr "rootPath"
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0105: stloc.s 6
+			IL_0107: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_010c: dup
+			IL_010d: ldstr "source"
+			IL_0112: ldloc.2
+			IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0118: dup
+			IL_0119: ldstr "rootPath"
+			IL_011e: ldloc.s 6
+			IL_0120: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0125: dup
+			IL_0126: ldstr "reused"
+			IL_012b: ldc.i4.1
+			IL_012c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0131: ret
+
+			IL_0132: ldc.i4.1
+			IL_0133: newarr [System.Runtime]System.Object
+			IL_0138: dup
+			IL_0139: ldc.i4.0
+			IL_013a: ldarg.0
+			IL_013b: stelem.ref
+			IL_013c: ldc.i4.0
+			IL_013d: ldelem.ref
+			IL_013e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0143: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_014e: ldnull
+			IL_014f: ldarg.2
+			IL_0150: ldarg.3
+			IL_0151: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0156: stloc.s 6
+			IL_0158: ldarg.s args
+			IL_015a: ldstr "force"
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0164: stloc.2
+			IL_0165: ldc.i4.1
+			IL_0166: newarr [System.Runtime]System.Object
+			IL_016b: dup
+			IL_016c: ldc.i4.0
+			IL_016d: ldarg.0
+			IL_016e: stelem.ref
+			IL_016f: ldc.i4.0
+			IL_0170: ldelem.ref
+			IL_0171: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0176: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_017c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0181: ldnull
+			IL_0182: ldloc.s 6
+			IL_0184: ldarg.3
+			IL_0185: ldloc.2
+			IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_018b: stloc.2
+			IL_018c: ldloc.2
+			IL_018d: ret
+		} // end of method resolveBootstrapRoot::__js_call__
+
+	} // end of class resolveBootstrapRoot
+
+	.class nested public auto ansi abstract sealed beforefieldinit printResolvedRoot
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L334C21
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4cf0
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L334C21::.ctor
+
+			} // end of class Block_L334C21
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4ce7
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object result,
+				object pin,
+				object printRootOnly
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x474c
+			// Header size: 12
+			// Code size: 346 (0x15a)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] bool,
+				[3] string,
+				[4] object,
+				[5] string,
+				[6] string,
+				[7] string,
+				[8] string,
+				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array
+			)
+
+			IL_0000: ldarg.s printRootOnly
+			IL_0002: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0007: stloc.2
+			IL_0008: ldloc.2
+			IL_0009: brfalse IL_0026
+
+			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0013: ldarg.2
+			IL_0014: ldstr "rootPath"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0023: pop
+			IL_0024: ldnull
+			IL_0025: ret
+
+			IL_0026: ldarg.2
+			IL_0027: ldstr "reused"
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0031: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0036: stloc.2
+			IL_0037: ldloc.2
+			IL_0038: brfalse IL_0048
+
+			IL_003d: ldstr "reused"
+			IL_0042: stloc.0
+			IL_0043: br IL_004e
+
+			IL_0048: ldstr "fetched"
+			IL_004d: stloc.0
+
+			IL_004e: ldloc.0
+			IL_004f: stloc.1
+			IL_0050: ldarg.2
+			IL_0051: ldstr "source"
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0060: stloc.3
+			IL_0061: ldstr "source "
+			IL_0066: ldloc.3
+			IL_0067: call string [System.Runtime]System.String::Concat(string, string)
+			IL_006c: stloc.3
+			IL_006d: ldarg.2
+			IL_006e: ldstr "rootPath"
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0078: stloc.s 4
+			IL_007a: ldnull
+			IL_007b: ldloc.s 4
+			IL_007d: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_0082: stloc.s 4
+			IL_0084: ldloc.s 4
+			IL_0086: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_008b: stloc.s 5
+			IL_008d: ldstr "root "
+			IL_0092: ldloc.s 5
+			IL_0094: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0099: stloc.s 5
+			IL_009b: ldarg.3
+			IL_009c: ldstr "upstream"
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a6: ldstr "commit"
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b5: stloc.s 6
+			IL_00b7: ldstr "commit "
+			IL_00bc: ldloc.s 6
+			IL_00be: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00c3: stloc.s 6
+			IL_00c5: ldarg.3
+			IL_00c6: ldstr "upstream"
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d0: ldstr "packageVersion"
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00da: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00df: stloc.s 7
+			IL_00e1: ldstr "packageVersion "
+			IL_00e6: ldloc.s 7
+			IL_00e8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ed: stloc.s 7
+			IL_00ef: ldloc.1
+			IL_00f0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00f5: stloc.s 8
+			IL_00f7: ldstr "status "
+			IL_00fc: ldloc.s 8
+			IL_00fe: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0103: stloc.s 8
+			IL_0105: ldc.i4.5
+			IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_010b: dup
+			IL_010c: ldloc.3
+			IL_010d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0112: dup
+			IL_0113: ldloc.s 5
+			IL_0115: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011a: dup
+			IL_011b: ldloc.s 6
+			IL_011d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0122: dup
+			IL_0123: ldloc.s 7
+			IL_0125: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012a: dup
+			IL_012b: ldloc.s 8
+			IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0132: stloc.s 9
+			IL_0134: ldloc.s 9
+			IL_0136: ldc.i4.1
+			IL_0137: newarr [System.Runtime]System.Object
+			IL_013c: dup
+			IL_013d: ldc.i4.0
+			IL_013e: ldstr "\n"
+			IL_0143: stelem.ref
+			IL_0144: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0149: stloc.s 8
+			IL_014b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0150: ldloc.s 8
+			IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0157: pop
+			IL_0158: ldnull
+			IL_0159: ret
+		} // end of method printResolvedRoot::__js_call__
+
+	} // end of class printResolvedRoot
+
+	.class nested public auto ansi abstract sealed beforefieldinit main
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L353C17
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4d02
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L353C17::.ctor
+
+			} // end of class Block_L353C17
+
+			.class nested private auto ansi beforefieldinit Block_L362C21
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4d0b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L362C21::.ctor
+
+			} // end of class Block_L362C21
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4cf9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1a 00 00 02
+			)
+			// Method begins at RVA 0x48b4
+			// Header size: 12
+			// Code size: 496 (0x1f0)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] bool,
+				[7] object,
+				[8] object,
+				[9] object
+			)
+
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0005: ldstr "argv"
+			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000f: stloc.s 5
+			IL_0011: ldloc.s 5
+			IL_0013: ldstr "slice"
+			IL_0018: ldc.r8 2
+			IL_0021: box [System.Runtime]System.Double
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002b: stloc.s 5
+			IL_002d: ldc.i4.1
+			IL_002e: newarr [System.Runtime]System.Object
+			IL_0033: dup
+			IL_0034: ldc.i4.0
+			IL_0035: ldarg.0
+			IL_0036: stelem.ref
+			IL_0037: ldc.i4.0
+			IL_0038: ldelem.ref
+			IL_0039: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_003e: ldftn object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0044: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0049: ldnull
+			IL_004a: ldloc.s 5
+			IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0051: stloc.s 5
+			IL_0053: ldloc.s 5
+			IL_0055: stloc.0
+			IL_0056: ldloc.0
+			IL_0057: ldstr "help"
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0066: stloc.s 6
+			IL_0068: ldloc.s 6
+			IL_006a: brfalse IL_0078
+
+			IL_006f: ldnull
+			IL_0070: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
+			IL_0075: pop
+			IL_0076: ldnull
+			IL_0077: ret
+
+			IL_0078: ldloc.0
+			IL_0079: ldstr "pin"
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0083: stloc.s 5
+			IL_0085: ldloc.s 5
+			IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_008c: stloc.s 6
+			IL_008e: ldloc.s 6
+			IL_0090: brtrue IL_00c2
+
+			IL_0095: ldc.i4.1
+			IL_0096: newarr [System.Runtime]System.Object
+			IL_009b: dup
+			IL_009c: ldc.i4.0
+			IL_009d: ldarg.0
+			IL_009e: stelem.ref
+			IL_009f: ldc.i4.0
+			IL_00a0: ldelem.ref
+			IL_00a1: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00a6: ldftn object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+			IL_00ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00b1: ldnull
+			IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+			IL_00b7: stloc.s 7
+			IL_00b9: ldloc.s 7
+			IL_00bb: stloc.s 9
+			IL_00bd: br IL_00c6
+
+			IL_00c2: ldloc.s 5
+			IL_00c4: stloc.s 9
+
+			IL_00c6: ldc.i4.1
+			IL_00c7: newarr [System.Runtime]System.Object
+			IL_00cc: dup
+			IL_00cd: ldc.i4.0
+			IL_00ce: ldarg.0
+			IL_00cf: stelem.ref
+			IL_00d0: ldc.i4.0
+			IL_00d1: ldelem.ref
+			IL_00d2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00d7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00e2: ldnull
+			IL_00e3: ldloc.s 9
+			IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_00ea: stloc.s 5
+			IL_00ec: ldloc.s 5
+			IL_00ee: stloc.1
+			IL_00ef: ldc.i4.1
+			IL_00f0: newarr [System.Runtime]System.Object
+			IL_00f5: dup
+			IL_00f6: ldc.i4.0
+			IL_00f7: ldarg.0
+			IL_00f8: stelem.ref
+			IL_00f9: ldc.i4.0
+			IL_00fa: ldelem.ref
+			IL_00fb: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0100: ldftn object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_010b: ldnull
+			IL_010c: ldloc.1
+			IL_010d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0112: stloc.s 5
+			IL_0114: ldloc.s 5
+			IL_0116: stloc.2
+			IL_0117: ldc.i4.1
+			IL_0118: newarr [System.Runtime]System.Object
+			IL_011d: dup
+			IL_011e: ldc.i4.0
+			IL_011f: ldarg.0
+			IL_0120: stelem.ref
+			IL_0121: ldc.i4.0
+			IL_0122: ldelem.ref
+			IL_0123: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0128: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_012e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0133: ldnull
+			IL_0134: ldloc.0
+			IL_0135: ldloc.2
+			IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_013b: stloc.s 5
+			IL_013d: ldloc.s 5
+			IL_013f: stloc.3
+			IL_0140: ldloc.0
+			IL_0141: ldstr "describe"
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0150: stloc.s 6
+			IL_0152: ldloc.s 6
+			IL_0154: brfalse IL_018e
+
+			IL_0159: ldc.i4.1
+			IL_015a: newarr [System.Runtime]System.Object
+			IL_015f: dup
+			IL_0160: ldc.i4.0
+			IL_0161: ldarg.0
+			IL_0162: stelem.ref
+			IL_0163: ldc.i4.0
+			IL_0164: ldelem.ref
+			IL_0165: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_016a: ldftn object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0170: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0175: ldnull
+			IL_0176: ldloc.2
+			IL_0177: ldloc.3
+			IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_017d: stloc.s 5
+			IL_017f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0184: ldloc.s 5
+			IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_018b: pop
+			IL_018c: ldnull
+			IL_018d: ret
+
+			IL_018e: ldc.i4.1
+			IL_018f: newarr [System.Runtime]System.Object
+			IL_0194: dup
+			IL_0195: ldc.i4.0
+			IL_0196: ldarg.0
+			IL_0197: stelem.ref
+			IL_0198: ldc.i4.0
+			IL_0199: ldelem.ref
+			IL_019a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_019f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_01a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_01aa: ldnull
+			IL_01ab: ldloc.1
+			IL_01ac: ldloc.2
+			IL_01ad: ldloc.0
+			IL_01ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_01b3: stloc.s 5
+			IL_01b5: ldloc.s 5
+			IL_01b7: stloc.s 4
+			IL_01b9: ldloc.0
+			IL_01ba: ldstr "printRoot"
+			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c4: stloc.s 5
+			IL_01c6: ldc.i4.1
+			IL_01c7: newarr [System.Runtime]System.Object
+			IL_01cc: dup
+			IL_01cd: ldc.i4.0
+			IL_01ce: ldarg.0
+			IL_01cf: stelem.ref
+			IL_01d0: ldc.i4.0
+			IL_01d1: ldelem.ref
+			IL_01d2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_01d7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_01dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_01e2: ldnull
+			IL_01e3: ldloc.s 4
+			IL_01e5: ldloc.2
+			IL_01e6: ldloc.s 5
+			IL_01e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_01ed: pop
+			IL_01ee: ldnull
+			IL_01ef: ret
+		} // end of method main::__js_call__
+
+	} // end of class main
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 80 d5 53 63 6f 70 65 20 63 68 69 6c 64 50
+			72 6f 63 65 73 73 3d 7b 63 68 69 6c 64 50 72 6f
+			63 65 73 73 7d 2c 20 66 73 3d 7b 66 73 7d 2c 20
+			70 61 74 68 3d 7b 70 61 74 68 7d 2c 20 70 61 72
+			73 65 41 72 67 73 3d 7b 70 61 72 73 65 41 72 67
+			73 7d 2c 20 70 72 69 6e 74 48 65 6c 70 3d 7b 70
+			72 69 6e 74 48 65 6c 70 7d 2c 20 64 65 66 61 75
+			6c 74 50 69 6e 50 61 74 68 3d 7b 64 65 66 61 75
+			6c 74 50 69 6e 50 61 74 68 7d 2c 20 72 65 73 6f
+			6c 76 65 50 61 74 68 46 72 6f 6d 43 77 64 3d 7b
+			72 65 73 6f 6c 76 65 50 61 74 68 46 72 6f 6d 43
+			77 64 7d 2c 20 74 6f 50 6f 72 74 61 62 6c 65 50
+			61 74 68 3d 7b 74 6f 50 6f 72 74 61 62 6c 65 50
+			61 74 68 7d 2c 20 e2 80 a6 00 00
+		)
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Block_L384C29
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L385C6
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4d1d
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L385C6::.ctor
+
+			} // end of class Block_L385C6
+
+			.class nested private auto ansi beforefieldinit Block_L387C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4d26
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L387C18::.ctor
+
+			} // end of class Block_L387C18
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4d14
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L384C29::.ctor
+
+		} // end of class Block_L384C29
+
+
+		// Fields
+		.field public object __dirname
+		.field public object childProcess
+		.field public object fs
+		.field public object path
+		.field public object parseArgs
+		.field public object printHelp
+		.field public object defaultPinPath
+		.field public object resolvePathFromCwd
+		.field public object toPortablePath
+		.field public object normalizeSpecPath
+		.field public object ensureString
+		.field public object ensureStringArray
+		.field public object validatePin
+		.field public object loadPin
+		.field public object resolveManagedCheckoutRoot
+		.field public object resolveManagedCheckoutLabel
+		.field public object resolveOverrideRoot
+		.field public object describePlan
+		.field public object ensureDir
+		.field public object removeDir
+		.field public object runGit
+		.field public object buildSparsePatterns
+		.field public object validateResolvedRoot
+		.field public object ensureManagedCheckout
+		.field public object resolveBootstrapRoot
+		.field public object printResolvedRoot
+		.field public object main
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x4ab0
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 1354 (0x54a)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
+			[1] object,
+			[2] class [System.Runtime]System.Exception,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] object,
+			[7] object,
+			[8] object,
+			[9] object,
+			[10] object,
+			[11] object,
+			[12] object,
+			[13] object,
+			[14] object,
+			[15] bool,
+			[16] object,
+			[17] object,
+			[18] string
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: ldarg.s __dirname
+		IL_0009: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::__dirname
+		IL_000e: ldc.i4.1
+		IL_000f: newarr [System.Runtime]System.Object
+		IL_0014: dup
+		IL_0015: ldc.i4.0
+		IL_0016: ldloc.0
+		IL_0017: stelem.ref
+		IL_0018: ldc.i4.0
+		IL_0019: ldelem.ref
+		IL_001a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_001f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_002a: stloc.s 7
+		IL_002c: ldloc.0
+		IL_002d: ldloc.s 7
+		IL_002f: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
+		IL_0034: ldnull
+		IL_0035: ldftn object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
+		IL_003b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0040: stloc.s 7
+		IL_0042: ldloc.0
+		IL_0043: ldloc.s 7
+		IL_0045: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
+		IL_004a: ldc.i4.1
+		IL_004b: newarr [System.Runtime]System.Object
+		IL_0050: dup
+		IL_0051: ldc.i4.0
+		IL_0052: ldloc.0
+		IL_0053: stelem.ref
+		IL_0054: ldc.i4.0
+		IL_0055: ldelem.ref
+		IL_0056: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_005b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+		IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0066: stloc.s 7
+		IL_0068: ldloc.0
+		IL_0069: ldloc.s 7
+		IL_006b: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
+		IL_0070: ldc.i4.1
+		IL_0071: newarr [System.Runtime]System.Object
+		IL_0076: dup
+		IL_0077: ldc.i4.0
+		IL_0078: ldloc.0
+		IL_0079: stelem.ref
+		IL_007a: ldc.i4.0
+		IL_007b: ldelem.ref
+		IL_007c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_0081: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_008c: stloc.s 7
+		IL_008e: ldloc.0
+		IL_008f: ldloc.s 7
+		IL_0091: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
+		IL_0096: ldnull
+		IL_0097: ldftn object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+		IL_009d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00a2: stloc.s 7
+		IL_00a4: ldloc.0
+		IL_00a5: ldloc.s 7
+		IL_00a7: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
+		IL_00ac: ldc.i4.1
+		IL_00ad: newarr [System.Runtime]System.Object
+		IL_00b2: dup
+		IL_00b3: ldc.i4.0
+		IL_00b4: ldloc.0
+		IL_00b5: stelem.ref
+		IL_00b6: ldc.i4.0
+		IL_00b7: ldelem.ref
+		IL_00b8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_00bd: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_00c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00c8: stloc.s 7
+		IL_00ca: ldloc.0
+		IL_00cb: ldloc.s 7
+		IL_00cd: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+		IL_00d2: ldnull
+		IL_00d3: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
+		IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00de: stloc.s 7
+		IL_00e0: ldloc.0
+		IL_00e1: ldloc.s 7
+		IL_00e3: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+		IL_00e8: ldnull
+		IL_00e9: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+		IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00f4: stloc.s 7
+		IL_00f6: ldloc.0
+		IL_00f7: ldloc.s 7
+		IL_00f9: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+		IL_00fe: ldc.i4.1
+		IL_00ff: newarr [System.Runtime]System.Object
+		IL_0104: dup
+		IL_0105: ldc.i4.0
+		IL_0106: ldloc.0
+		IL_0107: stelem.ref
+		IL_0108: ldc.i4.0
+		IL_0109: ldelem.ref
+		IL_010a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_010f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0115: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_011a: stloc.s 7
+		IL_011c: ldloc.0
+		IL_011d: ldloc.s 7
+		IL_011f: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
+		IL_0124: ldc.i4.1
+		IL_0125: newarr [System.Runtime]System.Object
+		IL_012a: dup
+		IL_012b: ldc.i4.0
+		IL_012c: ldloc.0
+		IL_012d: stelem.ref
+		IL_012e: ldc.i4.0
+		IL_012f: ldelem.ref
+		IL_0130: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_0135: ldftn object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_013b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0140: stloc.s 7
+		IL_0142: ldloc.0
+		IL_0143: ldloc.s 7
+		IL_0145: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
+		IL_014a: ldc.i4.1
+		IL_014b: newarr [System.Runtime]System.Object
+		IL_0150: dup
+		IL_0151: ldc.i4.0
+		IL_0152: ldloc.0
+		IL_0153: stelem.ref
+		IL_0154: ldc.i4.0
+		IL_0155: ldelem.ref
+		IL_0156: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_015b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0166: stloc.s 7
+		IL_0168: ldloc.0
+		IL_0169: ldloc.s 7
+		IL_016b: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
+		IL_0170: ldc.i4.1
+		IL_0171: newarr [System.Runtime]System.Object
+		IL_0176: dup
+		IL_0177: ldc.i4.0
+		IL_0178: ldloc.0
+		IL_0179: stelem.ref
+		IL_017a: ldc.i4.0
+		IL_017b: ldelem.ref
+		IL_017c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_0181: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0187: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_018c: stloc.s 7
+		IL_018e: ldloc.0
+		IL_018f: ldloc.s 7
+		IL_0191: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
+		IL_0196: ldc.i4.1
+		IL_0197: newarr [System.Runtime]System.Object
+		IL_019c: dup
+		IL_019d: ldc.i4.0
+		IL_019e: ldloc.0
+		IL_019f: stelem.ref
+		IL_01a0: ldc.i4.0
+		IL_01a1: ldelem.ref
+		IL_01a2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_01a7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_01ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01b2: stloc.s 7
+		IL_01b4: ldloc.0
+		IL_01b5: ldloc.s 7
+		IL_01b7: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+		IL_01bc: ldc.i4.1
+		IL_01bd: newarr [System.Runtime]System.Object
+		IL_01c2: dup
+		IL_01c3: ldc.i4.0
+		IL_01c4: ldloc.0
+		IL_01c5: stelem.ref
+		IL_01c6: ldc.i4.0
+		IL_01c7: ldelem.ref
+		IL_01c8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_01cd: ldftn object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_01d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01d8: stloc.s 7
+		IL_01da: ldloc.0
+		IL_01db: ldloc.s 7
+		IL_01dd: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
+		IL_01e2: ldc.i4.1
+		IL_01e3: newarr [System.Runtime]System.Object
+		IL_01e8: dup
+		IL_01e9: ldc.i4.0
+		IL_01ea: ldloc.0
+		IL_01eb: stelem.ref
+		IL_01ec: ldc.i4.0
+		IL_01ed: ldelem.ref
+		IL_01ee: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_01f3: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01fe: stloc.s 7
+		IL_0200: ldloc.0
+		IL_0201: ldloc.s 7
+		IL_0203: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
+		IL_0208: ldc.i4.1
+		IL_0209: newarr [System.Runtime]System.Object
+		IL_020e: dup
+		IL_020f: ldc.i4.0
+		IL_0210: ldloc.0
+		IL_0211: stelem.ref
+		IL_0212: ldc.i4.0
+		IL_0213: ldelem.ref
+		IL_0214: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_0219: ldftn object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_021f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0224: stloc.s 7
+		IL_0226: ldloc.0
+		IL_0227: ldloc.s 7
+		IL_0229: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
+		IL_022e: ldc.i4.1
+		IL_022f: newarr [System.Runtime]System.Object
+		IL_0234: dup
+		IL_0235: ldc.i4.0
+		IL_0236: ldloc.0
+		IL_0237: stelem.ref
+		IL_0238: ldc.i4.0
+		IL_0239: ldelem.ref
+		IL_023a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_023f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_024a: stloc.s 7
+		IL_024c: ldloc.0
+		IL_024d: ldloc.s 7
+		IL_024f: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+		IL_0254: ldc.i4.1
+		IL_0255: newarr [System.Runtime]System.Object
+		IL_025a: dup
+		IL_025b: ldc.i4.0
+		IL_025c: ldloc.0
+		IL_025d: stelem.ref
+		IL_025e: ldc.i4.0
+		IL_025f: ldelem.ref
+		IL_0260: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_0265: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_026b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0270: stloc.s 7
+		IL_0272: ldloc.0
+		IL_0273: ldloc.s 7
+		IL_0275: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
+		IL_027a: ldc.i4.1
+		IL_027b: newarr [System.Runtime]System.Object
+		IL_0280: dup
+		IL_0281: ldc.i4.0
+		IL_0282: ldloc.0
+		IL_0283: stelem.ref
+		IL_0284: ldc.i4.0
+		IL_0285: ldelem.ref
+		IL_0286: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_028b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_0291: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0296: stloc.s 7
+		IL_0298: ldloc.0
+		IL_0299: ldloc.s 7
+		IL_029b: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+		IL_02a0: ldc.i4.1
+		IL_02a1: newarr [System.Runtime]System.Object
+		IL_02a6: dup
+		IL_02a7: ldc.i4.0
+		IL_02a8: ldloc.0
+		IL_02a9: stelem.ref
+		IL_02aa: ldc.i4.0
+		IL_02ab: ldelem.ref
+		IL_02ac: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_02b1: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+		IL_02b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_02bc: stloc.s 7
+		IL_02be: ldloc.0
+		IL_02bf: ldloc.s 7
+		IL_02c1: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureManagedCheckout
+		IL_02c6: ldc.i4.1
+		IL_02c7: newarr [System.Runtime]System.Object
+		IL_02cc: dup
+		IL_02cd: ldc.i4.0
+		IL_02ce: ldloc.0
+		IL_02cf: stelem.ref
+		IL_02d0: ldc.i4.0
+		IL_02d1: ldelem.ref
+		IL_02d2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_02d7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+		IL_02dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_02e2: stloc.s 7
+		IL_02e4: ldloc.0
+		IL_02e5: ldloc.s 7
+		IL_02e7: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
+		IL_02ec: ldc.i4.1
+		IL_02ed: newarr [System.Runtime]System.Object
+		IL_02f2: dup
+		IL_02f3: ldc.i4.0
+		IL_02f4: ldloc.0
+		IL_02f5: stelem.ref
+		IL_02f6: ldc.i4.0
+		IL_02f7: ldelem.ref
+		IL_02f8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_02fd: ldftn object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+		IL_0303: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_0308: stloc.s 7
+		IL_030a: ldloc.0
+		IL_030b: ldloc.s 7
+		IL_030d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
+		IL_0312: ldc.i4.1
+		IL_0313: newarr [System.Runtime]System.Object
+		IL_0318: dup
+		IL_0319: ldc.i4.0
+		IL_031a: ldloc.0
+		IL_031b: stelem.ref
+		IL_031c: ldc.i4.0
+		IL_031d: ldelem.ref
+		IL_031e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_0323: ldftn object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+		IL_0329: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_032e: stloc.s 7
+		IL_0330: ldloc.s 7
+		IL_0332: stloc.1
+		IL_0333: ldarg.1
+		IL_0334: ldstr "node:child_process"
+		IL_0339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_033e: stloc.s 7
+		IL_0340: ldloc.0
+		IL_0341: ldloc.s 7
+		IL_0343: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
+		IL_0348: ldarg.1
+		IL_0349: ldstr "node:fs"
+		IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0353: stloc.s 7
+		IL_0355: ldloc.0
+		IL_0356: ldloc.s 7
+		IL_0358: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+		IL_035d: ldarg.1
+		IL_035e: ldstr "node:path"
+		IL_0363: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0368: stloc.s 7
+		IL_036a: ldloc.0
+		IL_036b: ldloc.s 7
+		IL_036d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+		IL_0372: ldloc.0
+		IL_0373: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
+		IL_0378: stloc.s 7
+		IL_037a: ldloc.0
+		IL_037b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
+		IL_0380: stloc.s 8
+		IL_0382: ldloc.0
+		IL_0383: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureManagedCheckout
+		IL_0388: stloc.s 9
+		IL_038a: ldloc.0
+		IL_038b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
+		IL_0390: stloc.s 10
+		IL_0392: ldloc.0
+		IL_0393: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
+		IL_0398: stloc.s 11
+		IL_039a: ldloc.0
+		IL_039b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
+		IL_03a0: stloc.s 12
+		IL_03a2: ldloc.0
+		IL_03a3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
+		IL_03a8: stloc.s 13
+		IL_03aa: ldloc.0
+		IL_03ab: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
+		IL_03b0: stloc.s 14
+		IL_03b2: ldarg.2
+		IL_03b3: ldstr "exports"
+		IL_03b8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03bd: dup
+		IL_03be: ldstr "buildSparsePatterns"
+		IL_03c3: ldloc.0
+		IL_03c4: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
+		IL_03c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03ce: dup
+		IL_03cf: ldstr "defaultPinPath"
+		IL_03d4: ldloc.s 7
+		IL_03d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03db: dup
+		IL_03dc: ldstr "describePlan"
+		IL_03e1: ldloc.s 8
+		IL_03e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03e8: dup
+		IL_03e9: ldstr "ensureManagedCheckout"
+		IL_03ee: ldloc.s 9
+		IL_03f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03f5: dup
+		IL_03f6: ldstr "loadPin"
+		IL_03fb: ldloc.s 10
+		IL_03fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0402: dup
+		IL_0403: ldstr "parseArgs"
+		IL_0408: ldloc.s 11
+		IL_040a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_040f: dup
+		IL_0410: ldstr "resolveBootstrapRoot"
+		IL_0415: ldloc.s 12
+		IL_0417: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_041c: dup
+		IL_041d: ldstr "resolveManagedCheckoutLabel"
+		IL_0422: ldloc.s 13
+		IL_0424: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0429: dup
+		IL_042a: ldstr "resolveManagedCheckoutRoot"
+		IL_042f: ldloc.s 14
+		IL_0431: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0436: dup
+		IL_0437: ldstr "validateResolvedRoot"
+		IL_043c: ldloc.0
+		IL_043d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+		IL_0442: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_044c: pop
+		IL_044d: ldarg.1
+		IL_044e: ldstr "main"
+		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0458: ldarg.2
+		IL_0459: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_045e: stloc.s 15
+		IL_0460: ldloc.s 15
+		IL_0462: brfalse IL_0549
+		.try
+		{
+			IL_0467: ldc.i4.1
+			IL_0468: newarr [System.Runtime]System.Object
+			IL_046d: dup
+			IL_046e: ldc.i4.0
+			IL_046f: ldloc.0
+			IL_0470: stelem.ref
+			IL_0471: ldc.i4.0
+			IL_0472: ldelem.ref
+			IL_0473: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0478: ldftn object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+			IL_047e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0483: ldnull
+			IL_0484: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+			IL_0489: pop
+			IL_048a: leave IL_0549
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_048f: stloc.2
+			IL_0490: ldloc.2
+			IL_0491: dup
+			IL_0492: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0497: dup
+			IL_0498: brtrue IL_04ae
+
+			IL_049d: pop
+			IL_049e: dup
+			IL_049f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04a4: dup
+			IL_04a5: brtrue IL_04ba
+
+			IL_04aa: pop
+			IL_04ab: pop
+			IL_04ac: rethrow
+
+			IL_04ae: pop
+			IL_04af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04b4: stloc.3
+			IL_04b5: br IL_04bc
+
+			IL_04ba: pop
+			IL_04bb: stloc.3
+
+			IL_04bc: ldloc.3
+			IL_04bd: stloc.s 14
+			IL_04bf: ldloc.s 14
+			IL_04c1: stloc.s 4
+			IL_04c3: ldloc.s 4
+			IL_04c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04ca: stloc.s 15
+			IL_04cc: ldloc.s 15
+			IL_04ce: brfalse IL_04e6
+
+			IL_04d3: ldloc.s 4
+			IL_04d5: ldstr "message"
+			IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04df: stloc.s 17
+			IL_04e1: br IL_04ea
+
+			IL_04e6: ldloc.s 4
+			IL_04e8: stloc.s 17
+
+			IL_04ea: ldloc.s 17
+			IL_04ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04f1: stloc.s 15
+			IL_04f3: ldloc.s 15
+			IL_04f5: brfalse IL_050d
+
+			IL_04fa: ldloc.s 4
+			IL_04fc: ldstr "message"
+			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0506: stloc.s 5
+			IL_0508: br IL_051a
+
+			IL_050d: ldloc.s 4
+			IL_050f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0514: stloc.s 18
+			IL_0516: ldloc.s 18
+			IL_0518: stloc.s 5
+
+			IL_051a: ldloc.s 5
+			IL_051c: stloc.s 6
+			IL_051e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0523: ldloc.s 6
+			IL_0525: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_052a: pop
+			IL_052b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0530: ldstr "exitCode"
+			IL_0535: ldc.r8 1
+			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_0543: pop
+			IL_0544: leave IL_0549
+		} // end handler
+
+		IL_0549: ret
+	} // end of method Compile_Scripts_Test262Bootstrap::__js_module_init__
+
+} // end of class Modules.Compile_Scripts_Test262Bootstrap
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x4d2f
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Compile_Scripts_Test262Bootstrap::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class interface public auto ansi abstract Js2IL.Compile_Scripts_Test262Bootstrap.ICompileScriptsTest262BootstrapExports
+	implements [System.Runtime]System.IDisposable
+{
+	.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsModuleAttribute::.ctor(string) = (
+		01 00 20 43 6f 6d 70 69 6c 65 5f 53 63 72 69 70
+		74 73 5f 54 65 73 74 32 36 32 42 6f 6f 74 73 74
+		72 61 70 00 00
+	)
+	// Methods
+	.method public hidebysig newslot abstract virtual 
+		instance object BuildSparsePatterns (
+			object pin
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::BuildSparsePatterns
+
+	.method public hidebysig newslot abstract virtual 
+		instance object DefaultPinPath () cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::DefaultPinPath
+
+	.method public hidebysig newslot abstract virtual 
+		instance object DescribePlan (
+			object pin,
+			object override
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::DescribePlan
+
+	.method public hidebysig newslot abstract virtual 
+		instance object EnsureManagedCheckout (
+			object rootPath,
+			object pin,
+			object force
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::EnsureManagedCheckout
+
+	.method public hidebysig newslot abstract virtual 
+		instance object LoadPin (
+			object pinPath
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::LoadPin
+
+	.method public hidebysig newslot abstract virtual 
+		instance object ParseArgs (
+			object argv
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::ParseArgs
+
+	.method public hidebysig newslot abstract virtual 
+		instance object ResolveBootstrapRoot (
+			object pinPath,
+			object pin,
+			object args
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::ResolveBootstrapRoot
+
+	.method public hidebysig newslot abstract virtual 
+		instance object ResolveManagedCheckoutLabel (
+			object pin
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::ResolveManagedCheckoutLabel
+
+	.method public hidebysig newslot abstract virtual 
+		instance object ResolveManagedCheckoutRoot (
+			object pinPath,
+			object pin
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::ResolveManagedCheckoutRoot
+
+	.method public hidebysig newslot abstract virtual 
+		instance object ValidateResolvedRoot (
+			object rootPath,
+			object pin
+		) cil managed 
+	{
+	} // end of method ICompileScriptsTest262BootstrapExports::ValidateResolvedRoot
+
+} // end of class Js2IL.Compile_Scripts_Test262Bootstrap.ICompileScriptsTest262BootstrapExports
+

--- a/tests/Js2IL.Tests/Js2IL.Tests.csproj
+++ b/tests/Js2IL.Tests/Js2IL.Tests.csproj
@@ -38,6 +38,9 @@
     <EmbeddedResource Include="..\..\scripts\decompileGeneratorTest.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_DecompileGeneratorTest.js</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\..\scripts\test262\bootstrap.js">
+      <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_Test262Bootstrap.js</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Integration\Resources\extractEcma262SectionHtml_urlMode.js">
       <LogicalName>Js2IL.Tests.Integration.JavaScript.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.js</LogicalName>
     </EmbeddedResource>

--- a/tests/test262/test262.pin.json
+++ b/tests/test262/test262.pin.json
@@ -1,0 +1,54 @@
+{
+  "upstream": {
+    "owner": "tc39",
+    "repo": "test262",
+    "cloneUrl": "https://github.com/tc39/test262.git",
+    "commit": "2b2ecead6e828dd9af13a9ec72065e645724a50f",
+    "packageVersion": "5.0.0"
+  },
+  "localOverrideEnvVar": "JS2IL_TEST262_ROOT",
+  "managedRoot": "../../artifacts/test262/cache",
+  "lineEndings": "lf",
+  "updateStrategy": "manual-pinned-sha",
+  "includeFiles": [
+    "LICENSE",
+    "INTERPRETING.md",
+    "features.txt",
+    "package.json"
+  ],
+  "includeDirectories": [
+    "harness",
+    "test/language",
+    "test/built-ins"
+  ],
+  "requiredFiles": [
+    "LICENSE",
+    "INTERPRETING.md",
+    "features.txt",
+    "package.json",
+    "harness/assert.js",
+    "harness/sta.js"
+  ],
+  "requiredDirectories": [
+    "harness",
+    "test/language",
+    "test/built-ins"
+  ],
+  "defaultHarnessFiles": [
+    "assert.js",
+    "sta.js"
+  ],
+  "excludedFromMvp": [
+    "test/annexB/**",
+    "test/intl402/**",
+    "test/staging/**",
+    "frontmatter:flags=module",
+    "frontmatter:flags=async",
+    "frontmatter:requires-agent-or-broadcast",
+    "frontmatter:requires-async-harness"
+  ],
+  "attributionFiles": [
+    "LICENSE",
+    "INTERPRETING.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a pinned `tests/test262/test262.pin.json` manifest plus `scripts/test262/bootstrap.js` for managed sparse checkout bootstrapping and local override support
- add npm entrypoints and ADR 0005 documenting the chosen test262 intake/sync, licensing, line-ending, and update policy
- add focused integration execution/generator coverage and snapshots for the bootstrap describe flow

## Validation
- npm run test262:describe
- npm run test262:root
- dotnet test .\tests\Js2IL.Tests\Js2IL.Tests.csproj -c Release /p:IsTestProject=true --no-build --filter "FullyQualifiedName~Compile_Scripts_Test262Bootstrap" --nologo

Closes #928