### PR TITLE
feat(test262): add CI suites and reporting workflow

### DIFF
--- a/.github/workflows/test262-mvp.yml
+++ b/.github/workflows/test262-mvp.yml
@@ -1,0 +1,277 @@
+name: test262 MVP
+run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.inputs.suite || github.head_ref || github.ref_name }}
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches: [ "master" ]
+  schedule:
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: "Named test262 MVP suite to run"
+        required: false
+        default: "pr"
+        type: choice
+        options:
+          - pr
+          - nightly
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  test262_pr:
+    name: test262 PR suite
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.suite != 'nightly') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    env:
+      TEST262_ARTIFACT_DIR: artifacts/test262/pr
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Restore dependencies
+        run: |
+          dotnet restore
+          npm ci
+
+      - name: Build JS2IL (Release)
+        run: dotnet build src/Cli/Js2IL.csproj --no-restore -c Release
+
+      - name: Bootstrap pinned test262 intake
+        run: npm run test262:bootstrap
+
+      - name: Run bounded test262 PR suite
+        run: npm run test262:run-pr -- --output "$TEST262_ARTIFACT_DIR"
+
+      - name: Append test262 PR summary
+        if: always()
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const summaryPath = path.join(process.env.TEST262_ARTIFACT_DIR, 'summary.json');
+          if (!fs.existsSync(summaryPath) || !process.env.GITHUB_STEP_SUMMARY) {
+            process.exit(0);
+          }
+
+          const report = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          const suite = report.selection && report.selection.namedSuite
+            ? report.selection.namedSuite.name
+            : 'ad-hoc';
+          const verdictCounts = report.summary && report.summary.verdictCounts ? report.summary.verdictCounts : {};
+          const kindCounts = report.summary && report.summary.kindCounts ? report.summary.kindCounts : {};
+          const lines = [
+            '## test262 MVP report',
+            '',
+            `- Suite: \`${suite}\``,
+            `- Matched: ${verdictCounts.matched || 0}`,
+            `- Unexpected: ${verdictCounts.unexpected || 0}`,
+            `- Not run: ${verdictCounts['not-run'] || 0}`,
+            `- Classified entries: ${report.selection ? report.selection.classifiedEntries : 0}`,
+            '',
+            '### Result kinds',
+            ''
+          ];
+
+          for (const [kind, count] of Object.entries(kindCounts)) {
+            lines.push(`- \`${kind}\`: ${count}`);
+          }
+
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+          NODE
+
+      - name: Upload test262 PR summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test262-pr-summary
+          path: artifacts/test262/pr/summary.json
+          if-no-files-found: error
+
+      - name: Upload test262 PR artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test262-pr-artifacts
+          path: artifacts/test262/pr
+          if-no-files-found: ignore
+
+  test262_nightly:
+    name: test262 nightly suite
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.suite == 'nightly') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    env:
+      TEST262_ARTIFACT_DIR: artifacts/test262/nightly
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Restore dependencies
+        run: |
+          dotnet restore
+          npm ci
+
+      - name: Build JS2IL (Release)
+        run: dotnet build src/Cli/Js2IL.csproj --no-restore -c Release
+
+      - name: Bootstrap pinned test262 intake
+        run: npm run test262:bootstrap
+
+      - name: Run bounded test262 nightly suite
+        run: npm run test262:run-nightly -- --output "$TEST262_ARTIFACT_DIR"
+
+      - name: Append test262 nightly summary
+        if: always()
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const summaryPath = path.join(process.env.TEST262_ARTIFACT_DIR, 'summary.json');
+          if (!fs.existsSync(summaryPath) || !process.env.GITHUB_STEP_SUMMARY) {
+            process.exit(0);
+          }
+
+          const report = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          const suite = report.selection && report.selection.namedSuite
+            ? report.selection.namedSuite.name
+            : 'ad-hoc';
+          const verdictCounts = report.summary && report.summary.verdictCounts ? report.summary.verdictCounts : {};
+          const kindCounts = report.summary && report.summary.kindCounts ? report.summary.kindCounts : {};
+          const lines = [
+            '## test262 MVP report',
+            '',
+            `- Suite: \`${suite}\``,
+            `- Matched: ${verdictCounts.matched || 0}`,
+            `- Unexpected: ${verdictCounts.unexpected || 0}`,
+            `- Not run: ${verdictCounts['not-run'] || 0}`,
+            `- Classified entries: ${report.selection ? report.selection.classifiedEntries : 0}`,
+            '',
+            '### Result kinds',
+            ''
+          ];
+
+          for (const [kind, count] of Object.entries(kindCounts)) {
+            lines.push(`- \`${kind}\`: ${count}`);
+          }
+
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+          NODE
+
+      - name: Upload test262 nightly summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test262-nightly-summary
+          path: artifacts/test262/nightly/summary.json
+          if-no-files-found: error
+
+      - name: Upload test262 nightly artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test262-nightly-artifacts
+          path: artifacts/test262/nightly
+          if-no-files-found: ignore
+
+  create-issue-on-nightly-failure:
+    name: Open issue on test262 nightly failure
+    runs-on: ubuntu-latest
+    needs: [test262_nightly]
+    if: ${{ always() && github.event_name == 'schedule' && needs.test262_nightly.result == 'failure' }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create failure issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = 'test262 nightly MVP workflow failed';
+            const label = 'test262-nightly-failure';
+            const body = [
+              'The scheduled test262 nightly MVP workflow failed.',
+              '',
+              `- Workflow run: ${runUrl}`,
+              `- Repository: ${owner}/${repo}`,
+              `- Branch: ${context.ref}`,
+              '',
+              'Please inspect the uploaded summary/artifacts and triage the regression or infrastructure issue.'
+            ].join('\n');
+
+            try {
+              const labels = await github.paginate(github.rest.issues.listLabelsForRepo, { owner, repo, per_page: 100 });
+              if (!labels.some(current => current.name === label)) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label,
+                  color: 'B60205',
+                  description: 'Automated issues for scheduled test262 nightly workflow failures'
+                });
+              }
+            } catch (error) {
+              core.info(`Could not ensure label '${label}': ${error.message}`);
+            }
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: label,
+              per_page: 100
+            });
+
+            const existing = openIssues.find(issue => issue.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body: `Another scheduled test262 nightly run has failed: ${runUrl}`
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: [label]
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- tooling/tests/docs: close issue #932 by adding named bounded test262 MVP suites for PR vs nightly runs, exposing local npm entrypoints for those suites, publishing `summary.json` artifacts from a dedicated GitHub Actions workflow, and reusing the repository's scheduled-failure issue pattern for nightly regressions while extending focused runner integration coverage.
 - tooling/tests/docs: close issue #931 by formalizing test262 MVP result kinds/verdicts, classifying parse/runtime negatives plus policy skips vs unsupported requirements, emitting a stable `summary.json` baseline artifact for each runner invocation, documenting the contract in a new ADR, and extending focused runner integration coverage.
 - tooling/tests: close issue #930 by adding a plain synchronous script MVP test262 runner that resolves the pinned checkout, filters unsupported/module/async/agent cases, executes strict/non-strict variants plus parse/runtime negatives through js2il, emits per-test outcomes with repro commands, and adds focused runner integration coverage.
 - tooling/tests: close issue #929 by adding a test262 frontmatter parser with a normalized runner-facing metadata model, explicit MVP blocker/unsupported metadata reporting, and focused integration coverage for representative strict/module/async/negative/fixture cases.

--- a/docs/adr/0007-test262-ci-suites-and-reporting-workflow.md
+++ b/docs/adr/0007-test262-ci-suites-and-reporting-workflow.md
@@ -1,0 +1,92 @@
+# ADR 0007: test262 CI Suites and Reporting Workflow
+
+- Date: 2026-04-20
+- Status: Accepted
+
+## Context
+
+Issue #932 follows the intake/bootstrap work (#928), metadata parser (#929), MVP runner (#930), and classified `summary.json` baseline artifact (#931).
+
+At this point JS2IL already has:
+
+- a local manual runner entry point (`npm run test262:run-mvp`)
+- a bounded MVP contract
+- a machine-readable summary artifact for each invocation
+
+What it still lacks is a repository-level CI/reporting story:
+
+- PR validation needs a **small deterministic smoke slice** instead of an unbounded test262 run
+- scheduled/manual GitHub runs need a **larger bounded slice**
+- CI needs to **publish** the machine-readable summary instead of keeping it local-only
+- scheduled regressions should open or update a tracking issue the same way the differential workflow already does
+
+## Decision
+
+JS2IL adds **named test262 MVP suites** plus a dedicated **`test262 MVP` GitHub Actions workflow**.
+
+## Named suites
+
+Suites are defined in `tests/test262/mvp-suites.json`.
+
+- `pr`
+  - small curated file list
+  - intended for PR and push validation
+- `nightly`
+  - broader bounded `test/language/` slice with an explicit limit
+  - intended for scheduled and manual workflow runs
+
+The runner now accepts:
+
+- `--suite <name>`
+- `--suite-config <path>` (primarily for testing/overrides)
+
+and records named-suite metadata in `summary.json` under `selection.namedSuite`.
+
+## CI workflow
+
+`.github/workflows/test262-mvp.yml` runs two bounded modes:
+
+1. **PR suite**
+   - on `pull_request`, `push`, and manual dispatch with `suite=pr`
+2. **Nightly suite**
+   - on `schedule` and manual dispatch with `suite=nightly`
+
+Both jobs:
+
+- restore dependencies
+- build JS2IL in Release
+- bootstrap the pinned test262 intake
+- run the named suite
+- upload `summary.json` as an artifact
+
+On failure, the workflow also uploads the full test262 run directory for debugging.
+
+## Failure tracking
+
+Scheduled nightly failures reuse the repository's existing scheduled-workflow issue pattern:
+
+- ensure a dedicated label exists
+- comment on an existing open tracking issue when possible
+- otherwise create a new issue with the workflow run URL
+
+This keeps nightly failures visible without spamming duplicate issues.
+
+## Consequences
+
+### Positive
+
+- Contributors and CI now share the same bounded suite definitions.
+- PR validation stays bounded and review-friendly.
+- Scheduled/manual runs publish machine-readable reports suitable for triage and backlog refreshes.
+- The nightly failure signal is explicit and durable.
+
+### Negative
+
+- The named suites are intentionally heuristic rather than comprehensive coverage claims.
+- The curated PR suite will need occasional review if the pinned upstream commit changes enough to make the chosen files less representative.
+
+### Mitigations
+
+- Keep suite definitions small and checked in for review.
+- Record the named suite in `summary.json` so historical artifacts stay attributable.
+- Keep the nightly slice bounded even as the runner grows.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,11 @@
     "test262:describe": "node scripts/test262/bootstrap.js --describe",
     "test262:root": "node scripts/test262/bootstrap.js --print-root",
     "test262:run-mvp": "node scripts/test262/runMvp.js",
-    "test262:list-mvp": "node scripts/test262/runMvp.js --list"
+    "test262:list-mvp": "node scripts/test262/runMvp.js --list",
+    "test262:run-pr": "node scripts/test262/runMvp.js --suite pr",
+    "test262:list-pr": "node scripts/test262/runMvp.js --suite pr --list",
+    "test262:run-nightly": "node scripts/test262/runMvp.js --suite nightly",
+    "test262:list-nightly": "node scripts/test262/runMvp.js --suite nightly --list"
   },
   "dependencies": {
     "turndown": "^7.2.2"

--- a/scripts/test262/runMvp.js
+++ b/scripts/test262/runMvp.js
@@ -8,6 +8,7 @@ const bootstrap = require('./bootstrap');
 const { parseTest262File } = require('./metadataParser');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DEFAULT_SUITE_CONFIG_PATH = path.join(REPO_ROOT, 'tests', 'test262', 'mvp-suites.json');
 const DEFAULT_TIMEOUT_SECONDS = 20;
 const DEFAULT_COMPILE_TIMEOUT_SECONDS = 60;
 const VALID_VARIANTS = new Set(['non-strict', 'strict']);
@@ -51,6 +52,8 @@ function printHelp() {
     '  --force                    Reuse an out-of-date managed checkout instead of failing validation.',
     '  --js2il <path>             Override the js2il executable or Js2IL.dll path.',
     '  --output <path>            Directory for generated case inputs and compiled assemblies.',
+    '  --suite <name>             Apply a named bounded suite from tests/test262/mvp-suites.json.',
+    '  --suite-config <path>      Override the named suite definition file used by --suite.',
     '  --timeout <seconds>        Per-test execution timeout (default: 20).',
     '  --compile-timeout <secs>   Per-test compile timeout (default: 60).',
     '  --file <relative-path>     Run one specific test262 file.',
@@ -69,6 +72,8 @@ function parseArgs(argv) {
     force: false,
     js2il: null,
     output: null,
+    suite: null,
+    suiteConfig: null,
     timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
     compileTimeoutSeconds: DEFAULT_COMPILE_TIMEOUT_SECONDS,
     file: null,
@@ -101,6 +106,12 @@ function parseArgs(argv) {
       case '--output':
         args.output = requireValue(argv, ++i, '--output');
         break;
+      case '--suite':
+        args.suite = requireValue(argv, ++i, '--suite');
+        break;
+      case '--suite-config':
+        args.suiteConfig = requireValue(argv, ++i, '--suite-config');
+        break;
       case '--timeout':
         args.timeoutSeconds = parsePositiveInteger(requireValue(argv, ++i, '--timeout'), '--timeout');
         break;
@@ -129,6 +140,14 @@ function parseArgs(argv) {
 
   if (args.file && args.filter) {
     throw new Error('--file and --filter cannot be used together.');
+  }
+
+  if (args.suite && (args.file || args.filter || args.limit !== null)) {
+    throw new Error('--suite cannot be combined with --file, --filter, or --limit.');
+  }
+
+  if (args.suiteConfig && !args.suite) {
+    throw new Error('--suite-config requires --suite.');
   }
 
   if (args.variant !== null && !VALID_VARIANTS.has(args.variant)) {
@@ -179,6 +198,120 @@ function defaultOutputRoot() {
 
 function defaultSummaryPath(outputRoot) {
   return path.join(outputRoot, SUMMARY_FILE_NAME);
+}
+
+function resolveSuiteConfigPath(suiteConfigPath) {
+  return path.resolve(suiteConfigPath || DEFAULT_SUITE_CONFIG_PATH);
+}
+
+function formatConfigPathForReport(filePath) {
+  const absolutePath = path.resolve(filePath);
+  const relativePath = path.relative(REPO_ROOT, absolutePath);
+  if (relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)) {
+    return normalizePortablePath(relativePath);
+  }
+
+  return normalizePortablePath(absolutePath);
+}
+
+function normalizeSuiteDefinition(name, rawDefinition, suiteConfigPath) {
+  if (!rawDefinition || typeof rawDefinition !== 'object' || Array.isArray(rawDefinition)) {
+    throw new Error(`Suite '${name}' in ${suiteConfigPath} must be an object.`);
+  }
+
+  const description = typeof rawDefinition.description === 'string' && rawDefinition.description.trim().length > 0
+    ? rawDefinition.description.trim()
+    : null;
+  const files = Array.isArray(rawDefinition.files)
+    ? rawDefinition.files.map((entry, index) => {
+      if (typeof entry !== 'string' || entry.trim().length === 0) {
+        throw new Error(`Suite '${name}' file entry #${index + 1} must be a non-empty string.`);
+      }
+
+      return normalizeRelativeTestPath(entry);
+    })
+    : null;
+  const filter = typeof rawDefinition.filter === 'string' && rawDefinition.filter.trim().length > 0
+    ? rawDefinition.filter
+    : null;
+  const limit = rawDefinition.limit === undefined || rawDefinition.limit === null
+    ? null
+    : parsePositiveInteger(String(rawDefinition.limit), `suite '${name}' limit`);
+
+  if (files !== null && files.length === 0) {
+    throw new Error(`Suite '${name}' must define at least one file when 'files' is present.`);
+  }
+
+  if (files !== null && (filter !== null || limit !== null)) {
+    throw new Error(`Suite '${name}' cannot combine 'files' with 'filter' or 'limit'.`);
+  }
+
+  if (files === null && filter === null && limit === null) {
+    throw new Error(`Suite '${name}' must define either 'files' or a bounded 'filter'/'limit' selection.`);
+  }
+
+  return {
+    name,
+    description,
+    files,
+    filter,
+    limit,
+  };
+}
+
+function loadNamedSuites(suiteConfigPath) {
+  const resolvedPath = resolveSuiteConfigPath(suiteConfigPath);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Named suite config not found: ${resolvedPath}`);
+  }
+
+  let rawValue;
+  try {
+    rawValue = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Failed to parse named suite config '${resolvedPath}': ${error.message}`);
+  }
+
+  if (!rawValue || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
+    throw new Error(`Named suite config '${resolvedPath}' must be a JSON object.`);
+  }
+
+  const suites = {};
+  const names = Object.keys(rawValue).sort();
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    suites[name] = normalizeSuiteDefinition(name, rawValue[name], resolvedPath);
+  }
+
+  return {
+    path: resolvedPath,
+    suites,
+  };
+}
+
+function applyNamedSuite(args) {
+  if (!args.suite) {
+    return args;
+  }
+
+  const suiteConfig = loadNamedSuites(args.suiteConfig);
+  const suiteDefinition = suiteConfig.suites[args.suite];
+  if (!suiteDefinition) {
+    const available = Object.keys(suiteConfig.suites);
+    throw new Error(
+      available.length === 0
+        ? `No named suites are defined in ${suiteConfig.path}.`
+        : `Unknown suite '${args.suite}'. Available suites: ${available.join(', ')}.`
+    );
+  }
+
+  return Object.assign({}, args, {
+    filter: suiteDefinition.filter,
+    limit: suiteDefinition.limit,
+    suiteDefinition,
+    suiteConfigPath: suiteConfig.path,
+    suiteFiles: suiteDefinition.files ? suiteDefinition.files.slice() : null,
+  });
 }
 
 function collectCandidateFiles(rootPath, pin) {
@@ -418,7 +551,29 @@ function createSelectionResult(relativePath, metadata, kind, reasons, detail) {
 
 function createExecutionPlan(rootPath, pin, args) {
   const discoveredFiles = collectCandidateFiles(rootPath, pin);
-  let selectedFiles = discoveredFiles.slice();
+  let selectedFiles;
+
+  if (Array.isArray(args.suiteFiles) && args.suiteFiles.length > 0) {
+    const discoveredSet = new Set(discoveredFiles);
+    const seen = new Set();
+    selectedFiles = [];
+
+    for (let i = 0; i < args.suiteFiles.length; i++) {
+      const relativePath = normalizeRelativeTestPath(args.suiteFiles[i]);
+      if (!discoveredSet.has(relativePath)) {
+        throw new Error(`Suite-selected test file was not found in the pinned intake: ${relativePath}`);
+      }
+
+      if (seen.has(relativePath)) {
+        continue;
+      }
+
+      seen.add(relativePath);
+      selectedFiles.push(relativePath);
+    }
+  } else {
+    selectedFiles = discoveredFiles.slice();
+  }
 
   if (args.file) {
     selectedFiles = selectedFiles.filter(relativePath => relativePath === args.file);
@@ -1053,6 +1208,10 @@ function createCountMap(results, selector, orderedKeys) {
 }
 
 function createSummaryReport(pin, args, plan, results, exitCode) {
+  const suiteConfigPath = args.suiteConfigPath
+    ? formatConfigPathForReport(args.suiteConfigPath)
+    : null;
+
   return {
     schemaVersion: SUMMARY_SCHEMA_VERSION,
     suite: 'js2il-test262-mvp',
@@ -1079,6 +1238,12 @@ function createSummaryReport(pin, args, plan, results, exitCode) {
       },
     },
     selection: {
+      namedSuite: args.suiteDefinition ? {
+        name: args.suiteDefinition.name,
+        description: args.suiteDefinition.description,
+        sourceConfig: suiteConfigPath || normalizePortablePath(args.suiteConfigPath),
+        files: args.suiteDefinition.files ? args.suiteDefinition.files.slice() : null,
+      } : null,
       file: args.file,
       filter: args.filter,
       limit: args.limit,
@@ -1104,6 +1269,9 @@ function writeSummaryReport(summaryPath, report) {
 function printPlanHeader(rootPath, outputRoot, js2il, plan, args) {
   console.log(`root ${rootPath}`);
   console.log(`js2il ${js2il.path}`);
+  if (args.suiteDefinition) {
+    console.log(`suite ${args.suiteDefinition.name}`);
+  }
   if (!args.list) {
     console.log(`output ${outputRoot}`);
   }
@@ -1113,7 +1281,7 @@ function printPlanHeader(rootPath, outputRoot, js2il, plan, args) {
 }
 
 function runMvp(argv) {
-  const args = parseArgs(argv);
+  const args = applyNamedSuite(parseArgs(argv));
   if (args.help) {
     printHelp();
     return 0;
@@ -1175,6 +1343,7 @@ module.exports = {
   createExecutionPlan,
   determineVariants,
   findJs2IL,
+  loadNamedSuites,
   parseArgs,
   runMvp,
 };

--- a/tests/Js2IL.Test262.Tests/Integration/RunnerCliTests.cs
+++ b/tests/Js2IL.Test262.Tests/Integration/RunnerCliTests.cs
@@ -61,6 +61,52 @@ public class RunnerCliTests
         return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path, outputRoot));
     }
 
+    [Fact]
+    public Task RunMvp_UsesNamedSuiteSelection()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string test262Root = CreateTest262Fixture(tempDirectory.Path, includeFailingPositive: false);
+        string outputRoot = Path.Combine(tempDirectory.Path, "runner-output");
+        string suiteConfigPath = CreateSuiteConfigFile(
+            tempDirectory.Path,
+            [
+                "test/language/mvp/basic-pass.js",
+                "test/language/mvp/runtime-negative.js",
+            ]);
+
+        RunnerResult result = RunRunner(
+            test262Root,
+            outputRoot,
+            $" --suite pr --suite-config \"{suiteConfigPath}\"");
+
+        Assert.Equal(0, result.ExitCode);
+
+        return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path, outputRoot));
+    }
+
+    [Fact]
+    public Task RunMvp_RejectsSuiteWhenCombinedWithAdHocSelection()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string test262Root = CreateTest262Fixture(tempDirectory.Path, includeFailingPositive: false);
+        string outputRoot = Path.Combine(tempDirectory.Path, "runner-output");
+        string suiteConfigPath = CreateSuiteConfigFile(
+            tempDirectory.Path,
+            [
+                "test/language/mvp/basic-pass.js",
+                "test/language/mvp/runtime-negative.js",
+            ]);
+
+        RunnerResult result = RunRunner(
+            test262Root,
+            outputRoot,
+            $" --suite pr --suite-config \"{suiteConfigPath}\" --limit 1");
+
+        Assert.Equal(1, result.ExitCode);
+
+        return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path, outputRoot));
+    }
+
     private static RunnerResult RunRunner(string test262Root, string outputRoot, string extraArguments = "", int timeoutMilliseconds = 180000)
     {
         string repoRoot = FindRepoRoot();
@@ -152,6 +198,34 @@ public class RunnerCliTests
             """.ReplaceLineEndings("\n"));
 
         return pinPath;
+    }
+
+    private static string CreateSuiteConfigFile(string root, IReadOnlyList<string> prFiles)
+    {
+        string suitePath = Path.Combine(root, "fixture.suites.json");
+        string filesJson = string.Join(
+            ",\n",
+            prFiles.Select(entry => $"      \"{entry.Replace("\\", "\\\\")}\""));
+
+        File.WriteAllText(
+            suitePath,
+            $$"""
+            {
+              "pr": {
+                "description": "fixture PR suite",
+                "files": [
+            {{filesJson}}
+                ]
+              },
+              "nightly": {
+                "description": "fixture nightly suite",
+                "filter": "test/language/mvp",
+                "limit": 3
+              }
+            }
+            """.ReplaceLineEndings("\n"));
+
+        return suitePath;
     }
 
     private static string CreateTest262Fixture(string root, bool includeFailingPositive, bool includeClassificationEdges = false)

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ClassifiesPolicyWrongPhaseAndWrongErrorKind.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ClassifiesPolicyWrongPhaseAndWrongErrorKind.verified.txt
@@ -45,6 +45,7 @@ summary.json:
     }
   },
   "selection": {
+    "namedSuite": null,
     "file": null,
     "filter": "classification-",
     "limit": null,

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ExecutesStableSubset.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ExecutesStableSubset.verified.txt
@@ -49,6 +49,7 @@ summary.json:
     }
   },
   "selection": {
+    "namedSuite": null,
     "file": null,
     "filter": null,
     "limit": null,

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_RejectsSuiteWhenCombinedWithAdHocSelection.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_RejectsSuiteWhenCombinedWithAdHocSelection.verified.txt
@@ -1,0 +1,5 @@
+﻿exit: 1
+stdout:
+
+stderr:
+--suite cannot be combined with --file, --filter, or --limit.

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ReportsFailureWithRepro.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ReportsFailureWithRepro.verified.txt
@@ -44,6 +44,7 @@ summary.json:
     }
   },
   "selection": {
+    "namedSuite": null,
     "file": "test/language/mvp/fail-positive.js",
     "filter": null,
     "limit": null,

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_UsesNamedSuiteSelection.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_UsesNamedSuiteSelection.verified.txt
@@ -1,0 +1,187 @@
+﻿exit: 0
+stdout:
+root <temp>/test262-root
+js2il <repo>/src/Cli/bin/<configuration>/net10.0/Js2IL.dll
+suite pr
+output <temp>/runner-output
+discovered 6
+selected-files 2
+selected-cases 3
+PASS test/language/mvp/basic-pass.js [non-strict] positive
+PASS test/language/mvp/basic-pass.js [strict] positive
+RUNTIME-REJECTION test/language/mvp/runtime-negative.js [non-strict] matched negative(runtime:TypeError)
+SUMMARY matched=3 unexpected=0 not-run=0 selected=3 classified=3 pass=2 runtime-rejection=1
+REPORT <temp>/runner-output/summary.json
+summary.json:
+{
+  "schemaVersion": 1,
+  "suite": "js2il-test262-mvp",
+  "pin": {
+    "commit": "2b2ecead6e828dd9af13a9ec72065e645724a50f",
+    "packageVersion": "5.0.0"
+  },
+  "policy": {
+    "pathExclusions": [
+      "test/annexB/**",
+      "test/intl402/**",
+      "test/staging/**"
+    ],
+    "unsupportedResultSources": [
+      "metadata.unsupported",
+      "metadata.mvpBlockers"
+    ],
+    "negativeExpectations": {
+      "parse": {
+        "expectedObservedPhase": "compile",
+        "validateErrorType": false
+      },
+      "runtime": {
+        "expectedObservedPhase": "runtime",
+        "validateErrorType": true
+      }
+    },
+    "baselineArtifact": {
+      "fileName": "summary.json",
+      "format": "js2il-test262-summary-v1"
+    }
+  },
+  "selection": {
+    "namedSuite": {
+      "name": "pr",
+      "description": "fixture PR suite",
+      "sourceConfig": "<temp>/fixture.suites.json",
+      "files": [
+        "test/language/mvp/basic-pass.js",
+        "test/language/mvp/runtime-negative.js"
+      ]
+    },
+    "file": null,
+    "filter": null,
+    "limit": null,
+    "variant": null,
+    "discoveredFiles": 6,
+    "selectedFiles": 2,
+    "selectedCases": 3,
+    "classifiedEntries": 3
+  },
+  "summary": {
+    "exitCode": 0,
+    "verdictCounts": {
+      "matched": 3
+    },
+    "kindCounts": {
+      "pass": 2,
+      "runtime-rejection": 1
+    }
+  },
+  "results": [
+    {
+      "id": "test/language/mvp/basic-pass.js#non-strict",
+      "relativePath": "test/language/mvp/basic-pass.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "pass",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "positive"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "passed",
+          "exitCode": 0,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/basic-pass.js",
+        "variant": "non-strict"
+      }
+    },
+    {
+      "id": "test/language/mvp/basic-pass.js#strict",
+      "relativePath": "test/language/mvp/basic-pass.js",
+      "variant": "strict",
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "pass",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "positive"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "passed",
+          "exitCode": 0,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/basic-pass.js",
+        "variant": "strict"
+      }
+    },
+    {
+      "id": "test/language/mvp/runtime-negative.js#non-strict",
+      "relativePath": "test/language/mvp/runtime-negative.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "negative",
+        "phase": "runtime",
+        "errorType": "TypeError",
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "runtime-rejection",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "matched negative(runtime:TypeError)"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "rejected",
+          "exitCode": 1,
+          "errorType": "TypeError",
+          "summary": "TypeError: runtime boom"
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/runtime-negative.js",
+        "variant": "non-strict"
+      }
+    }
+  ]
+}

--- a/tests/test262/mvp-suites.json
+++ b/tests/test262/mvp-suites.json
@@ -1,0 +1,32 @@
+{
+  "pr": {
+    "description": "Small deterministic smoke slice for pull requests and push validation.",
+    "files": [
+      "test/language/arguments-object/10.5-1gs.js",
+      "test/language/arguments-object/10.5-7-b-2-s.js",
+      "test/language/arguments-object/10.6-12-1.js",
+      "test/language/expressions/arrow-function/array-destructuring-param-strict-body.js",
+      "test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-1.js",
+      "test/language/statements/for-of/array-contract.js"
+    ]
+  },
+  "nightly": {
+    "description": "Broader deterministic passing MVP slice for scheduled and manual conformance tracking.",
+    "files": [
+      "test/language/arguments-object/10.5-1gs.js",
+      "test/language/arguments-object/10.5-7-b-2-s.js",
+      "test/language/arguments-object/10.5-7-b-3-s.js",
+      "test/language/arguments-object/10.5-7-b-4-s.js",
+      "test/language/arguments-object/10.6-10-c-ii-1-s.js",
+      "test/language/arguments-object/10.6-10-c-ii-1.js",
+      "test/language/arguments-object/10.6-10-c-ii-2.js",
+      "test/language/arguments-object/10.6-12-1.js",
+      "test/language/expressions/arrow-function/array-destructuring-param-strict-body.js",
+      "test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-1.js",
+      "test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-2.js",
+      "test/language/statements/for-of/array-contract.js",
+      "test/language/statements/for-of/array-contract-expand.js",
+      "test/language/statements/for-of/array-expand-contract.js"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add named bounded test262 MVP suites plus local npm entrypoints for PR and nightly runs
- publish machine-readable `summary.json` artifacts from a dedicated GitHub Actions workflow and open an issue on scheduled nightly failures
- record the CI/reporting strategy in a new ADR and extend focused runner integration coverage

## Testing
- dotnet test .\tests\Js2IL.Test262.Tests\Js2IL.Test262.Tests.csproj -c Release /p:IsTestProject=true --nologo
- node .\scripts\test262\runMvp.js --suite pr --output .\artifacts\test262\local-pr-validation
- node .\scripts\test262\runMvp.js --suite nightly --output .\artifacts\test262\local-nightly-validation

Closes #932