### PR TITLE
docs(test262): link conformance results to ecma backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- tooling/tests/docs: close issue #933 by mapping bounded test262 MVP results back to ECMA-262 support docs and backlog ownership through a checked-in linkage manifest, annotating `summary.json` with clause/doc linkage, surfacing test262 evidence in the relevant ECMA-262 section docs, and documenting when linked failures should update docs vs attach to or create issues.
 - tooling/tests/docs: close issue #932 by adding named bounded test262 MVP suites for PR vs nightly runs, exposing local npm entrypoints for those suites, publishing `summary.json` artifacts from a dedicated GitHub Actions workflow, and reusing the repository's scheduled-failure issue pattern for nightly regressions while extending focused runner integration coverage.
 - tooling/tests/docs: close issue #931 by formalizing test262 MVP result kinds/verdicts, classifying parse/runtime negatives plus policy skips vs unsupported requirements, emitting a stable `summary.json` baseline artifact for each runner invocation, documenting the contract in a new ADR, and extending focused runner integration coverage.
 - tooling/tests: close issue #930 by adding a plain synchronous script MVP test262 runner that resolves the pinned checkout, filters unsupported/module/async/agent cases, executes strict/non-strict variants plus parse/runtime negatives through js2il, emits per-test outcomes with repro commands, and adds focused runner integration coverage.

--- a/docs/ECMA262/10/Section10_4.json
+++ b/docs/ECMA262/10/Section10_4.json
@@ -414,7 +414,21 @@
           "tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_MappedParameterAliasing.js",
           "tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_Unmapped_StrictAndComplex.js"
         ],
