### PR TITLE
docs(tracking): sync issue backlog snapshots

### DIFF
--- a/docs/tracking-issues/ECMA262TopMissingBacklog.md
+++ b/docs/tracking-issues/ECMA262TopMissingBacklog.md
@@ -1,31 +1,39 @@
 # ECMA-262 Top Missing Features Backlog
 
-> **Last Updated**: 2026-03-29
+> **Last Updated**: 2026-04-13
 > Purpose: capture the highest-impact ECMA-262 gaps still marked missing or materially incomplete in `docs\ECMA262`.
-> Source basis: current `docs\ECMA262\**\Section*.json` tracking only; this pass intentionally avoids stale issue / PR history.
+> Source basis: current generated `docs\ECMA262\**\Section*.md` / JSON tracking, cross-checked against live GitHub issue state.
+
+## What changed since the previous pass
+
+- The previous top tracked issue [#859](https://github.com/tomacox74/js2il/issues/859) is now **closed**, so the remaining highest-value ECMA gaps are mostly **issue-creation candidates**, not already-open GitHub issues.
+- The best remaining backlog items are now concentrated in TypedArray fidelity, the new Uint8Array base64/hex surface, Promise follow-ons, and missing constructor/prototype intrinsics for generator-family function objects.
 
 ## How this pass was filtered
 
-- Included items that are still marked `Not Yet Supported`, plus a few materially incomplete user-visible surfaces where the docs describe a large missing feature family.
-- Collapsed closely related clauses into a single backlog item when the docs describe one missing surface (for example, iterator helpers).
-- De-prioritized deprecated or low-value gaps (`with`, `debugger`) and metadata-only constructor/prototype parity where the underlying syntax/runtime behavior already works.
+- Included items that are still marked `Not Yet Supported`, plus materially incomplete user-visible surfaces where the docs describe a large missing feature family.
+- Collapsed closely related clauses into a single backlog item when the docs describe one missing surface.
+- De-prioritized low-value or intentionally unsupported items (`with`, `debugger`) and metadata-only gaps whose underlying runtime behavior is already broadly usable.
 
 ## Current ranked backlog (recommended order)
 
-| Rank | Issue | Missing feature | Key tracked clauses | Why it is still top-10 |
+| Rank | GitHub issue | Missing feature | Key tracked clauses | Why it is still top-ranked |
 |---:|---|---|---|---|
-| 1 | [#859](https://github.com/tomacox74/js2il/issues/859) | Remaining modern class element limitations | [`15.7 Class Definitions`](../ECMA262/15/Section15_7.md) - `15.7.1`, `15.7.10`, `15.7.11` | Most modern class elements now work, but arbitrary runtime-computed method keys and the remaining class-element edge cases tracked in the docs are still incomplete. |
+| 1 | No dedicated issue yet | TypedArray constructor / prototype fidelity and remaining methods | [`23.2 TypedArray Objects`](../ECMA262/23/Section23_2.md), [`10.4.5 TypedArray Exotic Objects`](../ECMA262/10/Section10_4.md) | The current docs show a meaningful supported slice for `Int32Array`, `Uint8Array`, and `Float64Array`, but `%TypedArray%` constructor/prototype fidelity, species hooks, metadata surfaces, and many remaining methods are still incomplete. |
+| 2 | No dedicated issue yet | Uint8Array base64 / hex extensions | [`23.3 Uint8Array Objects`](../ECMA262/23/Section23_3.md) | This entire ES2025-facing surface is still `Not Yet Supported`, making it one of the clearest user-visible missing built-in families in the docs. |
+| 3 | No dedicated issue yet | Promise follow-up surface and prototype metadata | [`27.2 Promise Objects`](../ECMA262/27/Section27_2.md) | Core Promise behavior is in good shape, but the docs still call out missing `HostPromiseRejectionTracker`, `Promise.try`, `%Symbol.species%`, and prototype metadata/toStringTag details. |
+| 4 | No dedicated issue yet | Generator / async / async-generator constructor and prototype intrinsics | [`27.3`](../ECMA262/27/Section27_3.md), [`27.4`](../ECMA262/27/Section27_4.md), [`27.7`](../ECMA262/27/Section27_7.md) | Syntax support is mostly there, but the spec-shaped `GeneratorFunction`, `AsyncGeneratorFunction`, and `AsyncFunction` constructor/prototype surfaces remain unimplemented. |
+| 5 | No dedicated issue yet | Remaining class/runtime edge-case fidelity after [#859](https://github.com/tomacox74/js2il/issues/859) | [`15.7 Class Definitions`](../ECMA262/15/Section15_7.md) | The major class-element tranche landed, but the docs still show limitations around arbitrary runtime-computed class method names and at least one not-yet-supported static-block-related clause (`15.7.12`). |
 
 ## Notable next-tier gaps
 
-- **TypedArray constructor / prototype fidelity and remaining methods**: [`23.2 TypedArray Objects`](../ECMA262/23/Section23_2.md) and [`10.4.5 TypedArray Exotic Objects`](../ECMA262/10/Section10_4.md) are still `Incomplete`, but the docs now track a substantial supported subset for `Int32Array`, `Uint8Array`, and `Float64Array`.
-- **Uint8Array base64 / hex extensions**: [`23.3 Uint8Array Objects`](../ECMA262/23/Section23_3.md) is still `Not Yet Supported`.
-- **Promise follow-up surface**: [`27.2 Promise Objects`](../ECMA262/27/Section27_2.md) still has gaps such as `HostPromiseRejectionTracker`, `Promise.try`, and `Symbol.species`.
-- **Function-constructor intrinsics for generator / async function families**: [`27.3`](../ECMA262/27/Section27_3.md), [`27.4`](../ECMA262/27/Section27_4.md), and [`27.7`](../ECMA262/27/Section27_7.md) still miss constructor / prototype parity even though the underlying syntax is mostly supported.
+- **ArrayBuffer-backed binary fidelity around the TypedArray slice**: much of the remaining pain is clustered around the same TypedArray / ArrayBuffer family, so future issue scoping should probably split user-visible methods from lower-level buffer/spec-invariant work.
+- **Promise host integration semantics**: if runtime-host parity becomes more important, the Promise follow-up should probably split host rejection tracking from the remaining constructor/prototype metadata.
+- **Function-object intrinsic parity**: the generator-family constructor/prototype follow-on is primarily about reflective and meta-programming compatibility rather than syntax support.
 
 ## Intentionally de-prioritized missing items
 
 - [`14.11 The with Statement`](../ECMA262/14/Section14_11.md)
 - [`14.16 The debugger Statement`](../ECMA262/14/Section14_16.md)
 
-These are still marked unsupported, but they are low-value or intentionally rejected compared with the ten gaps above.
+These are still marked unsupported, but they remain low-value or intentionally deferred compared with the backlog above.

--- a/docs/tracking-issues/IssueTriage.md
+++ b/docs/tracking-issues/IssueTriage.md
@@ -1,84 +1,74 @@
-# Issue triage snapshot (refreshed 2026-04-09)
+# Issue triage snapshot (refreshed 2026-04-13)
 
 This file captures a point-in-time recommended ordering for all currently open GitHub issues.
 
 Synced to:
-- Repo: `master` @ `9f2abca1`
-- Latest release on `master`: `v0.9.7` via PR [#966](https://github.com/tomacox74/js2il/pull/966)
-- Active review branches at latest update: none
-- GitHub: open issues / PR state as of 2026-04-09 after merging PR [#966](https://github.com/tomacox74/js2il/pull/966) and publishing `v0.9.7`
-- Open issues: 22
-- Open PRs: 0
+- Repo: `origin/master` @ `731a54f4`
+- Latest tagged release on `master`: `v0.9.7` via PR [#966](https://github.com/tomacox74/js2il/pull/966)
+- Recent merged PRs since the previous snapshot: [#969](https://github.com/tomacox74/js2il/pull/969), [#970](https://github.com/tomacox74/js2il/pull/970), [#971](https://github.com/tomacox74/js2il/pull/971), [#972](https://github.com/tomacox74/js2il/pull/972), [#973](https://github.com/tomacox74/js2il/pull/973)
+- GitHub: open issue / PR state as of 2026-04-13
+- Open issues: **17**
+- Open PRs: **0**
 
 ## What changed since the previous snapshot
 
-- PR [#966](https://github.com/tomacox74/js2il/pull/966) merged as commit `9f2abca1` and published patch release `v0.9.7`, so the earlier merge/release queue is now fully landed on `master`.
-- The previously top-ranked Node tranche is mostly complete now: issues [#946](https://github.com/tomacox74/js2il/issues/946) and [#950](https://github.com/tomacox74/js2il/issues/950)-[#955](https://github.com/tomacox74/js2il/issues/955) were all closed by the merged PR queue and the release follow-up fix.
-- The open issue count dropped from 29 to 22 while the open PR count stayed at 0. The remaining queue is materially smaller, not just reorganized.
-- The remaining backlog is now split into:
-  - 4 Node/runtime follow-ons ([#841](https://github.com/tomacox74/js2il/issues/841), [#947](https://github.com/tomacox74/js2il/issues/947), [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956))
-  - 8 `test262` adoption issues ([#927](https://github.com/tomacox74/js2il/issues/927)-[#934](https://github.com/tomacox74/js2il/issues/934))
-  - 10 deferred performance issues ([#451](https://github.com/tomacox74/js2il/issues/451), [#737](https://github.com/tomacox74/js2il/issues/737), [#738](https://github.com/tomacox74/js2il/issues/738), [#742](https://github.com/tomacox74/js2il/issues/742), [#743](https://github.com/tomacox74/js2il/issues/743), [#746](https://github.com/tomacox74/js2il/issues/746), [#747](https://github.com/tomacox74/js2il/issues/747), [#748](https://github.com/tomacox74/js2il/issues/748), [#768](https://github.com/tomacox74/js2il/issues/768), [#837](https://github.com/tomacox74/js2il/issues/837))
+- PRs [#969](https://github.com/tomacox74/js2il/pull/969)-[#973](https://github.com/tomacox74/js2il/pull/973) landed on `master`, closing [#946](https://github.com/tomacox74/js2il/issues/946), [#947](https://github.com/tomacox74/js2il/issues/947), [#950](https://github.com/tomacox74/js2il/issues/950)-[#955](https://github.com/tomacox74/js2il/issues/955), and the first three concrete `test262` child issues [#928](https://github.com/tomacox74/js2il/issues/928)-[#930](https://github.com/tomacox74/js2il/issues/930).
+- The open Node/runtime queue dropped from four follow-ons to two: [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956).
+- The `test262` program moved out of intake/bootstrap setup and into post-MVP follow-ons: [#927](https://github.com/tomacox74/js2il/issues/927) remains the umbrella issue; [#931](https://github.com/tomacox74/js2il/issues/931)-[#934](https://github.com/tomacox74/js2il/issues/934) remain open; [#928](https://github.com/tomacox74/js2il/issues/928)-[#930](https://github.com/tomacox74/js2il/issues/930) are now closed.
+- Open issue count dropped from **22** to **17** while open PR count stayed at **0**.
 
 ## Ranking method
 
-- Use [TriageScoreboard.md](./TriageScoreboard.md) as the strategic source of truth, and let [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md) drive the remaining Node lane order now that most of its earlier top items are already issue-backed and closed.
-- Prefer concrete, repo-driven compatibility/tooling slices first; then keep the `test262` program in dependency order; keep research behind shipping slices; and keep performance behind correctness/tooling unless it directly unblocks those tracks.
-- Treat [#927](https://github.com/tomacox74/js2il/issues/927) as the umbrella tracker for the `test262` program, and rank the child issues by execution order rather than by issue number alone.
+- Use [TriageScoreboard.md](./TriageScoreboard.md) as the strategic source of truth.
+- Prefer concrete, user-visible compatibility slices before research and benchmark work.
+- Treat [#927](https://github.com/tomacox74/js2il/issues/927) as the umbrella tracker for the `test262` program, and rank the concrete child issues by execution order.
+- Keep performance behind compatibility and conformance unless it directly unblocks those lanes.
 
 ## Recommended next picks
 
-- **Primary next item:** [#947](https://github.com/tomacox74/js2il/issues/947) `scripts/ECMA262: enable network mode under js2il via HTTP client fixes`
-- **Best next Node platform follow-on:** [#949](https://github.com/tomacox74/js2il/issues/949) `node: add global fetch / Request / Response / Headers baseline`
+- **Primary next item:** [#949](https://github.com/tomacox74/js2il/issues/949) `node: add global fetch / Request / Response / Headers baseline`
 - **Best next production-network follow-on:** [#956](https://github.com/tomacox74/js2il/issues/956) `node: expand TLS/HTTPS trust, client-auth, and agent parity`
-- **Best research / architecture follow-on:** [#841](https://github.com/tomacox74/js2il/issues/841) `Investigate using existing .NET HTTP primitives for future Node HTTP work`
-- **Strategic next program:** [#927](https://github.com/tomacox74/js2il/issues/927) `test262: create a phased conformance program for js2il`, starting with [#928](https://github.com/tomacox74/js2il/issues/928) -> [#929](https://github.com/tomacox74/js2il/issues/929) -> [#930](https://github.com/tomacox74/js2il/issues/930) -> [#931](https://github.com/tomacox74/js2il/issues/931) -> [#932](https://github.com/tomacox74/js2il/issues/932) -> [#933](https://github.com/tomacox74/js2il/issues/933), while keeping [#934](https://github.com/tomacox74/js2il/issues/934) explicitly deferred until the MVP exists.
+- **Best next `test262` implementation slice:** [#931](https://github.com/tomacox74/js2il/issues/931) `test262: classify negative tests, exclusions, and baselines`
+- **Best next `test262` reporting slice:** [#932](https://github.com/tomacox74/js2il/issues/932) `test262: add CI workflow and machine-readable reporting`
+- **Umbrella only, not the next direct code pick:** [#927](https://github.com/tomacox74/js2il/issues/927) stays open as the parent issue for the remaining `test262` lane.
 
 ## Recommended order
 
-### Tier 1 - Immediate compatibility and tooling wins
+### Tier 1 - Immediate compatibility wins
 
-1. **[#947](https://github.com/tomacox74/js2il/issues/947)** `scripts/ECMA262: enable network mode under js2il via HTTP client fixes` - This is now the clearest top-of-stack item because it is a checked-in self-hosting/tooling repro with direct user value and obvious dependency overlap with the remaining network-oriented Node work.
-2. **[#949](https://github.com/tomacox74/js2il/issues/949)** `node: add global fetch / Request / Response / Headers baseline` - This remains the highest-leverage missing platform surface after the recent URL/stream/crypto/fs/timers wins; modern packages assume `fetch`-style globals early.
-3. **[#956](https://github.com/tomacox74/js2il/issues/956)** `node: expand TLS/HTTPS trust, client-auth, and agent parity` - With the local HTTPS/TLS baseline already in place, the next real ecosystem blocker is production-grade trust and connection-management parity for outbound integrations.
+1. **[#949](https://github.com/tomacox74/js2il/issues/949)** `node: add global fetch / Request / Response / Headers baseline` - The highest-leverage remaining platform gap after the recent URL/HTTP/TLS/stream/fs/crypto tranche; modern packages frequently assume `fetch`-style globals first.
+2. **[#956](https://github.com/tomacox74/js2il/issues/956)** `node: expand TLS/HTTPS trust, client-auth, and agent parity` - The current TLS/HTTPS baseline is good enough for local/self-signed flows, but real outbound integrations still need trust-store, client-cert, and richer agent behavior.
 
-### Tier 2 - `test262` program bootstrapping
+### Tier 2 - `test262` follow-ons after the MVP landed
 
-4. **[#927](https://github.com/tomacox74/js2il/issues/927)** `test262: create a phased conformance program for js2il` - Keep this as the umbrella issue that defines the scope, sequencing, and reporting model for the child issues below.
-5. **[#928](https://github.com/tomacox74/js2il/issues/928)** `test262: decide upstream intake and sync model` - This remains the first concrete decision point because acquisition, pinning, and licensing expectations constrain every downstream runner and CI decision.
-6. **[#929](https://github.com/tomacox74/js2il/issues/929)** `test262: implement metadata/frontmatter parser` - Once intake is decided, metadata parsing is the next hard dependency; the runner cannot classify includes, flags, features, or negative tests without it.
-7. **[#930](https://github.com/tomacox74/js2il/issues/930)** `test262: create MVP runner for plain synchronous script tests` - This is still the first runnable delivery slice and should stay intentionally narrow so failures remain actionable.
-8. **[#931](https://github.com/tomacox74/js2il/issues/931)** `test262: classify negative tests, exclusions, and baselines` - This can partially evolve alongside the MVP runner, but it should land before broadening the slice so output stays reproducible and triageable.
-9. **[#932](https://github.com/tomacox74/js2il/issues/932)** `test262: add CI workflow and machine-readable reporting` - CI and summary output should follow a working local slice rather than arrive before the runner semantics are stable.
-10. **[#933](https://github.com/tomacox74/js2il/issues/933)** `test262: connect conformance results to ECMA-262 docs and backlog` - This becomes high value once there is real output to map back into the docs and issue system.
-11. **[#934](https://github.com/tomacox74/js2il/issues/934)** `test262: expand beyond the MVP to modules, async, and harness-heavy suites` - Important, but explicitly later: this should remain deferred until the narrow MVP runner and reporting loop are already working.
+3. **[#927](https://github.com/tomacox74/js2il/issues/927)** `test262: create a phased conformance program for js2il` - Keep this open as the sequencing umbrella and reporting parent while the remaining child issues land.
+4. **[#931](https://github.com/tomacox74/js2il/issues/931)** `test262: classify negative tests, exclusions, and baselines` - The right next concrete slice after the MVP runner because reproducible classification is the prerequisite for meaningful results.
+5. **[#932](https://github.com/tomacox74/js2il/issues/932)** `test262: add CI workflow and machine-readable reporting` - CI and machine-readable output should follow once the local classification and baseline story is stable enough to automate.
+6. **[#933](https://github.com/tomacox74/js2il/issues/933)** `test262: connect conformance results to ECMA-262 docs and backlog` - High value once the runner emits stable, triageable output rather than just the initial narrow MVP slice.
+7. **[#934](https://github.com/tomacox74/js2il/issues/934)** `test262: expand beyond the MVP to modules, async, and harness-heavy suites` - Important, but still deliberately later than getting the narrow slice classified, reported, and wired back into docs.
 
-### Tier 3 - Research / architecture follow-on
+### Tier 3 - Deferred performance queue
 
-12. **[#841](https://github.com/tomacox74/js2il/issues/841)** `Investigate using existing .NET HTTP primitives for future Node HTTP work` - Still useful architectural input and likely relevant to both [#947](https://github.com/tomacox74/js2il/issues/947) and [#956](https://github.com/tomacox74/js2il/issues/956), but it remains research rather than the next direct shipping slice.
-
-### Tier 4 - Deferred performance queue
-
-13. **[#451](https://github.com/tomacox74/js2il/issues/451)** `perf(il): expand typed temps/locals to reduce casts/boxing` - Best broad performance enabler once the current compatibility and conformance priorities relax.
-14. **[#737](https://github.com/tomacox74/js2il/issues/737)** `perf: callsite-based typed parameter specialization for non-exported functions` - Builds on the same typed-fast-path direction as [#451](https://github.com/tomacox74/js2il/issues/451).
-15. **[#738](https://github.com/tomacox74/js2il/issues/738)** `perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations` - Still the umbrella Prime performance issue, but now clearly a secondary lane behind the remaining Node and `test262` work.
-16. **[#742](https://github.com/tomacox74/js2il/issues/742)** `perf(prime): trim timing/config coercion overhead in main path` - Scoped child under [#738](https://github.com/tomacox74/js2il/issues/738).
-17. **[#743](https://github.com/tomacox74/js2il/issues/743)** `perf(prime): add Prime perf acceptance gate and reporting` - Best once the next round of Prime tuning resumes.
-18. **[#746](https://github.com/tomacox74/js2il/issues/746)** `perf: make dromaeo-object-regexp faster than Jint prepared` - Valuable benchmark target, but still behind compatibility and tooling work.
-19. **[#747](https://github.com/tomacox74/js2il/issues/747)** `perf(regexp): cache Regex instances by source+flags` - Child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
-20. **[#748](https://github.com/tomacox74/js2il/issues/748)** `perf(dispatch): add RegExp fast paths in Object.CallMember1/2` - Another child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
-21. **[#768](https://github.com/tomacox74/js2il/issues/768)** `Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)` - Still scenario-specific rather than a broad ecosystem unblocker.
-22. **[#837](https://github.com/tomacox74/js2il/issues/837)** `perf(runtime): investigate DLR-backed CallMember fast path` - Remains a research-heavy idea rather than a near-term implementation slice.
+8. **[#451](https://github.com/tomacox74/js2il/issues/451)** `perf(il): expand typed temps/locals to reduce casts/boxing` - Best broad performance enabler once the current compatibility and conformance priorities relax.
+9. **[#737](https://github.com/tomacox74/js2il/issues/737)** `perf: callsite-based typed parameter specialization for non-exported functions` - Builds on the same typed fast-path direction as [#451](https://github.com/tomacox74/js2il/issues/451).
+10. **[#738](https://github.com/tomacox74/js2il/issues/738)** `perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations` - Still the umbrella Prime performance issue, but now clearly secondary to the remaining Node and `test262` work.
+11. **[#742](https://github.com/tomacox74/js2il/issues/742)** `perf(prime): trim timing/config coercion overhead in main path` - Scoped child under [#738](https://github.com/tomacox74/js2il/issues/738).
+12. **[#743](https://github.com/tomacox74/js2il/issues/743)** `perf(prime): add Prime perf acceptance gate and reporting` - Best once Prime tuning resumes.
+13. **[#746](https://github.com/tomacox74/js2il/issues/746)** `perf: make dromaeo-object-regexp faster than Jint prepared` - Valuable benchmark target, but still behind compatibility and tooling work.
+14. **[#747](https://github.com/tomacox74/js2il/issues/747)** `perf(regexp): cache Regex instances by source+flags` - Child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
+15. **[#748](https://github.com/tomacox74/js2il/issues/748)** `perf(dispatch): add RegExp fast paths in Object.CallMember1/2` - Another child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
+16. **[#768](https://github.com/tomacox74/js2il/issues/768)** `Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)` - Still scenario-specific rather than a broad ecosystem unblocker.
+17. **[#837](https://github.com/tomacox74/js2il/issues/837)** `perf(runtime): investigate DLR-backed CallMember fast path` - Remains research-heavy rather than a near-term implementation slice.
 
 ## Execution notes
 
-- **No active review queue remains:** there are currently no open PRs on `master`, so the next work can start directly instead of finishing review branches first.
-- **Immediate top-of-stack track:** [#947](https://github.com/tomacox74/js2il/issues/947) -> [#949](https://github.com/tomacox74/js2il/issues/949) -> [#956](https://github.com/tomacox74/js2il/issues/956). [#841](https://github.com/tomacox74/js2il/issues/841) remains the next research-oriented follow-on after that concrete compatibility queue.
-- **`test262` track:** use [#927](https://github.com/tomacox74/js2il/issues/927) as the parent, then deliver [#928](https://github.com/tomacox74/js2il/issues/928) -> [#929](https://github.com/tomacox74/js2il/issues/929) -> [#930](https://github.com/tomacox74/js2il/issues/930) -> [#931](https://github.com/tomacox74/js2il/issues/931) -> [#932](https://github.com/tomacox74/js2il/issues/932) -> [#933](https://github.com/tomacox74/js2il/issues/933), leaving [#934](https://github.com/tomacox74/js2il/issues/934) as the deliberate post-MVP expansion bucket.
-- **Performance track:** [#451](https://github.com/tomacox74/js2il/issues/451) -> [#737](https://github.com/tomacox74/js2il/issues/737) remains the best general optimization path; [#738](https://github.com/tomacox74/js2il/issues/738) stays the Prime umbrella with [#742](https://github.com/tomacox74/js2il/issues/742) / [#743](https://github.com/tomacox74/js2il/issues/743) as child slices, while [#746](https://github.com/tomacox74/js2il/issues/746) -> [#747](https://github.com/tomacox74/js2il/issues/747) / [#748](https://github.com/tomacox74/js2il/issues/748) and [#768](https://github.com/tomacox74/js2il/issues/768) / [#837](https://github.com/tomacox74/js2il/issues/837) remain lower-priority benchmark work.
+- **No active review queue remains:** there are currently no open PRs, so the next work can start directly instead of finishing review branches first.
+- **Immediate top-of-stack Node track:** [#949](https://github.com/tomacox74/js2il/issues/949) -> [#956](https://github.com/tomacox74/js2il/issues/956).
+- **`test262` track:** keep [#927](https://github.com/tomacox74/js2il/issues/927) as the umbrella, then execute [#931](https://github.com/tomacox74/js2il/issues/931) -> [#932](https://github.com/tomacox74/js2il/issues/932) -> [#933](https://github.com/tomacox74/js2il/issues/933), leaving [#934](https://github.com/tomacox74/js2il/issues/934) as the deliberate post-MVP expansion bucket. The bootstrap/parser/MVP foundation [#928](https://github.com/tomacox74/js2il/issues/928)-[#930](https://github.com/tomacox74/js2il/issues/930) is already landed via PRs [#971](https://github.com/tomacox74/js2il/pull/971)-[#973](https://github.com/tomacox74/js2il/pull/973).
+- **Architecture note:** closed issue [#841](https://github.com/tomacox74/js2il/issues/841) is now reference material for the remaining network work, not a current queue item.
+- **Performance track:** [#451](https://github.com/tomacox74/js2il/issues/451) -> [#737](https://github.com/tomacox74/js2il/issues/737) remains the best general optimization path; the Prime and regexp benchmark sub-queues stay explicitly secondary.
 
 ## Metadata gaps
 
-- Open-issue labeling still lags the actual queue: `0/22` open issues currently carry a `priority:*` label, `0/22` carry a `lane:*` label, and `14/22` have no labels at all.
-- The queue is materially smaller after the recent merges and release, but the remaining Node, `test262`, and performance issues still are not consistently labeled for priority/lane filtering.
-- With no open PRs and the release queue now fully landed, this triage document plus `NodeGapPopularityBacklog.md` are currently more reliable ordering signals than any active review-queue metadata.
+- Open-issue labeling still lags the actual queue: **2/17** open issues currently carry a `priority:*` label, **0/17** carry a `lane:*` label, and **10/17** have no labels at all.
+- With no open PRs and a smaller issue set after the recent merges, this triage document plus [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md) remain the clearest current ordering signals until issue metadata catches up.

--- a/docs/tracking-issues/NodeGapPopularityBacklog.md
+++ b/docs/tracking-issues/NodeGapPopularityBacklog.md
@@ -1,9 +1,9 @@
 # Node Gap Popularity Backlog
 
-> **Last Updated**: 2026-04-06
+> **Last Updated**: 2026-04-13
 > Purpose: Persist a holistic, popularity-weighted view of the highest-value remaining Node.js gaps so triage context is not lost between sessions.
 > Scope: Node.js compatibility first, with adjacent web/runtime work called out when it directly blocks common Node workloads.
-> Active review item: none. This ranking assumes the recent child-process, networking, stream, fs, timers/promises, and `node:url` baselines are already on `master`.
+> Active review item: none.
 
 ## Inputs Used
 
@@ -12,28 +12,26 @@
 - Module-level coverage: `docs/nodejs/*.json`
 - Runtime module footprint: `src/JavaScriptRuntime/Node/*` and `src/JavaScriptRuntime/CommonJS/*`
 - Repo-local demand signals: `tests/Js2IL.Tests/Node/**/*`, `tests/Js2IL.Tests/CommonJS/**/*`, and `tests/Js2IL.Tests/Import/**/*`
-- Current open Node/runtime follow-up issues: [#841](https://github.com/tomacox74/js2il/issues/841), [#946](https://github.com/tomacox74/js2il/issues/946), [#947](https://github.com/tomacox74/js2il/issues/947), [#949](https://github.com/tomacox74/js2il/issues/949), [#950](https://github.com/tomacox74/js2il/issues/950), [#951](https://github.com/tomacox74/js2il/issues/951), [#952](https://github.com/tomacox74/js2il/issues/952), [#953](https://github.com/tomacox74/js2il/issues/953), [#954](https://github.com/tomacox74/js2il/issues/954), [#955](https://github.com/tomacox74/js2il/issues/955), [#956](https://github.com/tomacox74/js2il/issues/956)
+- Current open Node/runtime follow-up issues: [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956)
+- Recently closed Node/runtime issues that changed the backlog shape: [#946](https://github.com/tomacox74/js2il/issues/946), [#947](https://github.com/tomacox74/js2il/issues/947), [#950](https://github.com/tomacox74/js2il/issues/950)-[#955](https://github.com/tomacox74/js2il/issues/955), and the architecture investigation [#841](https://github.com/tomacox74/js2il/issues/841)
 
 ## Current Baseline (Snapshot)
 
-- Node docs currently track **19 modules** (**17 `partial`**, **2 `completed`**) and **14 globals** (**14 `supported`**).
-- Several high-value families have moved from "missing" to "follow-on" status on `master`:
-  - `child_process` now has a documented `fork()` + JSON IPC baseline for compiled child modules.
-  - `http`, `https`, `tls`, and `net` all have practical loopback/local baselines.
-  - `stream` has lifecycle helpers (`pipeline`, `finished`, pause/resume, UTF-8 decoding, basic backpressure) instead of only raw class stubs.
-  - `fs` / `fs/promises` now cover whole-file helpers, FileHandle open/read/write/close, and file stream basics.
-  - `timers/promises` now supports the one-shot Promise helpers.
-  - `node:url` now exposes a focused WHATWG URL module baseline.
+- Node docs currently track **19 modules** (**16 `partial`**, **3 `completed`**) and **16 globals** (**15 `supported`**, **1 `partial`**).
+- Several previously top-ranked gaps are now shipped on `master`:
+  - `globalThis.URL` is supported and shares constructor identity with `node:url`.
+  - The extractor network-mode follow-on landed, so JS2IL can now run the real `scripts/ECMA262` networking path instead of being limited to offline/manual fetch flows.
+  - `child_process`, `timers/promises`, loader/runtime probing, `fs`, `crypto`, and `stream` all moved forward enough that their previous issue-backed follow-ons are now closed.
 - The biggest remaining popularity-weighted gaps are now concentrated in:
-  - missing globals and web-adjacent surfaces (`URL`, `URLSearchParams`, `fetch`, `Headers`, `Request`, `Response`)
-  - outbound client parity beyond local loopback baselines (`http`, `https`, `tls`)
-  - deeper process-control and scheduler follow-ons (`child_process`, `timers/promises`)
-  - mature toolchain surfaces that still have only pragmatic baselines (`fs`, `stream`, `crypto`, package loader/runtime probing)
+  - missing high-level web-style globals (`fetch`, `Headers`, `Request`, `Response`)
+  - production-grade TLS/HTTPS parity beyond the current local/self-signed baseline
+  - still-thin but commonly assumed module surfaces (`os`, `path.posix` / `path.win32`, `util`, `URLSearchParams`)
+  - deeper networking/runtime polish (`net`, broader outbound client behavior)
 
 ## Repo-local Demand Signals
 
-- Node coverage is now strongest around the landed foundations: `fs`, `fs/promises`, `http`, `https`, `tls`, `net`, `stream`, `timers/promises`, `child_process`, `url`, and `util`.
-- Because those foundations exist, the next backlog should optimize for **ecosystem unblock value**: finishing the most commonly assumed follow-ons on top of those modules rather than starting lower-value new modules.
+- Node coverage is strongest around the recently delivered foundations: `child_process`, `crypto`, `fs`, `http`, `https`, `net`, `stream`, `timers/promises`, `url`, `util`, and `zlib`.
+- Because those foundations now exist, the next backlog should optimize for **ecosystem unblock value**: finish the most commonly assumed follow-ons on top of those modules instead of starting low-value new modules.
 
 ## Ranking Criteria
 
@@ -45,31 +43,31 @@
 
 ## Current ranked backlog (recommended order)
 
+Only [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956) remain open from the previous issue-backed top 10. Ranks 3-10 below are the best current **issue-creation candidates** if they remain high-priority after those two land.
+
 | Rank | Feature family | Primary Node area | GitHub issue | Current status signal | Why it is top-10 now |
 |---:|---|---|---|---|---|
-| 1 | [Global WHATWG URL / URLSearchParams exposure](https://github.com/tomacox74/js2il/issues/946) | globals + `url` | [#946](https://github.com/tomacox74/js2il/issues/946) | `node:url` works, but bare globals are still missing and direct global usage is still a known gap | Common Node/browser-style code assumes `globalThis.URL`, and this already surfaced as a real repo-local tooling blocker. |
-| 2 | [Outbound HTTP client parity for real tooling](https://github.com/tomacox74/js2il/issues/947) | `http` / `https` | [#947](https://github.com/tomacox74/js2il/issues/947) (related [#841](https://github.com/tomacox74/js2il/issues/841)) | Loopback HTTP/HTTPS baselines exist, but real network-mode workflows still need broader request/redirect/text-path parity | This is the clearest self-hosting/runtime follow-on after the recent extractor investigation and would unlock more than synthetic loopback demos. |
-| 3 | [Global `fetch` / `Headers` / `Request` / `Response` baseline](https://github.com/tomacox74/js2il/issues/949) | globals + web platform | [#949](https://github.com/tomacox74/js2il/issues/949) | These globals are not listed in the current supported Node global inventory, even though the lower transport stack now exists in partial form | Modern Node 18+/22 packages increasingly assume fetch-style APIs first and only fall back to raw `node:http` in edge cases. |
-| 4 | [Advanced child-process parity after the current fork baseline](https://github.com/tomacox74/js2il/issues/950) | `child_process` | [#950](https://github.com/tomacox74/js2il/issues/950) (hosted-fork sub-gap: [#914](https://github.com/tomacox74/js2il/issues/914)) | `spawn`/`exec`/`execFile`/`fork` basics now work, but detached children, handle passing, advanced serialization, and hosted-engine parity remain unsupported | Dev servers, worker orchestration, and IPC-heavy toolchains often need more than the current compiled-child JSON IPC slice. |
-| 5 | [`timers/promises.setInterval(...)` async-iterator contract](https://github.com/tomacox74/js2il/issues/951) | `timers/promises` | [#951](https://github.com/tomacox74/js2il/issues/951) | The one-shot Promise helpers are supported, but `setInterval(...)` is still explicitly rejected | Polling, retry, and scheduler libraries use this exact modern timer surface and it is now the only clearly missing API in that module. |
-| 6 | [Broader package loader and runtime-probing parity](https://github.com/tomacox74/js2il/issues/952) | `require()` / package resolution | [#952](https://github.com/tomacox74/js2il/issues/952) | Literal compile-time resolution works, but runtime probing, non-`./` package imports targets, and custom loaders/hooks remain unsupported | Plugin ecosystems and CLIs frequently depend on dynamic resolution patterns that the current compile-time-only slice cannot model. |
-| 7 | [File watching, rich stats, and raw-fd parity](https://github.com/tomacox74/js2il/issues/953) | `fs` / `fs/promises` | [#953](https://github.com/tomacox74/js2il/issues/953) | Whole-file helpers, FileHandle basics, and file streams exist; watchers, richer stats/permissions, and raw numeric-fd workflows are still missing | Build tools and dev servers hit watch/stat/raw-fd gaps quickly even when the basic file I/O baseline is present. |
-| 8 | [Practical crypto expansion beyond hashes/HMAC](https://github.com/tomacox74/js2il/issues/954) | `crypto` | [#954](https://github.com/tomacox74/js2il/issues/954) | Hash/HMAC/random/subtle-HMAC baselines exist, but pbkdf2Sync, ciphers, asymmetric keys, key import/export, and broader Web Crypto are still absent | Real auth, signing, and secure-config workloads still need more than the current digest-focused slice. |
-| 9 | [Stream `objectMode` / `stream/promises` / AbortSignal completeness](https://github.com/tomacox74/js2il/issues/955) | `stream` | [#955](https://github.com/tomacox74/js2il/issues/955) | Callback `pipeline`/`finished` and basic Readable/Writable/Transform support exist, but object mode, promise helpers, AbortSignal, and richer buffering semantics remain out of scope | Many adapters and higher-level libraries assume these helpers instead of wiring raw `pipe()` + events manually. |
-| 10 | [TLS trust, client-auth, and agent parity](https://github.com/tomacox74/js2il/issues/956) | `https` / `tls` | [#956](https://github.com/tomacox74/js2il/issues/956) | Local self-signed loopback flows work, but custom CA trust, client certificates, ALPN, and HTTPS agent pooling are still unsupported | Real outbound service integrations often fail here even after basic local HTTPS tests pass. |
+| 1 | [Global `fetch` / `Headers` / `Request` / `Response` baseline](https://github.com/tomacox74/js2il/issues/949) | globals + web platform | [#949](https://github.com/tomacox74/js2il/issues/949) | These globals are still absent from the supported global inventory even though the lower transport stack now exists in partial form | Modern Node 18+/22 packages increasingly assume fetch-style APIs first and only fall back to raw `node:http` in edge cases. |
+| 2 | [TLS trust, client-auth, and agent parity](https://github.com/tomacox74/js2il/issues/956) | `https` / `tls` | [#956](https://github.com/tomacox74/js2il/issues/956) | Local self-signed loopback flows work, but custom CA trust, client certificates, ALPN, and richer agent behavior remain unsupported | Real outbound service integrations still fail here even after the recent HTTP/TLS baseline wins. |
+| 3 | `os` surface expansion | `os` | No dedicated issue yet | The documented baseline is still only `tmpdir()` and `homedir()` | CLI and tooling code frequently expects many more environment and platform helpers than the current tiny slice exposes. |
+| 4 | `URLSearchParams` completion and legacy `url` follow-ons | globals + `url` | No dedicated issue yet | `URL` is now supported, but `URLSearchParams` is still `partial`, and legacy `url.parse` / `url.format` remain unimplemented | URL support is much more useful now, which makes the remaining gaps more visible to real workloads. |
+| 5 | `path.posix` / `path.win32` completeness | `path` | No dedicated issue yet | Core `path` helpers are in good shape, but the namespaced `posix` / `win32` surfaces are intentionally minimal | Bundlers, build tools, and cross-platform fixtures often rely on the namespaced helpers rather than the host-default surface. |
+| 6 | Broader `net` parity beyond loopback IPv4 | `net` | No dedicated issue yet | `ref()` / `unref()`, non-UTF-8 encoding paths, `keepAlive` initialDelay, and broader IPv6/non-loopback expectations remain unsupported | Lower-level networking stacks, dev servers, and adapters hit these controls quickly once basic TCP already works. |
+| 7 | Broader outbound `http` / `https` client polish after the extractor baseline | `http` / `https` | No dedicated issue yet | The extractor-specific network mode landed, but the public client surfaces still expose only a pragmatic subset of broader outbound behavior | There is still a meaningful gap between "works for the checked-in extractor path" and "safe for arbitrary Node HTTP clients". |
+| 8 | `util` follow-ons | `util` | No dedicated issue yet | `promisify`, `inherits`, `format`, and practical `types` / `inspect` slices exist, but the module remains `partial` | Utility shims get pulled in by a wide range of packages, so missing edges here create diffuse ecosystem friction. |
+| 9 | Practical compression expansion beyond the current gzip slice | `zlib` | No dedicated issue yet | `gzipSync`, `gunzipSync`, `createGzip`, and `createGunzip` exist, but deflate/inflate/brotli and richer streaming/tuning remain unsupported | Compression support is increasingly relevant once HTTP/stream baselines exist and packages start expecting richer content-encoding coverage. |
+| 10 | `perf_hooks` baseline expansion | `perf_hooks` | No dedicated issue yet | Only `performance` and `performance.now()` are documented today | Lower impact than the items above, but still a common helper surface for modern tooling and metrics libraries. |
 
 ## Notable next-tier gaps
 
-- **Broader `net` parity beyond loopback IPv4**: `ref()` / `unref()`, non-UTF-8 encoding paths, `keepAlive` initialDelay, IPv6/non-loopback expectations, and other broader socket controls remain lower-level but still meaningful follow-ons.
-- **`os` surface expansion**: the documented baseline is still only `tmpdir()` and `homedir()`, so a lot of common CLI/environment helpers remain absent.
-- **`path.posix` / `path.win32` completeness**: the core `path` helpers are in good shape, but the namespaced `posix`/`win32` surfaces are still intentionally minimal.
-- **`util` follow-ons**: `promisify`, `inherits`, `format`, and practical `types`/`inspect` slices exist, but broader utility parity is still incomplete.
-- **Legacy low-priority gaps**: `querystring` helper extras and broader `perf_hooks` APIs are still partial, but they currently unblock fewer workloads than the ten items above.
+- **Further `child_process` polish**: the module is much stronger now, but detached launches, handle passing, and advanced serialization remain unsupported by design in the delivered slice.
+- **`querystring` helper extras**: lower priority now that WHATWG URL support is present, but still incomplete.
+- **More `zlib` streaming fidelity**: today the delivered transform helpers buffer the full payload and emit a single output chunk on `end()`.
 
 ## Recommended sequencing
 
-- **Start with the current high-signal issue-backed items first:** [#946](https://github.com/tomacox74/js2il/issues/946) -> [#947](https://github.com/tomacox74/js2il/issues/947).
-- **The previously untracked top-10 gaps now have dedicated issues:** [#949](https://github.com/tomacox74/js2il/issues/949), [#950](https://github.com/tomacox74/js2il/issues/950), [#951](https://github.com/tomacox74/js2il/issues/951), [#952](https://github.com/tomacox74/js2il/issues/952), [#953](https://github.com/tomacox74/js2il/issues/953), [#954](https://github.com/tomacox74/js2il/issues/954), [#955](https://github.com/tomacox74/js2il/issues/955), and [#956](https://github.com/tomacox74/js2il/issues/956).
+- **Finish the remaining issue-backed Node work first:** [#949](https://github.com/tomacox74/js2il/issues/949) -> [#956](https://github.com/tomacox74/js2il/issues/956).
+- **Then cut the next issue from the highest remaining untracked gap:** ranks 3-5 above are the strongest current candidates.
 - **Keep transport follow-ons layered:** do not start a higher-level convenience surface (`fetch`, advanced HTTPS, agent pooling) without the minimum lower-layer HTTP/TLS behavior it depends on.
 
 ## Gate for Each Delivered Item
@@ -83,24 +81,24 @@
 
 - This ranking is deliberately heuristic. It reflects the current docs plus repo-local demand signals, not external npm telemetry.
 - Some items are feature families rather than single APIs. Each should still be delivered in explicit, documented slices.
-- The global/web-platform items (`URL`, `fetch`, `Request`, `Response`, `Headers`) are included because they now directly affect common Node workloads, even when they are not packaged as core-module gaps.
+- The global/web-platform items are included because they now directly affect common Node workloads, even when they are not packaged as classic core-module gaps.
 
-## Issue #841 investigation addendum (2026-04-09)
+## Issue #841 investigation addendum (closed 2026-04-09)
 
-This addendum is the concrete output for [#841](https://github.com/tomacox74/js2il/issues/841). It does not rewrite the historical 2026-04-06 ranking above; it records the transport architecture recommendation against the current post-`v0.9.7` HTTP/TLS baseline.
+This addendum is the concrete output for [#841](https://github.com/tomacox74/js2il/issues/841). It remains useful reference material for the remaining network work; it is no longer an open queue item.
 
 ### Current-state inventory
 
-- `src/JavaScriptRuntime/Node/Net.cs` already owns the transport/event-loop model through `TcpClient` / `TcpListener`, `IIOScheduler`, `NodeSchedulerState`, incremental reads/writes, and Node-shaped socket lifecycle behavior.
-- `src/JavaScriptRuntime/Node/Http.cs` already owns the custom HTTP/1.1 request/response model: `HttpClientRequest`, `HttpServer`, `IncomingMessage`, `ServerResponse`, a custom parser/decoder, chunked framing, sequential keep-alive reuse, and explicit unsupported handling for CONNECT, Upgrade, Expect/100-continue, and pipelining.
-- `src/JavaScriptRuntime/Node/Https.cs` already layers TLS on top of that same transport through `SslStream`, with a documented local/self-signed baseline and explicit omissions around custom CA trust, client certificates, ALPN, and advanced `https.Agent` behavior.
+- `src/JavaScriptRuntime/Node/Net.cs` owns the transport/event-loop model through `TcpClient` / `TcpListener`, `IIOScheduler`, `NodeSchedulerState`, incremental reads/writes, and Node-shaped socket lifecycle behavior.
+- `src/JavaScriptRuntime/Node/Http.cs` owns the custom HTTP/1.1 request/response model: `HttpClientRequest`, `HttpServer`, `IncomingMessage`, `ServerResponse`, custom parsing/decoding, chunked framing, sequential keep-alive reuse, and explicit unsupported handling for CONNECT, Upgrade, Expect/100-continue, and pipelining.
+- `src/JavaScriptRuntime/Node/Https.cs` layers TLS on top of that same transport through `SslStream`, with a documented local/self-signed baseline and explicit omissions around custom CA trust, client certificates, ALPN, and advanced `https.Agent` behavior.
 - Because JS2IL already exposes Node-shaped request/response/socket/event surfaces, any .NET-backed reuse has to sit behind those existing objects instead of replacing them wholesale.
 
 ### Options comparison
 
 | Option | Best fit | Advantages | Main risks / mismatches | Recommendation |
 |---|---|---|---|---|
-| Current custom TCP + parser path | Existing server and client baseline | Full control over socket visibility, unsupported-feature gating, event-loop scheduling, and Node-shaped objects | More incremental work is needed to grow outbound parity and TLS follow-ons | **Keep as the server-side and transport foundation** |
+| Current custom TCP + parser path | Existing server and client baseline | Full control over socket visibility, unsupported-feature gating, event-loop scheduling, and Node-shaped objects | More incremental work is still needed to grow outbound parity and TLS follow-ons | **Keep as the server-side and transport foundation** |
 | `HttpClient` / `SocketsHttpHandler` | Outbound client follow-ons only | Mature cross-platform HTTP/TLS behavior, strong handler knobs, and headers-first response streaming | Raw socket visibility is limited, default auto-behaviors must be disabled, agent semantics are not 1:1, and abort/error timing still needs a Node adapter | **Investigate selectively for outbound-only flows** |
 | `HttpListener` | Narrow server experiments at most | Built-in server API with low immediate coding cost | Older API, host/OS friction, and a poor fit for Node's stream/event/socket model | **Do not adopt for core `node:http` server work** |
 | Kestrel / ASP.NET Core | Heavyweight hosting only | Rich HTTP/TLS infrastructure and a well-tested server stack | Large dependency/runtime weight, request-pipeline model differs from Node, and it does not naturally expose Node-like socket/request lifecycles | **Possible for a hosting-specific integration layer, but not recommended for the baseline Node runtime** |
@@ -116,13 +114,10 @@ This addendum is the concrete output for [#841](https://github.com/tomacox74/js2
   - Explicit mapping for abort/destroy/error timing and clear preservation of supported keep-alive / agent behavior.
   - A deliberate answer for any supported `request.socket` / `response.socket` expectations before widening the public surface.
 - Do not pursue `HttpListener` or Kestrel as the baseline `node:http` server implementation; both fight the Node evented stream model harder than the current parser path helps.
-- Kestrel is still technically worth considering for a separate hosting-oriented integration layer if the goal changes and strict Node socket/runtime semantics become less important than leveraging a richer ASP.NET Core host stack.
 
 ### Follow-on map
 
-- [#947](https://github.com/tomacox74/js2il/issues/947) should use this recommendation to choose between:
-  1. extending the current custom client path for the extractor's exact needs, or
-  2. prototyping a narrow outbound `HttpClient` adapter against the real `scripts/ECMA262/extractEcma262SectionHtml.js` workload.
-- The extractor's transport needs today are intentionally modest: simple GET, manual redirect handling in the `https` fallback, and UTF-8 text body consumption. That makes it a good spike target without forcing a full client rewrite.
+- [#947](https://github.com/tomacox74/js2il/issues/947) is now closed and should be treated as the first worked example of this recommendation being applied to a real tooling workload.
+- [#949](https://github.com/tomacox74/js2il/issues/949) should reuse the same transport guidance when layering fetch-style globals over the current HTTP/HTTPS baseline.
 - [#956](https://github.com/tomacox74/js2il/issues/956) should only build on a `HttpClient` path if the spike proves we can map CA trust, client certificates, ALPN, and agent behavior cleanly; otherwise it should continue extending the current `SslStream` + `NetSocket` / `https` stack.
-- Non-goals for the first follow-on after [#841](https://github.com/tomacox74/js2il/issues/841): server rewrite, HTTP/2, WebSocket/Upgrade, CONNECT tunneling, or replacing `node:net`.
+- Non-goals for the next transport follow-ons: server rewrite, HTTP/2, WebSocket/Upgrade, CONNECT tunneling, or replacing `node:net`.

--- a/docs/tracking-issues/Phase1-TrackingIssues.md
+++ b/docs/tracking-issues/Phase1-TrackingIssues.md
@@ -1,16 +1,17 @@
 # Phase 1: Rest/Spread Foundation - Tracking Issues
 
-> **Created**: 2026-02-12  
-> **Phase Duration**: 4-6 weeks  
+> **Created**: 2026-02-12
+> **Status**: Historical completed reference
+> **Original Phase Duration**: 4-6 weeks
 > **Goal**: Enable modern function signatures and array/object manipulation
 
-This document contains the tracking issues for Phase 1 features. These issues are ready to be created in GitHub.
+This document contains the historical tracking drafts for the original Phase 1 rest/spread work. The phase has already shipped on `master`; keep this file for reference only rather than as the template for new GitHub issues.
 
-## Current State (2026-02-18)
+## Current State (2026-04-13)
 
-- ✅ Core implementation for all 4 Phase 1 issues is in place (rest parameters; spread in calls, arrays, and objects).
-- ✅ Focused rest/spread test suites currently pass (329 passed, 0 failed across Validator/Function/Array/Object execution + generator tests).
-- ✅ ECMA documentation alignment is complete for Phase 1 scope (`docs/ECMA262/13/Section13_2.json` and `docs/ECMA262/15/Section15_1.json`, with regenerated markdown).
+- ✅ Phase 1 scope is long since shipped on `master` (rest parameters; spread in calls, arrays, and objects).
+- ✅ The active queue has moved on to Node compatibility, `test262` follow-ons, and the deferred performance lane.
+- ℹ️ Any unchecked acceptance items below are preserved as historical drafting artifacts rather than current blockers.
 
 ---
 
@@ -359,7 +360,9 @@ const modified = { ...original, name: 'new name' };
 
 ---
 
-## Phase 1 Success Criteria
+## Phase 1 Success Criteria (historical completion gate)
+
+The checklist below is preserved from the original planning draft. It is no longer the active release gate for current work.
 
 When all 4 issues are complete:
 
@@ -409,6 +412,7 @@ function useCustomHook(...deps) {
 ## Notes
 
 - These issues track **Phase 1** of the ECMA-262 Feature Implementation Roadmap
+- This file is retained as historical planning context, not as the active GitHub issue queue
 - See `docs/archive/FeatureImplementationRoadmap.md` for complete context
 - See `docs/archive/ECMA262FeaturePriority.md` for executive summary
 - Total estimated effort: **4-6 weeks**
@@ -416,5 +420,5 @@ function useCustomHook(...deps) {
 
 ---
 
-*Generated from ECMA-262 Feature Implementation Analysis*  
-*Last updated: 2026-02-18*
+*Generated from ECMA-262 Feature Implementation Analysis*
+*Last updated: 2026-04-13*

--- a/docs/tracking-issues/README.md
+++ b/docs/tracking-issues/README.md
@@ -1,234 +1,62 @@
 # Tracking Issues and Triage
 
-This directory contains planning/tracking artifacts used to prioritize ECMA-262, Node.js compatibility, and issue-driven reliability work.
+This directory contains the active and historical tracking artifacts used to prioritize Node compatibility, `test262` adoption, and remaining ECMA-262 backlog work.
 
 ## Current Source of Truth (Active)
 
-**Primary planning doc**: [TriageScoreboard.md](./TriageScoreboard.md)
+- **Primary planning doc**: [TriageScoreboard.md](./TriageScoreboard.md)
+- **Live issue-order snapshot**: [IssueTriage.md](./IssueTriage.md)
+- **Node backlog snapshot**: [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md)
+- **ECMA issue-creation candidates**: [ECMA262TopMissingBacklog.md](./ECMA262TopMissingBacklog.md)
 
-- Uses the current implementation split: **70% features / 30% docs+issues**
-- Prioritizes **Node compatibility** as primary implementation lane
-- Includes mandatory feature PR docs-sync gate
-- Defines weekly triage cadence and ranking criteria
+These files should stay aligned with:
 
----
+1. `origin/master`
+2. `gh issue list` / `gh pr list`
+3. Generated support docs under `docs/nodejs` and `docs/ECMA262`
 
-## Historical Phase Plans (Context)
+## Current Repo Snapshot (2026-04-13)
 
-The phase-based ECMA planning docs remain useful context but are **not** the active source of truth for current sequencing:
+- `origin/master` @ `731a54f4`
+- Open issues: **17**
+- Open PRs: **0**
+- Recent merged PRs that materially changed the queue: [#969](https://github.com/tomacox74/js2il/pull/969), [#970](https://github.com/tomacox74/js2il/pull/970), [#971](https://github.com/tomacox74/js2il/pull/971), [#972](https://github.com/tomacox74/js2il/pull/972), [#973](https://github.com/tomacox74/js2il/pull/973)
+- Remaining open lanes:
+  - Node/runtime follow-ons: [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956)
+  - `test262` program: [#927](https://github.com/tomacox74/js2il/issues/927), [#931](https://github.com/tomacox74/js2il/issues/931)-[#934](https://github.com/tomacox74/js2il/issues/934)
+  - Performance queue: [#451](https://github.com/tomacox74/js2il/issues/451), [#737](https://github.com/tomacox74/js2il/issues/737), [#738](https://github.com/tomacox74/js2il/issues/738), [#742](https://github.com/tomacox74/js2il/issues/742), [#743](https://github.com/tomacox74/js2il/issues/743), [#746](https://github.com/tomacox74/js2il/issues/746), [#747](https://github.com/tomacox74/js2il/issues/747), [#748](https://github.com/tomacox74/js2il/issues/748), [#768](https://github.com/tomacox74/js2il/issues/768), [#837](https://github.com/tomacox74/js2il/issues/837)
 
-- [Phase1-TrackingIssues.md](./Phase1-TrackingIssues.md)
+## Historical Context
 
-Use them as background/reference only when drafting or updating issue scopes.
+- [Phase1-TrackingIssues.md](./Phase1-TrackingIssues.md) is a completed historical rest/spread planning document. Keep it for reference only; do not use it as the template for new GitHub issues.
 
-## Quick Start
+## Updating These Docs
 
-### Creating or Updating GitHub Issues
+1. Refresh GitHub state with `gh issue list --state all` and `gh pr list --state all`.
+2. Sync rankings against shipped behavior in `docs/nodejs/Index.md` and `docs/ECMA262/**/Section*.md`.
+3. Update [TriageScoreboard.md](./TriageScoreboard.md) first, then bring [IssueTriage.md](./IssueTriage.md), [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md), and [ECMA262TopMissingBacklog.md](./ECMA262TopMissingBacklog.md) into alignment.
+4. Keep historical docs explicitly marked historical when the active queue moves on.
 
-The tracking issue documents are formatted to be directly copied into GitHub issues. Each issue includes:
-- Detailed description and context
-- Implementation checklist
-- Acceptance criteria
-- Estimated effort
-- Dependencies
+## Mandatory Docs-Sync Gate
 
-Before creating new issues, rank work in [TriageScoreboard.md](./TriageScoreboard.md) and verify no duplicate issue exists.
+Feature work is not ready to merge until:
 
----
-
-## How to Create Issues
-
-> Follow `.github/copilot-instructions.md` guidance: use `issue-body.md` for complex issue bodies and the dedupe flow when possible.
-
-### Option 1: Manual Creation (Recommended if no GitHub CLI)
-
-1. Open [Phase1-TrackingIssues.md](./Phase1-TrackingIssues.md)
-2. Copy the content for each issue (from "## Issue N" to the next issue or section)
-3. Create a new GitHub issue
-4. Paste the content as the issue body
-5. Add labels as specified
-6. Set the title as specified
-
-### Option 2: Bulk Creation Script
-
-Create all Phase 1 issues at once:
-
-```bash
-cd /home/runner/work/js2il/js2il
-
-# Create Issue 1: Rest Parameters
-gh issue create \
-  --repo tomacox74/js2il \
-  --title "Implement Rest Parameters (...args)" \
-  --label "enhancement,phase-1,critical,rest-spread" \
-  --body "$(awk '/^## Issue 1:/,/^## Issue 2:/' docs/tracking-issues/Phase1-TrackingIssues.md | head -n -2)"
-
-# Create Issue 2: Spread in Function Calls
-gh issue create \
-  --repo tomacox74/js2il \
-  --title "Implement Spread Operator in Function Calls" \
-  --label "enhancement,phase-1,critical,rest-spread" \
-  --body "$(awk '/^## Issue 2:/,/^## Issue 3:/' docs/tracking-issues/Phase1-TrackingIssues.md | head -n -2)"
-
-# Create Issue 3: Spread in Array Literals
-gh issue create \
-  --repo tomacox74/js2il \
-  --title "Implement Spread in Array Literals" \
-  --label "enhancement,phase-1,high-priority,rest-spread" \
-  --body "$(awk '/^## Issue 3:/,/^## Issue 4:/' docs/tracking-issues/Phase1-TrackingIssues.md | head -n -2)"
-
-# Create Issue 4: Spread in Object Literals
-gh issue create \
-  --repo tomacox74/js2il \
-  --title "Implement Spread in Object Literals" \
-  --label "enhancement,phase-1,high-priority,rest-spread" \
-  --body "$(awk '/^## Issue 4:/,/^## Phase 1 Success/' docs/tracking-issues/Phase1-TrackingIssues.md | head -n -2)"
-```
-
----
-
-## Issue Structure
-
-Each tracking issue includes:
-
-### Header
-- **Title**: Clear, concise feature description
-- **Labels**: Priority, phase, and feature category
-- **Priority**: Visual indicator (🔴 CRITICAL, 🟡 HIGH, 🟢 MEDIUM, 🔵 LOW)
-
-### Content Sections
-1. **Description**: What the feature does
-2. **Priority & Why This Matters**: Business justification
-3. **Usage Examples**: Code samples showing the feature in action
-4. **ECMA-262 Reference**: Spec sections and links
-5. **Implementation Checklist**: Broken down by area (Parser, IL Gen, Testing, Docs)
-6. **Acceptance Criteria**: Definition of done
-7. **Estimated Effort**: Time estimate
-8. **Dependencies**: Related issues
-
----
-
-## Implementation Workflow
-
-For each issue:
-
-1. **Pre-Implementation**
-   - Review the tracking issue
-   - Read related ECMA-262 spec sections
-   - Understand dependencies
-   - Set up test infrastructure
-
-2. **Implementation**
-   - Follow the implementation checklist
-   - Make small, incremental changes
-   - Test frequently
-   - Update documentation as you go
-
-3. **Testing**
-   - Add execution tests (compile + run + verify output)
-   - Add generator tests (IL snapshot tests)
-   - Update snapshots: `node scripts/updateVerifiedFiles.js`
-   - Ensure all existing tests pass
-
-4. **Documentation**
-   - Update relevant `docs/ECMA262/*/Section*.json` files
-   - Regenerate markdown: `node scripts/ECMA262/generateEcma262SectionMarkdown.js --section X.Y`
-   - Update `CHANGELOG.md`
-   - Add usage examples
-
-5. **Completion**
-   - All checklist items complete
-   - All acceptance criteria met
-   - Code review passed
-   - Tests passing
-   - Documentation updated
-
-### Mandatory Docs-Sync Gate for Feature PRs
-
-Feature PRs are not ready to merge until docs are synchronized:
-
-1. Update relevant source JSON docs (`docs/ECMA262/**/Section*.json` and/or `docs/nodejs/*.json`)
-2. Regenerate markdown/index artifacts
-3. Ensure status summaries reflect shipped behavior
-4. Include changelog entry when behavior is user-visible
-
----
-
-## Phase Tracking (Historical Snapshot)
-
-### Phase 1: Rest/Spread Foundation
-- **Status**: Historical planning context
-- **Duration**: 4-6 weeks
-- **Issues**: 4 tracking issues created
-- **Impact**: 60% modern JavaScript coverage
-
-### Phase 2: Object Utilities
-- **Status**: Historical planning context
-- **Duration**: 2-3 weeks
-- **Impact**: 85% coverage
-
-### Phase 3: Array Methods
-- **Status**: Historical planning context
-- **Duration**: 3-4 weeks
-- **Impact**: 95% coverage
-
-### Phase 4: Advanced Features
-- **Status**: Historical planning context
-- **Duration**: 4-6 weeks
-- **Impact**: ~100% coverage
-
----
+1. Relevant source JSON docs under `docs/ECMA262` and/or `docs/nodejs` are updated
+2. Generated markdown/index artifacts are regenerated
+3. Tracking docs reflect the new issue/priority state when the queue materially changes
+4. `CHANGELOG.md` is updated for user-visible behavior
 
 ## Related Documentation
 
-- **[TriageScoreboard.md](./TriageScoreboard.md)**: Active prioritization and weekly execution board
-- **[NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md)**: Persisted holistic gap analysis + popularity-weighted Node backlog snapshot
-- **[ECMA262TopMissingBacklog.md](./ECMA262TopMissingBacklog.md)**: Top 10 unsupported/incomplete ECMA-262 features ranked for tracking issue creation
-- **[FeatureImplementationRoadmap.md](../archive/FeatureImplementationRoadmap.md)**: Complete technical roadmap
-- **[ECMA262FeaturePriority.md](../archive/ECMA262FeaturePriority.md)**: Executive summary
-- **[ECMA262FeatureStatus.md](../archive/ECMA262FeatureStatus.md)**: Quick reference
-- **[ECMA262_README.md](../archive/ECMA262_README.md)**: Documentation index
+- **[TriageScoreboard.md](./TriageScoreboard.md)**: Active prioritization and lane ordering
+- **[IssueTriage.md](./IssueTriage.md)**: Current open-issue ordering snapshot
+- **[NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md)**: Remaining Node backlog after the recent April delivery tranche
+- **[ECMA262TopMissingBacklog.md](./ECMA262TopMissingBacklog.md)**: Current ECMA-262 issue-creation candidates derived from the generated section docs
+- **[FeatureImplementationRoadmap.md](../archive/FeatureImplementationRoadmap.md)**: Historical technical roadmap
+- **[ECMA262FeaturePriority.md](../archive/ECMA262FeaturePriority.md)**: Historical executive summary
+- **[ECMA262FeatureStatus.md](../archive/ECMA262FeatureStatus.md)**: Historical status snapshot
 
 ---
 
-## Tips for Implementers
-
-### Getting Started
-1. Start with Issue 1 (Rest Parameters) - it's foundational
-2. Set up your development environment
-3. Run existing tests to establish baseline
-4. Review the copilot instructions: `.github/copilot-instructions.md`
-
-### During Implementation
-- Make small, focused commits
-- Test early and often
-- Use the existing code patterns in the codebase
-- Don't hesitate to ask questions
-
-### Testing Best Practices
-- Write tests before implementation (TDD)
-- Test both positive and negative cases
-- Test edge cases (empty arrays, null, undefined, etc.)
-- Ensure existing tests still pass
-
-### Common Pitfalls to Avoid
-- Don't skip the symbol table updates
-- Don't forget to handle edge cases
-- Don't skip documentation updates
-- Don't leave TODOs in production code
-
----
-
-## Questions?
-
-If you have questions about:
-- **What to implement now**: See [TriageScoreboard.md](./TriageScoreboard.md)
-- **What was originally planned**: See the phase tracking docs
-- **How to implement**: See `docs/archive/FeatureImplementationRoadmap.md`
-- **Why we're implementing**: See `docs/archive/ECMA262FeaturePriority.md`
-- **Current status**: See `docs/archive/ECMA262FeatureStatus.md`
-
----
-
-*This directory supports ongoing ECMA-262 + Node.js compatibility triage*  
-*Last updated: 2026-02-21*
+*This directory supports ongoing Node compatibility, `test262`, and ECMA-262 triage.*
+*Last updated: 2026-04-13*

--- a/docs/tracking-issues/TriageScoreboard.md
+++ b/docs/tracking-issues/TriageScoreboard.md
@@ -1,70 +1,91 @@
 # JS2IL Triage Scoreboard
 
-> **Last Updated**: 2026-03-15
+> **Last Updated**: 2026-04-13
 > **Planning Horizon**: Rolling 2 weeks
 > **North Star**: Real-world unblock impact
+> **Live Queue**: 17 open issues / 0 open PRs
 
 This file is the working source of truth for implementation prioritization.
 
 ## Session Context Snapshots
 
-- [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md): Holistic missing-functionality analysis with popularity-weighted priority ranking.
-- [ECMA262TopMissingBacklog.md](./ECMA262TopMissingBacklog.md): Top 10 unsupported/incomplete ECMA-262 features prioritized for issue creation.
+- [IssueTriage.md](./IssueTriage.md): Current open-issue ordering snapshot synced to live GitHub state.
+- [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md): Holistic missing-functionality analysis with the remaining Node backlog after the recent April merges.
+- [ECMA262TopMissingBacklog.md](./ECMA262TopMissingBacklog.md): Current ECMA-262 issue-creation candidates derived from the generated section docs.
+
+## Current Queue Highlights
+
+- Recent landed work: [#969](https://github.com/tomacox74/js2il/pull/969)-[#973](https://github.com/tomacox74/js2il/pull/973) delivered the extractor networking fix, the test project split, pinned `test262` intake, the metadata parser, and the MVP runner.
+- Primary open Node follow-ons are now [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956).
+- Primary open `test262` follow-ons are [#931](https://github.com/tomacox74/js2il/issues/931)-[#934](https://github.com/tomacox74/js2il/issues/934) under umbrella [#927](https://github.com/tomacox74/js2il/issues/927).
+- The performance queue remains unchanged and explicitly secondary to compatibility and conformance.
 
 ## Capacity Split
 
 - **70%** feature implementation
   - Primary: Node.js compatibility
-  - Secondary: ECMA-262 high-leverage semantics
+  - Secondary: `test262`-driven conformance and ECMA-262 correctness
 - **30%** issue throughput + documentation/status consistency
 
 ## Priority Lanes
 
-### Lane A — Node Compatibility (Primary)
+### Lane A - Node Compatibility (Primary)
 
-Goal: unblock real package/script scenarios with highest user impact.
+Goal: unblock real package and script scenarios with the highest ecosystem impact.
 
 **Selection criteria**
-- Unblocks widely-used ecosystem patterns
+- Unblocks widely used platform assumptions
 - Reproducible via focused execution tests
 - Clear runtime/hosting touchpoints
 
-**Candidate queue (rank during weekly triage)**
-- [ ] Expand `fs` APIs needed by real-world fixtures
-- [ ] Expand `path` parity for common bundler/tooling patterns
-- [ ] Expand `process` surface used by transpiled/bundled code
-- [ ] Improve `child_process` and `os` minimal parity based on failing fixtures
-- [ ] Add missing Node globals where frequently requested
+**Current ranked queue**
+1. [#949](https://github.com/tomacox74/js2il/issues/949) - global `fetch` / `Headers` / `Request` / `Response` baseline
+2. [#956](https://github.com/tomacox74/js2il/issues/956) - TLS/HTTPS trust, client-auth, and agent parity
+3. No dedicated issue yet - whichever top remaining gap stays highest in [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md) after [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956) are re-ranked or split
 
-### Lane B — ECMA-262 High-Leverage Semantics (Secondary)
+**Recently delivered**
+- [#946](https://github.com/tomacox74/js2il/issues/946) - global URL support
+- [#947](https://github.com/tomacox74/js2il/issues/947) - extractor network mode under JS2IL
+- [#950](https://github.com/tomacox74/js2il/issues/950)-[#955](https://github.com/tomacox74/js2il/issues/955) - child_process / timers-promises / loader / fs / crypto / stream follow-ons
 
-Goal: improve language/runtime correctness where breakage is common.
+### Lane B - Conformance / `test262` / ECMA Semantics (Secondary)
+
+Goal: improve correctness in small, reportable slices that can feed back into docs and backlog triage.
 
 **Selection criteria**
-- High breakage frequency in partner or fixture workloads
+- High leverage for conformance confidence
 - Tight scope with strong testability
-- Low-to-medium implementation risk relative to impact
+- Produces actionable results instead of a broad, noisy failure set
 
-**Candidate queue (rank during weekly triage)**
-- [x] #772: ES modules live bindings / cyclic ESM graphs (pragmatic lowering; dynamic `import()` namespace/default interop now matches the practical static ESM path, with deeper module-record semantics remaining under #857)
-- [ ] `Object.hasOwn` and `Object.is`
-- [ ] `Array.from`, `Array.prototype.forEach`, `every`, `some`, `includes`
-- [ ] Remaining Symbol/well-known-symbol gaps affecting iterator semantics
-- [ ] TDZ and remaining modern class edge-case completeness
+**Current ranked queue**
+1. [#931](https://github.com/tomacox74/js2il/issues/931) - classify negative tests, exclusions, and baselines
+2. [#932](https://github.com/tomacox74/js2il/issues/932) - add CI workflow and machine-readable reporting
+3. [#933](https://github.com/tomacox74/js2il/issues/933) - connect conformance results to ECMA-262 docs and backlog
+4. [#934](https://github.com/tomacox74/js2il/issues/934) - expand beyond the MVP to modules, async, and harness-heavy suites
+5. [#927](https://github.com/tomacox74/js2il/issues/927) remains the umbrella tracker and should stay open until the child lane is actually complete
 
-### Lane C — Issue Throughput + Reliability Hygiene
+**Recently delivered**
+- [#928](https://github.com/tomacox74/js2il/issues/928) - pinned intake/bootstrap
+- [#929](https://github.com/tomacox74/js2il/issues/929) - metadata/frontmatter parser
+- [#930](https://github.com/tomacox74/js2il/issues/930) - MVP runner for the narrow initial slice
 
-Goal: reduce issue aging while keeping docs/status trustworthy.
+**Current caveat**
+- The current runner is an MVP foundation, not a broad official coverage claim. Keep automation/reporting/docs integration behind the remaining follow-ons rather than treating the landed slice as full-corpus conformance reporting.
+
+### Lane C - Issue Throughput + Reliability Hygiene
+
+Goal: keep the issue queue actionable while preventing status-document drift.
 
 **Selection criteria**
 - User-facing bug/regression severity
 - Reproducibility and clear acceptance criteria
 - Documentation drift risk
 
-**Candidate queue (continuous)**
-- [ ] Prioritize issues labeled regression/bug/unblocker
-- [ ] Triage stale issues and close/retag with reproducible scope
-- [ ] Keep coverage/status docs synchronized with shipped behavior
+**Current queue**
+- Keep `docs/tracking-issues` synchronized after each merge tranche
+- Backfill `priority:*` labels and future `lane:*` labels on the remaining 17 open issues
+- Keep [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956), and [#931](https://github.com/tomacox74/js2il/issues/931)-[#934](https://github.com/tomacox74/js2il/issues/934) scoped with crisp acceptance criteria
+- Close or retag stale issues only when the replacement scope is clearly documented
 
 ## Mandatory PR Gate (Feature Work)
 
@@ -75,26 +96,28 @@ All feature PRs must include:
    - `docs/ECMA262/**/Section*.json` for language features
    - `docs/nodejs/*.json` for Node modules/globals
 3. Regenerated markdown/index artifacts after JSON updates
-4. Changelog entry when user-visible behavior changes
+4. Tracking-doc updates when the queue or ranking materially changes
+5. `CHANGELOG.md` entry when behavior changes are user-visible
 
-If documentation is not synchronized, PR is not ready to merge.
+If documentation is not synchronized, the PR is not ready to merge.
 
 ## Weekly Triage Cadence
 
 At the start of each week:
 
-1. Re-rank top 3 items in each lane
+1. Re-rank the top 3 items in each lane
 2. Commit to a 2-week slice using the 70/30 split
 3. Define acceptance criteria and owner for each committed item
-4. Verify all open feature PRs include docs sync updates
+4. Verify all open feature PRs include docs-sync updates
 
 ## Source-of-Truth Order
 
 When status signals conflict, use this precedence:
 
 1. Runtime behavior validated by tests
-2. `CHANGELOG.md` entries for released behavior
-3. Section/module JSON docs under `docs/ECMA262` and `docs/nodejs`
-4. Strategy/roadmap markdown summaries
+2. Merged state on `origin/master` plus `CHANGELOG.md`
+3. Generated JSON-backed docs under `docs/ECMA262` and `docs/nodejs`
+4. Live GitHub issue / PR state
+5. Strategy / roadmap markdown summaries
 
 Older phase roadmaps remain useful for context, but this scoreboard drives active prioritization.


### PR DESCRIPTION
## Summary
- sync docs/tracking-issues with current master / GitHub issue state
- refresh the active triage docs after the recent Node and 	est262 merges
- mark the Phase 1 rest/spread plan as historical reference instead of an active issue template

## Scope
- documentation-only change