### PR TITLE
feat(test262): classify MVP results and baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- tooling/tests/docs: close issue #931 by formalizing test262 MVP result kinds/verdicts, classifying parse/runtime negatives plus policy skips vs unsupported requirements, emitting a stable `summary.json` baseline artifact for each runner invocation, documenting the contract in a new ADR, and extending focused runner integration coverage.
 - tooling/tests: close issue #930 by adding a plain synchronous script MVP test262 runner that resolves the pinned checkout, filters unsupported/module/async/agent cases, executes strict/non-strict variants plus parse/runtime negatives through js2il, emits per-test outcomes with repro commands, and adds focused runner integration coverage.
 - tooling/tests: close issue #929 by adding a test262 frontmatter parser with a normalized runner-facing metadata model, explicit MVP blocker/unsupported metadata reporting, and focused integration coverage for representative strict/module/async/negative/fixture cases.
 - tooling/tests/docs: close issue #928 by adopting a pinned sparse-checkout intake model for upstream `tc39/test262`, adding the bootstrap CLI + pin metadata used by local/CI acquisition, recording the licensing/update policy in a new ADR, and adding focused integration coverage for the bootstrap describe flow.

--- a/docs/adr/0006-test262-result-classification-and-baseline.md
+++ b/docs/adr/0006-test262-result-classification-and-baseline.md
@@ -1,0 +1,106 @@
+# ADR 0006: test262 Result Classification and Baseline Artifact
+
+- Date: 2026-04-13
+- Status: Accepted
+
+## Context
+
+Issue #931 follows the pinned intake/bootstrap work (#928), metadata parser (#929), and first MVP runner (#930).
+
+The initial runner can execute the bounded plain-script slice, but it only emits ad hoc `PASS` / `FAIL` / `SKIP` text. That is not enough for conformance triage because JS2IL still needs to distinguish:
+
+- expected parse-phase rejection vs runtime-phase rejection
+- wrong-phase failures
+- wrong runtime error kind
+- policy skips vs unsupported requirements
+- a stable artifact that later CI/reporting work can publish or compare
+
+We also want to keep the policy source of truth small and reviewable instead of introducing another large checked-in manifest too early.
+
+## Decision
+
+JS2IL adopts a **result-kind + verdict** model for the test262 MVP runner and uses the runner's `summary.json` as the baseline artifact.
+
+### Result model
+
+Each classified entry records:
+
+- a stable `kind`
+- a `verdict`
+- the observed phase (`selection`, `compile`, or `runtime`)
+- machine-readable reasons for not-run entries
+- a stable repro descriptor (`file` + optional `variant`)
+
+The current MVP kinds are:
+
+- `pass`
+- `compile-rejection`
+- `runtime-rejection`
+- `wrong-phase`
+- `wrong-error-kind`
+- `runtime-mismatch`
+- `timeout`
+- `runner-error`
+- `unsupported-requirement`
+- `skipped-by-policy`
+
+The current verdicts are:
+
+- `matched`
+- `unexpected`
+- `not-run`
+
+### Policy sources
+
+There is **not** a second dedicated checked-in policy file for the MVP.
+
+Instead, the machine-readable policy is split across the existing sources that already own that information:
+
+1. `tests/test262/test262.pin.json#excludedFromMvp`
+   - path-based policy exclusions only
+   - this field no longer carries pseudo-frontmatter rules
+2. `scripts/test262/metadataParser.js`
+   - `unsupported` codes describe metadata the runner cannot model yet
+   - `mvpBlockers` codes describe harness/runtime requirements outside the MVP slice
+3. upstream test262 frontmatter
+   - `negative.phase` and `negative.type` remain the canonical expectation source for negative tests
+
+### Negative-test expectations
+
+- `negative.phase=parse` is currently validated at the **compile** phase only. JS2IL does not yet surface normalized parser error objects, so parse negatives are phase-classified but do not yet assert parse error kind.
+- `negative.phase=runtime` is validated at the **runtime** phase and does check the observed runtime error kind.
+
+### Baseline artifact
+
+Every non-list runner invocation writes:
+
+- `<output>/summary.json`
+
+That JSON file is the baseline/report artifact for the MVP. It includes:
+
+- pin identity (`commit`, `packageVersion`)
+- the effective path-exclusion policy
+- the negative-phase expectation contract
+- selection counts
+- verdict/kind counts
+- per-entry classification records
+
+This is the artifact later CI work (#932) should publish or compare. For checked-in baselines, contributors should use a bounded deterministic selection (for example `--file` or a narrow `--filter`) and commit only `summary.json`, not the generated compiled outputs.
+
+## Consequences
+
+### Positive
+
+- Conformance output becomes actionable without pretending the MVP slice is a full-suite result.
+- Policy skips and unsupported requirements are distinguished instead of both collapsing into generic `SKIP`.
+- The baseline artifact is stable enough for later CI/reporting work without introducing a second large manifest prematurely.
+
+### Negative
+
+- Parse-negative kind checking is still incomplete because compiler diagnostics are not yet normalized to JS error objects.
+- Path exclusions still live in the pin file even though later phases may eventually want a richer dedicated policy surface.
+
+### Mitigations
+
+- Record the parse-negative limitation explicitly in `summary.json` and this ADR.
+- Keep the result schema narrow and versioned so a future dedicated policy or richer baseline compare step can evolve without breaking the MVP contract silently.

--- a/docs/adr/0006-test262-result-classification-and-baseline.md
+++ b/docs/adr/0006-test262-result-classification-and-baseline.md
@@ -85,6 +85,8 @@ That JSON file is the baseline/report artifact for the MVP. It includes:
 - verdict/kind counts
 - per-entry classification records
 
+To keep the artifact stable across operating systems, runtime observations normalize process exits to pass (`0`) vs rejected (`1`) instead of preserving OS-specific non-zero values for thrown failures.
+
 This is the artifact later CI work (#932) should publish or compare. For checked-in baselines, contributors should use a bounded deterministic selection (for example `--file` or a narrow `--filter`) and commit only `summary.json`, not the generated compiled outputs.
 
 ## Consequences

--- a/scripts/test262/bootstrap.js
+++ b/scripts/test262/bootstrap.js
@@ -110,6 +110,16 @@ function ensureStringArray(value, label) {
   }
 }
 
+function validateExcludedFromMvp(value) {
+  ensureStringArray(value, 'excludedFromMvp');
+
+  for (const entry of value) {
+    if (entry.startsWith('frontmatter:')) {
+      throw new Error("Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification.");
+    }
+  }
+}
+
 function validatePin(pin) {
   if (!pin || typeof pin !== 'object') {
     throw new Error('Invalid pin file: expected a JSON object.');
@@ -133,7 +143,7 @@ function validatePin(pin) {
   ensureStringArray(pin.requiredFiles, 'requiredFiles');
   ensureStringArray(pin.requiredDirectories, 'requiredDirectories');
   ensureStringArray(pin.defaultHarnessFiles, 'defaultHarnessFiles');
-  ensureStringArray(pin.excludedFromMvp, 'excludedFromMvp');
+  validateExcludedFromMvp(pin.excludedFromMvp);
   ensureStringArray(pin.attributionFiles, 'attributionFiles');
 
   if (!/^[0-9a-f]{40}$/i.test(pin.upstream.commit)) {

--- a/scripts/test262/runMvp.js
+++ b/scripts/test262/runMvp.js
@@ -307,6 +307,14 @@ function createObservation(status, overrides) {
   );
 }
 
+function normalizeReportedExitCode(exitCode) {
+  if (!Number.isInteger(exitCode)) {
+    return null;
+  }
+
+  return exitCode === 0 ? 0 : 1;
+}
+
 function createResult(relativePath, variant, metadata, classification, reasons, observed, repro) {
   return {
     id: createResultId(relativePath, variant),
@@ -873,9 +881,9 @@ function evaluateCase(rootPath, outputRoot, testCase, js2il, args) {
     runtime: executionResult.timedOut
       ? createObservation('timeout', { summary: 'TIMEOUT' })
       : executionResult.exitCode === 0
-        ? createObservation('passed', { exitCode: 0 })
+        ? createObservation('passed', { exitCode: normalizeReportedExitCode(executionResult.exitCode) })
         : createObservation('rejected', {
-            exitCode: executionResult.exitCode,
+            exitCode: normalizeReportedExitCode(executionResult.exitCode),
             errorType: runtimeErrorType,
             summary: runtimeSummary,
           }),

--- a/scripts/test262/runMvp.js
+++ b/scripts/test262/runMvp.js
@@ -11,6 +11,33 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const DEFAULT_TIMEOUT_SECONDS = 20;
 const DEFAULT_COMPILE_TIMEOUT_SECONDS = 60;
 const VALID_VARIANTS = new Set(['non-strict', 'strict']);
+const SUMMARY_FILE_NAME = 'summary.json';
+const SUMMARY_SCHEMA_VERSION = 1;
+const RESULT_KIND_ORDER = [
+  'pass',
+  'compile-rejection',
+  'runtime-rejection',
+  'wrong-phase',
+  'wrong-error-kind',
+  'runtime-mismatch',
+  'timeout',
+  'runner-error',
+  'unsupported-requirement',
+  'skipped-by-policy',
+];
+const VERDICT_ORDER = ['matched', 'unexpected', 'not-run'];
+const RESULT_LABELS = {
+  pass: 'PASS',
+  'compile-rejection': 'COMPILE-REJECTION',
+  'runtime-rejection': 'RUNTIME-REJECTION',
+  'wrong-phase': 'WRONG-PHASE',
+  'wrong-error-kind': 'WRONG-ERROR-KIND',
+  'runtime-mismatch': 'RUNTIME-MISMATCH',
+  timeout: 'TIMEOUT',
+  'runner-error': 'RUNNER-ERROR',
+  'unsupported-requirement': 'UNSUPPORTED',
+  'skipped-by-policy': 'SKIP-POLICY',
+};
 
 function printHelp() {
   console.log([
@@ -150,6 +177,10 @@ function defaultOutputRoot() {
   return path.join(REPO_ROOT, 'artifacts', 'test262', 'runs', `${stamp}-${process.pid}`);
 }
 
+function defaultSummaryPath(outputRoot) {
+  return path.join(outputRoot, SUMMARY_FILE_NAME);
+}
+
 function collectCandidateFiles(rootPath, pin) {
   const files = [];
   const includeDirectories = Array.isArray(pin.includeDirectories) ? pin.includeDirectories : [];
@@ -247,15 +278,134 @@ function determineVariants(execution, requestedVariant, relativePath) {
   throw new Error(`Variant '${requestedVariant}' is not valid for ${relativePath}; supported variants: ${variants.join(', ')}.`);
 }
 
-function issueCodes(issues) {
-  if (!Array.isArray(issues) || issues.length === 0) {
-    return [];
+function createResultId(relativePath, variant) {
+  return variant ? `${relativePath}#${variant}` : `${relativePath}#all`;
+}
+
+function createReproData(relativePath, variant) {
+  return variant ? { file: relativePath, variant } : { file: relativePath };
+}
+
+function createClassification(kind, verdict, phase, detail) {
+  return {
+    kind,
+    verdict,
+    phase,
+    detail,
+  };
+}
+
+function createObservation(status, overrides) {
+  return Object.assign(
+    {
+      status,
+      exitCode: null,
+      errorType: null,
+      summary: null,
+    },
+    overrides || {}
+  );
+}
+
+function createResult(relativePath, variant, metadata, classification, reasons, observed, repro) {
+  return {
+    id: createResultId(relativePath, variant),
+    relativePath,
+    variant,
+    expected: buildExpectedOutcome(metadata),
+    classification,
+    reasons: Array.isArray(reasons) ? reasons : [],
+    observed,
+    repro: repro || null,
+  };
+}
+
+function buildExpectedOutcome(metadata) {
+  if (!metadata || !metadata.negative) {
+    return {
+      category: 'positive',
+      phase: null,
+      errorType: null,
+      validatesErrorType: true,
+    };
   }
 
-  return issues
-    .map(issue => issue && issue.code ? issue.code : 'unknown-issue')
-    .filter((value, index, array) => array.indexOf(value) === index)
-    .sort();
+  return {
+    category: 'negative',
+    phase: metadata.negative.phase,
+    errorType: metadata.negative.type,
+    validatesErrorType: metadata.negative.phase !== 'parse',
+  };
+}
+
+function expectedOutcomeLabel(testCase) {
+  const negative = testCase.metadata.negative;
+  if (!negative) {
+    return 'positive';
+  }
+
+  return `negative(${negative.phase}:${negative.type})`;
+}
+
+function createPathExclusionReason(exclusion) {
+  return {
+    code: 'path-excluded',
+    source: 'excludedFromMvp',
+    reason: `Path matched excludedFromMvp entry '${exclusion}'.`,
+    pattern: exclusion,
+  };
+}
+
+function createNotRunResult(relativePath, metadata, kind, reasons, detail) {
+  return createResult(
+    relativePath,
+    null,
+    metadata,
+    createClassification(kind, 'not-run', 'selection', detail),
+    reasons,
+    {
+      compile: createObservation('not-run'),
+      runtime: createObservation('not-run'),
+    },
+    null
+  );
+}
+
+function normalizeReasonEntries(reasons) {
+  const entries = Array.isArray(reasons) ? reasons : [];
+  const seen = new Set();
+  const normalized = [];
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+
+    const normalizedEntry = {
+      code: entry.code || 'unknown-issue',
+      source: entry.source || '<unknown>',
+      reason: entry.reason || '',
+    };
+
+    if (entry.pattern) {
+      normalizedEntry.pattern = entry.pattern;
+    }
+
+    const key = JSON.stringify(normalizedEntry);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalized.push(normalizedEntry);
+  }
+
+  return normalized;
+}
+
+function createSelectionResult(relativePath, metadata, kind, reasons, detail) {
+  return createNotRunResult(relativePath, metadata, kind, normalizeReasonEntries(reasons), detail);
 }
 
 function createExecutionPlan(rootPath, pin, args) {
@@ -284,18 +434,31 @@ function createExecutionPlan(rootPath, pin, args) {
     const relativePath = selectedFiles[i];
     const exclusion = matchPathExclusion(relativePath, pin);
     if (exclusion !== null) {
-      skipped.push({
-        relativePath,
-        reasons: [`pin-excluded:${exclusion}`],
-      });
+      skipped.push(
+        createSelectionResult(
+          relativePath,
+          null,
+          'skipped-by-policy',
+          [createPathExclusionReason(exclusion)],
+          `excluded by policy (${exclusion})`
+        )
+      );
       continue;
     }
 
     const absolutePath = path.join(rootPath, ...relativePath.split('/'));
     const parsed = parseTest262File(absolutePath);
-    const reasons = issueCodes(parsed.unsupported).concat(issueCodes(parsed.mvpBlockers));
+    const reasons = normalizeReasonEntries(parsed.unsupported.concat(parsed.mvpBlockers));
     if (reasons.length > 0) {
-      skipped.push({ relativePath, reasons });
+      skipped.push(
+        createSelectionResult(
+          relativePath,
+          parsed,
+          'unsupported-requirement',
+          reasons,
+          'unsupported requirement'
+        )
+      );
       continue;
     }
 
@@ -472,6 +635,11 @@ function extractJsError(stderr) {
     return dotnetMatch[1].trim();
   }
 
+  const dotnetUnhandledMatch = stderr.match(/Unhandled exception\.\s*([A-Za-z]+Error|Error|EvalError|RangeError|ReferenceError|SyntaxError|TypeError|URIError):\s*(.+)/m);
+  if (dotnetUnhandledMatch) {
+    return `${dotnetUnhandledMatch[1]}: ${dotnetUnhandledMatch[2].trim()}`;
+  }
+
   const nodeMatch = stderr.match(/^([A-Za-z]+Error|Error|EvalError|RangeError|ReferenceError|SyntaxError|TypeError|URIError):\s*(.+)/m);
   if (nodeMatch) {
     return `${nodeMatch[1]}: ${nodeMatch[2].trim()}`;
@@ -485,8 +653,46 @@ function extractJsError(stderr) {
   return '';
 }
 
-function summarizeFailureText(text) {
-  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+function normalizeDiagnosticText(text, diagnosticContext) {
+  let normalized = String(text || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\\/g, '/')
+    .trim();
+
+  const replacements = Array.isArray(diagnosticContext) ? diagnosticContext : [];
+  for (let i = 0; i < replacements.length; i++) {
+    const replacement = replacements[i];
+    if (!replacement || !replacement.from) {
+      continue;
+    }
+
+    normalized = normalized.split(replacement.from).join(replacement.to);
+  }
+
+  return normalized.trim();
+}
+
+function createDiagnosticContext(rootPath, outputRoot) {
+  return [
+    { from: normalizePortablePath(outputRoot), to: '<output>' },
+    { from: normalizePortablePath(rootPath), to: '<test262-root>' },
+    { from: normalizePortablePath(REPO_ROOT), to: '<repo>' },
+  ].sort((left, right) => right.from.length - left.from.length);
+}
+
+function extractErrorType(text) {
+  const jsError = extractJsError(text);
+  if (!jsError) {
+    return null;
+  }
+
+  const match = /^([A-Za-z]+Error|Error)\b/.exec(jsError);
+  return match ? match[1] : null;
+}
+
+function summarizeFailureText(text, diagnosticContext) {
+  const normalized = normalizeDiagnosticText(text, diagnosticContext);
   const jsError = extractJsError(normalized);
   if (jsError) {
     return jsError;
@@ -504,21 +710,16 @@ function summarizeFailureText(text) {
   return lines[0];
 }
 
-function containsExpectedError(text, expectedType) {
+function matchesExpectedErrorType(observedType, expectedType) {
   if (!expectedType) {
     return true;
   }
 
-  return text.toLowerCase().indexOf(String(expectedType).toLowerCase()) >= 0;
-}
-
-function expectedOutcomeLabel(testCase) {
-  const negative = testCase.metadata.negative;
-  if (!negative) {
-    return 'positive';
+  if (!observedType) {
+    return false;
   }
 
-  return `negative(${negative.phase}:${negative.type})`;
+  return String(observedType).toLowerCase() === String(expectedType).toLowerCase();
 }
 
 function createCaseDirectory(outputRoot, testCase) {
@@ -530,23 +731,49 @@ function quoteForDisplay(value) {
   return `"${String(value).replace(/"/g, '\\"')}"`;
 }
 
-function createReproCommand(rootPath, testCase, args) {
+function createReproCommand(rootPath, repro, args) {
   const command = [
     'node',
     'scripts/test262/runMvp.js',
     '--root',
     quoteForDisplay(rootPath),
     '--file',
-    quoteForDisplay(testCase.relativePath),
-    '--variant',
-    testCase.variant,
+    quoteForDisplay(repro.file),
   ];
+
+  if (repro.variant) {
+    command.push('--variant', repro.variant);
+  }
 
   if (args.js2il) {
     command.push('--js2il', quoteForDisplay(args.js2il));
   }
 
   return command.join(' ');
+}
+
+function createMatchedCaseResult(testCase, kind, phase, detail, observed) {
+  return createResult(
+    testCase.relativePath,
+    testCase.variant,
+    testCase.metadata,
+    createClassification(kind, 'matched', phase, detail),
+    [],
+    observed,
+    createReproData(testCase.relativePath, testCase.variant)
+  );
+}
+
+function createUnexpectedCaseResult(testCase, kind, phase, detail, observed) {
+  return createResult(
+    testCase.relativePath,
+    testCase.variant,
+    testCase.metadata,
+    createClassification(kind, 'unexpected', phase, detail),
+    [],
+    observed,
+    createReproData(testCase.relativePath, testCase.variant)
+  );
 }
 
 function evaluateCase(rootPath, outputRoot, testCase, js2il, args) {
@@ -556,6 +783,7 @@ function evaluateCase(rootPath, outputRoot, testCase, js2il, args) {
   const compositeSourcePath = path.join(caseDirectory, 'input.js');
   fs.writeFileSync(compositeSourcePath, buildCompositeSource(rootPath, testCase), 'utf8');
   const compilerArgs = ['--strictMode', 'Ignore'];
+  const diagnosticContext = createDiagnosticContext(rootPath, outputRoot);
 
   const compileResult = compileWithJs2IL(
     compositeSourcePath,
@@ -566,100 +794,303 @@ function evaluateCase(rootPath, outputRoot, testCase, js2il, args) {
   );
 
   const negative = testCase.metadata.negative;
-  if (negative && negative.phase === 'parse') {
-    // JS2IL's front-end currently reports parse/early failures with compiler diagnostics rather
-    // than a normalized JS error object, so the MVP parse-negative contract is compile-time failure.
-    if (!compileResult.success && compileResult.stderr !== 'COMPILE_TIMEOUT' && compileResult.stderr !== 'DLL not found after compilation') {
-      return {
-        status: 'pass',
-        testCase,
-        detail: expectedOutcomeLabel(testCase),
-      };
-    }
-
-    if (!compileResult.success) {
-      return {
-        status: 'fail',
-        testCase,
-        detail: `expected ${expectedOutcomeLabel(testCase)} but compilation failed with ${summarizeFailureText(compileResult.stderr)}`,
-        repro: createReproCommand(rootPath, testCase, args),
-      };
-    }
-
-    return {
-      status: 'fail',
-      testCase,
-      detail: `expected ${expectedOutcomeLabel(testCase)} but compilation succeeded`,
-      repro: createReproCommand(rootPath, testCase, args),
-    };
-  }
+  const expectedLabel = expectedOutcomeLabel(testCase);
 
   if (!compileResult.success) {
-    return {
-      status: 'fail',
-      testCase,
-      detail: `compilation failed: ${summarizeFailureText(compileResult.stderr)}`,
-      repro: createReproCommand(rootPath, testCase, args),
+    if (compileResult.stderr === 'COMPILE_TIMEOUT') {
+      return createUnexpectedCaseResult(
+        testCase,
+        'timeout',
+        'compile',
+        'compilation timed out',
+        {
+          compile: createObservation('timeout', { summary: 'COMPILE_TIMEOUT' }),
+          runtime: createObservation('not-run'),
+        }
+      );
+    }
+
+    if (compileResult.stderr === 'DLL not found after compilation') {
+      return createUnexpectedCaseResult(
+        testCase,
+        'runner-error',
+        'compile',
+        'compiler completed without emitting a DLL',
+        {
+          compile: createObservation('runner-error', { summary: 'DLL not found after compilation' }),
+          runtime: createObservation('not-run'),
+        }
+      );
+    }
+
+    const compileSummary = summarizeFailureText(compileResult.stderr, diagnosticContext);
+    const compileErrorType = extractErrorType(normalizeDiagnosticText(compileResult.stderr, diagnosticContext));
+    const observed = {
+      compile: createObservation('rejected', {
+        errorType: compileErrorType,
+        summary: compileSummary,
+      }),
+      runtime: createObservation('not-run'),
     };
+
+    if (negative && negative.phase === 'parse') {
+      // Parse negatives are currently phase-classified at compile time. JS2IL does not yet surface
+      // normalized parser error objects, so the MVP baseline records phase match but not parse error kind.
+      return createMatchedCaseResult(
+        testCase,
+        'compile-rejection',
+        'compile',
+        `matched ${expectedLabel}`,
+        observed
+      );
+    }
+
+    if (negative && negative.phase === 'runtime') {
+      return createUnexpectedCaseResult(
+        testCase,
+        'wrong-phase',
+        'compile',
+        `expected ${expectedLabel} but rejection happened during compile`,
+        observed
+      );
+    }
+
+    return createUnexpectedCaseResult(
+      testCase,
+      'compile-rejection',
+      'compile',
+      `expected ${expectedLabel} but compilation rejected (${compileSummary})`,
+      observed
+    );
   }
 
   const executionResult = runDotnet(compileResult.dllPath, args.timeoutSeconds * 1000);
   const combinedExecutionOutput = `${executionResult.stderr}\n${executionResult.stdout}`;
+  const runtimeSummary = summarizeFailureText(combinedExecutionOutput, diagnosticContext);
+  const runtimeErrorType = extractErrorType(normalizeDiagnosticText(combinedExecutionOutput, diagnosticContext));
+  const observed = {
+    compile: createObservation('succeeded'),
+    runtime: executionResult.timedOut
+      ? createObservation('timeout', { summary: 'TIMEOUT' })
+      : executionResult.exitCode === 0
+        ? createObservation('passed', { exitCode: 0 })
+        : createObservation('rejected', {
+            exitCode: executionResult.exitCode,
+            errorType: runtimeErrorType,
+            summary: runtimeSummary,
+          }),
+  };
 
-  if (negative && negative.phase === 'runtime') {
-    if (!executionResult.timedOut && executionResult.exitCode !== 0 && containsExpectedError(combinedExecutionOutput, negative.type)) {
-      return {
-        status: 'pass',
+  if (negative && negative.phase === 'parse') {
+    if (executionResult.timedOut) {
+      return createUnexpectedCaseResult(
         testCase,
-        detail: expectedOutcomeLabel(testCase),
-      };
+        'timeout',
+        'runtime',
+        `expected ${expectedLabel} but runtime timed out after a successful compile`,
+        observed
+      );
     }
 
-    const runtimeDetail = executionResult.timedOut
-      ? 'runtime timed out'
-      : executionResult.exitCode === 0
-        ? 'runtime completed successfully'
-        : summarizeFailureText(combinedExecutionOutput);
+    if (executionResult.exitCode !== 0) {
+      const runtimeDetail = runtimeErrorType ? ` (${runtimeErrorType})` : '';
+      return createUnexpectedCaseResult(
+        testCase,
+        'wrong-phase',
+        'runtime',
+        `expected ${expectedLabel} but rejection moved to runtime${runtimeDetail}`,
+        observed
+      );
+    }
 
-    return {
-      status: 'fail',
+    return createUnexpectedCaseResult(
       testCase,
-      detail: `expected ${expectedOutcomeLabel(testCase)} but observed ${runtimeDetail}`,
-      repro: createReproCommand(rootPath, testCase, args),
-    };
+      'runtime-mismatch',
+      'runtime',
+      `expected ${expectedLabel} but the test completed successfully`,
+      observed
+    );
+  }
+
+  if (negative && negative.phase === 'runtime') {
+    if (executionResult.timedOut) {
+      return createUnexpectedCaseResult(
+        testCase,
+        'timeout',
+        'runtime',
+        'runtime timed out',
+        observed
+      );
+    }
+
+    if (executionResult.exitCode === 0) {
+      return createUnexpectedCaseResult(
+        testCase,
+        'runtime-mismatch',
+        'runtime',
+        `expected ${expectedLabel} but the test completed successfully`,
+        observed
+      );
+    }
+
+    if (matchesExpectedErrorType(runtimeErrorType, negative.type)) {
+      return createMatchedCaseResult(
+        testCase,
+        'runtime-rejection',
+        'runtime',
+        `matched ${expectedLabel}`,
+        observed
+      );
+    }
+
+    const observedType = runtimeErrorType || runtimeSummary;
+    return createUnexpectedCaseResult(
+      testCase,
+      'wrong-error-kind',
+      'runtime',
+      `expected ${expectedLabel} but observed ${observedType}`,
+      observed
+    );
   }
 
   if (executionResult.timedOut) {
-    return {
-      status: 'fail',
+    return createUnexpectedCaseResult(
       testCase,
-      detail: 'runtime timed out',
-      repro: createReproCommand(rootPath, testCase, args),
-    };
+      'timeout',
+      'runtime',
+      'runtime timed out',
+      observed
+    );
   }
 
   if (executionResult.exitCode !== 0) {
-    return {
-      status: 'fail',
+    return createUnexpectedCaseResult(
       testCase,
-      detail: `runtime failed: ${summarizeFailureText(combinedExecutionOutput)}`,
-      repro: createReproCommand(rootPath, testCase, args),
-    };
+      'runtime-mismatch',
+      'runtime',
+      `expected ${expectedLabel} but runtime rejected (${runtimeSummary})`,
+      observed
+    );
   }
 
-  return {
-    status: 'pass',
+  return createMatchedCaseResult(
     testCase,
-    detail: expectedOutcomeLabel(testCase),
+    'pass',
+    'runtime',
+    expectedLabel,
+    observed
+  );
+}
+
+function formatReasonCodes(reasons) {
+  const codes = [];
+  const entries = Array.isArray(reasons) ? reasons : [];
+
+  for (let i = 0; i < entries.length; i++) {
+    const reason = entries[i];
+    if (!reason) {
+      continue;
+    }
+
+    if (reason.code === 'path-excluded' && reason.pattern) {
+      codes.push(`path-excluded:${reason.pattern}`);
+      continue;
+    }
+
+    codes.push(reason.code || 'unknown-issue');
+  }
+
+  return codes
+    .filter((value, index, array) => array.indexOf(value) === index)
+    .join(', ');
+}
+
+function formatVariant(variant) {
+  return variant || 'all';
+}
+
+function formatResultStatus(result) {
+  const label = RESULT_LABELS[result.classification.kind] || result.classification.kind.toUpperCase();
+  const reasonSuffix = result.reasons.length > 0 ? ` [${formatReasonCodes(result.reasons)}]` : '';
+  return `${label} ${result.relativePath} [${formatVariant(result.variant)}]${reasonSuffix} ${result.classification.detail}`;
+}
+
+function createCountMap(results, selector, orderedKeys) {
+  const counts = {};
+  const order = Array.isArray(orderedKeys) ? orderedKeys : [];
+
+  for (let i = 0; i < order.length; i++) {
+    counts[order[i]] = 0;
+  }
+
+  for (let i = 0; i < results.length; i++) {
+    const key = selector(results[i]);
+    if (!Object.prototype.hasOwnProperty.call(counts, key)) {
+      counts[key] = 0;
+    }
+
+    counts[key]++;
+  }
+
+  const compact = {};
+  const keys = order.concat(Object.keys(counts).filter(key => order.indexOf(key) < 0).sort());
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (counts[key] > 0) {
+      compact[key] = counts[key];
+    }
+  }
+
+  return compact;
+}
+
+function createSummaryReport(pin, args, plan, results, exitCode) {
+  return {
+    schemaVersion: SUMMARY_SCHEMA_VERSION,
+    suite: 'js2il-test262-mvp',
+    pin: {
+      commit: pin.upstream.commit,
+      packageVersion: pin.upstream.packageVersion,
+    },
+    policy: {
+      pathExclusions: Array.isArray(pin.excludedFromMvp) ? pin.excludedFromMvp.slice() : [],
+      unsupportedResultSources: ['metadata.unsupported', 'metadata.mvpBlockers'],
+      negativeExpectations: {
+        parse: {
+          expectedObservedPhase: 'compile',
+          validateErrorType: false,
+        },
+        runtime: {
+          expectedObservedPhase: 'runtime',
+          validateErrorType: true,
+        },
+      },
+      baselineArtifact: {
+        fileName: SUMMARY_FILE_NAME,
+        format: 'js2il-test262-summary-v1',
+      },
+    },
+    selection: {
+      file: args.file,
+      filter: args.filter,
+      limit: args.limit,
+      variant: args.variant,
+      discoveredFiles: plan.discoveredCount,
+      selectedFiles: plan.selectedFileCount,
+      selectedCases: plan.cases.length,
+      classifiedEntries: results.length,
+    },
+    summary: {
+      exitCode,
+      verdictCounts: createCountMap(results, result => result.classification.verdict, VERDICT_ORDER),
+      kindCounts: createCountMap(results, result => result.classification.kind, RESULT_KIND_ORDER),
+    },
+    results,
   };
 }
 
-function formatCaseStatus(result) {
-  return `${result.status.toUpperCase()} ${result.testCase.relativePath} [${result.testCase.variant}] ${result.detail}`;
-}
-
-function formatSkipStatus(skip) {
-  return `SKIP ${skip.relativePath} [${skip.reasons.join(', ')}]`;
+function writeSummaryReport(summaryPath, report) {
+  fs.writeFileSync(summaryPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
 }
 
 function printPlanHeader(rootPath, outputRoot, js2il, plan, args) {
@@ -691,7 +1122,7 @@ function runMvp(argv) {
   printPlanHeader(rootPath, outputRoot, js2il, plan, args);
 
   for (let i = 0; i < plan.skipped.length; i++) {
-    console.log(formatSkipStatus(plan.skipped[i]));
+    console.log(formatResultStatus(plan.skipped[i]));
   }
 
   if (args.list) {
@@ -700,30 +1131,36 @@ function runMvp(argv) {
       console.log(`LIST ${testCase.relativePath} [${testCase.variant}] ${expectedOutcomeLabel(testCase)}`);
     }
 
-    console.log(`SUMMARY passed=0 failed=0 skipped=${plan.skipped.length} listed=${plan.cases.length}`);
+    console.log(`SUMMARY matched=0 unexpected=0 not-run=${plan.skipped.length} listed=${plan.cases.length}`);
     return 0;
   }
 
   fs.mkdirSync(outputRoot, { recursive: true });
+  const results = plan.skipped.slice();
 
-  let passed = 0;
-  let failed = 0;
   for (let i = 0; i < plan.cases.length; i++) {
     const result = evaluateCase(rootPath, outputRoot, plan.cases[i], js2il, args);
-    console.log(formatCaseStatus(result));
-    if (result.status === 'pass') {
-      passed++;
-      continue;
-    }
-
-    failed++;
-    if (result.repro) {
-      console.log(`REPRO ${result.repro}`);
+    results.push(result);
+    console.log(formatResultStatus(result));
+    if (result.classification.verdict === 'unexpected' && result.repro) {
+      console.log(`REPRO ${createReproCommand(rootPath, result.repro, args)}`);
     }
   }
 
-  console.log(`SUMMARY passed=${passed} failed=${failed} skipped=${plan.skipped.length} selected=${plan.cases.length}`);
-  return failed === 0 ? 0 : 1;
+  const exitCode = results.some(result => result.classification.verdict === 'unexpected') ? 1 : 0;
+  const verdictCounts = createCountMap(results, result => result.classification.verdict, VERDICT_ORDER);
+  const kindCounts = createCountMap(results, result => result.classification.kind, RESULT_KIND_ORDER);
+  const summaryPath = defaultSummaryPath(outputRoot);
+  writeSummaryReport(summaryPath, createSummaryReport(pin, args, plan, results, exitCode));
+
+  const kindSummary = Object.keys(kindCounts)
+    .map(key => `${key}=${kindCounts[key]}`)
+    .join(' ');
+  console.log(
+    `SUMMARY matched=${verdictCounts.matched || 0} unexpected=${verdictCounts.unexpected || 0} not-run=${verdictCounts['not-run'] || 0} selected=${plan.cases.length} classified=${results.length}${kindSummary ? ` ${kindSummary}` : ''}`
+  );
+  console.log(`REPORT ${summaryPath}`);
+  return exitCode;
 }
 
 module.exports = {

--- a/tests/Js2IL.Test262.Tests/Integration/ExecutionTests.cs
+++ b/tests/Js2IL.Test262.Tests/Integration/ExecutionTests.cs
@@ -65,11 +65,7 @@ public class ExecutionTests : ExecutionTestsBase
               "excludedFromMvp": [
                 "test/annexB/**",
                 "test/intl402/**",
-                "test/staging/**",
-                "frontmatter:flags=module",
-                "frontmatter:flags=async",
-                "frontmatter:requires-agent-or-broadcast",
-                "frontmatter:requires-async-harness"
+                "test/staging/**"
               ],
               "attributionFiles": [
                 "LICENSE",

--- a/tests/Js2IL.Test262.Tests/Integration/RunnerCliTests.cs
+++ b/tests/Js2IL.Test262.Tests/Integration/RunnerCliTests.cs
@@ -23,7 +23,7 @@ public class RunnerCliTests
         RunnerResult result = RunRunner(test262Root, outputRoot);
         Assert.Equal(0, result.ExitCode);
 
-        return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path));
+        return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path, outputRoot));
     }
 
     [Fact]
@@ -40,7 +40,25 @@ public class RunnerCliTests
 
         Assert.Equal(1, result.ExitCode);
 
-        return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path));
+        return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path, outputRoot));
+    }
+
+    [Fact]
+    public Task RunMvp_ClassifiesPolicyWrongPhaseAndWrongErrorKind()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string test262Root = CreateTest262Fixture(tempDirectory.Path, includeFailingPositive: false, includeClassificationEdges: true);
+        string outputRoot = Path.Combine(tempDirectory.Path, "runner-output");
+        string pinPath = CreatePinFile(tempDirectory.Path, ["test/language/mvp/classification-policy-skip.js"]);
+
+        RunnerResult result = RunRunner(
+            test262Root,
+            outputRoot,
+            $" --pin \"{pinPath}\" --filter \"classification-\"");
+
+        Assert.Equal(1, result.ExitCode);
+
+        return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path, outputRoot));
     }
 
     private static RunnerResult RunRunner(string test262Root, string outputRoot, string extraArguments = "", int timeoutMilliseconds = 180000)
@@ -73,7 +91,70 @@ public class RunnerCliTests
         return new RunnerResult(process.ExitCode, stdoutTask.Result, stderrTask.Result);
     }
 
-    private static string CreateTest262Fixture(string root, bool includeFailingPositive)
+    private static string CreatePinFile(string root, IReadOnlyList<string> excludedFromMvp)
+    {
+        string pinPath = Path.Combine(root, "fixture.pin.json");
+        string exclusionsJson = string.Join(
+            ",\n",
+            excludedFromMvp.Select(entry => $"                \"{entry.Replace("\\", "\\\\")}\""));
+
+        File.WriteAllText(
+            pinPath,
+            $$"""
+            {
+              "upstream": {
+                "owner": "tc39",
+                "repo": "test262",
+                "cloneUrl": "https://github.com/tc39/test262.git",
+                "commit": "0123456789abcdef0123456789abcdef01234567",
+                "packageVersion": "5.0.0"
+              },
+              "localOverrideEnvVar": "JS2IL_TEST262_ROOT",
+              "managedRoot": "./managed-cache",
+              "lineEndings": "lf",
+              "updateStrategy": "manual-pinned-sha",
+              "includeFiles": [
+                "LICENSE",
+                "INTERPRETING.md",
+                "features.txt",
+                "package.json"
+              ],
+              "includeDirectories": [
+                "harness",
+                "test/language",
+                "test/built-ins"
+              ],
+              "requiredFiles": [
+                "LICENSE",
+                "INTERPRETING.md",
+                "features.txt",
+                "package.json",
+                "harness/assert.js",
+                "harness/sta.js"
+              ],
+              "requiredDirectories": [
+                "harness",
+                "test/language",
+                "test/built-ins"
+              ],
+              "defaultHarnessFiles": [
+                "assert.js",
+                "sta.js"
+              ],
+              "excludedFromMvp": [
+            {{exclusionsJson}}
+              ],
+              "attributionFiles": [
+                "LICENSE",
+                "INTERPRETING.md"
+              ]
+            }
+            """.ReplaceLineEndings("\n"));
+
+        return pinPath;
+    }
+
+    private static string CreateTest262Fixture(string root, bool includeFailingPositive, bool includeClassificationEdges = false)
     {
         string test262Root = Path.Combine(root, "test262-root");
         Directory.CreateDirectory(test262Root);
@@ -165,6 +246,37 @@ public class RunnerCliTests
                 """);
         }
 
+        if (includeClassificationEdges)
+        {
+            WriteFile(test262Root, @"test\language\mvp\classification-policy-skip.js", """
+                /*---
+                description: skipped by policy
+                flags: [noStrict]
+                ---*/
+                assert.sameValue(1, 1);
+                """);
+            WriteFile(test262Root, @"test\language\mvp\classification-parse-wrong-phase.js", """
+                /*---
+                description: parse negative wrong phase
+                flags: [noStrict]
+                negative:
+                  phase: parse
+                  type: SyntaxError
+                ---*/
+                throw new SyntaxError('late parse-like boom');
+                """);
+            WriteFile(test262Root, @"test\language\mvp\classification-runtime-wrong-error.js", """
+                /*---
+                description: runtime negative wrong error kind
+                flags: [noStrict]
+                negative:
+                  phase: runtime
+                  type: TypeError
+                ---*/
+                throw new RangeError('wrong kind');
+                """);
+        }
+
         return test262Root;
     }
 
@@ -178,7 +290,7 @@ public class RunnerCliTests
         File.WriteAllText(filePath, content.ReplaceLineEndings("\n"));
     }
 
-    private static string FormatResult(RunnerResult result, string tempRoot)
+    private static string FormatResult(RunnerResult result, string tempRoot, string outputRoot)
     {
         string normalizedTempRoot = NormalizePath(tempRoot);
         string normalizedRepoRoot = NormalizePath(FindRepoRoot());
@@ -192,6 +304,13 @@ public class RunnerCliTests
         {
             builder.AppendLine("stderr:");
             builder.AppendLine(NormalizeText(result.StdErr, normalizedTempRoot, normalizedRepoRoot));
+        }
+
+        string summaryPath = Path.Combine(outputRoot, "summary.json");
+        if (File.Exists(summaryPath))
+        {
+            builder.AppendLine("summary.json:");
+            builder.AppendLine(NormalizeText(File.ReadAllText(summaryPath), normalizedTempRoot, normalizedRepoRoot));
         }
 
         return builder.ToString().TrimEnd();

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -12,5 +12,5 @@ includeDirectories harness, test/language, test/built-ins
 requiredFiles LICENSE, INTERPRETING.md, features.txt, package.json, harness/assert.js, harness/sta.js
 requiredDirectories harness, test/language, test/built-ins
 defaultHarnessFiles assert.js, sta.js
-excludedFromMvp test/annexB/**; test/intl402/**; test/staging/**; frontmatter:flags=module; frontmatter:flags=async; frontmatter:requires-agent-or-broadcast; frontmatter:requires-async-harness
+excludedFromMvp test/annexB/**; test/intl402/**; test/staging/**
 attributionFiles LICENSE, INTERPRETING.md

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ab9
+				// Method begins at RVA 0x4bc1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4ad4
+						// Method begins at RVA 0x4bdc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4add
+						// Method begins at RVA 0x4be5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4ae6
+						// Method begins at RVA 0x4bee
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4aef
+						// Method begins at RVA 0x4bf7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4af8
+						// Method begins at RVA 0x4c00
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b01
+						// Method begins at RVA 0x4c09
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4acb
+					// Method begins at RVA 0x4bd3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ac2
+				// Method begins at RVA 0x4bca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -207,9 +207,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x25b8
+			// Method begins at RVA 0x25dc
 			// Header size: 12
 			// Code size: 621 (0x26d)
 			.maxstack 8
@@ -476,7 +476,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b0a
+				// Method begins at RVA 0x4c12
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -499,7 +499,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2834
+			// Method begins at RVA 0x2858
 			// Header size: 12
 			// Code size: 184 (0xb8)
 			.maxstack 8
@@ -577,7 +577,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b13
+				// Method begins at RVA 0x4c1b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -601,9 +601,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x28f8
+			// Method begins at RVA 0x291c
 			// Header size: 12
 			// Code size: 76 (0x4c)
 			.maxstack 8
@@ -666,7 +666,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b25
+					// Method begins at RVA 0x4c2d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -684,7 +684,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b1c
+				// Method begins at RVA 0x4c24
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -709,9 +709,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2950
+			// Method begins at RVA 0x2974
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -782,7 +782,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b2e
+				// Method begins at RVA 0x4c36
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -806,7 +806,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29c4
+			// Method begins at RVA 0x29e8
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -842,7 +842,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b37
+				// Method begins at RVA 0x4c3f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -867,9 +867,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x29f4
+			// Method begins at RVA 0x2a18
 			// Header size: 12
 			// Code size: 78 (0x4e)
 			.maxstack 8
@@ -923,7 +923,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b49
+					// Method begins at RVA 0x4c51
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -941,7 +941,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b40
+				// Method begins at RVA 0x4c48
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -966,7 +966,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a50
+			// Method begins at RVA 0x2a74
 			// Header size: 12
 			// Code size: 164 (0xa4)
 			.maxstack 8
@@ -1065,7 +1065,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b5b
+					// Method begins at RVA 0x4c63
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1083,7 +1083,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b52
+				// Method begins at RVA 0x4c5a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1111,7 +1111,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b76
+						// Method begins at RVA 0x4c7e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1129,7 +1129,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b6d
+					// Method begins at RVA 0x4c75
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1147,7 +1147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b64
+				// Method begins at RVA 0x4c6c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1172,7 +1172,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b00
+			// Method begins at RVA 0x2b24
 			// Header size: 12
 			// Code size: 453 (0x1c5)
 			.maxstack 8
@@ -1378,6 +1378,208 @@
 
 	} // end of class ensureStringArray
 
+	.class nested public auto ansi abstract sealed beforefieldinit validateExcludedFromMvp
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4c87
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L116C7
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested private auto ansi beforefieldinit Block_L116C29
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested private auto ansi beforefieldinit Block_L117C42
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x4ca2
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L117C42::.ctor
+
+				} // end of class Block_L117C42
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x4c99
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L116C29::.ctor
+
+			} // end of class Block_L116C29
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4c90
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L116C7::.ctor
+
+		} // end of class Scope_ForOf_L116C7
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_Test262Bootstrap/Scope scope,
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1b 00 00 02
+			)
+			// Method begins at RVA 0x2d08
+			// Header size: 12
+			// Code size: 176 (0xb0)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[1] bool,
+				[2] bool,
+				[3] object,
+				[4] object,
+				[5] bool
+			)
+
+			IL_0000: ldnull
+			IL_0001: ldarg.2
+			IL_0002: ldstr "excludedFromMvp"
+			IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_000c: pop
+			IL_000d: ldarg.2
+			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0013: stloc.0
+			IL_0014: ldc.i4.0
+			IL_0015: stloc.1
+			IL_0016: ldc.i4.0
+			IL_0017: stloc.2
+			.try
+			{
+				// loop start (head: IL_0018)
+					IL_0018: ldloc.0
+					IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_001e: stloc.s 4
+					IL_0020: ldloc.s 4
+					IL_0022: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_0027: stloc.s 5
+					IL_0029: ldloc.s 5
+					IL_002b: brtrue IL_0094
+
+					IL_0030: ldloc.s 4
+					IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_0037: stloc.s 4
+					IL_0039: ldloc.s 4
+					IL_003b: stloc.3
+					IL_003c: ldloc.3
+					IL_003d: ldstr "startsWith"
+					IL_0042: ldstr "frontmatter:"
+					IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_004c: stloc.s 4
+					IL_004e: ldloc.s 4
+					IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0055: stloc.s 5
+					IL_0057: ldloc.s 5
+					IL_0059: brfalse IL_0082
+
+					IL_005e: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
+					IL_0063: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_006d: dup
+					IL_006e: isinst [System.Runtime]System.Exception
+					IL_0073: dup
+					IL_0074: brtrue IL_0080
+
+					IL_0079: pop
+					IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_007f: throw
+
+					IL_0080: pop
+					IL_0081: throw
+
+					IL_0082: br IL_0018
+				// end loop
+				IL_0087: ldloc.0
+				IL_0088: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_008d: ldc.i4.1
+				IL_008e: stloc.2
+				IL_008f: leave IL_00ae
+
+				IL_0094: ldc.i4.1
+				IL_0095: stloc.1
+				IL_0096: leave IL_00ae
+			} // end .try
+			finally
+			{
+				IL_009b: ldloc.1
+				IL_009c: brtrue IL_00ad
+
+				IL_00a1: ldloc.2
+				IL_00a2: brtrue IL_00ad
+
+				IL_00a7: ldloc.0
+				IL_00a8: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+
+				IL_00ad: endfinally
+			} // end handler
+
+			IL_00ae: ldnull
+			IL_00af: ret
+		} // end of method validateExcludedFromMvp::__js_call__
+
+	} // end of class validateExcludedFromMvp
+
 	.class nested public auto ansi abstract sealed beforefieldinit validatePin
 		extends [System.Runtime]System.Object
 	{
@@ -1386,14 +1588,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L114C39
+			.class nested private auto ansi beforefieldinit Block_L124C39
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b88
+					// Method begins at RVA 0x4cb4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1402,18 +1604,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L114C39::.ctor
+				} // end of method Block_L124C39::.ctor
 
-			} // end of class Block_L114C39
+			} // end of class Block_L124C39
 
-			.class nested private auto ansi beforefieldinit Block_L118C57
+			.class nested private auto ansi beforefieldinit Block_L128C57
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b91
+					// Method begins at RVA 0x4cbd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1422,18 +1624,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L118C57::.ctor
+				} // end of method Block_L128C57::.ctor
 
-			} // end of class Block_L118C57
+			} // end of class Block_L128C57
 
-			.class nested private auto ansi beforefieldinit Block_L139C52
+			.class nested private auto ansi beforefieldinit Block_L149C52
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b9a
+					// Method begins at RVA 0x4cc6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1442,16 +1644,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L139C52::.ctor
+				} // end of method Block_L149C52::.ctor
 
-			} // end of class Block_L139C52
+			} // end of class Block_L149C52
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b7f
+				// Method begins at RVA 0x4cab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1476,11 +1678,11 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2ce4
+			// Method begins at RVA 0x2dd4
 			// Header size: 12
-			// Code size: 834 (0x342)
+			// Code size: 857 (0x359)
 			.maxstack 8
 			.locals init (
 				[0] bool,
@@ -1737,57 +1939,67 @@
 			IL_02a7: ldstr "excludedFromMvp"
 			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_02b1: stloc.s 6
-			IL_02b3: ldnull
-			IL_02b4: ldloc.s 6
-			IL_02b6: ldstr "excludedFromMvp"
-			IL_02bb: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_02c0: pop
-			IL_02c1: ldarg.2
-			IL_02c2: ldstr "attributionFiles"
-			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02cc: stloc.s 6
-			IL_02ce: ldnull
-			IL_02cf: ldloc.s 6
-			IL_02d1: ldstr "attributionFiles"
-			IL_02d6: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_02db: pop
-			IL_02dc: ldstr "^[0-9a-f]{40}$"
-			IL_02e1: ldstr "i"
-			IL_02e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02eb: stloc.s 7
-			IL_02ed: ldloc.s 7
-			IL_02ef: ldarg.2
-			IL_02f0: ldstr "upstream"
-			IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02fa: ldstr "commit"
-			IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0304: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0309: stloc.s 6
-			IL_030b: ldloc.s 6
-			IL_030d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0312: ldc.i4.0
-			IL_0313: ceq
-			IL_0315: stloc.0
-			IL_0316: ldloc.0
-			IL_0317: brfalse IL_0340
+			IL_02b3: ldc.i4.1
+			IL_02b4: newarr [System.Runtime]System.Object
+			IL_02b9: dup
+			IL_02ba: ldc.i4.0
+			IL_02bb: ldarg.0
+			IL_02bc: stelem.ref
+			IL_02bd: ldc.i4.0
+			IL_02be: ldelem.ref
+			IL_02bf: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_02c4: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_02ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_02cf: ldnull
+			IL_02d0: ldloc.s 6
+			IL_02d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_02d7: pop
+			IL_02d8: ldarg.2
+			IL_02d9: ldstr "attributionFiles"
+			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e3: stloc.s 6
+			IL_02e5: ldnull
+			IL_02e6: ldloc.s 6
+			IL_02e8: ldstr "attributionFiles"
+			IL_02ed: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_02f2: pop
+			IL_02f3: ldstr "^[0-9a-f]{40}$"
+			IL_02f8: ldstr "i"
+			IL_02fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0302: stloc.s 7
+			IL_0304: ldloc.s 7
+			IL_0306: ldarg.2
+			IL_0307: ldstr "upstream"
+			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0311: ldstr "commit"
+			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0320: stloc.s 6
+			IL_0322: ldloc.s 6
+			IL_0324: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0329: ldc.i4.0
+			IL_032a: ceq
+			IL_032c: stloc.0
+			IL_032d: ldloc.0
+			IL_032e: brfalse IL_0357
 
-			IL_031c: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
-			IL_0321: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0326: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_032b: dup
-			IL_032c: isinst [System.Runtime]System.Exception
-			IL_0331: dup
-			IL_0332: brtrue IL_033e
+			IL_0333: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_0338: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_033d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0342: dup
+			IL_0343: isinst [System.Runtime]System.Exception
+			IL_0348: dup
+			IL_0349: brtrue IL_0355
 
-			IL_0337: pop
-			IL_0338: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_033d: throw
+			IL_034e: pop
+			IL_034f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0354: throw
 
-			IL_033e: pop
-			IL_033f: throw
+			IL_0355: pop
+			IL_0356: throw
 
-			IL_0340: ldnull
-			IL_0341: ret
+			IL_0357: ldnull
+			IL_0358: ret
 		} // end of method validatePin::__js_call__
 
 	} // end of class validatePin
@@ -1803,7 +2015,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ba3
+				// Method begins at RVA 0x4ccf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1828,9 +2040,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3034
+			// Method begins at RVA 0x313c
 			// Header size: 12
 			// Code size: 72 (0x48)
 			.maxstack 8
@@ -1886,7 +2098,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bac
+				// Method begins at RVA 0x4cd8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1912,9 +2124,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3088
+			// Method begins at RVA 0x3190
 			// Header size: 12
 			// Code size: 76 (0x4c)
 			.maxstack 8
@@ -1967,7 +2179,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bb5
+				// Method begins at RVA 0x4ce1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1992,9 +2204,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x30e0
+			// Method begins at RVA 0x31e8
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -2055,14 +2267,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L162C22
+			.class nested private auto ansi beforefieldinit Block_L172C22
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bc7
+					// Method begins at RVA 0x4cf3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2071,16 +2283,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L162C22::.ctor
+				} // end of method Block_L172C22::.ctor
 
-			} // end of class Block_L162C22
+			} // end of class Block_L172C22
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bbe
+				// Method begins at RVA 0x4cea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2106,9 +2318,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x315c
+			// Method begins at RVA 0x3264
 			// Header size: 12
 			// Code size: 238 (0xee)
 			.maxstack 8
@@ -2229,14 +2441,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L192C16
+			.class nested private auto ansi beforefieldinit Block_L202C16
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bd9
+					// Method begins at RVA 0x4d05
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2245,16 +2457,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L192C16::.ctor
+				} // end of method Block_L202C16::.ctor
 
-			} // end of class Block_L192C16
+			} // end of class Block_L202C16
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bd0
+				// Method begins at RVA 0x4cfc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2280,9 +2492,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3258
+			// Method begins at RVA 0x3360
 			// Header size: 12
 			// Code size: 1007 (0x3ef)
 			.maxstack 8
@@ -2643,7 +2855,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4be2
+				// Method begins at RVA 0x4d0e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2668,9 +2880,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3654
+			// Method begins at RVA 0x375c
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -2705,14 +2917,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L205C37
+			.class nested private auto ansi beforefieldinit Block_L215C37
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bf4
+					// Method begins at RVA 0x4d20
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2721,16 +2933,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L205C37::.ctor
+				} // end of method Block_L215C37::.ctor
 
-			} // end of class Block_L205C37
+			} // end of class Block_L215C37
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4beb
+				// Method begins at RVA 0x4d17
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2755,9 +2967,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3688
+			// Method begins at RVA 0x3790
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -2814,14 +3026,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L220C20
+			.class nested private auto ansi beforefieldinit Block_L230C20
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c06
+					// Method begins at RVA 0x4d32
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2830,18 +3042,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L220C20::.ctor
+				} // end of method Block_L230C20::.ctor
 
-			} // end of class Block_L220C20
+			} // end of class Block_L230C20
 
-			.class nested private auto ansi beforefieldinit Block_L224C27
+			.class nested private auto ansi beforefieldinit Block_L234C27
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c0f
+					// Method begins at RVA 0x4d3b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2850,16 +3062,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L224C27::.ctor
+				} // end of method Block_L234C27::.ctor
 
-			} // end of class Block_L224C27
+			} // end of class Block_L234C27
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bfd
+				// Method begins at RVA 0x4d29
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2885,9 +3097,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x36ec
+			// Method begins at RVA 0x37f4
 			// Header size: 12
 			// Code size: 628 (0x274)
 			.maxstack 8
@@ -3147,7 +3359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c18
+				// Method begins at RVA 0x4d44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3160,18 +3372,18 @@
 
 		} // end of class Scope
 
-		.class nested private auto ansi beforefieldinit Scope_ForOf_L237C7
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L247C7
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L237C43
+			.class nested private auto ansi beforefieldinit Block_L247C43
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c2a
+					// Method begins at RVA 0x4d56
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3180,16 +3392,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L237C43::.ctor
+				} // end of method Block_L247C43::.ctor
 
-			} // end of class Block_L237C43
+			} // end of class Block_L247C43
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c21
+				// Method begins at RVA 0x4d4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3198,22 +3410,22 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Scope_ForOf_L237C7::.ctor
+			} // end of method Scope_ForOf_L247C7::.ctor
 
-		} // end of class Scope_ForOf_L237C7
+		} // end of class Scope_ForOf_L247C7
 
-		.class nested private auto ansi beforefieldinit Scope_ForOf_L241C7
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L251C7
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L241C54
+			.class nested private auto ansi beforefieldinit Block_L251C54
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c3c
+					// Method begins at RVA 0x4d68
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3222,16 +3434,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L241C54::.ctor
+				} // end of method Block_L251C54::.ctor
 
-			} // end of class Block_L241C54
+			} // end of class Block_L251C54
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c33
+				// Method begins at RVA 0x4d5f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3240,9 +3452,9 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Scope_ForOf_L241C7::.ctor
+			} // end of method Scope_ForOf_L251C7::.ctor
 
-		} // end of class Scope_ForOf_L241C7
+		} // end of class Scope_ForOf_L251C7
 
 
 		// Methods
@@ -3256,9 +3468,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x396c
+			// Method begins at RVA 0x3a74
 			// Header size: 12
 			// Code size: 427 (0x1ab)
 			.maxstack 8
@@ -3472,18 +3684,18 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L268C64
+			.class nested private auto ansi beforefieldinit Block_L278C64
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L270C33
+				.class nested private auto ansi beforefieldinit Block_L280C33
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c8d
+						// Method begins at RVA 0x4db9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3492,18 +3704,18 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L270C33::.ctor
+					} // end of method Block_L280C33::.ctor
 
-				} // end of class Block_L270C33
+				} // end of class Block_L280C33
 
-				.class nested private auto ansi beforefieldinit Block_L273C39
+				.class nested private auto ansi beforefieldinit Block_L283C39
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c96
+						// Method begins at RVA 0x4dc2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3512,16 +3724,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L273C39::.ctor
+					} // end of method Block_L283C39::.ctor
 
-				} // end of class Block_L273C39
+				} // end of class Block_L283C39
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c84
+					// Method begins at RVA 0x4db0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3530,18 +3742,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L268C64::.ctor
+				} // end of method Block_L278C64::.ctor
 
-			} // end of class Block_L268C64
+			} // end of class Block_L278C64
 
-			.class nested private auto ansi beforefieldinit Block_L281C75
+			.class nested private auto ansi beforefieldinit Block_L291C75
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c9f
+					// Method begins at RVA 0x4dcb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3550,16 +3762,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L281C75::.ctor
+				} // end of method Block_L291C75::.ctor
 
-			} // end of class Block_L281C75
+			} // end of class Block_L291C75
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c45
+				// Method begins at RVA 0x4d71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3572,22 +3784,22 @@
 
 		} // end of class Scope
 
-		.class nested private auto ansi beforefieldinit Scope_ForOf_L254C7
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L264C7
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L254C44
+			.class nested private auto ansi beforefieldinit Block_L264C44
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L256C69
+				.class nested private auto ansi beforefieldinit Block_L266C69
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c60
+						// Method begins at RVA 0x4d8c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3596,16 +3808,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L256C69::.ctor
+					} // end of method Block_L266C69::.ctor
 
-				} // end of class Block_L256C69
+				} // end of class Block_L266C69
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c57
+					// Method begins at RVA 0x4d83
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3614,16 +3826,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L254C44::.ctor
+				} // end of method Block_L264C44::.ctor
 
-			} // end of class Block_L254C44
+			} // end of class Block_L264C44
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c4e
+				// Method begins at RVA 0x4d7a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3632,26 +3844,26 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Scope_ForOf_L254C7::.ctor
+			} // end of method Scope_ForOf_L264C7::.ctor
 
-		} // end of class Scope_ForOf_L254C7
+		} // end of class Scope_ForOf_L264C7
 
-		.class nested private auto ansi beforefieldinit Scope_ForOf_L261C7
+		.class nested private auto ansi beforefieldinit Scope_ForOf_L271C7
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L261C55
+			.class nested private auto ansi beforefieldinit Block_L271C55
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L263C74
+				.class nested private auto ansi beforefieldinit Block_L273C74
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c7b
+						// Method begins at RVA 0x4da7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3660,16 +3872,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L263C74::.ctor
+					} // end of method Block_L273C74::.ctor
 
-				} // end of class Block_L263C74
+				} // end of class Block_L273C74
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c72
+					// Method begins at RVA 0x4d9e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3678,16 +3890,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L261C55::.ctor
+				} // end of method Block_L271C55::.ctor
 
-			} // end of class Block_L261C55
+			} // end of class Block_L271C55
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c69
+				// Method begins at RVA 0x4d95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3696,9 +3908,9 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Scope_ForOf_L261C7::.ctor
+			} // end of method Scope_ForOf_L271C7::.ctor
 
-		} // end of class Scope_ForOf_L261C7
+		} // end of class Scope_ForOf_L271C7
 
 
 		// Methods
@@ -3713,9 +3925,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3b40
+			// Method begins at RVA 0x3c48
 			// Header size: 12
 			// Code size: 1491 (0x5d3)
 			.maxstack 8
@@ -4322,18 +4534,18 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L292C14
+			.class nested private auto ansi beforefieldinit Block_L302C14
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L294C20
+				.class nested private auto ansi beforefieldinit Block_L304C20
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4cba
+						// Method begins at RVA 0x4de6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4342,16 +4554,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L294C20::.ctor
+					} // end of method Block_L304C20::.ctor
 
-				} // end of class Block_L294C20
+				} // end of class Block_L304C20
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4cb1
+					// Method begins at RVA 0x4ddd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4360,18 +4572,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L292C14::.ctor
+				} // end of method Block_L302C14::.ctor
 
-			} // end of class Block_L292C14
+			} // end of class Block_L302C14
 
-			.class nested private auto ansi beforefieldinit Block_L312C22
+			.class nested private auto ansi beforefieldinit Block_L322C22
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4cc3
+					// Method begins at RVA 0x4def
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4380,16 +4592,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L312C22::.ctor
+				} // end of method Block_L322C22::.ctor
 
-			} // end of class Block_L312C22
+			} // end of class Block_L322C22
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ca8
+				// Method begins at RVA 0x4dd4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4416,9 +4628,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4154
+			// Method begins at RVA 0x425c
 			// Header size: 12
 			// Code size: 1103 (0x44f)
 			.maxstack 8
@@ -4847,18 +5059,18 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L321C16
+			.class nested private auto ansi beforefieldinit Block_L331C16
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested private auto ansi beforefieldinit Block_L323C24
+				.class nested private auto ansi beforefieldinit Block_L333C24
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4cde
+						// Method begins at RVA 0x4e0a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4867,16 +5079,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L323C24::.ctor
+					} // end of method Block_L333C24::.ctor
 
-				} // end of class Block_L323C24
+				} // end of class Block_L333C24
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4cd5
+					// Method begins at RVA 0x4e01
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4885,16 +5097,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L321C16::.ctor
+				} // end of method Block_L331C16::.ctor
 
-			} // end of class Block_L321C16
+			} // end of class Block_L331C16
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ccc
+				// Method begins at RVA 0x4df8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4921,9 +5133,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x45b0
+			// Method begins at RVA 0x46b8
 			// Header size: 12
 			// Code size: 398 (0x18e)
 			.maxstack 8
@@ -5104,14 +5316,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L334C21
+			.class nested private auto ansi beforefieldinit Block_L344C21
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4cf0
+					// Method begins at RVA 0x4e1c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5120,16 +5332,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L334C21::.ctor
+				} // end of method Block_L344C21::.ctor
 
-			} // end of class Block_L334C21
+			} // end of class Block_L344C21
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ce7
+				// Method begins at RVA 0x4e13
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5156,9 +5368,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x474c
+			// Method begins at RVA 0x4854
 			// Header size: 12
 			// Code size: 346 (0x15a)
 			.maxstack 8
@@ -5305,14 +5517,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L353C17
+			.class nested private auto ansi beforefieldinit Block_L363C17
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d02
+					// Method begins at RVA 0x4e2e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5321,18 +5533,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L353C17::.ctor
+				} // end of method Block_L363C17::.ctor
 
-			} // end of class Block_L353C17
+			} // end of class Block_L363C17
 
-			.class nested private auto ansi beforefieldinit Block_L362C21
+			.class nested private auto ansi beforefieldinit Block_L372C21
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d0b
+					// Method begins at RVA 0x4e37
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5341,16 +5553,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L362C21::.ctor
+				} // end of method Block_L372C21::.ctor
 
-			} // end of class Block_L362C21
+			} // end of class Block_L372C21
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cf9
+				// Method begins at RVA 0x4e25
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5374,9 +5586,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x48b4
+			// Method begins at RVA 0x49bc
 			// Header size: 12
 			// Code size: 496 (0x1f0)
 			.maxstack 8
@@ -5614,18 +5826,18 @@
 			61 74 68 7d 2c 20 e2 80 a6 00 00
 		)
 		// Nested Types
-		.class nested private auto ansi beforefieldinit Block_L384C29
+		.class nested private auto ansi beforefieldinit Block_L394C29
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested private auto ansi beforefieldinit Block_L385C6
+			.class nested private auto ansi beforefieldinit Block_L395C6
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d1d
+					// Method begins at RVA 0x4e49
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5634,18 +5846,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L385C6::.ctor
+				} // end of method Block_L395C6::.ctor
 
-			} // end of class Block_L385C6
+			} // end of class Block_L395C6
 
-			.class nested private auto ansi beforefieldinit Block_L387C18
+			.class nested private auto ansi beforefieldinit Block_L397C18
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d26
+					// Method begins at RVA 0x4e52
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5654,16 +5866,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L387C18::.ctor
+				} // end of method Block_L397C18::.ctor
 
-			} // end of class Block_L387C18
+			} // end of class Block_L397C18
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d14
+				// Method begins at RVA 0x4e40
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5672,9 +5884,9 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L384C29::.ctor
+			} // end of method Block_L394C29::.ctor
 
-		} // end of class Block_L384C29
+		} // end of class Block_L394C29
 
 
 		// Fields
@@ -5690,6 +5902,7 @@
 		.field public object normalizeSpecPath
 		.field public object ensureString
 		.field public object ensureStringArray
+		.field public object validateExcludedFromMvp
 		.field public object validatePin
 		.field public object loadPin
 		.field public object resolveManagedCheckoutRoot
@@ -5710,7 +5923,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4ab0
+			// Method begins at RVA 0x4bb8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5736,7 +5949,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1354 (0x54a)
+		// Code size: 1392 (0x570)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
@@ -5862,12 +6075,12 @@
 		IL_0108: ldc.i4.0
 		IL_0109: ldelem.ref
 		IL_010a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_010f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_010f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 		IL_0115: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_011a: stloc.s 7
 		IL_011c: ldloc.0
 		IL_011d: ldloc.s 7
-		IL_011f: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
+		IL_011f: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateExcludedFromMvp
 		IL_0124: ldc.i4.1
 		IL_0125: newarr [System.Runtime]System.Object
 		IL_012a: dup
@@ -5877,12 +6090,12 @@
 		IL_012e: ldc.i4.0
 		IL_012f: ldelem.ref
 		IL_0130: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0135: ldftn object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0135: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 		IL_013b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_0140: stloc.s 7
 		IL_0142: ldloc.0
 		IL_0143: ldloc.s 7
-		IL_0145: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
+		IL_0145: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
 		IL_014a: ldc.i4.1
 		IL_014b: newarr [System.Runtime]System.Object
 		IL_0150: dup
@@ -5892,12 +6105,12 @@
 		IL_0154: ldc.i4.0
 		IL_0155: ldelem.ref
 		IL_0156: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_015b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_015b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_0166: stloc.s 7
 		IL_0168: ldloc.0
 		IL_0169: ldloc.s 7
-		IL_016b: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
+		IL_016b: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
 		IL_0170: ldc.i4.1
 		IL_0171: newarr [System.Runtime]System.Object
 		IL_0176: dup
@@ -5907,12 +6120,12 @@
 		IL_017a: ldc.i4.0
 		IL_017b: ldelem.ref
 		IL_017c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0181: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0187: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0181: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_0187: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
 		IL_018c: stloc.s 7
 		IL_018e: ldloc.0
 		IL_018f: ldloc.s 7
-		IL_0191: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
+		IL_0191: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
 		IL_0196: ldc.i4.1
 		IL_0197: newarr [System.Runtime]System.Object
 		IL_019c: dup
@@ -5922,12 +6135,12 @@
 		IL_01a0: ldc.i4.0
 		IL_01a1: ldelem.ref
 		IL_01a2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_01a7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_01ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01a7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_01ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_01b2: stloc.s 7
 		IL_01b4: ldloc.0
 		IL_01b5: ldloc.s 7
-		IL_01b7: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+		IL_01b7: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
 		IL_01bc: ldc.i4.1
 		IL_01bd: newarr [System.Runtime]System.Object
 		IL_01c2: dup
@@ -5937,12 +6150,12 @@
 		IL_01c6: ldc.i4.0
 		IL_01c7: ldelem.ref
 		IL_01c8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_01cd: ldftn object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_01cd: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 		IL_01d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
 		IL_01d8: stloc.s 7
 		IL_01da: ldloc.0
 		IL_01db: ldloc.s 7
-		IL_01dd: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
+		IL_01dd: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
 		IL_01e2: ldc.i4.1
 		IL_01e3: newarr [System.Runtime]System.Object
 		IL_01e8: dup
@@ -5952,12 +6165,12 @@
 		IL_01ec: ldc.i4.0
 		IL_01ed: ldelem.ref
 		IL_01ee: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_01f3: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01f3: ldftn object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
 		IL_01fe: stloc.s 7
 		IL_0200: ldloc.0
 		IL_0201: ldloc.s 7
-		IL_0203: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
+		IL_0203: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
 		IL_0208: ldc.i4.1
 		IL_0209: newarr [System.Runtime]System.Object
 		IL_020e: dup
@@ -5967,12 +6180,12 @@
 		IL_0212: ldc.i4.0
 		IL_0213: ldelem.ref
 		IL_0214: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0219: ldftn object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0219: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 		IL_021f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_0224: stloc.s 7
 		IL_0226: ldloc.0
 		IL_0227: ldloc.s 7
-		IL_0229: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
+		IL_0229: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
 		IL_022e: ldc.i4.1
 		IL_022f: newarr [System.Runtime]System.Object
 		IL_0234: dup
@@ -5982,12 +6195,12 @@
 		IL_0238: ldc.i4.0
 		IL_0239: ldelem.ref
 		IL_023a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_023f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_023f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_024a: stloc.s 7
 		IL_024c: ldloc.0
 		IL_024d: ldloc.s 7
-		IL_024f: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+		IL_024f: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
 		IL_0254: ldc.i4.1
 		IL_0255: newarr [System.Runtime]System.Object
 		IL_025a: dup
@@ -5997,12 +6210,12 @@
 		IL_025e: ldc.i4.0
 		IL_025f: ldelem.ref
 		IL_0260: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0265: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_026b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0265: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_026b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
 		IL_0270: stloc.s 7
 		IL_0272: ldloc.0
 		IL_0273: ldloc.s 7
-		IL_0275: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
+		IL_0275: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
 		IL_027a: ldc.i4.1
 		IL_027b: newarr [System.Runtime]System.Object
 		IL_0280: dup
@@ -6012,12 +6225,12 @@
 		IL_0284: ldc.i4.0
 		IL_0285: ldelem.ref
 		IL_0286: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_028b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_0291: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_028b: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+		IL_0291: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_0296: stloc.s 7
 		IL_0298: ldloc.0
 		IL_0299: ldloc.s 7
-		IL_029b: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+		IL_029b: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
 		IL_02a0: ldc.i4.1
 		IL_02a1: newarr [System.Runtime]System.Object
 		IL_02a6: dup
@@ -6027,12 +6240,12 @@
 		IL_02aa: ldc.i4.0
 		IL_02ab: ldelem.ref
 		IL_02ac: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_02b1: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-		IL_02b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_02b1: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+		IL_02b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
 		IL_02bc: stloc.s 7
 		IL_02be: ldloc.0
 		IL_02bf: ldloc.s 7
-		IL_02c1: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureManagedCheckout
+		IL_02c1: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
 		IL_02c6: ldc.i4.1
 		IL_02c7: newarr [System.Runtime]System.Object
 		IL_02cc: dup
@@ -6042,12 +6255,12 @@
 		IL_02d0: ldc.i4.0
 		IL_02d1: ldelem.ref
 		IL_02d2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_02d7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+		IL_02d7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
 		IL_02dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
 		IL_02e2: stloc.s 7
 		IL_02e4: ldloc.0
 		IL_02e5: ldloc.s 7
-		IL_02e7: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
+		IL_02e7: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureManagedCheckout
 		IL_02ec: ldc.i4.1
 		IL_02ed: newarr [System.Runtime]System.Object
 		IL_02f2: dup
@@ -6057,12 +6270,12 @@
 		IL_02f6: ldc.i4.0
 		IL_02f7: ldelem.ref
 		IL_02f8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_02fd: ldftn object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+		IL_02fd: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
 		IL_0303: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
 		IL_0308: stloc.s 7
 		IL_030a: ldloc.0
 		IL_030b: ldloc.s 7
-		IL_030d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
+		IL_030d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
 		IL_0312: ldc.i4.1
 		IL_0313: newarr [System.Runtime]System.Object
 		IL_0318: dup
@@ -6072,208 +6285,223 @@
 		IL_031c: ldc.i4.0
 		IL_031d: ldelem.ref
 		IL_031e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0323: ldftn object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-		IL_0329: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0323: ldftn object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+		IL_0329: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
 		IL_032e: stloc.s 7
-		IL_0330: ldloc.s 7
-		IL_0332: stloc.1
-		IL_0333: ldarg.1
-		IL_0334: ldstr "node:child_process"
-		IL_0339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_033e: stloc.s 7
+		IL_0330: ldloc.0
+		IL_0331: ldloc.s 7
+		IL_0333: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
+		IL_0338: ldc.i4.1
+		IL_0339: newarr [System.Runtime]System.Object
+		IL_033e: dup
+		IL_033f: ldc.i4.0
 		IL_0340: ldloc.0
-		IL_0341: ldloc.s 7
-		IL_0343: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
-		IL_0348: ldarg.1
-		IL_0349: ldstr "node:fs"
-		IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0353: stloc.s 7
-		IL_0355: ldloc.0
+		IL_0341: stelem.ref
+		IL_0342: ldc.i4.0
+		IL_0343: ldelem.ref
+		IL_0344: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+		IL_0349: ldftn object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+		IL_034f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0354: stloc.s 7
 		IL_0356: ldloc.s 7
-		IL_0358: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-		IL_035d: ldarg.1
-		IL_035e: ldstr "node:path"
-		IL_0363: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0368: stloc.s 7
-		IL_036a: ldloc.0
-		IL_036b: ldloc.s 7
-		IL_036d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-		IL_0372: ldloc.0
-		IL_0373: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
-		IL_0378: stloc.s 7
-		IL_037a: ldloc.0
-		IL_037b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
-		IL_0380: stloc.s 8
-		IL_0382: ldloc.0
-		IL_0383: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureManagedCheckout
-		IL_0388: stloc.s 9
-		IL_038a: ldloc.0
-		IL_038b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
-		IL_0390: stloc.s 10
-		IL_0392: ldloc.0
-		IL_0393: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
-		IL_0398: stloc.s 11
-		IL_039a: ldloc.0
-		IL_039b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
-		IL_03a0: stloc.s 12
-		IL_03a2: ldloc.0
-		IL_03a3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
-		IL_03a8: stloc.s 13
-		IL_03aa: ldloc.0
-		IL_03ab: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
-		IL_03b0: stloc.s 14
-		IL_03b2: ldarg.2
-		IL_03b3: ldstr "exports"
-		IL_03b8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03bd: dup
-		IL_03be: ldstr "buildSparsePatterns"
-		IL_03c3: ldloc.0
-		IL_03c4: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
-		IL_03c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03ce: dup
-		IL_03cf: ldstr "defaultPinPath"
-		IL_03d4: ldloc.s 7
-		IL_03d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03db: dup
-		IL_03dc: ldstr "describePlan"
-		IL_03e1: ldloc.s 8
-		IL_03e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03e8: dup
-		IL_03e9: ldstr "ensureManagedCheckout"
-		IL_03ee: ldloc.s 9
-		IL_03f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03f5: dup
-		IL_03f6: ldstr "loadPin"
-		IL_03fb: ldloc.s 10
-		IL_03fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0402: dup
-		IL_0403: ldstr "parseArgs"
-		IL_0408: ldloc.s 11
-		IL_040a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_040f: dup
-		IL_0410: ldstr "resolveBootstrapRoot"
-		IL_0415: ldloc.s 12
-		IL_0417: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_041c: dup
-		IL_041d: ldstr "resolveManagedCheckoutLabel"
-		IL_0422: ldloc.s 13
-		IL_0424: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0429: dup
-		IL_042a: ldstr "resolveManagedCheckoutRoot"
-		IL_042f: ldloc.s 14
-		IL_0431: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0436: dup
-		IL_0437: ldstr "validateResolvedRoot"
-		IL_043c: ldloc.0
-		IL_043d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-		IL_0442: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
-		IL_044c: pop
-		IL_044d: ldarg.1
-		IL_044e: ldstr "main"
-		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0458: ldarg.2
-		IL_0459: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_045e: stloc.s 15
-		IL_0460: ldloc.s 15
-		IL_0462: brfalse IL_0549
+		IL_0358: stloc.1
+		IL_0359: ldarg.1
+		IL_035a: ldstr "node:child_process"
+		IL_035f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0364: stloc.s 7
+		IL_0366: ldloc.0
+		IL_0367: ldloc.s 7
+		IL_0369: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
+		IL_036e: ldarg.1
+		IL_036f: ldstr "node:fs"
+		IL_0374: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0379: stloc.s 7
+		IL_037b: ldloc.0
+		IL_037c: ldloc.s 7
+		IL_037e: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+		IL_0383: ldarg.1
+		IL_0384: ldstr "node:path"
+		IL_0389: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_038e: stloc.s 7
+		IL_0390: ldloc.0
+		IL_0391: ldloc.s 7
+		IL_0393: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+		IL_0398: ldloc.0
+		IL_0399: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
+		IL_039e: stloc.s 7
+		IL_03a0: ldloc.0
+		IL_03a1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
+		IL_03a6: stloc.s 8
+		IL_03a8: ldloc.0
+		IL_03a9: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureManagedCheckout
+		IL_03ae: stloc.s 9
+		IL_03b0: ldloc.0
+		IL_03b1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
+		IL_03b6: stloc.s 10
+		IL_03b8: ldloc.0
+		IL_03b9: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
+		IL_03be: stloc.s 11
+		IL_03c0: ldloc.0
+		IL_03c1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
+		IL_03c6: stloc.s 12
+		IL_03c8: ldloc.0
+		IL_03c9: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
+		IL_03ce: stloc.s 13
+		IL_03d0: ldloc.0
+		IL_03d1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
+		IL_03d6: stloc.s 14
+		IL_03d8: ldarg.2
+		IL_03d9: ldstr "exports"
+		IL_03de: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03e3: dup
+		IL_03e4: ldstr "buildSparsePatterns"
+		IL_03e9: ldloc.0
+		IL_03ea: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
+		IL_03ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03f4: dup
+		IL_03f5: ldstr "defaultPinPath"
+		IL_03fa: ldloc.s 7
+		IL_03fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0401: dup
+		IL_0402: ldstr "describePlan"
+		IL_0407: ldloc.s 8
+		IL_0409: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_040e: dup
+		IL_040f: ldstr "ensureManagedCheckout"
+		IL_0414: ldloc.s 9
+		IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_041b: dup
+		IL_041c: ldstr "loadPin"
+		IL_0421: ldloc.s 10
+		IL_0423: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0428: dup
+		IL_0429: ldstr "parseArgs"
+		IL_042e: ldloc.s 11
+		IL_0430: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0435: dup
+		IL_0436: ldstr "resolveBootstrapRoot"
+		IL_043b: ldloc.s 12
+		IL_043d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0442: dup
+		IL_0443: ldstr "resolveManagedCheckoutLabel"
+		IL_0448: ldloc.s 13
+		IL_044a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_044f: dup
+		IL_0450: ldstr "resolveManagedCheckoutRoot"
+		IL_0455: ldloc.s 14
+		IL_0457: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_045c: dup
+		IL_045d: ldstr "validateResolvedRoot"
+		IL_0462: ldloc.0
+		IL_0463: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+		IL_0468: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_0472: pop
+		IL_0473: ldarg.1
+		IL_0474: ldstr "main"
+		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_047e: ldarg.2
+		IL_047f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0484: stloc.s 15
+		IL_0486: ldloc.s 15
+		IL_0488: brfalse IL_056f
 		.try
 		{
-			IL_0467: ldc.i4.1
-			IL_0468: newarr [System.Runtime]System.Object
-			IL_046d: dup
-			IL_046e: ldc.i4.0
-			IL_046f: ldloc.0
-			IL_0470: stelem.ref
-			IL_0471: ldc.i4.0
-			IL_0472: ldelem.ref
-			IL_0473: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0478: ldftn object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-			IL_047e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0483: ldnull
-			IL_0484: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0489: pop
-			IL_048a: leave IL_0549
+			IL_048d: ldc.i4.1
+			IL_048e: newarr [System.Runtime]System.Object
+			IL_0493: dup
+			IL_0494: ldc.i4.0
+			IL_0495: ldloc.0
+			IL_0496: stelem.ref
+			IL_0497: ldc.i4.0
+			IL_0498: ldelem.ref
+			IL_0499: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_049e: ldftn object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+			IL_04a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_04a9: ldnull
+			IL_04aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+			IL_04af: pop
+			IL_04b0: leave IL_056f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_048f: stloc.2
-			IL_0490: ldloc.2
-			IL_0491: dup
-			IL_0492: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0497: dup
-			IL_0498: brtrue IL_04ae
+			IL_04b5: stloc.2
+			IL_04b6: ldloc.2
+			IL_04b7: dup
+			IL_04b8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04bd: dup
+			IL_04be: brtrue IL_04d4
 
-			IL_049d: pop
-			IL_049e: dup
-			IL_049f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_04a4: dup
-			IL_04a5: brtrue IL_04ba
+			IL_04c3: pop
+			IL_04c4: dup
+			IL_04c5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04ca: dup
+			IL_04cb: brtrue IL_04e0
 
-			IL_04aa: pop
-			IL_04ab: pop
-			IL_04ac: rethrow
+			IL_04d0: pop
+			IL_04d1: pop
+			IL_04d2: rethrow
 
-			IL_04ae: pop
-			IL_04af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04b4: stloc.3
-			IL_04b5: br IL_04bc
+			IL_04d4: pop
+			IL_04d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04da: stloc.3
+			IL_04db: br IL_04e2
 
-			IL_04ba: pop
-			IL_04bb: stloc.3
+			IL_04e0: pop
+			IL_04e1: stloc.3
 
-			IL_04bc: ldloc.3
-			IL_04bd: stloc.s 14
-			IL_04bf: ldloc.s 14
-			IL_04c1: stloc.s 4
-			IL_04c3: ldloc.s 4
-			IL_04c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04ca: stloc.s 15
-			IL_04cc: ldloc.s 15
-			IL_04ce: brfalse IL_04e6
+			IL_04e2: ldloc.3
+			IL_04e3: stloc.s 14
+			IL_04e5: ldloc.s 14
+			IL_04e7: stloc.s 4
+			IL_04e9: ldloc.s 4
+			IL_04eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04f0: stloc.s 15
+			IL_04f2: ldloc.s 15
+			IL_04f4: brfalse IL_050c
 
-			IL_04d3: ldloc.s 4
-			IL_04d5: ldstr "message"
-			IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04df: stloc.s 17
-			IL_04e1: br IL_04ea
+			IL_04f9: ldloc.s 4
+			IL_04fb: ldstr "message"
+			IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0505: stloc.s 17
+			IL_0507: br IL_0510
 
-			IL_04e6: ldloc.s 4
-			IL_04e8: stloc.s 17
+			IL_050c: ldloc.s 4
+			IL_050e: stloc.s 17
 
-			IL_04ea: ldloc.s 17
-			IL_04ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04f1: stloc.s 15
-			IL_04f3: ldloc.s 15
-			IL_04f5: brfalse IL_050d
+			IL_0510: ldloc.s 17
+			IL_0512: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0517: stloc.s 15
+			IL_0519: ldloc.s 15
+			IL_051b: brfalse IL_0533
 
-			IL_04fa: ldloc.s 4
-			IL_04fc: ldstr "message"
-			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0506: stloc.s 5
-			IL_0508: br IL_051a
+			IL_0520: ldloc.s 4
+			IL_0522: ldstr "message"
+			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_052c: stloc.s 5
+			IL_052e: br IL_0540
 
-			IL_050d: ldloc.s 4
-			IL_050f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0514: stloc.s 18
-			IL_0516: ldloc.s 18
-			IL_0518: stloc.s 5
+			IL_0533: ldloc.s 4
+			IL_0535: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_053a: stloc.s 18
+			IL_053c: ldloc.s 18
+			IL_053e: stloc.s 5
 
-			IL_051a: ldloc.s 5
-			IL_051c: stloc.s 6
-			IL_051e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0523: ldloc.s 6
-			IL_0525: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_052a: pop
-			IL_052b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0530: ldstr "exitCode"
-			IL_0535: ldc.r8 1
-			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
-			IL_0543: pop
-			IL_0544: leave IL_0549
+			IL_0540: ldloc.s 5
+			IL_0542: stloc.s 6
+			IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0549: ldloc.s 6
+			IL_054b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0550: pop
+			IL_0551: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0556: ldstr "exitCode"
+			IL_055b: ldc.r8 1
+			IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64)
+			IL_0569: pop
+			IL_056a: leave IL_056f
 		} // end handler
 
-		IL_0549: ret
+		IL_056f: ret
 	} // end of method Compile_Scripts_Test262Bootstrap::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262Bootstrap
@@ -6285,7 +6513,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4d2f
+		// Method begins at RVA 0x4e5b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ClassifiesPolicyWrongPhaseAndWrongErrorKind.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ClassifiesPolicyWrongPhaseAndWrongErrorKind.verified.txt
@@ -1,0 +1,183 @@
+﻿exit: 1
+stdout:
+root <temp>/test262-root
+js2il <repo>/src/Cli/bin/<configuration>/net10.0/Js2IL.dll
+output <temp>/runner-output
+discovered 9
+selected-files 3
+selected-cases 2
+SKIP-POLICY test/language/mvp/classification-policy-skip.js [all] [path-excluded:test/language/mvp/classification-policy-skip.js] excluded by policy (test/language/mvp/classification-policy-skip.js)
+WRONG-PHASE test/language/mvp/classification-parse-wrong-phase.js [non-strict] expected negative(parse:SyntaxError) but rejection moved to runtime (SyntaxError)
+REPRO node scripts/test262/runMvp.js --root "<temp>/test262-root" --file "test/language/mvp/classification-parse-wrong-phase.js" --variant non-strict
+WRONG-ERROR-KIND test/language/mvp/classification-runtime-wrong-error.js [non-strict] expected negative(runtime:TypeError) but observed RangeError
+REPRO node scripts/test262/runMvp.js --root "<temp>/test262-root" --file "test/language/mvp/classification-runtime-wrong-error.js" --variant non-strict
+SUMMARY matched=0 unexpected=2 not-run=1 selected=2 classified=3 wrong-phase=1 wrong-error-kind=1 skipped-by-policy=1
+REPORT <temp>/runner-output/summary.json
+summary.json:
+{
+  "schemaVersion": 1,
+  "suite": "js2il-test262-mvp",
+  "pin": {
+    "commit": "0123456789abcdef0123456789abcdef01234567",
+    "packageVersion": "5.0.0"
+  },
+  "policy": {
+    "pathExclusions": [
+      "test/language/mvp/classification-policy-skip.js"
+    ],
+    "unsupportedResultSources": [
+      "metadata.unsupported",
+      "metadata.mvpBlockers"
+    ],
+    "negativeExpectations": {
+      "parse": {
+        "expectedObservedPhase": "compile",
+        "validateErrorType": false
+      },
+      "runtime": {
+        "expectedObservedPhase": "runtime",
+        "validateErrorType": true
+      }
+    },
+    "baselineArtifact": {
+      "fileName": "summary.json",
+      "format": "js2il-test262-summary-v1"
+    }
+  },
+  "selection": {
+    "file": null,
+    "filter": "classification-",
+    "limit": null,
+    "variant": null,
+    "discoveredFiles": 9,
+    "selectedFiles": 3,
+    "selectedCases": 2,
+    "classifiedEntries": 3
+  },
+  "summary": {
+    "exitCode": 1,
+    "verdictCounts": {
+      "unexpected": 2,
+      "not-run": 1
+    },
+    "kindCounts": {
+      "wrong-phase": 1,
+      "wrong-error-kind": 1,
+      "skipped-by-policy": 1
+    }
+  },
+  "results": [
+    {
+      "id": "test/language/mvp/classification-policy-skip.js#all",
+      "relativePath": "test/language/mvp/classification-policy-skip.js",
+      "variant": null,
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "skipped-by-policy",
+        "verdict": "not-run",
+        "phase": "selection",
+        "detail": "excluded by policy (test/language/mvp/classification-policy-skip.js)"
+      },
+      "reasons": [
+        {
+          "code": "path-excluded",
+          "source": "excludedFromMvp",
+          "reason": "Path matched excludedFromMvp entry 'test/language/mvp/classification-policy-skip.js'.",
+          "pattern": "test/language/mvp/classification-policy-skip.js"
+        }
+      ],
+      "observed": {
+        "compile": {
+          "status": "not-run",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "not-run",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": null
+    },
+    {
+      "id": "test/language/mvp/classification-parse-wrong-phase.js#non-strict",
+      "relativePath": "test/language/mvp/classification-parse-wrong-phase.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "negative",
+        "phase": "parse",
+        "errorType": "SyntaxError",
+        "validatesErrorType": false
+      },
+      "classification": {
+        "kind": "wrong-phase",
+        "verdict": "unexpected",
+        "phase": "runtime",
+        "detail": "expected negative(parse:SyntaxError) but rejection moved to runtime (SyntaxError)"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "rejected",
+          "exitCode": 3762504530,
+          "errorType": "SyntaxError",
+          "summary": "SyntaxError: late parse-like boom"
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/classification-parse-wrong-phase.js",
+        "variant": "non-strict"
+      }
+    },
+    {
+      "id": "test/language/mvp/classification-runtime-wrong-error.js#non-strict",
+      "relativePath": "test/language/mvp/classification-runtime-wrong-error.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "negative",
+        "phase": "runtime",
+        "errorType": "TypeError",
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "wrong-error-kind",
+        "verdict": "unexpected",
+        "phase": "runtime",
+        "detail": "expected negative(runtime:TypeError) but observed RangeError"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "rejected",
+          "exitCode": 3762504530,
+          "errorType": "RangeError",
+          "summary": "RangeError: wrong kind"
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/classification-runtime-wrong-error.js",
+        "variant": "non-strict"
+      }
+    }
+  ]
+}

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ClassifiesPolicyWrongPhaseAndWrongErrorKind.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ClassifiesPolicyWrongPhaseAndWrongErrorKind.verified.txt
@@ -133,7 +133,7 @@ summary.json:
         },
         "runtime": {
           "status": "rejected",
-          "exitCode": 3762504530,
+          "exitCode": 1,
           "errorType": "SyntaxError",
           "summary": "SyntaxError: late parse-like boom"
         }
@@ -169,7 +169,7 @@ summary.json:
         },
         "runtime": {
           "status": "rejected",
-          "exitCode": 3762504530,
+          "exitCode": 1,
           "errorType": "RangeError",
           "summary": "RangeError: wrong kind"
         }

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ExecutesStableSubset.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ExecutesStableSubset.verified.txt
@@ -284,7 +284,7 @@ summary.json:
         },
         "runtime": {
           "status": "rejected",
-          "exitCode": 3762504530,
+          "exitCode": 1,
           "errorType": "TypeError",
           "summary": "TypeError: runtime boom"
         }

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ExecutesStableSubset.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ExecutesStableSubset.verified.txt
@@ -6,11 +6,329 @@ output <temp>/runner-output
 discovered 6
 selected-files 6
 selected-cases 5
-SKIP test/language/mvp/skip-module.js [module-flag]
-SKIP test/language/mvp/unsupported-flag.js [unknown-flag]
+UNSUPPORTED test/language/mvp/skip-module.js [all] [module-flag] unsupported requirement
+UNSUPPORTED test/language/mvp/unsupported-flag.js [all] [unknown-flag] unsupported requirement
 PASS test/language/mvp/basic-pass.js [non-strict] positive
 PASS test/language/mvp/basic-pass.js [strict] positive
-PASS test/language/mvp/parse-negative.js [non-strict] negative(parse:SyntaxError)
-PASS test/language/mvp/runtime-negative.js [non-strict] negative(runtime:TypeError)
+COMPILE-REJECTION test/language/mvp/parse-negative.js [non-strict] matched negative(parse:SyntaxError)
+RUNTIME-REJECTION test/language/mvp/runtime-negative.js [non-strict] matched negative(runtime:TypeError)
 PASS test/language/mvp/strict-only-pass.js [strict] positive
-SUMMARY passed=5 failed=0 skipped=2 selected=5
+SUMMARY matched=5 unexpected=0 not-run=2 selected=5 classified=7 pass=3 compile-rejection=1 runtime-rejection=1 unsupported-requirement=2
+REPORT <temp>/runner-output/summary.json
+summary.json:
+{
+  "schemaVersion": 1,
+  "suite": "js2il-test262-mvp",
+  "pin": {
+    "commit": "2b2ecead6e828dd9af13a9ec72065e645724a50f",
+    "packageVersion": "5.0.0"
+  },
+  "policy": {
+    "pathExclusions": [
+      "test/annexB/**",
+      "test/intl402/**",
+      "test/staging/**"
+    ],
+    "unsupportedResultSources": [
+      "metadata.unsupported",
+      "metadata.mvpBlockers"
+    ],
+    "negativeExpectations": {
+      "parse": {
+        "expectedObservedPhase": "compile",
+        "validateErrorType": false
+      },
+      "runtime": {
+        "expectedObservedPhase": "runtime",
+        "validateErrorType": true
+      }
+    },
+    "baselineArtifact": {
+      "fileName": "summary.json",
+      "format": "js2il-test262-summary-v1"
+    }
+  },
+  "selection": {
+    "file": null,
+    "filter": null,
+    "limit": null,
+    "variant": null,
+    "discoveredFiles": 6,
+    "selectedFiles": 6,
+    "selectedCases": 5,
+    "classifiedEntries": 7
+  },
+  "summary": {
+    "exitCode": 0,
+    "verdictCounts": {
+      "matched": 5,
+      "not-run": 2
+    },
+    "kindCounts": {
+      "pass": 3,
+      "compile-rejection": 1,
+      "runtime-rejection": 1,
+      "unsupported-requirement": 2
+    }
+  },
+  "results": [
+    {
+      "id": "test/language/mvp/skip-module.js#all",
+      "relativePath": "test/language/mvp/skip-module.js",
+      "variant": null,
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "unsupported-requirement",
+        "verdict": "not-run",
+        "phase": "selection",
+        "detail": "unsupported requirement"
+      },
+      "reasons": [
+        {
+          "code": "module-flag",
+          "source": "flags:module",
+          "reason": "Module tests are outside the plain synchronous script MVP."
+        }
+      ],
+      "observed": {
+        "compile": {
+          "status": "not-run",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "not-run",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": null
+    },
+    {
+      "id": "test/language/mvp/unsupported-flag.js#all",
+      "relativePath": "test/language/mvp/unsupported-flag.js",
+      "variant": null,
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "unsupported-requirement",
+        "verdict": "not-run",
+        "phase": "selection",
+        "detail": "unsupported requirement"
+      },
+      "reasons": [
+        {
+          "code": "unknown-flag",
+          "source": "flags:mysteryFlag",
+          "reason": "Unsupported flag 'mysteryFlag'."
+        }
+      ],
+      "observed": {
+        "compile": {
+          "status": "not-run",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "not-run",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": null
+    },
+    {
+      "id": "test/language/mvp/basic-pass.js#non-strict",
+      "relativePath": "test/language/mvp/basic-pass.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "pass",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "positive"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "passed",
+          "exitCode": 0,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/basic-pass.js",
+        "variant": "non-strict"
+      }
+    },
+    {
+      "id": "test/language/mvp/basic-pass.js#strict",
+      "relativePath": "test/language/mvp/basic-pass.js",
+      "variant": "strict",
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "pass",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "positive"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "passed",
+          "exitCode": 0,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/basic-pass.js",
+        "variant": "strict"
+      }
+    },
+    {
+      "id": "test/language/mvp/parse-negative.js#non-strict",
+      "relativePath": "test/language/mvp/parse-negative.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "negative",
+        "phase": "parse",
+        "errorType": "SyntaxError",
+        "validatesErrorType": false
+      },
+      "classification": {
+        "kind": "compile-rejection",
+        "verdict": "matched",
+        "phase": "compile",
+        "detail": "matched negative(parse:SyntaxError)"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "rejected",
+          "exitCode": null,
+          "errorType": "Error",
+          "summary": "Error: [input] <output>/cases/test/language/mvp/parse-negative/non-strict/input.js: Failed to parse JavaScript: Unexpected token '(' (<output>/cases/test/language/mvp/parse-negative/non-strict/input.js:27:10)"
+        },
+        "runtime": {
+          "status": "not-run",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/parse-negative.js",
+        "variant": "non-strict"
+      }
+    },
+    {
+      "id": "test/language/mvp/runtime-negative.js#non-strict",
+      "relativePath": "test/language/mvp/runtime-negative.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "negative",
+        "phase": "runtime",
+        "errorType": "TypeError",
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "runtime-rejection",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "matched negative(runtime:TypeError)"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "rejected",
+          "exitCode": 3762504530,
+          "errorType": "TypeError",
+          "summary": "TypeError: runtime boom"
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/runtime-negative.js",
+        "variant": "non-strict"
+      }
+    },
+    {
+      "id": "test/language/mvp/strict-only-pass.js#strict",
+      "relativePath": "test/language/mvp/strict-only-pass.js",
+      "variant": "strict",
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "pass",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "positive"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "passed",
+          "exitCode": 0,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/strict-only-pass.js",
+        "variant": "strict"
+      }
+    }
+  ]
+}

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ReportsFailureWithRepro.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ReportsFailureWithRepro.verified.txt
@@ -6,6 +6,98 @@ output <temp>/runner-output
 discovered 7
 selected-files 1
 selected-cases 1
-FAIL test/language/mvp/fail-positive.js [non-strict] runtime failed: Unhandled exception. JavaScriptRuntime.JsThrownValueException: JavaScript threw a non-exception value
+RUNTIME-MISMATCH test/language/mvp/fail-positive.js [non-strict] expected positive but runtime rejected (Unhandled exception. JavaScriptRuntime.JsThrownValueException: JavaScript threw a non-exception value)
 REPRO node scripts/test262/runMvp.js --root "<temp>/test262-root" --file "test/language/mvp/fail-positive.js" --variant non-strict
-SUMMARY passed=0 failed=1 skipped=0 selected=1
+SUMMARY matched=0 unexpected=1 not-run=0 selected=1 classified=1 runtime-mismatch=1
+REPORT <temp>/runner-output/summary.json
+summary.json:
+{
+  "schemaVersion": 1,
+  "suite": "js2il-test262-mvp",
+  "pin": {
+    "commit": "2b2ecead6e828dd9af13a9ec72065e645724a50f",
+    "packageVersion": "5.0.0"
+  },
+  "policy": {
+    "pathExclusions": [
+      "test/annexB/**",
+      "test/intl402/**",
+      "test/staging/**"
+    ],
+    "unsupportedResultSources": [
+      "metadata.unsupported",
+      "metadata.mvpBlockers"
+    ],
+    "negativeExpectations": {
+      "parse": {
+        "expectedObservedPhase": "compile",
+        "validateErrorType": false
+      },
+      "runtime": {
+        "expectedObservedPhase": "runtime",
+        "validateErrorType": true
+      }
+    },
+    "baselineArtifact": {
+      "fileName": "summary.json",
+      "format": "js2il-test262-summary-v1"
+    }
+  },
+  "selection": {
+    "file": "test/language/mvp/fail-positive.js",
+    "filter": null,
+    "limit": null,
+    "variant": null,
+    "discoveredFiles": 7,
+    "selectedFiles": 1,
+    "selectedCases": 1,
+    "classifiedEntries": 1
+  },
+  "summary": {
+    "exitCode": 1,
+    "verdictCounts": {
+      "unexpected": 1
+    },
+    "kindCounts": {
+      "runtime-mismatch": 1
+    }
+  },
+  "results": [
+    {
+      "id": "test/language/mvp/fail-positive.js#non-strict",
+      "relativePath": "test/language/mvp/fail-positive.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "runtime-mismatch",
+        "verdict": "unexpected",
+        "phase": "runtime",
+        "detail": "expected positive but runtime rejected (Unhandled exception. JavaScriptRuntime.JsThrownValueException: JavaScript threw a non-exception value)"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "rejected",
+          "exitCode": 3762504530,
+          "errorType": null,
+          "summary": "Unhandled exception. JavaScriptRuntime.JsThrownValueException: JavaScript threw a non-exception value"
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/fail-positive.js",
+        "variant": "non-strict"
+      }
+    }
+  ]
+}

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ReportsFailureWithRepro.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ReportsFailureWithRepro.verified.txt
@@ -89,7 +89,7 @@ summary.json:
         },
         "runtime": {
           "status": "rejected",
-          "exitCode": 3762504530,
+          "exitCode": 1,
           "errorType": null,
           "summary": "Unhandled exception. JavaScriptRuntime.JsThrownValueException: JavaScript threw a non-exception value"
         }

--- a/tests/test262/test262.pin.json
+++ b/tests/test262/test262.pin.json
@@ -41,11 +41,7 @@
   "excludedFromMvp": [
     "test/annexB/**",
     "test/intl402/**",
-    "test/staging/**",
-    "frontmatter:flags=module",
-    "frontmatter:flags=async",
-    "frontmatter:requires-agent-or-broadcast",
-    "frontmatter:requires-async-harness"
+    "test/staging/**"
   ],
   "attributionFiles": [
     "LICENSE",


### PR DESCRIPTION
## Summary
- classify test262 MVP runner outcomes with stable result kinds/verdicts and emit a machine-readable summary.json baseline artifact
- treat excludedFromMvp as path-only policy, use metadata/parser codes for unsupported requirements, and document the contract in ADR 0006
- extend focused test262 runner coverage for policy skips, wrong-phase negatives, wrong-error-kind negatives, and the refreshed snapshot outputs

## Testing
- dotnet build .\\tests\\Js2IL.Test262.Tests\\Js2IL.Test262.Tests.csproj -c Release /p:IsTestProject=true --nologo
- dotnet test .\\tests\\Js2IL.Test262.Tests\\Js2IL.Test262.Tests.csproj -c Release /p:IsTestProject=true --no-build --nologo

Closes #931