-        "notes": "When referenced, non-arrow functions now materialize a dedicated arguments object. Non-strict functions with simple parameter lists use mapped aliasing against parameter storage, while strict-mode and complex-parameter functions use unmapped snapshot semantics. Basic length/indexed access, deletion, and own-key enumeration now work for the covered cases, but full [[DefineOwnProperty]] invariants, callee/caller legacy details, and the exact accessor-helper machinery from 10.4.4.7 remain incomplete."
+        "test262Suites": [
+          "pr",
+          "nightly"
+        ],
+        "test262Paths": [
+          "test/language/arguments-object/10.5-1gs.js",
+          "test/language/arguments-object/10.5-7-b-2-s.js",
+          "test/language/arguments-object/10.5-7-b-3-s.js",
+          "test/language/arguments-object/10.5-7-b-4-s.js",
+          "test/language/arguments-object/10.6-10-c-ii-1-s.js",
+          "test/language/arguments-object/10.6-10-c-ii-1.js",
+          "test/language/arguments-object/10.6-10-c-ii-2.js",
+          "test/language/arguments-object/10.6-12-1.js"
+        ],
+        "notes": "When referenced, non-arrow functions now materialize a dedicated arguments object. Non-strict functions with simple parameter lists use mapped aliasing against parameter storage, while strict-mode and complex-parameter functions use unmapped snapshot semantics. Basic length/indexed access, deletion, and own-key enumeration now work for the covered cases, but full [[DefineOwnProperty]] invariants, callee/caller legacy details, and the exact accessor-helper machinery from 10.4.4.7 remain incomplete. The current bounded test262 MVP suites exercise both parse-negative strict-mode handling and mapped/unmapped arguments cases in this area."
       },
       {
         "clause": "10.4.5",

--- a/docs/ECMA262/10/Section10_4.md
+++ b/docs/ECMA262/10/Section10_4.md
@@ -4,7 +4,7 @@
 
 [Back to Section10](Section10.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-29T05:07:03Z
+> Last generated (UTC): 2026-04-20T14:39:44Z
 
 JS2IL implements a pragmatic subset of spec-defined exotic-object behavior for the features it currently supports. Arrays, bound functions, typed arrays, and namespace imports expose useful observable behavior, but the engine does not model true exotic internal methods/slots with full ECMA-262 invariants.
 
@@ -80,41 +80,41 @@ JS2IL implements a pragmatic subset of spec-defined exotic-object behavior for t
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 10.4.1 ([tc39.es](https://tc39.es/ecma262/#sec-bound-function-exotic-objects))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Bound functions created by Function.prototype.bind | Supported with Limitations | [`Function_Bind_Basic_PartialApplication.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Bind_Basic_PartialApplication.js)<br>[`Function_Bind_ThisBinding_IgnoresCallReceiver.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Bind_ThisBinding_IgnoresCallReceiver.js)<br>[`Function_Prototype_Bind_PropertyExists.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Prototype_Bind_PropertyExists.js) | bind creates wrapper delegates with captured this/arguments and remembers the original target for metadata lookups. Bound call semantics are useful in practice, but bound-function construction and true [[BoundTargetFunction]] / [[BoundArguments]] slot semantics remain incomplete. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Bound functions created by Function.prototype.bind | Supported with Limitations | [`Function_Bind_Basic_PartialApplication.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Bind_Basic_PartialApplication.js)<br>[`Function_Bind_ThisBinding_IgnoresCallReceiver.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Bind_ThisBinding_IgnoresCallReceiver.js)<br>[`Function_Prototype_Bind_PropertyExists.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Prototype_Bind_PropertyExists.js) |  | bind creates wrapper delegates with captured this/arguments and remembers the original target for metadata lookups. Bound call semantics are useful in practice, but bound-function construction and true [[BoundTargetFunction]] / [[BoundArguments]] slot semantics remain incomplete. |
 
 ### 10.4.2 ([tc39.es](https://tc39.es/ecma262/#sec-array-exotic-objects))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Array exotic indexing and length behavior | Supported with Limitations | [`Array_New_Length.js`](../../../tests/Js2IL.Tests/Array/JavaScript/Array_New_Length.js)<br>[`Array_New_MultipleArgs.js`](../../../tests/Js2IL.Tests/Array/JavaScript/Array_New_MultipleArgs.js)<br>[`Array_Length_Set_Fractional_ThrowsRangeError.js`](../../../tests/Js2IL.Tests/Array/JavaScript/Array_Length_Set_Fractional_ThrowsRangeError.js) | Arrays support numeric element access, length-based construction, and range-checked length writes that truncate or extend the backing store. The specialized [[DefineOwnProperty]] / ArraySpeciesCreate machinery is still only partially modeled. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Array exotic indexing and length behavior | Supported with Limitations | [`Array_New_Length.js`](../../../tests/Js2IL.Tests/Array/JavaScript/Array_New_Length.js)<br>[`Array_New_MultipleArgs.js`](../../../tests/Js2IL.Tests/Array/JavaScript/Array_New_MultipleArgs.js)<br>[`Array_Length_Set_Fractional_ThrowsRangeError.js`](../../../tests/Js2IL.Tests/Array/JavaScript/Array_Length_Set_Fractional_ThrowsRangeError.js) |  | Arrays support numeric element access, length-based construction, and range-checked length writes that truncate or extend the backing store. The specialized [[DefineOwnProperty]] / ArraySpeciesCreate machinery is still only partially modeled. |
 
 ### 10.4.4 ([tc39.es](https://tc39.es/ecma262/#sec-arguments-exotic-objects))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Arguments objects materialize with mapped/unmapped exotic-object basics | Supported with Limitations | [`Function_Arguments_Basics.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_Basics.js)<br>[`Function_Arguments_ComputedKey_TriggersBinding.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_ComputedKey_TriggersBinding.js)<br>[`Function_Arguments_MappedParameterAliasing.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_MappedParameterAliasing.js)<br>[`Function_Arguments_Unmapped_StrictAndComplex.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_Unmapped_StrictAndComplex.js) | When referenced, non-arrow functions now materialize a dedicated arguments object. Non-strict functions with simple parameter lists use mapped aliasing against parameter storage, while strict-mode and complex-parameter functions use unmapped snapshot semantics. Basic length/indexed access, deletion, and own-key enumeration now work for the covered cases, but full [[DefineOwnProperty]] invariants, callee/caller legacy details, and the exact accessor-helper machinery from 10.4.4.7 remain incomplete. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Arguments objects materialize with mapped/unmapped exotic-object basics | Supported with Limitations | [`Function_Arguments_Basics.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_Basics.js)<br>[`Function_Arguments_ComputedKey_TriggersBinding.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_ComputedKey_TriggersBinding.js)<br>[`Function_Arguments_MappedParameterAliasing.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_MappedParameterAliasing.js)<br>[`Function_Arguments_Unmapped_StrictAndComplex.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Arguments_Unmapped_StrictAndComplex.js) | suite `pr`<br>suite `nightly`<br>`test/language/arguments-object/10.5-1gs.js`<br>`test/language/arguments-object/10.5-7-b-2-s.js`<br>`test/language/arguments-object/10.5-7-b-3-s.js`<br>`test/language/arguments-object/10.5-7-b-4-s.js`<br>`test/language/arguments-object/10.6-10-c-ii-1-s.js`<br>`test/language/arguments-object/10.6-10-c-ii-1.js`<br>`test/language/arguments-object/10.6-10-c-ii-2.js`<br>`test/language/arguments-object/10.6-12-1.js` | When referenced, non-arrow functions now materialize a dedicated arguments object. Non-strict functions with simple parameter lists use mapped aliasing against parameter storage, while strict-mode and complex-parameter functions use unmapped snapshot semantics. Basic length/indexed access, deletion, and own-key enumeration now work for the covered cases, but full [[DefineOwnProperty]] invariants, callee/caller legacy details, and the exact accessor-helper machinery from 10.4.4.7 remain incomplete. The current bounded test262 MVP suites exercise both parse-negative strict-mode handling and mapped/unmapped arguments cases in this area. |
 
 ### 10.4.5 ([tc39.es](https://tc39.es/ecma262/#sec-typedarray-exotic-objects))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Int32Array construction, element access, and integer-index semantics | Supported with Limitations | [`Int32Array_Construct_Length.js`](../../../tests/Js2IL.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js)<br>[`Int32Array_Index_Assign.js`](../../../tests/Js2IL.Tests/TypedArray/JavaScript/Int32Array_Index_Assign.js)<br>[`Int32Array_FromArray_CopyAndCoerce.js`](../../../tests/Js2IL.Tests/TypedArray/JavaScript/Int32Array_FromArray_CopyAndCoerce.js)<br>[`Int32Array_NaN_Index_NoOp.js`](../../../tests/Js2IL.Tests/TypedArray/JavaScript/Int32Array_NaN_Index_NoOp.js) | JS2IL currently implements only Int32Array, with construction from length/iterables, integer index reads and writes, and pragmatic out-of-bounds handling. It does not model ArrayBuffer-backed typed-array witness records, detach/out-of-bounds abstract operations, or the full family of typed array exotics. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Int32Array construction, element access, and integer-index semantics | Supported with Limitations | [`Int32Array_Construct_Length.js`](../../../tests/Js2IL.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js)<br>[`Int32Array_Index_Assign.js`](../../../tests/Js2IL.Tests/TypedArray/JavaScript/Int32Array_Index_Assign.js)<br>[`Int32Array_FromArray_CopyAndCoerce.js`](../../../tests/Js2IL.Tests/TypedArray/JavaScript/Int32Array_FromArray_CopyAndCoerce.js)<br>[`Int32Array_NaN_Index_NoOp.js`](../../../tests/Js2IL.Tests/TypedArray/JavaScript/Int32Array_NaN_Index_NoOp.js) |  | JS2IL currently implements only Int32Array, with construction from length/iterables, integer index reads and writes, and pragmatic out-of-bounds handling. It does not model ArrayBuffer-backed typed-array witness records, detach/out-of-bounds abstract operations, or the full family of typed array exotics. |
 
 ### 10.4.6 ([tc39.es](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Namespace import interop objects with live getter properties | Supported with Limitations | [`Import_Namespace_Esm_Basic.js`](../../../tests/Js2IL.Tests/Import/JavaScript/Import_Namespace_Esm_Basic.js)<br>[`Import_Namespace_FromCjs_Stable.js`](../../../tests/Js2IL.Tests/Import/JavaScript/Import_Namespace_FromCjs_Stable.js) | JSImport namespace lowering rewrites imports to a helper that builds a plain object with accessor descriptors for live reads of exported members. That captures common namespace-import behavior, but the result is not a true Module Namespace Exotic Object with the full non-extensible, non-configurable invariant set from the spec. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Namespace import interop objects with live getter properties | Supported with Limitations | [`Import_Namespace_Esm_Basic.js`](../../../tests/Js2IL.Tests/Import/JavaScript/Import_Namespace_Esm_Basic.js)<br>[`Import_Namespace_FromCjs_Stable.js`](../../../tests/Js2IL.Tests/Import/JavaScript/Import_Namespace_FromCjs_Stable.js) |  | JSImport namespace lowering rewrites imports to a helper that builds a plain object with accessor descriptors for live reads of exported members. That captures common namespace-import behavior, but the result is not a true Module Namespace Exotic Object with the full non-extensible, non-configurable invariant set from the spec. |
 
 ### 10.4.7 ([tc39.es](https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Immutable prototype exotic invariants | Not Yet Supported |  | JS2IL does not currently model any object with a dedicated immutable-prototype exotic internal method. Prototype mutation is handled through the ordinary PrototypeChain side-table instead. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Immutable prototype exotic invariants | Not Yet Supported |  |  | JS2IL does not currently model any object with a dedicated immutable-prototype exotic internal method. Prototype mutation is handled through the ordinary PrototypeChain side-table instead. |
 

--- a/docs/ECMA262/14/Section14_7.json
+++ b/docs/ECMA262/14/Section14_7.json
@@ -385,7 +385,16 @@
           "tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledBreak.js",
           "tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js"
         ],
-        "notes": "Lowered using the iterator protocol via JavaScriptRuntime.Object.GetIterator + iterator.next() + result.value/result.done, and invokes JavaScriptRuntime.Object.IteratorClose on abrupt completion (break/throw/return and iterator throws). Supports built-ins (Array/string/Int32Array), user-defined iterables via [Symbol.iterator], and a best-effort fallback for .NET IEnumerable."
+        "test262Suites": [
+          "pr",
+          "nightly"
+        ],
+        "test262Paths": [
+          "test/language/statements/for-of/array-contract.js",
+          "test/language/statements/for-of/array-contract-expand.js",
+          "test/language/statements/for-of/array-expand-contract.js"
+        ],
+        "notes": "Lowered using the iterator protocol via JavaScriptRuntime.Object.GetIterator + iterator.next() + result.value/result.done, and invokes JavaScriptRuntime.Object.IteratorClose on abrupt completion (break/throw/return and iterator throws). Supports built-ins (Array/string/Int32Array), user-defined iterables via [Symbol.iterator], and a best-effort fallback for .NET IEnumerable. The current bounded test262 MVP suites cover the common array for-of contract and expansion paths here."
       },
       {
         "clause": "14.7.5.7",

--- a/docs/ECMA262/14/Section14_7.md
+++ b/docs/ECMA262/14/Section14_7.md
@@ -4,7 +4,7 @@
 
 [Back to Section14](Section14.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-04-20T14:39:44Z
 
 do/while/for loops are supported including break/continue (with labels). for..of uses the iterator protocol; for..in uses a dedicated For-In Iterator (mutation-aware key enumeration) but does not yet provide full spec fidelity for all exotic objects. for await..of is supported in async functions.
 
@@ -48,57 +48,57 @@ do/while/for loops are supported including break/continue (with labels). for..of
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 14.7.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-dowhileloopevaluation))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| do-while loop (CountDownFromFive) | Supported | [`ControlFlow_DoWhile_CountDownFromFive.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_CountDownFromFive.js) |  |
-| do-while loop: break | Supported | [`ControlFlow_DoWhile_Break_AtThree.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_Break_AtThree.js) | break branches to loop end (LoopContext). |
-| do-while loop: continue (skip even) | Supported | [`ControlFlow_DoWhile_Continue_SkipEven.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_Continue_SkipEven.js) | continue branches to the post-body test point (LoopContext). |
-| do-while loop: labeled break | Supported | [`ControlFlow_DoWhile_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_LabeledBreak.js) | Supports break <label> where <label> targets an enclosing loop. |
-| do-while loop: labeled continue | Supported | [`ControlFlow_DoWhile_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_LabeledContinue.js) | Supports continue <label> where <label> targets an enclosing loop. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| do-while loop (CountDownFromFive) | Supported | [`ControlFlow_DoWhile_CountDownFromFive.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_CountDownFromFive.js) |  |  |
+| do-while loop: break | Supported | [`ControlFlow_DoWhile_Break_AtThree.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_Break_AtThree.js) |  | break branches to loop end (LoopContext). |
+| do-while loop: continue (skip even) | Supported | [`ControlFlow_DoWhile_Continue_SkipEven.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_Continue_SkipEven.js) |  | continue branches to the post-body test point (LoopContext). |
+| do-while loop: labeled break | Supported | [`ControlFlow_DoWhile_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_LabeledBreak.js) |  | Supports break <label> where <label> targets an enclosing loop. |
+| do-while loop: labeled continue | Supported | [`ControlFlow_DoWhile_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_DoWhile_LabeledContinue.js) |  | Supports continue <label> where <label> targets an enclosing loop. |
 
 ### 14.7.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-whileloopevaluation))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| while loop (CountDownFromFive) | Supported | [`ControlFlow_While_CountDownFromFive.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_CountDownFromFive.js) |  |
-| while loop: break | Supported | [`ControlFlow_While_Break_AtThree.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_Break_AtThree.js) | break branches to loop end (LoopContext). |
-| while loop: continue (skip even) | Supported | [`ControlFlow_While_Continue_SkipEven.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_Continue_SkipEven.js) | continue branches to loop head (LoopContext). |
-| while loop: labeled break | Supported | [`ControlFlow_While_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_LabeledBreak.js) | Supports break <label> where <label> targets an enclosing loop. |
-| while loop: labeled continue | Supported | [`ControlFlow_While_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_LabeledContinue.js) | Supports continue <label> where <label> targets an enclosing loop. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| while loop (CountDownFromFive) | Supported | [`ControlFlow_While_CountDownFromFive.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_CountDownFromFive.js) |  |  |
+| while loop: break | Supported | [`ControlFlow_While_Break_AtThree.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_Break_AtThree.js) |  | break branches to loop end (LoopContext). |
+| while loop: continue (skip even) | Supported | [`ControlFlow_While_Continue_SkipEven.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_Continue_SkipEven.js) |  | continue branches to loop head (LoopContext). |
+| while loop: labeled break | Supported | [`ControlFlow_While_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_LabeledBreak.js) |  | Supports break <label> where <label> targets an enclosing loop. |
+| while loop: labeled continue | Supported | [`ControlFlow_While_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_While_LabeledContinue.js) |  | Supports continue <label> where <label> targets an enclosing loop. |
 
 ### 14.7.4.2 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-forloopevaluation))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| for loop (CountDownFromFive) | Supported | [`ControlFlow_ForLoop_CountDownFromFive.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_CountDownFromFive.js) |  |
-| for loop (CountToFive) | Supported | [`ControlFlow_ForLoop_CountToFive.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_CountToFive.js) |  |
-| for loop (GreaterThanOrEqual) | Supported | [`ControlFlow_ForLoop_GreaterThanOrEqual.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_GreaterThanOrEqual.js) |  |
-| for loop (LessThanOrEqual) | Supported | [`ControlFlow_ForLoop_LessThanOrEqual.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LessThanOrEqual.js) |  |
-| for loop: break | Supported | [`ControlFlow_ForLoop_Break_AtThree.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_Break_AtThree.js) | Implements break by branching to loop end label (LoopContext). |
-| for loop: continue | Supported | [`ControlFlow_ForLoop_Continue_SkipEven.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_Continue_SkipEven.js) | Implements continue by branching to the update expression (LoopContext). |
-| for loop: labeled break | Supported | [`ControlFlow_ForLoop_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LabeledBreak.js) | Supports break <label> where <label> targets an enclosing loop. |
-| for loop: labeled continue | Supported | [`ControlFlow_ForLoop_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LabeledContinue.js) | Supports continue <label> where <label> targets an enclosing loop. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| for loop (CountDownFromFive) | Supported | [`ControlFlow_ForLoop_CountDownFromFive.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_CountDownFromFive.js) |  |  |
+| for loop (CountToFive) | Supported | [`ControlFlow_ForLoop_CountToFive.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_CountToFive.js) |  |  |
+| for loop (GreaterThanOrEqual) | Supported | [`ControlFlow_ForLoop_GreaterThanOrEqual.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_GreaterThanOrEqual.js) |  |  |
+| for loop (LessThanOrEqual) | Supported | [`ControlFlow_ForLoop_LessThanOrEqual.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LessThanOrEqual.js) |  |  |
+| for loop: break | Supported | [`ControlFlow_ForLoop_Break_AtThree.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_Break_AtThree.js) |  | Implements break by branching to loop end label (LoopContext). |
+| for loop: continue | Supported | [`ControlFlow_ForLoop_Continue_SkipEven.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_Continue_SkipEven.js) |  | Implements continue by branching to the update expression (LoopContext). |
+| for loop: labeled break | Supported | [`ControlFlow_ForLoop_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LabeledBreak.js) |  | Supports break <label> where <label> targets an enclosing loop. |
+| for loop: labeled continue | Supported | [`ControlFlow_ForLoop_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LabeledContinue.js) |  | Supports continue <label> where <label> targets an enclosing loop. |
 
 ### 14.7.4.4 ([tc39.es](https://tc39.es/ecma262/#sec-createperiterationenvironment))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| for-loop per-iteration lexical environment (let closure capture) | Supported | [`ControlFlow_ForLoop_LetClosureCapture.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LetClosureCapture.js)<br>[`ControlFlow_ForLoop_LetClosureCapture_Continue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LetClosureCapture_Continue.js) | Implements CreatePerIterationEnvironment by materializing a dedicated loop-head scope instance per iteration and capturing that scope in closures, so closures observe 0,1,2 rather than the final value. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| for-loop per-iteration lexical environment (let closure capture) | Supported | [`ControlFlow_ForLoop_LetClosureCapture.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LetClosureCapture.js)<br>[`ControlFlow_ForLoop_LetClosureCapture_Continue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForLoop_LetClosureCapture_Continue.js) |  | Implements CreatePerIterationEnvironment by materializing a dedicated loop-head scope instance per iteration and capturing that scope in closures, so closures observe 0,1,2 rather than the final value. |
 
 ### 14.7.5 ([tc39.es](https://tc39.es/ecma262/#sec-for-in-and-for-of-statements))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| for await..of | Supported | [`Async_ForAwaitOf_Array.js`](../../../tests/Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_Array.js)<br>[`Async_ForAwaitOf_AsyncIterator_BreakCloses.js`](../../../tests/Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_AsyncIterator_BreakCloses.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../tests/Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js) | Lowered using the async iterator protocol (GetAsyncIterator/AsyncIteratorNext/AsyncIteratorClose), including awaiting AsyncIteratorClose on abrupt completion (break/throw/return). |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| for await..of | Supported | [`Async_ForAwaitOf_Array.js`](../../../tests/Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_Array.js)<br>[`Async_ForAwaitOf_AsyncIterator_BreakCloses.js`](../../../tests/Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_AsyncIterator_BreakCloses.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../tests/Js2IL.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js) |  | Lowered using the async iterator protocol (GetAsyncIterator/AsyncIteratorNext/AsyncIteratorClose), including awaiting AsyncIteratorClose on abrupt completion (break/throw/return). |
 
 ### 14.7.5.7 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| for-in over objects (enumerate enumerable keys) | Supported | [`ControlFlow_ForIn_Object_Basic.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Object_Basic.js)<br>[`ControlFlow_ForIn_Continue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Continue.js)<br>[`ControlFlow_ForIn_Break.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Break.js)<br>[`ControlFlow_ForIn_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_LabeledContinue.js)<br>[`ControlFlow_ForIn_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_LabeledBreak.js)<br>[`ControlFlow_ForIn_Mutation_DeleteAndAdd.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Mutation_DeleteAndAdd.js)<br>[`ControlFlow_ForIn_ClassFields_BaseAndDerived.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_ClassFields_BaseAndDerived.js)<br>[`ControlFlow_ForIn_Shadowing_NoDuplicateKeys.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Shadowing_NoDuplicateKeys.js) | Lowered via a native For-In Iterator (EnumerateObjectProperties/CreateForInIterator) and consumed through JavaScriptRuntime.Object.IteratorNext + IteratorResultDone/Value. Each next() step re-checks key presence so deletions during enumeration are respected. Prototype chain semantics are approximated for CLR objects by walking the CLR type hierarchy (declared public instance members per type); ExpandoObject/IDictionary do not currently expose a JS-observable [[Prototype]] chain. |
-| for-of over arrays (enumerate values) | Supported | [`ControlFlow_ForOf_Array_Basic.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Array_Basic.js)<br>[`ControlFlow_ForOf_Continue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Continue.js)<br>[`ControlFlow_ForOf_Break.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Break.js)<br>[`ControlFlow_ForOf_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledContinue.js)<br>[`ControlFlow_ForOf_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledBreak.js)<br>[`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) | Lowered using the iterator protocol via JavaScriptRuntime.Object.GetIterator + iterator.next() + result.value/result.done, and invokes JavaScriptRuntime.Object.IteratorClose on abrupt completion (break/throw/return and iterator throws). Supports built-ins (Array/string/Int32Array), user-defined iterables via [Symbol.iterator], and a best-effort fallback for .NET IEnumerable. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| for-in over objects (enumerate enumerable keys) | Supported | [`ControlFlow_ForIn_Object_Basic.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Object_Basic.js)<br>[`ControlFlow_ForIn_Continue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Continue.js)<br>[`ControlFlow_ForIn_Break.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Break.js)<br>[`ControlFlow_ForIn_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_LabeledContinue.js)<br>[`ControlFlow_ForIn_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_LabeledBreak.js)<br>[`ControlFlow_ForIn_Mutation_DeleteAndAdd.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Mutation_DeleteAndAdd.js)<br>[`ControlFlow_ForIn_ClassFields_BaseAndDerived.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_ClassFields_BaseAndDerived.js)<br>[`ControlFlow_ForIn_Shadowing_NoDuplicateKeys.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForIn_Shadowing_NoDuplicateKeys.js) |  | Lowered via a native For-In Iterator (EnumerateObjectProperties/CreateForInIterator) and consumed through JavaScriptRuntime.Object.IteratorNext + IteratorResultDone/Value. Each next() step re-checks key presence so deletions during enumeration are respected. Prototype chain semantics are approximated for CLR objects by walking the CLR type hierarchy (declared public instance members per type); ExpandoObject/IDictionary do not currently expose a JS-observable [[Prototype]] chain. |
+| for-of over arrays (enumerate values) | Supported | [`ControlFlow_ForOf_Array_Basic.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Array_Basic.js)<br>[`ControlFlow_ForOf_Continue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Continue.js)<br>[`ControlFlow_ForOf_Break.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Break.js)<br>[`ControlFlow_ForOf_LabeledContinue.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledContinue.js)<br>[`ControlFlow_ForOf_LabeledBreak.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_LabeledBreak.js)<br>[`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Js2IL.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) | suite `pr`<br>suite `nightly`<br>`test/language/statements/for-of/array-contract.js`<br>`test/language/statements/for-of/array-contract-expand.js`<br>`test/language/statements/for-of/array-expand-contract.js` | Lowered using the iterator protocol via JavaScriptRuntime.Object.GetIterator + iterator.next() + result.value/result.done, and invokes JavaScriptRuntime.Object.IteratorClose on abrupt completion (break/throw/return and iterator throws). Supports built-ins (Array/string/Int32Array), user-defined iterables via [Symbol.iterator], and a best-effort fallback for .NET IEnumerable. The current bounded test262 MVP suites cover the common array for-of contract and expansion paths here. |
 

--- a/docs/ECMA262/15/Section15_3.json
+++ b/docs/ECMA262/15/Section15_3.json
@@ -60,14 +60,29 @@
           "tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_DefaultParameterExpression.js",
           "tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_ParameterDestructuring_Object.js"
         ],
-        "notes": "Arrow functions compile via the IR pipeline and are emitted as callable methods (see JavaScriptArrowFunctionGenerator)."
+        "test262Suites": [
+          "pr",
+          "nightly"
+        ],
+        "test262Paths": [
+          "test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-1.js",
+          "test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-2.js"
+        ],
+        "notes": "Arrow functions compile via the IR pipeline and are emitted as callable methods (see JavaScriptArrowFunctionGenerator). The current bounded test262 MVP suites provide additional evidence for concise-body parsing and invocation in the common non-async arrow path."
       },
       {
         "clause": "15.3.2",
         "feature": "directive prologue / strict mode (\"use strict\") semantics",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-concisebodycontainsusestrict",
-        "notes": "JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists."
+        "test262Suites": [
+          "pr",
+          "nightly"
+        ],
+        "test262Paths": [
+          "test/language/expressions/arrow-function/array-destructuring-param-strict-body.js"
+        ],
+        "notes": "JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists. The current bounded test262 MVP suites include a representative parse-negative case for non-simple arrow parameters plus a strict directive."
       },
       {
         "clause": "15.3.4",

--- a/docs/ECMA262/15/Section15_3.md
+++ b/docs/ECMA262/15/Section15_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-04-20T14:39:44Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -22,23 +22,23 @@
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 15.3 ([tc39.es](https://tc39.es/ecma262/#sec-arrow-function-definitions))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| arrow functions (=>) - basic syntax, closure, and invocation | Supported | [`ArrowFunction_SimpleExpression.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_SimpleExpression.js)<br>[`ArrowFunction_BlockBody_Return.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_BlockBody_Return.js)<br>[`ArrowFunction_CapturesOuterVariable.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_CapturesOuterVariable.js)<br>[`ArrowFunction_ClosureMutatesOuterVariable.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_ClosureMutatesOuterVariable.js)<br>[`ArrowFunction_GlobalFunctionWithMultipleParameters.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionWithMultipleParameters.js)<br>[`ArrowFunction_NestedFunctionAccessesMultipleScopes.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_NestedFunctionAccessesMultipleScopes.js)<br>[`ArrowFunction_GlobalFunctionCallsGlobalFunction.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionCallsGlobalFunction.js)<br>[`ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.js)<br>[`ArrowFunction_DefaultParameterValue.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_DefaultParameterValue.js)<br>[`ArrowFunction_DefaultParameterExpression.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_DefaultParameterExpression.js)<br>[`ArrowFunction_ParameterDestructuring_Object.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_ParameterDestructuring_Object.js) | Arrow functions compile via the IR pipeline and are emitted as callable methods (see JavaScriptArrowFunctionGenerator). |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| arrow functions (=>) - basic syntax, closure, and invocation | Supported | [`ArrowFunction_SimpleExpression.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_SimpleExpression.js)<br>[`ArrowFunction_BlockBody_Return.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_BlockBody_Return.js)<br>[`ArrowFunction_CapturesOuterVariable.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_CapturesOuterVariable.js)<br>[`ArrowFunction_ClosureMutatesOuterVariable.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_ClosureMutatesOuterVariable.js)<br>[`ArrowFunction_GlobalFunctionWithMultipleParameters.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionWithMultipleParameters.js)<br>[`ArrowFunction_NestedFunctionAccessesMultipleScopes.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_NestedFunctionAccessesMultipleScopes.js)<br>[`ArrowFunction_GlobalFunctionCallsGlobalFunction.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionCallsGlobalFunction.js)<br>[`ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.js)<br>[`ArrowFunction_DefaultParameterValue.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_DefaultParameterValue.js)<br>[`ArrowFunction_DefaultParameterExpression.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_DefaultParameterExpression.js)<br>[`ArrowFunction_ParameterDestructuring_Object.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_ParameterDestructuring_Object.js) | suite `pr`<br>suite `nightly`<br>`test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-1.js`<br>`test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-2.js` | Arrow functions compile via the IR pipeline and are emitted as callable methods (see JavaScriptArrowFunctionGenerator). The current bounded test262 MVP suites provide additional evidence for concise-body parsing and invocation in the common non-async arrow path. |
 
 ### 15.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-concisebodycontainsusestrict))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| directive prologue / strict mode ("use strict") semantics | Supported with Limitations |  | JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| directive prologue / strict mode ("use strict") semantics | Supported with Limitations |  | suite `pr`<br>suite `nightly`<br>`test/language/expressions/arrow-function/array-destructuring-param-strict-body.js` | JS2IL parses directive prologues but does not currently aim for full strict-mode semantics/early errors across the language. This clause is tracked as limited until a dedicated strict-mode test matrix exists. The current bounded test262 MVP suites include a representative parse-negative case for non-simple arrow parameters plus a strict directive. |
 
 ### 15.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-instantiatearrowfunctionexpression))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| lexical this for arrow functions | Supported | [`ArrowFunction_LexicalThis_ConstructorAssigned.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_LexicalThis_ConstructorAssigned.js)<br>[`ArrowFunction_LexicalThis_CreatedInMethod.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_LexicalThis_CreatedInMethod.js) | Arrow functions capture lexical this at creation time and invoke with that bound this (GitHub issue #219). |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| lexical this for arrow functions | Supported | [`ArrowFunction_LexicalThis_ConstructorAssigned.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_LexicalThis_ConstructorAssigned.js)<br>[`ArrowFunction_LexicalThis_CreatedInMethod.js`](../../../tests/Js2IL.Tests/ArrowFunction/JavaScript/ArrowFunction_LexicalThis_CreatedInMethod.js) |  | Arrow functions capture lexical this at creation time and invoke with that bound this (GitHub issue #219). |
 

--- a/docs/ECMA262/SectionDoc.schema.json
+++ b/docs/ECMA262/SectionDoc.schema.json
@@ -42,6 +42,16 @@
           "description": "Optional list of JS test scripts that exercise this feature.",
           "items": { "type": "string" }
         },
+        "test262Suites": {
+          "type": "array",
+          "description": "Optional list of JS2IL test262 suite names that currently provide evidence for this feature.",
+          "items": { "type": "string" }
+        },
+        "test262Paths": {
+          "type": "array",
+          "description": "Optional list of upstream test262 file paths that currently provide evidence for this feature.",
+          "items": { "type": "string" }
+        },
         "notes": {
           "type": "string",
           "description": "Optional notes about support status, limitations, or behavior."

--- a/docs/ECMA262/readme.md
+++ b/docs/ECMA262/readme.md
@@ -140,6 +140,19 @@ Feature-level support tracking lives alongside the subsection docs.
 
 - Add/update support metadata under `support.entries` in the relevant subsection JSON file(s) (e.g. `docs/ECMA262/27/Section27_1.json`).
 - Regenerate the subsection markdown using `node scripts/ECMA262/generateEcma262SectionMarkdown.js --section <section.subsection>`.
+- `support.entries[].testScripts` remains the place for repo-local regression coverage.
+- `support.entries[].test262Suites` and `support.entries[].test262Paths` are optional evidence fields for the bounded `test262` MVP workflow when a support claim is backed by current `summary.json` results.
+
+## Using test262 results as evidence
+
+`summary.json` is evidence for the docs, not a second source of truth for support status.
+
+- The machine-readable linkage between current MVP test262 files, ECMA-262 section docs, and backlog ownership lives in `tests/test262/mvp-linkage.json`.
+- The runner copies that linkage into `summary.json` when the selected cases match one of the configured linkage groups.
+- Update the relevant `docs/ECMA262/**/Section*.json` support entry when the latest bounded test262 evidence shows the support note or status is now inaccurate.
+- If a linked test262 result turns `unexpected` and an open GitHub issue already tracks the same clause or feature, attach the `summary.json` evidence to that issue instead of opening a duplicate.
+- If a linked test262 result turns `unexpected` and no open issue already tracks that clause or feature, open a new issue and link the affected clause, support entry, and `summary.json` evidence. Use `docs/tracking-issues/ECMA262TopMissingBacklog.md` when the failure reveals a backlog-worthy missing feature family rather than a narrow regression.
+- Do not update ECMA-262 docs merely because one bounded suite matched once; update them when the linked evidence changes the human-readable support claim contributors should rely on.
 
 ## Repo-local linking
 

--- a/docs/adr/0008-test262-docs-and-backlog-linkage.md
+++ b/docs/adr/0008-test262-docs-and-backlog-linkage.md
@@ -1,0 +1,80 @@
+# ADR 0008: test262 Docs and Backlog Linkage
+
+- Date: 2026-04-20
+- Status: Accepted
+
+## Context
+
+Issue #933 follows the intake/bootstrap work (#928), metadata parser (#929), MVP runner (#930), baseline/result classification (#931), and CI/reporting workflow (#932).
+
+At this point JS2IL already has:
+
+- bounded named test262 MVP suites
+- a machine-readable `summary.json` artifact for each runner invocation
+- ECMA-262 section docs that act as the repository's human-readable support matrix
+
+What is still missing is the connection between those two surfaces. Without it, a contributor can see that a test262 case passed or failed, but still has to manually infer:
+
+- which ECMA-262 clause doc should be updated
+- whether the result belongs to an existing backlog issue
+- when a new issue should be opened instead of mutating docs
+
+## Decision
+
+JS2IL keeps the ECMA-262 docs as the human-readable source of truth and treats test262 output as linked evidence.
+
+### Linkage manifest
+
+The current bounded MVP slice is mapped in `tests/test262/mvp-linkage.json`.
+
+Each linkage group records:
+
+- the upstream test262 file paths
+- the ECMA-262 clause(s) and section JSON doc(s) they inform
+- the specific `support.entries` rows they provide evidence for
+- backlog ownership hints (existing issue ids when present, otherwise the backlog doc used for triage)
+
+### Summary annotation
+
+The runner copies applicable linkage information into `summary.json`:
+
+- matching result entries get `linkageGroupIds`
+- the report gets a top-level `linkage` section with the referenced groups, guidance, and per-group verdict/kind counts
+
+This makes CI artifacts directly usable for docs/backlog triage without forcing contributors to rediscover the clause mapping from file names alone.
+
+### ECMA-262 doc evidence
+
+Relevant ECMA-262 `support.entries` may now cite bounded test262 evidence alongside repo-local regression tests using:
+
+- `test262Suites`
+- `test262Paths`
+
+These fields are evidence only; they do not replace the support status or notes maintained in the docs.
+
+## Contributor workflow
+
+1. Treat `summary.json` as evidence, not the source of truth for support status.
+2. If linked results stay matched but the current support note or status is stale, update the relevant ECMA-262 section JSON and regenerate the markdown.
+3. If linked results go unexpected and an open issue already tracks the same clause or feature, attach the artifact to that issue.
+4. If linked results go unexpected and no issue exists, open a new issue and link the affected clause, support entry, and artifact.
+5. Use the ECMA-262 backlog docs for ranking broader missing-feature families, not for every narrow regression.
+
+## Consequences
+
+### Positive
+
+- test262 artifacts now point back to the docs contributors actually maintain
+- contributors have a deterministic rule for docs vs existing issue vs new issue
+- bounded CI output becomes useful for backlog refreshes and prioritization
+
+### Negative
+
+- the linkage manifest needs maintenance as the bounded suites evolve
+- the mapping is intentionally incomplete until later issues broaden the suite scope
+
+### Mitigations
+
+- keep the linkage manifest small and reviewed alongside suite changes
+- only link the bounded MVP files that are intentionally used as evidence today
+- keep support status decisions in the ECMA-262 docs rather than letting raw test output become the primary narrative

--- a/scripts/ECMA262/generateEcma262SectionMarkdown.js
+++ b/scripts/ECMA262/generateEcma262SectionMarkdown.js
@@ -187,6 +187,24 @@ function formatTestScriptsCell(testScripts, mdDir, repoRootDir) {
     .join('<br>');
 }
 
+function formatCodeListCell(values, formatter) {
+  if (!Array.isArray(values) || values.length === 0) return '';
+  return values
+    .map((value) => {
+      const trimmed = String(value ?? '').trim();
+      if (!trimmed) return '';
+      return formatter(trimmed);
+    })
+    .filter((value) => value && value.length > 0)
+    .join('<br>');
+}
+
+function formatTest262EvidenceCell(test262Suites, test262Paths) {
+  const suiteEvidence = formatCodeListCell(test262Suites, (value) => `suite \`${escapePipes(value)}\``);
+  const pathEvidence = formatCodeListCell(test262Paths, (value) => `\`${escapePipes(toPosixPath(value))}\``);
+  return [suiteEvidence, pathEvidence].filter((value) => value && value.length > 0).join('<br>');
+}
+
 function getSpecUrlForClause(doc, clause) {
   if (!doc || typeof doc !== 'object') return '';
   if (doc.clause === clause && typeof doc.specUrl === 'string') return doc.specUrl;
@@ -286,15 +304,15 @@ function render(doc, sectionClause, mdPath, repoRootDir, generatedAt) {
 
     lines.push('## Support');
     lines.push('');
-    lines.push('Feature-level support tracking with test script references.');
+    lines.push('Feature-level support tracking with repo test references and optional test262 evidence.');
     lines.push('');
 
     for (const c of sortedClauses) {
       const url = getSpecUrlForClause(doc, c);
       lines.push(`### ${c}${url ? ` (${asSpecLink(url)})` : ''}`);
       lines.push('');
-      lines.push('| Feature name | Status | Test scripts | Notes |');
-      lines.push('|---|---|---|---|');
+      lines.push('| Feature name | Status | Test scripts | test262 evidence | Notes |');
+      lines.push('|---|---|---|---|---|');
 
       const list = entriesByClause.get(c) || [];
       list.sort((a, b) => String(a.feature || '').localeCompare(String(b.feature || ''), undefined, { numeric: true }));
@@ -303,8 +321,9 @@ function render(doc, sectionClause, mdPath, repoRootDir, generatedAt) {
         const es = normalizeLegacyStatus(requireString(e, 'status'));
         validateStatus(es);
         const scripts = formatTestScriptsCell(e.testScripts, mdDir, repoRootDir);
+        const test262Evidence = formatTest262EvidenceCell(e.test262Suites, e.test262Paths);
         const notes = formatTableCellText(e.notes || '');
-        lines.push(`| ${formatTableCellText(feature)} | ${formatTableCellText(es)} | ${scripts} | ${notes} |`);
+        lines.push(`| ${formatTableCellText(feature)} | ${formatTableCellText(es)} | ${scripts} | ${test262Evidence} | ${notes} |`);
       }
 
       lines.push('');

--- a/scripts/test262/runMvp.js
+++ b/scripts/test262/runMvp.js
@@ -9,6 +9,7 @@ const { parseTest262File } = require('./metadataParser');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const DEFAULT_SUITE_CONFIG_PATH = path.join(REPO_ROOT, 'tests', 'test262', 'mvp-suites.json');
+const DEFAULT_LINKAGE_CONFIG_PATH = path.join(REPO_ROOT, 'tests', 'test262', 'mvp-linkage.json');
 const DEFAULT_TIMEOUT_SECONDS = 20;
 const DEFAULT_COMPILE_TIMEOUT_SECONDS = 60;
 const VALID_VARIANTS = new Set(['non-strict', 'strict']);
@@ -54,6 +55,7 @@ function printHelp() {
     '  --output <path>            Directory for generated case inputs and compiled assemblies.',
     '  --suite <name>             Apply a named bounded suite from tests/test262/mvp-suites.json.',
     '  --suite-config <path>      Override the named suite definition file used by --suite.',
+    '  --linkage-config <path>    Override the ECMA/backlog linkage definition used for summary.json annotation.',
     '  --timeout <seconds>        Per-test execution timeout (default: 20).',
     '  --compile-timeout <secs>   Per-test compile timeout (default: 60).',
     '  --file <relative-path>     Run one specific test262 file.',
@@ -74,6 +76,7 @@ function parseArgs(argv) {
     output: null,
     suite: null,
     suiteConfig: null,
+    linkageConfig: null,
     timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
     compileTimeoutSeconds: DEFAULT_COMPILE_TIMEOUT_SECONDS,
     file: null,
@@ -111,6 +114,9 @@ function parseArgs(argv) {
         break;
       case '--suite-config':
         args.suiteConfig = requireValue(argv, ++i, '--suite-config');
+        break;
+      case '--linkage-config':
+        args.linkageConfig = requireValue(argv, ++i, '--linkage-config');
         break;
       case '--timeout':
         args.timeoutSeconds = parsePositiveInteger(requireValue(argv, ++i, '--timeout'), '--timeout');
@@ -204,6 +210,10 @@ function resolveSuiteConfigPath(suiteConfigPath) {
   return path.resolve(suiteConfigPath || DEFAULT_SUITE_CONFIG_PATH);
 }
 
+function resolveLinkageConfigPath(linkageConfigPath) {
+  return path.resolve(linkageConfigPath || DEFAULT_LINKAGE_CONFIG_PATH);
+}
+
 function formatConfigPathForReport(filePath) {
   const absolutePath = path.resolve(filePath);
   const relativePath = path.relative(REPO_ROOT, absolutePath);
@@ -212,6 +222,22 @@ function formatConfigPathForReport(filePath) {
   }
 
   return normalizePortablePath(absolutePath);
+}
+
+function ensureNonEmptyString(value, message) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(message);
+  }
+
+  return value.trim();
+}
+
+function normalizeStringArray(rawEntries, itemNormalizer, errorMessage) {
+  if (!Array.isArray(rawEntries) || rawEntries.length === 0) {
+    throw new Error(errorMessage);
+  }
+
+  return rawEntries.map(itemNormalizer);
 }
 
 function normalizeSuiteDefinition(name, rawDefinition, suiteConfigPath) {
@@ -256,6 +282,144 @@ function normalizeSuiteDefinition(name, rawDefinition, suiteConfigPath) {
     files,
     filter,
     limit,
+  };
+}
+
+function normalizeLinkageSupportEntry(rawEntry, index, groupId, linkageConfigPath) {
+  if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) {
+    throw new Error(`Linkage group '${groupId}' support entry #${index + 1} in ${linkageConfigPath} must be an object.`);
+  }
+
+  return {
+    clause: ensureNonEmptyString(
+      rawEntry.clause,
+      `Linkage group '${groupId}' support entry #${index + 1} in ${linkageConfigPath} must define a non-empty 'clause'.`
+    ),
+    feature: ensureNonEmptyString(
+      rawEntry.feature,
+      `Linkage group '${groupId}' support entry #${index + 1} in ${linkageConfigPath} must define a non-empty 'feature'.`
+    ),
+  };
+}
+
+function normalizeLinkageGroup(rawGroup, index, linkageConfigPath) {
+  if (!rawGroup || typeof rawGroup !== 'object' || Array.isArray(rawGroup)) {
+    throw new Error(`Linkage group #${index + 1} in ${linkageConfigPath} must be an object.`);
+  }
+
+  const id = ensureNonEmptyString(rawGroup.id, `Linkage group #${index + 1} in ${linkageConfigPath} must define a non-empty 'id'.`);
+  const title = ensureNonEmptyString(
+    rawGroup.title,
+    `Linkage group '${id}' in ${linkageConfigPath} must define a non-empty 'title'.`
+  );
+  const filePaths = normalizeStringArray(
+    rawGroup.filePaths,
+    entry => normalizeRelativeTestPath(ensureNonEmptyString(
+      entry,
+      `Linkage group '${id}' in ${linkageConfigPath} contains an empty 'filePaths' entry.`
+    )),
+    `Linkage group '${id}' in ${linkageConfigPath} must define a non-empty 'filePaths' array.`
+  );
+  const clauses = normalizeStringArray(
+    rawGroup.clauses,
+    entry => ensureNonEmptyString(
+      entry,
+      `Linkage group '${id}' in ${linkageConfigPath} contains an empty 'clauses' entry.`
+    ),
+    `Linkage group '${id}' in ${linkageConfigPath} must define a non-empty 'clauses' array.`
+  );
+  const docSections = normalizeStringArray(
+    rawGroup.docSections,
+    entry => normalizePortablePath(ensureNonEmptyString(
+      entry,
+      `Linkage group '${id}' in ${linkageConfigPath} contains an empty 'docSections' entry.`
+    )),
+    `Linkage group '${id}' in ${linkageConfigPath} must define a non-empty 'docSections' array.`
+  );
+  const supportEntries = normalizeStringArray(
+    rawGroup.supportEntries,
+    (entry, entryIndex) => normalizeLinkageSupportEntry(entry, entryIndex, id, linkageConfigPath),
+    `Linkage group '${id}' in ${linkageConfigPath} must define a non-empty 'supportEntries' array.`
+  );
+  const backlogDocs = Array.isArray(rawGroup.backlogDocs)
+    ? rawGroup.backlogDocs.map((entry, entryIndex) => normalizePortablePath(ensureNonEmptyString(
+      entry,
+      `Linkage group '${id}' in ${linkageConfigPath} contains an empty 'backlogDocs' entry #${entryIndex + 1}.`
+    )))
+    : [];
+  const existingIssues = Array.isArray(rawGroup.existingIssues)
+    ? rawGroup.existingIssues.map((entry, entryIndex) => {
+      const parsed = Number.parseInt(String(entry), 10);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`Linkage group '${id}' in ${linkageConfigPath} contains an invalid issue number at existingIssues[${entryIndex}].`);
+      }
+
+      return parsed;
+    })
+    : [];
+
+  return {
+    id,
+    title,
+    filePaths,
+    clauses,
+    docSections,
+    supportEntries,
+    backlogDocs,
+    existingIssues,
+  };
+}
+
+function loadLinkageConfig(linkageConfigPath, explicit) {
+  const resolvedPath = resolveLinkageConfigPath(linkageConfigPath);
+  if (!fs.existsSync(resolvedPath)) {
+    if (explicit) {
+      throw new Error(`Linkage config file was not found: ${resolvedPath}`);
+    }
+
+    return null;
+  }
+
+  const rawConfig = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+  if (!rawConfig || typeof rawConfig !== 'object' || Array.isArray(rawConfig)) {
+    throw new Error(`Linkage config ${resolvedPath} must contain a JSON object.`);
+  }
+
+  if (rawConfig.schemaVersion !== undefined && rawConfig.schemaVersion !== 1) {
+    throw new Error(`Unsupported linkage config schemaVersion '${rawConfig.schemaVersion}' in ${resolvedPath}.`);
+  }
+
+  const guidance = rawConfig.guidance && typeof rawConfig.guidance === 'object' && !Array.isArray(rawConfig.guidance)
+    ? {
+      updateDocsWhen: ensureNonEmptyString(
+        rawConfig.guidance.updateDocsWhen,
+        `Linkage config ${resolvedPath} must define guidance.updateDocsWhen.`
+      ),
+      attachToIssueWhen: ensureNonEmptyString(
+        rawConfig.guidance.attachToIssueWhen,
+        `Linkage config ${resolvedPath} must define guidance.attachToIssueWhen.`
+      ),
+      createIssueWhen: ensureNonEmptyString(
+        rawConfig.guidance.createIssueWhen,
+        `Linkage config ${resolvedPath} must define guidance.createIssueWhen.`
+      ),
+    }
+    : null;
+
+  if (guidance === null) {
+    throw new Error(`Linkage config ${resolvedPath} must define a guidance object.`);
+  }
+
+  const rawGroups = rawConfig.groups;
+  if (!Array.isArray(rawGroups) || rawGroups.length === 0) {
+    throw new Error(`Linkage config ${resolvedPath} must define a non-empty groups array.`);
+  }
+
+  const groups = rawGroups.map((group, index) => normalizeLinkageGroup(group, index, resolvedPath));
+  return {
+    path: resolvedPath,
+    guidance,
+    groups,
   };
 }
 
@@ -1207,12 +1371,82 @@ function createCountMap(results, selector, orderedKeys) {
   return compact;
 }
 
-function createSummaryReport(pin, args, plan, results, exitCode) {
+function annotateResultsWithLinkage(results, linkageConfig) {
+  if (!linkageConfig) {
+    return new Set();
+  }
+
+  const groupsByFilePath = new Map();
+  for (let groupIndex = 0; groupIndex < linkageConfig.groups.length; groupIndex++) {
+    const group = linkageConfig.groups[groupIndex];
+    for (let fileIndex = 0; fileIndex < group.filePaths.length; fileIndex++) {
+      const relativePath = group.filePaths[fileIndex];
+      const list = groupsByFilePath.get(relativePath) || [];
+      list.push(group);
+      groupsByFilePath.set(relativePath, list);
+    }
+  }
+
+  const matchedGroupIds = new Set();
+  for (let resultIndex = 0; resultIndex < results.length; resultIndex++) {
+    const result = results[resultIndex];
+    const groups = groupsByFilePath.get(result.relativePath);
+    if (!groups || groups.length === 0) {
+      continue;
+    }
+
+    result.linkageGroupIds = groups.map(group => group.id);
+    for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+      matchedGroupIds.add(groups[groupIndex].id);
+    }
+  }
+
+  return matchedGroupIds;
+}
+
+function createLinkageSummary(linkageConfig, results, matchedGroupIds, explicit) {
+  if (!linkageConfig) {
+    return null;
+  }
+
+  if (matchedGroupIds.size === 0 && !explicit) {
+    return null;
+  }
+
+  const includedGroups = linkageConfig.groups.filter(group => explicit || matchedGroupIds.has(group.id));
+  return {
+    sourceConfig: formatConfigPathForReport(linkageConfig.path),
+    guidance: linkageConfig.guidance,
+    groups: includedGroups.map(group => ({
+      id: group.id,
+      title: group.title,
+      clauses: group.clauses.slice(),
+      docSections: group.docSections.slice(),
+      supportEntries: group.supportEntries.map(entry => ({
+        clause: entry.clause,
+        feature: entry.feature,
+      })),
+      backlogDocs: group.backlogDocs.slice(),
+      existingIssues: group.existingIssues.slice(),
+      filePaths: group.filePaths.slice(),
+    })),
+    groupCounts: includedGroups.map(group => {
+      const groupResults = results.filter(result => Array.isArray(result.linkageGroupIds) && result.linkageGroupIds.includes(group.id));
+      return {
+        groupId: group.id,
+        verdictCounts: createCountMap(groupResults, result => result.classification.verdict, VERDICT_ORDER),
+        kindCounts: createCountMap(groupResults, result => result.classification.kind, RESULT_KIND_ORDER),
+      };
+    }),
+  };
+}
+
+function createSummaryReport(pin, args, plan, results, exitCode, linkageSummary) {
   const suiteConfigPath = args.suiteConfigPath
     ? formatConfigPathForReport(args.suiteConfigPath)
     : null;
 
-  return {
+  const report = {
     schemaVersion: SUMMARY_SCHEMA_VERSION,
     suite: 'js2il-test262-mvp',
     pin: {
@@ -1260,6 +1494,12 @@ function createSummaryReport(pin, args, plan, results, exitCode) {
     },
     results,
   };
+
+  if (linkageSummary !== null) {
+    report.linkage = linkageSummary;
+  }
+
+  return report;
 }
 
 function writeSummaryReport(summaryPath, report) {
@@ -1289,6 +1529,7 @@ function runMvp(argv) {
 
   const pinPath = path.resolve(args.pin);
   const pin = bootstrap.loadPin(pinPath);
+  const linkageConfig = loadLinkageConfig(args.linkageConfig, Boolean(args.linkageConfig));
   const resolvedRoot = bootstrap.resolveBootstrapRoot(pinPath, pin, args);
   const rootPath = resolvedRoot.rootPath;
   const outputRoot = path.resolve(args.output || defaultOutputRoot());
@@ -1324,10 +1565,12 @@ function runMvp(argv) {
   }
 
   const exitCode = results.some(result => result.classification.verdict === 'unexpected') ? 1 : 0;
+  const matchedLinkageGroupIds = annotateResultsWithLinkage(results, linkageConfig);
   const verdictCounts = createCountMap(results, result => result.classification.verdict, VERDICT_ORDER);
   const kindCounts = createCountMap(results, result => result.classification.kind, RESULT_KIND_ORDER);
   const summaryPath = defaultSummaryPath(outputRoot);
-  writeSummaryReport(summaryPath, createSummaryReport(pin, args, plan, results, exitCode));
+  const linkageSummary = createLinkageSummary(linkageConfig, results, matchedLinkageGroupIds, Boolean(args.linkageConfig));
+  writeSummaryReport(summaryPath, createSummaryReport(pin, args, plan, results, exitCode, linkageSummary));
 
   const kindSummary = Object.keys(kindCounts)
     .map(key => `${key}=${kindCounts[key]}`)

--- a/tests/Js2IL.Test262.Tests/Integration/RunnerCliTests.cs
+++ b/tests/Js2IL.Test262.Tests/Integration/RunnerCliTests.cs
@@ -107,6 +107,30 @@ public class RunnerCliTests
         return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path, outputRoot));
     }
 
+    [Fact]
+    public Task RunMvp_AnnotatesSummaryWithEcmaLinkage()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string test262Root = CreateTest262Fixture(tempDirectory.Path, includeFailingPositive: false);
+        string outputRoot = Path.Combine(tempDirectory.Path, "runner-output");
+        string suiteConfigPath = CreateSuiteConfigFile(
+            tempDirectory.Path,
+            [
+                "test/language/mvp/basic-pass.js",
+                "test/language/mvp/runtime-negative.js",
+            ]);
+        string linkageConfigPath = CreateLinkageConfigFile(tempDirectory.Path);
+
+        RunnerResult result = RunRunner(
+            test262Root,
+            outputRoot,
+            $" --suite pr --suite-config \"{suiteConfigPath}\" --linkage-config \"{linkageConfigPath}\"");
+
+        Assert.Equal(0, result.ExitCode);
+
+        return VerifyWithSnapshot(FormatResult(result, tempDirectory.Path, outputRoot));
+    }
+
     private static RunnerResult RunRunner(string test262Root, string outputRoot, string extraArguments = "", int timeoutMilliseconds = 180000)
     {
         string repoRoot = FindRepoRoot();
@@ -226,6 +250,75 @@ public class RunnerCliTests
             """.ReplaceLineEndings("\n"));
 
         return suitePath;
+    }
+
+    private static string CreateLinkageConfigFile(string root)
+    {
+        string linkagePath = Path.Combine(root, "fixture.linkage.json");
+        File.WriteAllText(
+            linkagePath,
+            """
+            {
+              "schemaVersion": 1,
+              "guidance": {
+                "updateDocsWhen": "Update the ECMA docs when the linked evidence changes the support claim.",
+                "attachToIssueWhen": "Attach to an existing issue when one already tracks the same feature.",
+                "createIssueWhen": "Create a new issue when no existing issue tracks the same feature."
+              },
+              "groups": [
+                {
+                  "id": "fixture-basic-pass",
+                  "title": "fixture basic pass",
+                  "filePaths": [
+                    "test/language/mvp/basic-pass.js"
+                  ],
+                  "clauses": [
+                    "15.3"
+                  ],
+                  "docSections": [
+                    "docs/ECMA262/15/Section15_3.json"
+                  ],
+                  "supportEntries": [
+                    {
+                      "clause": "15.3",
+                      "feature": "fixture basic pass"
+                    }
+                  ],
+                  "backlogDocs": [
+                    "docs/tracking-issues/ECMA262TopMissingBacklog.md"
+                  ],
+                  "existingIssues": []
+                },
+                {
+                  "id": "fixture-runtime-negative",
+                  "title": "fixture runtime negative",
+                  "filePaths": [
+                    "test/language/mvp/runtime-negative.js"
+                  ],
+                  "clauses": [
+                    "10.4.4"
+                  ],
+                  "docSections": [
+                    "docs/ECMA262/10/Section10_4.json"
+                  ],
+                  "supportEntries": [
+                    {
+                      "clause": "10.4.4",
+                      "feature": "fixture runtime negative"
+                    }
+                  ],
+                  "backlogDocs": [
+                    "docs/tracking-issues/ECMA262TopMissingBacklog.md"
+                  ],
+                  "existingIssues": [
+                    933
+                  ]
+                }
+              ]
+            }
+            """.ReplaceLineEndings("\n"));
+
+        return linkagePath;
     }
 
     private static string CreateTest262Fixture(string root, bool includeFailingPositive, bool includeClassificationEdges = false)

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_AnnotatesSummaryWithEcmaLinkage.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_AnnotatesSummaryWithEcmaLinkage.verified.txt
@@ -1,0 +1,274 @@
+﻿exit: 0
+stdout:
+root <temp>/test262-root
+js2il <repo>/src/Cli/bin/<configuration>/net10.0/Js2IL.dll
+suite pr
+output <temp>/runner-output
+discovered 6
+selected-files 2
+selected-cases 3
+PASS test/language/mvp/basic-pass.js [non-strict] positive
+PASS test/language/mvp/basic-pass.js [strict] positive
+RUNTIME-REJECTION test/language/mvp/runtime-negative.js [non-strict] matched negative(runtime:TypeError)
+SUMMARY matched=3 unexpected=0 not-run=0 selected=3 classified=3 pass=2 runtime-rejection=1
+REPORT <temp>/runner-output/summary.json
+summary.json:
+{
+  "schemaVersion": 1,
+  "suite": "js2il-test262-mvp",
+  "pin": {
+    "commit": "2b2ecead6e828dd9af13a9ec72065e645724a50f",
+    "packageVersion": "5.0.0"
+  },
+  "policy": {
+    "pathExclusions": [
+      "test/annexB/**",
+      "test/intl402/**",
+      "test/staging/**"
+    ],
+    "unsupportedResultSources": [
+      "metadata.unsupported",
+      "metadata.mvpBlockers"
+    ],
+    "negativeExpectations": {
+      "parse": {
+        "expectedObservedPhase": "compile",
+        "validateErrorType": false
+      },
+      "runtime": {
+        "expectedObservedPhase": "runtime",
+        "validateErrorType": true
+      }
+    },
+    "baselineArtifact": {
+      "fileName": "summary.json",
+      "format": "js2il-test262-summary-v1"
+    }
+  },
+  "selection": {
+    "namedSuite": {
+      "name": "pr",
+      "description": "fixture PR suite",
+      "sourceConfig": "<temp>/fixture.suites.json",
+      "files": [
+        "test/language/mvp/basic-pass.js",
+        "test/language/mvp/runtime-negative.js"
+      ]
+    },
+    "file": null,
+    "filter": null,
+    "limit": null,
+    "variant": null,
+    "discoveredFiles": 6,
+    "selectedFiles": 2,
+    "selectedCases": 3,
+    "classifiedEntries": 3
+  },
+  "summary": {
+    "exitCode": 0,
+    "verdictCounts": {
+      "matched": 3
+    },
+    "kindCounts": {
+      "pass": 2,
+      "runtime-rejection": 1
+    }
+  },
+  "results": [
+    {
+      "id": "test/language/mvp/basic-pass.js#non-strict",
+      "relativePath": "test/language/mvp/basic-pass.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "pass",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "positive"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "passed",
+          "exitCode": 0,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/basic-pass.js",
+        "variant": "non-strict"
+      },
+      "linkageGroupIds": [
+        "fixture-basic-pass"
+      ]
+    },
+    {
+      "id": "test/language/mvp/basic-pass.js#strict",
+      "relativePath": "test/language/mvp/basic-pass.js",
+      "variant": "strict",
+      "expected": {
+        "category": "positive",
+        "phase": null,
+        "errorType": null,
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "pass",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "positive"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "passed",
+          "exitCode": 0,
+          "errorType": null,
+          "summary": null
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/basic-pass.js",
+        "variant": "strict"
+      },
+      "linkageGroupIds": [
+        "fixture-basic-pass"
+      ]
+    },
+    {
+      "id": "test/language/mvp/runtime-negative.js#non-strict",
+      "relativePath": "test/language/mvp/runtime-negative.js",
+      "variant": "non-strict",
+      "expected": {
+        "category": "negative",
+        "phase": "runtime",
+        "errorType": "TypeError",
+        "validatesErrorType": true
+      },
+      "classification": {
+        "kind": "runtime-rejection",
+        "verdict": "matched",
+        "phase": "runtime",
+        "detail": "matched negative(runtime:TypeError)"
+      },
+      "reasons": [],
+      "observed": {
+        "compile": {
+          "status": "succeeded",
+          "exitCode": null,
+          "errorType": null,
+          "summary": null
+        },
+        "runtime": {
+          "status": "rejected",
+          "exitCode": 1,
+          "errorType": "TypeError",
+          "summary": "TypeError: runtime boom"
+        }
+      },
+      "repro": {
+        "file": "test/language/mvp/runtime-negative.js",
+        "variant": "non-strict"
+      },
+      "linkageGroupIds": [
+        "fixture-runtime-negative"
+      ]
+    }
+  ],
+  "linkage": {
+    "sourceConfig": "<temp>/fixture.linkage.json",
+    "guidance": {
+      "updateDocsWhen": "Update the ECMA docs when the linked evidence changes the support claim.",
+      "attachToIssueWhen": "Attach to an existing issue when one already tracks the same feature.",
+      "createIssueWhen": "Create a new issue when no existing issue tracks the same feature."
+    },
+    "groups": [
+      {
+        "id": "fixture-basic-pass",
+        "title": "fixture basic pass",
+        "clauses": [
+          "15.3"
+        ],
+        "docSections": [
+          "docs/ECMA262/15/Section15_3.json"
+        ],
+        "supportEntries": [
+          {
+            "clause": "15.3",
+            "feature": "fixture basic pass"
+          }
+        ],
+        "backlogDocs": [
+          "docs/tracking-issues/ECMA262TopMissingBacklog.md"
+        ],
+        "existingIssues": [],
+        "filePaths": [
+          "test/language/mvp/basic-pass.js"
+        ]
+      },
+      {
+        "id": "fixture-runtime-negative",
+        "title": "fixture runtime negative",
+        "clauses": [
+          "10.4.4"
+        ],
+        "docSections": [
+          "docs/ECMA262/10/Section10_4.json"
+        ],
+        "supportEntries": [
+          {
+            "clause": "10.4.4",
+            "feature": "fixture runtime negative"
+          }
+        ],
+        "backlogDocs": [
+          "docs/tracking-issues/ECMA262TopMissingBacklog.md"
+        ],
+        "existingIssues": [
+          933
+        ],
+        "filePaths": [
+          "test/language/mvp/runtime-negative.js"
+        ]
+      }
+    ],
+    "groupCounts": [
+      {
+        "groupId": "fixture-basic-pass",
+        "verdictCounts": {
+          "matched": 2
+        },
+        "kindCounts": {
+          "pass": 2
+        }
+      },
+      {
+        "groupId": "fixture-runtime-negative",
+        "verdictCounts": {
+          "matched": 1
+        },
+        "kindCounts": {
+          "runtime-rejection": 1
+        }
+      }
+    ]
+  }
+}

--- a/tests/test262/mvp-linkage.json
+++ b/tests/test262/mvp-linkage.json
@@ -1,0 +1,98 @@
+{
+  "schemaVersion": 1,
+  "guidance": {
+    "updateDocsWhen": "Update the linked ECMA-262 support entry when current bounded test262 evidence changes the human-readable support claim or limitations note contributors should rely on.",
+    "attachToIssueWhen": "If an unexpected result maps to a linkage group whose clause or feature is already tracked by an open GitHub issue, attach the summary evidence to that existing issue instead of opening a duplicate.",
+    "createIssueWhen": "If an unexpected result maps to a linkage group and no open GitHub issue already tracks that clause or feature, open a new issue and link the affected ECMA-262 support entry plus the summary evidence."
+  },
+  "groups": [
+    {
+      "id": "arguments-object-basics",
+      "title": "Arguments object materialization and mapped/unmapped semantics",
+      "filePaths": [
+        "test/language/arguments-object/10.5-1gs.js",
+        "test/language/arguments-object/10.5-7-b-2-s.js",
+        "test/language/arguments-object/10.5-7-b-3-s.js",
+        "test/language/arguments-object/10.5-7-b-4-s.js",
+        "test/language/arguments-object/10.6-10-c-ii-1-s.js",
+        "test/language/arguments-object/10.6-10-c-ii-1.js",
+        "test/language/arguments-object/10.6-10-c-ii-2.js",
+        "test/language/arguments-object/10.6-12-1.js"
+      ],
+      "clauses": [
+        "10.4.4",
+        "10.4.4.6",
+        "10.4.4.7"
+      ],
+      "docSections": [
+        "docs/ECMA262/10/Section10_4.json"
+      ],
+      "supportEntries": [
+        {
+          "clause": "10.4.4",
+          "feature": "Arguments objects materialize with mapped/unmapped exotic-object basics"
+        }
+      ],
+      "backlogDocs": [
+        "docs/tracking-issues/ECMA262TopMissingBacklog.md"
+      ],
+      "existingIssues": []
+    },
+    {
+      "id": "arrow-function-basics",
+      "title": "Arrow function concise-body parsing and evaluation",
+      "filePaths": [
+        "test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-1.js",
+        "test/language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-2.js",
+        "test/language/expressions/arrow-function/array-destructuring-param-strict-body.js"
+      ],
+      "clauses": [
+        "15.3",
+        "15.3.2",
+        "15.3.4"
+      ],
+      "docSections": [
+        "docs/ECMA262/15/Section15_3.json"
+      ],
+      "supportEntries": [
+        {
+          "clause": "15.3",
+          "feature": "arrow functions (=>) - basic syntax, closure, and invocation"
+        },
+        {
+          "clause": "15.3.2",
+          "feature": "directive prologue / strict mode (\"use strict\") semantics"
+        }
+      ],
+      "backlogDocs": [
+        "docs/tracking-issues/ECMA262TopMissingBacklog.md"
+      ],
+      "existingIssues": []
+    },
+    {
+      "id": "for-of-array-basics",
+      "title": "for-of over arrays",
+      "filePaths": [
+        "test/language/statements/for-of/array-contract.js",
+        "test/language/statements/for-of/array-contract-expand.js",
+        "test/language/statements/for-of/array-expand-contract.js"
+      ],
+      "clauses": [
+        "14.7.5.7"
+      ],
+      "docSections": [
+        "docs/ECMA262/14/Section14_7.json"
+      ],
+      "supportEntries": [
+        {
+          "clause": "14.7.5.7",
+          "feature": "for-of over arrays (enumerate values)"
+        }
+      ],
+      "backlogDocs": [
+        "docs/tracking-issues/ECMA262TopMissingBacklog.md"
+      ],
+      "existingIssues": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a checked-in test262 linkage manifest and annotate `summary.json` with ECMA-262 clause/doc/backlog mapping for linked MVP cases
- surface bounded test262 evidence in the relevant ECMA-262 section docs and document the contributor workflow for docs vs issue updates
- add ADR 0008 plus focused runner coverage for summary linkage annotation

## Testing
- node .\scripts\ECMA262\generateEcma262SectionMarkdown.js --section 10.4
- node .\scripts\ECMA262\generateEcma262SectionMarkdown.js --section 14.7
- node .\scripts\ECMA262\generateEcma262SectionMarkdown.js --section 15.3
- dotnet test .\tests\Js2IL.Test262.Tests\Js2IL.Test262.Tests.csproj -c Release /p:IsTestProject=true --nologo
- node .\scripts\test262\runMvp.js --suite pr --output .\artifacts\test262\local-pr-linkage-validation
- node .\scripts\test262\runMvp.js --suite nightly --output .\artifacts\test262\local-nightly-linkage-validation

Closes #933