### PR TITLE
docs(tracking): refresh repository state snapshots

### DIFF
--- a/docs/tracking-issues/ECMA262TopMissingBacklog.md
+++ b/docs/tracking-issues/ECMA262TopMissingBacklog.md
@@ -1,13 +1,13 @@
 # ECMA-262 Top Missing Features Backlog
 
-> **Last Updated**: 2026-04-13
+> **Last Updated**: 2026-04-20
 > Purpose: capture the highest-impact ECMA-262 gaps still marked missing or materially incomplete in `docs\ECMA262`.
 > Source basis: current generated `docs\ECMA262\**\Section*.md` / JSON tracking, cross-checked against live GitHub issue state.
 
 ## What changed since the previous pass
 
-- The previous top tracked issue [#859](https://github.com/tomacox74/js2il/issues/859) is now **closed**, so the remaining highest-value ECMA gaps are mostly **issue-creation candidates**, not already-open GitHub issues.
-- The best remaining backlog items are now concentrated in TypedArray fidelity, the new Uint8Array base64/hex surface, Promise follow-ons, and missing constructor/prototype intrinsics for generator-family function objects.
+- No new ECMA-262 support-doc updates landed after the previous pass, so the top missing-feature ranking is materially unchanged.
+- [#975](https://github.com/tomacox74/js2il/pull/975) strengthened the `test262` foundation with classified MVP results and a baseline artifact, but it did not close any of the feature gaps below; the best remaining backlog items are still concentrated in TypedArray fidelity, the new Uint8Array base64/hex surface, Promise follow-ons, and missing constructor/prototype intrinsics for generator-family function objects.
 
 ## How this pass was filtered
 

--- a/docs/tracking-issues/IssueTriage.md
+++ b/docs/tracking-issues/IssueTriage.md
@@ -1,21 +1,21 @@
-# Issue triage snapshot (refreshed 2026-04-13)
+# Issue triage snapshot (refreshed 2026-04-20)
 
 This file captures a point-in-time recommended ordering for all currently open GitHub issues.
 
 Synced to:
-- Repo: `origin/master` @ `731a54f4`
+- Repo: `origin/master` @ `163cb816`
 - Latest tagged release on `master`: `v0.9.7` via PR [#966](https://github.com/tomacox74/js2il/pull/966)
-- Recent merged PRs since the previous snapshot: [#969](https://github.com/tomacox74/js2il/pull/969), [#970](https://github.com/tomacox74/js2il/pull/970), [#971](https://github.com/tomacox74/js2il/pull/971), [#972](https://github.com/tomacox74/js2il/pull/972), [#973](https://github.com/tomacox74/js2il/pull/973)
-- GitHub: open issue / PR state as of 2026-04-13
-- Open issues: **17**
+- Recent merged PRs since the previous snapshot: [#974](https://github.com/tomacox74/js2il/pull/974), [#975](https://github.com/tomacox74/js2il/pull/975)
+- GitHub: open issue / PR state as of 2026-04-20
+- Open issues: **16**
 - Open PRs: **0**
 
 ## What changed since the previous snapshot
 
-- PRs [#969](https://github.com/tomacox74/js2il/pull/969)-[#973](https://github.com/tomacox74/js2il/pull/973) landed on `master`, closing [#946](https://github.com/tomacox74/js2il/issues/946), [#947](https://github.com/tomacox74/js2il/issues/947), [#950](https://github.com/tomacox74/js2il/issues/950)-[#955](https://github.com/tomacox74/js2il/issues/955), and the first three concrete `test262` child issues [#928](https://github.com/tomacox74/js2il/issues/928)-[#930](https://github.com/tomacox74/js2il/issues/930).
-- The open Node/runtime queue dropped from four follow-ons to two: [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956).
-- The `test262` program moved out of intake/bootstrap setup and into post-MVP follow-ons: [#927](https://github.com/tomacox74/js2il/issues/927) remains the umbrella issue; [#931](https://github.com/tomacox74/js2il/issues/931)-[#934](https://github.com/tomacox74/js2il/issues/934) remain open; [#928](https://github.com/tomacox74/js2il/issues/928)-[#930](https://github.com/tomacox74/js2il/issues/930) are now closed.
-- Open issue count dropped from **22** to **17** while open PR count stayed at **0**.
+- PR [#975](https://github.com/tomacox74/js2il/pull/975) landed on `master`, closing [#931](https://github.com/tomacox74/js2il/issues/931) and adding classified MVP results plus a machine-readable `summary.json` baseline artifact for the current `test262` slice.
+- The open Node/runtime queue is unchanged and still led by [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956).
+- The `test262` program is now down to umbrella [#927](https://github.com/tomacox74/js2il/issues/927) plus the remaining follow-ons [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934); the bootstrap/parser/MVP/classification foundation [#928](https://github.com/tomacox74/js2il/issues/928)-[#931](https://github.com/tomacox74/js2il/issues/931) is closed.
+- Open issue count dropped from **17** to **16** while open PR count stayed at **0**.
 
 ## Ranking method
 
@@ -28,8 +28,8 @@ Synced to:
 
 - **Primary next item:** [#949](https://github.com/tomacox74/js2il/issues/949) `node: add global fetch / Request / Response / Headers baseline`
 - **Best next production-network follow-on:** [#956](https://github.com/tomacox74/js2il/issues/956) `node: expand TLS/HTTPS trust, client-auth, and agent parity`
-- **Best next `test262` implementation slice:** [#931](https://github.com/tomacox74/js2il/issues/931) `test262: classify negative tests, exclusions, and baselines`
-- **Best next `test262` reporting slice:** [#932](https://github.com/tomacox74/js2il/issues/932) `test262: add CI workflow and machine-readable reporting`
+- **Best next `test262` automation slice:** [#932](https://github.com/tomacox74/js2il/issues/932) `test262: add CI workflow and machine-readable reporting`
+- **Best next `test262` docs/backlog slice:** [#933](https://github.com/tomacox74/js2il/issues/933) `test262: connect conformance results to ECMA-262 docs and backlog`
 - **Umbrella only, not the next direct code pick:** [#927](https://github.com/tomacox74/js2il/issues/927) stays open as the parent issue for the remaining `test262` lane.
 
 ## Recommended order
@@ -39,36 +39,35 @@ Synced to:
 1. **[#949](https://github.com/tomacox74/js2il/issues/949)** `node: add global fetch / Request / Response / Headers baseline` - The highest-leverage remaining platform gap after the recent URL/HTTP/TLS/stream/fs/crypto tranche; modern packages frequently assume `fetch`-style globals first.
 2. **[#956](https://github.com/tomacox74/js2il/issues/956)** `node: expand TLS/HTTPS trust, client-auth, and agent parity` - The current TLS/HTTPS baseline is good enough for local/self-signed flows, but real outbound integrations still need trust-store, client-cert, and richer agent behavior.
 
-### Tier 2 - `test262` follow-ons after the MVP landed
+### Tier 2 - `test262` follow-ons after the classification slice landed
 
 3. **[#927](https://github.com/tomacox74/js2il/issues/927)** `test262: create a phased conformance program for js2il` - Keep this open as the sequencing umbrella and reporting parent while the remaining child issues land.
-4. **[#931](https://github.com/tomacox74/js2il/issues/931)** `test262: classify negative tests, exclusions, and baselines` - The right next concrete slice after the MVP runner because reproducible classification is the prerequisite for meaningful results.
-5. **[#932](https://github.com/tomacox74/js2il/issues/932)** `test262: add CI workflow and machine-readable reporting` - CI and machine-readable output should follow once the local classification and baseline story is stable enough to automate.
-6. **[#933](https://github.com/tomacox74/js2il/issues/933)** `test262: connect conformance results to ECMA-262 docs and backlog` - High value once the runner emits stable, triageable output rather than just the initial narrow MVP slice.
-7. **[#934](https://github.com/tomacox74/js2il/issues/934)** `test262: expand beyond the MVP to modules, async, and harness-heavy suites` - Important, but still deliberately later than getting the narrow slice classified, reported, and wired back into docs.
+4. **[#932](https://github.com/tomacox74/js2il/issues/932)** `test262: add CI workflow and machine-readable reporting` - The local classification and baseline artifact now exist, so the next concrete step is turning that into repeatable CI and repo-consumable reporting.
+5. **[#933](https://github.com/tomacox74/js2il/issues/933)** `test262: connect conformance results to ECMA-262 docs and backlog` - More actionable now that the MVP runner produces stable verdicts and a summary artifact instead of only ad-hoc console output.
+6. **[#934](https://github.com/tomacox74/js2il/issues/934)** `test262: expand beyond the MVP to modules, async, and harness-heavy suites` - Important, but still deliberately later than stabilizing CI/reporting and wiring the current slice back into docs.
 
 ### Tier 3 - Deferred performance queue
 
-8. **[#451](https://github.com/tomacox74/js2il/issues/451)** `perf(il): expand typed temps/locals to reduce casts/boxing` - Best broad performance enabler once the current compatibility and conformance priorities relax.
-9. **[#737](https://github.com/tomacox74/js2il/issues/737)** `perf: callsite-based typed parameter specialization for non-exported functions` - Builds on the same typed fast-path direction as [#451](https://github.com/tomacox74/js2il/issues/451).
-10. **[#738](https://github.com/tomacox74/js2il/issues/738)** `perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations` - Still the umbrella Prime performance issue, but now clearly secondary to the remaining Node and `test262` work.
-11. **[#742](https://github.com/tomacox74/js2il/issues/742)** `perf(prime): trim timing/config coercion overhead in main path` - Scoped child under [#738](https://github.com/tomacox74/js2il/issues/738).
-12. **[#743](https://github.com/tomacox74/js2il/issues/743)** `perf(prime): add Prime perf acceptance gate and reporting` - Best once Prime tuning resumes.
-13. **[#746](https://github.com/tomacox74/js2il/issues/746)** `perf: make dromaeo-object-regexp faster than Jint prepared` - Valuable benchmark target, but still behind compatibility and tooling work.
-14. **[#747](https://github.com/tomacox74/js2il/issues/747)** `perf(regexp): cache Regex instances by source+flags` - Child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
-15. **[#748](https://github.com/tomacox74/js2il/issues/748)** `perf(dispatch): add RegExp fast paths in Object.CallMember1/2` - Another child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
-16. **[#768](https://github.com/tomacox74/js2il/issues/768)** `Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)` - Still scenario-specific rather than a broad ecosystem unblocker.
-17. **[#837](https://github.com/tomacox74/js2il/issues/837)** `perf(runtime): investigate DLR-backed CallMember fast path` - Remains research-heavy rather than a near-term implementation slice.
+7. **[#451](https://github.com/tomacox74/js2il/issues/451)** `perf(il): expand typed temps/locals to reduce casts/boxing` - Best broad performance enabler once the current compatibility and conformance priorities relax.
+8. **[#737](https://github.com/tomacox74/js2il/issues/737)** `perf: callsite-based typed parameter specialization for non-exported functions` - Builds on the same typed fast-path direction as [#451](https://github.com/tomacox74/js2il/issues/451).
+9. **[#738](https://github.com/tomacox74/js2il/issues/738)** `perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations` - Still the umbrella Prime performance issue, but now clearly secondary to the remaining Node and `test262` work.
+10. **[#742](https://github.com/tomacox74/js2il/issues/742)** `perf(prime): trim timing/config coercion overhead in main path` - Scoped child under [#738](https://github.com/tomacox74/js2il/issues/738).
+11. **[#743](https://github.com/tomacox74/js2il/issues/743)** `perf(prime): add Prime perf acceptance gate and reporting` - Best once Prime tuning resumes.
+12. **[#746](https://github.com/tomacox74/js2il/issues/746)** `perf: make dromaeo-object-regexp faster than Jint prepared` - Valuable benchmark target, but still behind compatibility and tooling work.
+13. **[#747](https://github.com/tomacox74/js2il/issues/747)** `perf(regexp): cache Regex instances by source+flags` - Child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
+14. **[#748](https://github.com/tomacox74/js2il/issues/748)** `perf(dispatch): add RegExp fast paths in Object.CallMember1/2` - Another child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
+15. **[#768](https://github.com/tomacox74/js2il/issues/768)** `Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)` - Still scenario-specific rather than a broad ecosystem unblocker.
+16. **[#837](https://github.com/tomacox74/js2il/issues/837)** `perf(runtime): investigate DLR-backed CallMember fast path` - Remains research-heavy rather than a near-term implementation slice.
 
 ## Execution notes
 
 - **No active review queue remains:** there are currently no open PRs, so the next work can start directly instead of finishing review branches first.
 - **Immediate top-of-stack Node track:** [#949](https://github.com/tomacox74/js2il/issues/949) -> [#956](https://github.com/tomacox74/js2il/issues/956).
-- **`test262` track:** keep [#927](https://github.com/tomacox74/js2il/issues/927) as the umbrella, then execute [#931](https://github.com/tomacox74/js2il/issues/931) -> [#932](https://github.com/tomacox74/js2il/issues/932) -> [#933](https://github.com/tomacox74/js2il/issues/933), leaving [#934](https://github.com/tomacox74/js2il/issues/934) as the deliberate post-MVP expansion bucket. The bootstrap/parser/MVP foundation [#928](https://github.com/tomacox74/js2il/issues/928)-[#930](https://github.com/tomacox74/js2il/issues/930) is already landed via PRs [#971](https://github.com/tomacox74/js2il/pull/971)-[#973](https://github.com/tomacox74/js2il/pull/973).
+- **`test262` track:** keep [#927](https://github.com/tomacox74/js2il/issues/927) as the umbrella, then execute [#932](https://github.com/tomacox74/js2il/issues/932) -> [#933](https://github.com/tomacox74/js2il/issues/933), leaving [#934](https://github.com/tomacox74/js2il/issues/934) as the deliberate post-MVP expansion bucket. The bootstrap/parser/MVP/classification foundation [#928](https://github.com/tomacox74/js2il/issues/928)-[#931](https://github.com/tomacox74/js2il/issues/931) is already landed via PRs [#971](https://github.com/tomacox74/js2il/pull/971)-[#973](https://github.com/tomacox74/js2il/pull/973) and [#975](https://github.com/tomacox74/js2il/pull/975).
 - **Architecture note:** closed issue [#841](https://github.com/tomacox74/js2il/issues/841) is now reference material for the remaining network work, not a current queue item.
 - **Performance track:** [#451](https://github.com/tomacox74/js2il/issues/451) -> [#737](https://github.com/tomacox74/js2il/issues/737) remains the best general optimization path; the Prime and regexp benchmark sub-queues stay explicitly secondary.
 
 ## Metadata gaps
 
-- Open-issue labeling still lags the actual queue: **2/17** open issues currently carry a `priority:*` label, **0/17** carry a `lane:*` label, and **10/17** have no labels at all.
-- With no open PRs and a smaller issue set after the recent merges, this triage document plus [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md) remain the clearest current ordering signals until issue metadata catches up.
+- Open-issue labeling still lags the actual queue: **2/16** open issues currently carry a `priority:*` label, **0/16** carry a `lane:*` label, and **9/16** have no labels at all.
+- With no open PRs and a smaller issue set after [#975](https://github.com/tomacox74/js2il/pull/975), this triage document plus [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md) remain the clearest current ordering signals until issue metadata catches up.

--- a/docs/tracking-issues/NodeGapPopularityBacklog.md
+++ b/docs/tracking-issues/NodeGapPopularityBacklog.md
@@ -1,6 +1,6 @@
 # Node Gap Popularity Backlog
 
-> **Last Updated**: 2026-04-13
+> **Last Updated**: 2026-04-20
 > Purpose: Persist a holistic, popularity-weighted view of the highest-value remaining Node.js gaps so triage context is not lost between sessions.
 > Scope: Node.js compatibility first, with adjacent web/runtime work called out when it directly blocks common Node workloads.
 > Active review item: none.
@@ -17,7 +17,8 @@
 
 ## Current Baseline (Snapshot)
 
-- Node docs currently track **19 modules** (**16 `partial`**, **3 `completed`**) and **16 globals** (**15 `supported`**, **1 `partial`**).
+- The JSON-backed Node docs currently track **19 modules** (**16 `partial`**, **3 `completed`**) and **16 globals** (**15 `supported`**, **1 `partial`**).
+- No Node-specific merges landed after the previous pass; the ranking below is therefore materially unchanged even though [#975](https://github.com/tomacox74/js2il/pull/975) moved the broader repo queue by closing a `test262` follow-on.
 - Several previously top-ranked gaps are now shipped on `master`:
   - `globalThis.URL` is supported and shares constructor identity with `node:url`.
   - The extractor network-mode follow-on landed, so JS2IL can now run the real `scripts/ECMA262` networking path instead of being limited to offline/manual fetch flows.

--- a/docs/tracking-issues/Phase1-TrackingIssues.md
+++ b/docs/tracking-issues/Phase1-TrackingIssues.md
@@ -7,10 +7,11 @@
 
 This document contains the historical tracking drafts for the original Phase 1 rest/spread work. The phase has already shipped on `master`; keep this file for reference only rather than as the template for new GitHub issues.
 
-## Current State (2026-04-13)
+## Current State (2026-04-20)
 
 - ✅ Phase 1 scope is long since shipped on `master` (rest parameters; spread in calls, arrays, and objects).
 - ✅ The active queue has moved on to Node compatibility, `test262` follow-ons, and the deferred performance lane.
+- ✅ The current live queue is **16 open issues / 0 open PRs**, with Node follow-ons [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956) plus `test262` umbrella [#927](https://github.com/tomacox74/js2il/issues/927) and follow-ons [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934) now taking priority instead.
 - ℹ️ Any unchecked acceptance items below are preserved as historical drafting artifacts rather than current blockers.
 
 ---
@@ -421,4 +422,4 @@ function useCustomHook(...deps) {
 ---
 
 *Generated from ECMA-262 Feature Implementation Analysis*
-*Last updated: 2026-04-13*
+*Last updated: 2026-04-20*

--- a/docs/tracking-issues/README.md
+++ b/docs/tracking-issues/README.md
@@ -15,15 +15,15 @@ These files should stay aligned with:
 2. `gh issue list` / `gh pr list`
 3. Generated support docs under `docs/nodejs` and `docs/ECMA262`
 
-## Current Repo Snapshot (2026-04-13)
+## Current Repo Snapshot (2026-04-20)
 
-- `origin/master` @ `731a54f4`
-- Open issues: **17**
+- `origin/master` @ `163cb816`
+- Open issues: **16**
 - Open PRs: **0**
-- Recent merged PRs that materially changed the queue: [#969](https://github.com/tomacox74/js2il/pull/969), [#970](https://github.com/tomacox74/js2il/pull/970), [#971](https://github.com/tomacox74/js2il/pull/971), [#972](https://github.com/tomacox74/js2il/pull/972), [#973](https://github.com/tomacox74/js2il/pull/973)
+- Recent merged PRs that materially changed the queue: [#969](https://github.com/tomacox74/js2il/pull/969), [#970](https://github.com/tomacox74/js2il/pull/970), [#971](https://github.com/tomacox74/js2il/pull/971), [#972](https://github.com/tomacox74/js2il/pull/972), [#973](https://github.com/tomacox74/js2il/pull/973), [#975](https://github.com/tomacox74/js2il/pull/975)
 - Remaining open lanes:
   - Node/runtime follow-ons: [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956)
-  - `test262` program: [#927](https://github.com/tomacox74/js2il/issues/927), [#931](https://github.com/tomacox74/js2il/issues/931)-[#934](https://github.com/tomacox74/js2il/issues/934)
+  - `test262` program: [#927](https://github.com/tomacox74/js2il/issues/927), [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934) ([#931](https://github.com/tomacox74/js2il/issues/931) closed via [#975](https://github.com/tomacox74/js2il/pull/975))
   - Performance queue: [#451](https://github.com/tomacox74/js2il/issues/451), [#737](https://github.com/tomacox74/js2il/issues/737), [#738](https://github.com/tomacox74/js2il/issues/738), [#742](https://github.com/tomacox74/js2il/issues/742), [#743](https://github.com/tomacox74/js2il/issues/743), [#746](https://github.com/tomacox74/js2il/issues/746), [#747](https://github.com/tomacox74/js2il/issues/747), [#748](https://github.com/tomacox74/js2il/issues/748), [#768](https://github.com/tomacox74/js2il/issues/768), [#837](https://github.com/tomacox74/js2il/issues/837)
 
 ## Historical Context
@@ -59,4 +59,4 @@ Feature work is not ready to merge until:
 ---
 
 *This directory supports ongoing Node compatibility, `test262`, and ECMA-262 triage.*
-*Last updated: 2026-04-13*
+*Last updated: 2026-04-20*

--- a/docs/tracking-issues/TriageScoreboard.md
+++ b/docs/tracking-issues/TriageScoreboard.md
@@ -1,9 +1,9 @@
 # JS2IL Triage Scoreboard
 
-> **Last Updated**: 2026-04-13
+> **Last Updated**: 2026-04-20
 > **Planning Horizon**: Rolling 2 weeks
 > **North Star**: Real-world unblock impact
-> **Live Queue**: 17 open issues / 0 open PRs
+> **Live Queue**: 16 open issues / 0 open PRs
 
 This file is the working source of truth for implementation prioritization.
 
@@ -15,9 +15,9 @@ This file is the working source of truth for implementation prioritization.
 
 ## Current Queue Highlights
 
-- Recent landed work: [#969](https://github.com/tomacox74/js2il/pull/969)-[#973](https://github.com/tomacox74/js2il/pull/973) delivered the extractor networking fix, the test project split, pinned `test262` intake, the metadata parser, and the MVP runner.
+- Recent landed work: [#969](https://github.com/tomacox74/js2il/pull/969)-[#973](https://github.com/tomacox74/js2il/pull/973) delivered the extractor networking fix, the test project split, pinned `test262` intake, the metadata parser, and the MVP runner; [#975](https://github.com/tomacox74/js2il/pull/975) then classified MVP results and added baseline reporting artifacts.
 - Primary open Node follow-ons are now [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956).
-- Primary open `test262` follow-ons are [#931](https://github.com/tomacox74/js2il/issues/931)-[#934](https://github.com/tomacox74/js2il/issues/934) under umbrella [#927](https://github.com/tomacox74/js2il/issues/927).
+- Primary open `test262` follow-ons are [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934) under umbrella [#927](https://github.com/tomacox74/js2il/issues/927).
 - The performance queue remains unchanged and explicitly secondary to compatibility and conformance.
 
 ## Capacity Split
@@ -58,19 +58,19 @@ Goal: improve correctness in small, reportable slices that can feed back into do
 - Produces actionable results instead of a broad, noisy failure set
 
 **Current ranked queue**
-1. [#931](https://github.com/tomacox74/js2il/issues/931) - classify negative tests, exclusions, and baselines
-2. [#932](https://github.com/tomacox74/js2il/issues/932) - add CI workflow and machine-readable reporting
-3. [#933](https://github.com/tomacox74/js2il/issues/933) - connect conformance results to ECMA-262 docs and backlog
-4. [#934](https://github.com/tomacox74/js2il/issues/934) - expand beyond the MVP to modules, async, and harness-heavy suites
-5. [#927](https://github.com/tomacox74/js2il/issues/927) remains the umbrella tracker and should stay open until the child lane is actually complete
+1. [#932](https://github.com/tomacox74/js2il/issues/932) - add CI workflow and machine-readable reporting
+2. [#933](https://github.com/tomacox74/js2il/issues/933) - connect conformance results to ECMA-262 docs and backlog
+3. [#934](https://github.com/tomacox74/js2il/issues/934) - expand beyond the MVP to modules, async, and harness-heavy suites
+4. [#927](https://github.com/tomacox74/js2il/issues/927) remains the umbrella tracker and should stay open until the child lane is actually complete
 
 **Recently delivered**
 - [#928](https://github.com/tomacox74/js2il/issues/928) - pinned intake/bootstrap
 - [#929](https://github.com/tomacox74/js2il/issues/929) - metadata/frontmatter parser
 - [#930](https://github.com/tomacox74/js2il/issues/930) - MVP runner for the narrow initial slice
+- [#931](https://github.com/tomacox74/js2il/issues/931) - classified MVP results, exclusions, and baseline outputs
 
 **Current caveat**
-- The current runner is an MVP foundation, not a broad official coverage claim. Keep automation/reporting/docs integration behind the remaining follow-ons rather than treating the landed slice as full-corpus conformance reporting.
+- The current runner now has stable MVP verdict classification and a baseline artifact, but it is still not a broad official coverage claim. Keep CI/reporting/docs integration and suite expansion behind the remaining follow-ons rather than treating the landed slice as full-corpus conformance reporting.
 
 ### Lane C - Issue Throughput + Reliability Hygiene
 
@@ -83,8 +83,8 @@ Goal: keep the issue queue actionable while preventing status-document drift.
 
 **Current queue**
 - Keep `docs/tracking-issues` synchronized after each merge tranche
-- Backfill `priority:*` labels and future `lane:*` labels on the remaining 17 open issues
-- Keep [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956), and [#931](https://github.com/tomacox74/js2il/issues/931)-[#934](https://github.com/tomacox74/js2il/issues/934) scoped with crisp acceptance criteria
+- Backfill `priority:*` labels and future `lane:*` labels on the remaining 16 open issues
+- Keep [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956), and [#927](https://github.com/tomacox74/js2il/issues/927) / [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934) scoped with crisp acceptance criteria
 - Close or retag stale issues only when the replacement scope is clearly documented
 
 ## Mandatory PR Gate (Feature Work)


### PR DESCRIPTION
## Summary
- refresh `docs/tracking-issues` to the current `master` / GitHub issue state
- account for PR #975 closing #931 and reducing the live queue to 16 open issues
- keep the Node and ECMA backlog snapshots aligned with the current source docs

## Scope
- documentation-only change