### PR TITLE
docs(test262): split post-MVP expansion roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- tooling/tests/docs: close issue #934 and umbrella #927 by replacing the single post-MVP `test262` expansion bucket with a checked-in rollout plan plus ADR, creating dedicated follow-on issues for modules, async/Promise, raw+harness-heavy, agent/CanBlock, and Intl/environment-sensitive suites so future conformance work lands in bounded slices instead of one vague umbrella.
 - tooling/tests/docs: close issue #933 by mapping bounded test262 MVP results back to ECMA-262 support docs and backlog ownership through a checked-in linkage manifest, annotating `summary.json` with clause/doc linkage, surfacing test262 evidence in the relevant ECMA-262 section docs, and documenting when linked failures should update docs vs attach to or create issues.
 - tooling/tests/docs: close issue #932 by adding named bounded test262 MVP suites for PR vs nightly runs, exposing local npm entrypoints for those suites, publishing `summary.json` artifacts from a dedicated GitHub Actions workflow, and reusing the repository's scheduled-failure issue pattern for nightly regressions while extending focused runner integration coverage.
 - tooling/tests/docs: close issue #931 by formalizing test262 MVP result kinds/verdicts, classifying parse/runtime negatives plus policy skips vs unsupported requirements, emitting a stable `summary.json` baseline artifact for each runner invocation, documenting the contract in a new ADR, and extending focused runner integration coverage.

--- a/docs/adr/0009-test262-post-mvp-expansion-plan.md
+++ b/docs/adr/0009-test262-post-mvp-expansion-plan.md
@@ -1,0 +1,78 @@
+# ADR 0009: test262 Post-MVP Expansion Plan
+
+- Date: 2026-04-20
+- Status: Accepted
+
+## Context
+
+Issue #934 follows the intake/bootstrap work (#928), metadata parser (#929), MVP runner (#930), classified baseline artifact (#931), CI/reporting workflow (#932), and docs/backlog linkage (#933).
+
+At this point JS2IL already has:
+
+- a pinned upstream intake and local bootstrap model
+- a bounded MVP runner with named suites and `summary.json`
+- a docs/backlog feedback loop for the current bounded evidence
+
+What it still lacks is a durable plan for **everything outside the MVP**. The runner and metadata parser already expose the real post-MVP blocker families:
+
+- `module-flag`
+- `resolution-negative`
+- `async-requirement`
+- `raw-flag`
+- `agent-requirement`
+- `can-block-requirement`
+- path exclusions such as `test/intl402/**`, `test/annexB/**`, and `test/staging/**`
+
+Keeping all of that behind one issue makes prioritization and contributor workflow too vague. It also leaves umbrella issue #927 carrying work that now belongs to narrower follow-ons.
+
+## Decision
+
+JS2IL replaces the single post-MVP bucket with a checked-in rollout plan plus dedicated follow-on issues for each expansion area.
+
+The machine-readable plan lives in `tests/test262/post-mvp-expansion.json`.
+
+### Ranked rollout areas
+
+1. **Modules** - issue [#981](https://github.com/tomacox74/js2il/issues/981)
+2. **Async and Promise-dependent tests** - issue [#982](https://github.com/tomacox74/js2il/issues/982)
+3. **Raw and harness-heavy tests** - issue [#983](https://github.com/tomacox74/js2il/issues/983)
+4. **Intl and environment-sensitive suites** - issue [#985](https://github.com/tomacox74/js2il/issues/985)
+5. **Agent and `CanBlock`-dependent tests** - issue [#984](https://github.com/tomacox74/js2il/issues/984)
+
+Each area records:
+
+- the current blocker codes and/or path exclusions that already identify the work
+- the rollout order
+- the dedicated issue number that owns the first bounded implementation slice
+- the support strategy that should guide future runner/harness expansion
+
+### Umbrella handling
+
+Issue #934 is satisfied once the expansion work is decomposed into these bounded areas with explicit strategies. After that, umbrella issue #927 no longer carries unique implementation work beyond the already-landed phases (#928-#933) plus the new follow-on issues (#981-#985), so it can close as well.
+
+## Contributor workflow
+
+1. Use `tests/test262/post-mvp-expansion.json` as the source of truth for post-MVP area ownership.
+2. When a `summary.json` report hits one of the known blocker codes or path exclusions, attach the evidence to the owning follow-on issue instead of reopening a generic umbrella discussion.
+3. Keep future runner or harness work bounded to one expansion area at a time unless a change is truly cross-cutting.
+4. Update the relevant ECMA-262 docs/backlog surfaces when a bounded expansion area lands new durable support claims.
+5. Only add a new expansion area when a genuinely new blocker family appears that is not already covered by the current plan.
+
+## Consequences
+
+### Positive
+
+- Contributors now have concrete issue ownership for the known post-MVP blocker families.
+- The phased `test262` program can close its original umbrella without losing future work.
+- Future expansion PRs can stay small and reviewable instead of reviving one vague long-running issue.
+
+### Negative
+
+- The rollout plan is another checked-in manifest that must stay aligned with issue ownership.
+- Some excluded suites remain policy decisions rather than near-term implementation promises.
+
+### Mitigations
+
+- Keep the manifest narrow and tied to blocker families that already exist in runner output.
+- Update the plan only when a new follow-on issue or blocker family is actually introduced.
+- Continue using ADR 0008's docs/backlog feedback loop so expansion work still feeds back into human-readable support status.

--- a/docs/tracking-issues/IssueTriage.md
+++ b/docs/tracking-issues/IssueTriage.md
@@ -3,34 +3,34 @@
 This file captures a point-in-time recommended ordering for all currently open GitHub issues.
 
 Synced to:
-- Repo: `origin/master` @ `163cb816`
+- Repo: `origin/master` @ `145d7a72`
 - Latest tagged release on `master`: `v0.9.7` via PR [#966](https://github.com/tomacox74/js2il/pull/966)
-- Recent merged PRs since the previous snapshot: [#974](https://github.com/tomacox74/js2il/pull/974), [#975](https://github.com/tomacox74/js2il/pull/975)
+- Recent merged PRs since the previous snapshot: [#974](https://github.com/tomacox74/js2il/pull/974), [#975](https://github.com/tomacox74/js2il/pull/975), [#977](https://github.com/tomacox74/js2il/pull/977), [#978](https://github.com/tomacox74/js2il/pull/978)
 - GitHub: open issue / PR state as of 2026-04-20
-- Open issues: **16**
-- Open PRs: **0**
+- Open issues: **20**
+- Open PRs: **1**
 
 ## What changed since the previous snapshot
 
-- PR [#975](https://github.com/tomacox74/js2il/pull/975) landed on `master`, closing [#931](https://github.com/tomacox74/js2il/issues/931) and adding classified MVP results plus a machine-readable `summary.json` baseline artifact for the current `test262` slice.
-- The open Node/runtime queue is unchanged and still led by [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956).
-- The `test262` program is now down to umbrella [#927](https://github.com/tomacox74/js2il/issues/927) plus the remaining follow-ons [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934); the bootstrap/parser/MVP/classification foundation [#928](https://github.com/tomacox74/js2il/issues/928)-[#931](https://github.com/tomacox74/js2il/issues/931) is closed.
-- Open issue count dropped from **17** to **16** while open PR count stayed at **0**.
+- PR [#977](https://github.com/tomacox74/js2il/pull/977) landed on `master`, closing [#932](https://github.com/tomacox74/js2il/issues/932) and adding bounded CI/reporting for the current `test262` MVP suites.
+- PR [#978](https://github.com/tomacox74/js2il/pull/978) landed on `master`, closing [#933](https://github.com/tomacox74/js2il/issues/933) and linking bounded `test262` evidence back into `docs/ECMA262` plus backlog ownership.
+- The old single post-MVP `test262` bucket is now decomposed into concrete follow-ons [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985), leaving [#934](https://github.com/tomacox74/js2il/issues/934) and umbrella [#927](https://github.com/tomacox74/js2il/issues/927) as closure/bookkeeping items rather than the next implementation picks.
+- Open issue count is now **20** and there is **1** open PR elsewhere in the repo.
 
 ## Ranking method
 
 - Use [TriageScoreboard.md](./TriageScoreboard.md) as the strategic source of truth.
 - Prefer concrete, user-visible compatibility slices before research and benchmark work.
-- Treat [#927](https://github.com/tomacox74/js2il/issues/927) as the umbrella tracker for the `test262` program, and rank the concrete child issues by execution order.
+- Treat [#934](https://github.com/tomacox74/js2il/issues/934) and [#927](https://github.com/tomacox74/js2il/issues/927) as closure/bookkeeping items for the roadmap split, and rank the concrete post-MVP follow-ons [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985) by execution order.
 - Keep performance behind compatibility and conformance unless it directly unblocks those lanes.
 
 ## Recommended next picks
 
 - **Primary next item:** [#949](https://github.com/tomacox74/js2il/issues/949) `node: add global fetch / Request / Response / Headers baseline`
 - **Best next production-network follow-on:** [#956](https://github.com/tomacox74/js2il/issues/956) `node: expand TLS/HTTPS trust, client-auth, and agent parity`
-- **Best next `test262` automation slice:** [#932](https://github.com/tomacox74/js2il/issues/932) `test262: add CI workflow and machine-readable reporting`
-- **Best next `test262` docs/backlog slice:** [#933](https://github.com/tomacox74/js2il/issues/933) `test262: connect conformance results to ECMA-262 docs and backlog`
-- **Umbrella only, not the next direct code pick:** [#927](https://github.com/tomacox74/js2il/issues/927) stays open as the parent issue for the remaining `test262` lane.
+- **Best next `test262` expansion slice:** [#981](https://github.com/tomacox74/js2il/issues/981) `test262: add module-mode conformance slice`
+- **Best next docs/tooling hygiene slice:** [#979](https://github.com/tomacox74/js2il/issues/979) `docs(changelog): archive older release lines and add browse-only archive index`
+- **Bookkeeping only, not the next direct code pick:** [#934](https://github.com/tomacox74/js2il/issues/934) and [#927](https://github.com/tomacox74/js2il/issues/927) should close once the roadmap-split PR lands.
 
 ## Recommended order
 
@@ -39,35 +39,43 @@ Synced to:
 1. **[#949](https://github.com/tomacox74/js2il/issues/949)** `node: add global fetch / Request / Response / Headers baseline` - The highest-leverage remaining platform gap after the recent URL/HTTP/TLS/stream/fs/crypto tranche; modern packages frequently assume `fetch`-style globals first.
 2. **[#956](https://github.com/tomacox74/js2il/issues/956)** `node: expand TLS/HTTPS trust, client-auth, and agent parity` - The current TLS/HTTPS baseline is good enough for local/self-signed flows, but real outbound integrations still need trust-store, client-cert, and richer agent behavior.
 
-### Tier 2 - `test262` follow-ons after the classification slice landed
+### Tier 2 - `test262` post-MVP follow-ons after the MVP foundation landed
 
-3. **[#927](https://github.com/tomacox74/js2il/issues/927)** `test262: create a phased conformance program for js2il` - Keep this open as the sequencing umbrella and reporting parent while the remaining child issues land.
-4. **[#932](https://github.com/tomacox74/js2il/issues/932)** `test262: add CI workflow and machine-readable reporting` - The local classification and baseline artifact now exist, so the next concrete step is turning that into repeatable CI and repo-consumable reporting.
-5. **[#933](https://github.com/tomacox74/js2il/issues/933)** `test262: connect conformance results to ECMA-262 docs and backlog` - More actionable now that the MVP runner produces stable verdicts and a summary artifact instead of only ad-hoc console output.
-6. **[#934](https://github.com/tomacox74/js2il/issues/934)** `test262: expand beyond the MVP to modules, async, and harness-heavy suites` - Important, but still deliberately later than stabilizing CI/reporting and wiring the current slice back into docs.
+3. **[#981](https://github.com/tomacox74/js2il/issues/981)** `test262: add module-mode conformance slice` - Highest-leverage post-MVP follow-on because JS2IL already has meaningful loader/module surface area and module conformance gaps are immediately user-visible.
+4. **[#982](https://github.com/tomacox74/js2il/issues/982)** `test262: add async and Promise conformance slice` - Async and Promise semantics are central to real-world compatibility, but they need an explicit completion/microtask contract rather than ad hoc harness growth.
+5. **[#983](https://github.com/tomacox74/js2il/issues/983)** `test262: add raw and harness-heavy conformance slice` - The next best expansion once modules/async hosting rules start solidifying, because it unlocks more corpus breadth without pretending the entire suite is ready.
+6. **[#985](https://github.com/tomacox74/js2il/issues/985)** `test262: add Intl and environment-sensitive suite strategy` - Important for turning current path exclusions into intentional, deterministic policy instead of a blanket skip forever.
+7. **[#984](https://github.com/tomacox74/js2il/issues/984)** `test262: add agent and CanBlock conformance slice` - Important long-term, but still the lowest near-term pick because it needs a substantially different host/runtime model than the current single-process runner.
+8. **[#934](https://github.com/tomacox74/js2il/issues/934)** `test262: expand beyond the MVP to modules, async, and harness-heavy suites` - Closure/bookkeeping only now that the work has been decomposed into [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985).
+9. **[#927](https://github.com/tomacox74/js2il/issues/927)** `test262: create a phased conformance program for js2il` - The original umbrella no longer owns unique implementation work once [#934](https://github.com/tomacox74/js2il/issues/934) closes.
 
-### Tier 3 - Deferred performance queue
+### Tier 3 - Docs/tooling hygiene
 
-7. **[#451](https://github.com/tomacox74/js2il/issues/451)** `perf(il): expand typed temps/locals to reduce casts/boxing` - Best broad performance enabler once the current compatibility and conformance priorities relax.
-8. **[#737](https://github.com/tomacox74/js2il/issues/737)** `perf: callsite-based typed parameter specialization for non-exported functions` - Builds on the same typed fast-path direction as [#451](https://github.com/tomacox74/js2il/issues/451).
-9. **[#738](https://github.com/tomacox74/js2il/issues/738)** `perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations` - Still the umbrella Prime performance issue, but now clearly secondary to the remaining Node and `test262` work.
-10. **[#742](https://github.com/tomacox74/js2il/issues/742)** `perf(prime): trim timing/config coercion overhead in main path` - Scoped child under [#738](https://github.com/tomacox74/js2il/issues/738).
-11. **[#743](https://github.com/tomacox74/js2il/issues/743)** `perf(prime): add Prime perf acceptance gate and reporting` - Best once Prime tuning resumes.
-12. **[#746](https://github.com/tomacox74/js2il/issues/746)** `perf: make dromaeo-object-regexp faster than Jint prepared` - Valuable benchmark target, but still behind compatibility and tooling work.
-13. **[#747](https://github.com/tomacox74/js2il/issues/747)** `perf(regexp): cache Regex instances by source+flags` - Child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
-14. **[#748](https://github.com/tomacox74/js2il/issues/748)** `perf(dispatch): add RegExp fast paths in Object.CallMember1/2` - Another child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
-15. **[#768](https://github.com/tomacox74/js2il/issues/768)** `Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)` - Still scenario-specific rather than a broad ecosystem unblocker.
-16. **[#837](https://github.com/tomacox74/js2il/issues/837)** `perf(runtime): investigate DLR-backed CallMember fast path` - Remains research-heavy rather than a near-term implementation slice.
+10. **[#979](https://github.com/tomacox74/js2il/issues/979)** `docs(changelog): archive older release lines and add browse-only archive index` - Important repository hygiene, but still behind compatibility and conformance slices with direct runtime impact.
+
+### Tier 4 - Deferred performance queue
+
+11. **[#451](https://github.com/tomacox74/js2il/issues/451)** `perf(il): expand typed temps/locals to reduce casts/boxing` - Best broad performance enabler once the current compatibility and conformance priorities relax.
+12. **[#737](https://github.com/tomacox74/js2il/issues/737)** `perf: callsite-based typed parameter specialization for non-exported functions` - Builds on the same typed fast-path direction as [#451](https://github.com/tomacox74/js2il/issues/451).
+13. **[#738](https://github.com/tomacox74/js2il/issues/738)** `perf(prime): close PrimeJavaScript gap with spec-safe hot-path optimizations` - Still the umbrella Prime performance issue, but now clearly secondary to the remaining Node and `test262` work.
+14. **[#742](https://github.com/tomacox74/js2il/issues/742)** `perf(prime): trim timing/config coercion overhead in main path` - Scoped child under [#738](https://github.com/tomacox74/js2il/issues/738).
+15. **[#743](https://github.com/tomacox74/js2il/issues/743)** `perf(prime): add Prime perf acceptance gate and reporting` - Best once Prime tuning resumes.
+16. **[#746](https://github.com/tomacox74/js2il/issues/746)** `perf: make dromaeo-object-regexp faster than Jint prepared` - Valuable benchmark target, but still behind compatibility and tooling work.
+17. **[#747](https://github.com/tomacox74/js2il/issues/747)** `perf(regexp): cache Regex instances by source+flags` - Child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
+18. **[#748](https://github.com/tomacox74/js2il/issues/748)** `perf(dispatch): add RegExp fast paths in Object.CallMember1/2` - Another child optimization under [#746](https://github.com/tomacox74/js2il/issues/746).
+19. **[#768](https://github.com/tomacox74/js2il/issues/768)** `Perf: devirtualize calls to const/arrow function bindings (dromaeo-object-regexp-modern)` - Still scenario-specific rather than a broad ecosystem unblocker.
+20. **[#837](https://github.com/tomacox74/js2il/issues/837)** `perf(runtime): investigate DLR-backed CallMember fast path` - Remains research-heavy rather than a near-term implementation slice.
 
 ## Execution notes
 
-- **No active review queue remains:** there are currently no open PRs, so the next work can start directly instead of finishing review branches first.
+- **There is an active review queue elsewhere:** there is currently 1 open PR in the repo, so new work should not assume the review lane is empty.
 - **Immediate top-of-stack Node track:** [#949](https://github.com/tomacox74/js2il/issues/949) -> [#956](https://github.com/tomacox74/js2il/issues/956).
-- **`test262` track:** keep [#927](https://github.com/tomacox74/js2il/issues/927) as the umbrella, then execute [#932](https://github.com/tomacox74/js2il/issues/932) -> [#933](https://github.com/tomacox74/js2il/issues/933), leaving [#934](https://github.com/tomacox74/js2il/issues/934) as the deliberate post-MVP expansion bucket. The bootstrap/parser/MVP/classification foundation [#928](https://github.com/tomacox74/js2il/issues/928)-[#931](https://github.com/tomacox74/js2il/issues/931) is already landed via PRs [#971](https://github.com/tomacox74/js2il/pull/971)-[#973](https://github.com/tomacox74/js2il/pull/973) and [#975](https://github.com/tomacox74/js2il/pull/975).
+- **`test262` track:** the MVP foundation [#928](https://github.com/tomacox74/js2il/issues/928)-[#933](https://github.com/tomacox74/js2il/issues/933) is already landed via PRs [#971](https://github.com/tomacox74/js2il/pull/971)-[#973](https://github.com/tomacox74/js2il/pull/973), [#975](https://github.com/tomacox74/js2il/pull/975), [#977](https://github.com/tomacox74/js2il/pull/977), and [#978](https://github.com/tomacox74/js2il/pull/978); the concrete post-MVP queue is now [#981](https://github.com/tomacox74/js2il/issues/981) -> [#982](https://github.com/tomacox74/js2il/issues/982) -> [#983](https://github.com/tomacox74/js2il/issues/983) -> [#985](https://github.com/tomacox74/js2il/issues/985) -> [#984](https://github.com/tomacox74/js2il/issues/984), with [#934](https://github.com/tomacox74/js2il/issues/934) and [#927](https://github.com/tomacox74/js2il/issues/927) pending closure once the roadmap split lands.
+- **Docs/tooling hygiene:** [#979](https://github.com/tomacox74/js2il/issues/979) is the one active non-runtime follow-on and can stay behind the compatibility/conformance lanes.
 - **Architecture note:** closed issue [#841](https://github.com/tomacox74/js2il/issues/841) is now reference material for the remaining network work, not a current queue item.
 - **Performance track:** [#451](https://github.com/tomacox74/js2il/issues/451) -> [#737](https://github.com/tomacox74/js2il/issues/737) remains the best general optimization path; the Prime and regexp benchmark sub-queues stay explicitly secondary.
 
 ## Metadata gaps
 
-- Open-issue labeling still lags the actual queue: **2/16** open issues currently carry a `priority:*` label, **0/16** carry a `lane:*` label, and **9/16** have no labels at all.
-- With no open PRs and a smaller issue set after [#975](https://github.com/tomacox74/js2il/pull/975), this triage document plus [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md) remain the clearest current ordering signals until issue metadata catches up.
+- Open-issue labeling still lags the actual queue: **2/20** open issues currently carry a `priority:*` label, **0/20** carry a `lane:*` label, and **13/20** have no labels at all.
+- With the issue queue expanded by the explicit `test262` follow-ons [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985), this triage document plus [NodeGapPopularityBacklog.md](./NodeGapPopularityBacklog.md) remain the clearest current ordering signals until issue metadata catches up.

--- a/docs/tracking-issues/Phase1-TrackingIssues.md
+++ b/docs/tracking-issues/Phase1-TrackingIssues.md
@@ -11,7 +11,7 @@ This document contains the historical tracking drafts for the original Phase 1 r
 
 - ✅ Phase 1 scope is long since shipped on `master` (rest parameters; spread in calls, arrays, and objects).
 - ✅ The active queue has moved on to Node compatibility, `test262` follow-ons, and the deferred performance lane.
-- ✅ The current live queue is **16 open issues / 0 open PRs**, with Node follow-ons [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956) plus `test262` umbrella [#927](https://github.com/tomacox74/js2il/issues/927) and follow-ons [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934) now taking priority instead.
+- ✅ The current live queue is **20 open issues / 1 open PR**, with Node follow-ons [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956), docs/tooling follow-on [#979](https://github.com/tomacox74/js2il/issues/979), and the concrete `test262` post-MVP issues [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985) now taking priority instead.
 - ℹ️ Any unchecked acceptance items below are preserved as historical drafting artifacts rather than current blockers.
 
 ---

--- a/docs/tracking-issues/README.md
+++ b/docs/tracking-issues/README.md
@@ -17,13 +17,14 @@ These files should stay aligned with:
 
 ## Current Repo Snapshot (2026-04-20)
 
-- `origin/master` @ `163cb816`
-- Open issues: **16**
-- Open PRs: **0**
-- Recent merged PRs that materially changed the queue: [#969](https://github.com/tomacox74/js2il/pull/969), [#970](https://github.com/tomacox74/js2il/pull/970), [#971](https://github.com/tomacox74/js2il/pull/971), [#972](https://github.com/tomacox74/js2il/pull/972), [#973](https://github.com/tomacox74/js2il/pull/973), [#975](https://github.com/tomacox74/js2il/pull/975)
+- `origin/master` @ `145d7a72`
+- Open issues: **20**
+- Open PRs: **1**
+- Recent merged PRs that materially changed the queue: [#969](https://github.com/tomacox74/js2il/pull/969), [#970](https://github.com/tomacox74/js2il/pull/970), [#971](https://github.com/tomacox74/js2il/pull/971), [#972](https://github.com/tomacox74/js2il/pull/972), [#973](https://github.com/tomacox74/js2il/pull/973), [#975](https://github.com/tomacox74/js2il/pull/975), [#977](https://github.com/tomacox74/js2il/pull/977), [#978](https://github.com/tomacox74/js2il/pull/978)
 - Remaining open lanes:
   - Node/runtime follow-ons: [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956)
-  - `test262` program: [#927](https://github.com/tomacox74/js2il/issues/927), [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934) ([#931](https://github.com/tomacox74/js2il/issues/931) closed via [#975](https://github.com/tomacox74/js2il/pull/975))
+  - `test262` program: the MVP foundation [#928](https://github.com/tomacox74/js2il/issues/928)-[#933](https://github.com/tomacox74/js2il/issues/933) is closed, and the concrete post-MVP lane is now [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985); [#927](https://github.com/tomacox74/js2il/issues/927) and [#934](https://github.com/tomacox74/js2il/issues/934) remain open only until this roadmap-split work lands
+  - Docs/tooling hygiene: [#979](https://github.com/tomacox74/js2il/issues/979)
   - Performance queue: [#451](https://github.com/tomacox74/js2il/issues/451), [#737](https://github.com/tomacox74/js2il/issues/737), [#738](https://github.com/tomacox74/js2il/issues/738), [#742](https://github.com/tomacox74/js2il/issues/742), [#743](https://github.com/tomacox74/js2il/issues/743), [#746](https://github.com/tomacox74/js2il/issues/746), [#747](https://github.com/tomacox74/js2il/issues/747), [#748](https://github.com/tomacox74/js2il/issues/748), [#768](https://github.com/tomacox74/js2il/issues/768), [#837](https://github.com/tomacox74/js2il/issues/837)
 
 ## Historical Context

--- a/docs/tracking-issues/TriageScoreboard.md
+++ b/docs/tracking-issues/TriageScoreboard.md
@@ -3,7 +3,7 @@
 > **Last Updated**: 2026-04-20
 > **Planning Horizon**: Rolling 2 weeks
 > **North Star**: Real-world unblock impact
-> **Live Queue**: 16 open issues / 0 open PRs
+> **Live Queue**: 20 open issues / 1 open PR
 
 This file is the working source of truth for implementation prioritization.
 
@@ -15,9 +15,10 @@ This file is the working source of truth for implementation prioritization.
 
 ## Current Queue Highlights
 
-- Recent landed work: [#969](https://github.com/tomacox74/js2il/pull/969)-[#973](https://github.com/tomacox74/js2il/pull/973) delivered the extractor networking fix, the test project split, pinned `test262` intake, the metadata parser, and the MVP runner; [#975](https://github.com/tomacox74/js2il/pull/975) then classified MVP results and added baseline reporting artifacts.
+- Recent landed work: [#969](https://github.com/tomacox74/js2il/pull/969)-[#973](https://github.com/tomacox74/js2il/pull/973) delivered the extractor networking fix, the test project split, pinned `test262` intake, and the MVP runner; [#975](https://github.com/tomacox74/js2il/pull/975), [#977](https://github.com/tomacox74/js2il/pull/977), and [#978](https://github.com/tomacox74/js2il/pull/978) then added classified reporting, bounded CI suites, and docs/backlog linkage.
 - Primary open Node follow-ons are now [#949](https://github.com/tomacox74/js2il/issues/949) and [#956](https://github.com/tomacox74/js2il/issues/956).
-- Primary open `test262` follow-ons are [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934) under umbrella [#927](https://github.com/tomacox74/js2il/issues/927).
+- Primary open `test262` follow-ons are now the explicit post-MVP issues [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985); [#927](https://github.com/tomacox74/js2il/issues/927) and [#934](https://github.com/tomacox74/js2il/issues/934) are now just closure items for the roadmap split.
+- Docs/tooling hygiene is represented by [#979](https://github.com/tomacox74/js2il/issues/979).
 - The performance queue remains unchanged and explicitly secondary to compatibility and conformance.
 
 ## Capacity Split
@@ -58,19 +59,24 @@ Goal: improve correctness in small, reportable slices that can feed back into do
 - Produces actionable results instead of a broad, noisy failure set
 
 **Current ranked queue**
-1. [#932](https://github.com/tomacox74/js2il/issues/932) - add CI workflow and machine-readable reporting
-2. [#933](https://github.com/tomacox74/js2il/issues/933) - connect conformance results to ECMA-262 docs and backlog
-3. [#934](https://github.com/tomacox74/js2il/issues/934) - expand beyond the MVP to modules, async, and harness-heavy suites
-4. [#927](https://github.com/tomacox74/js2il/issues/927) remains the umbrella tracker and should stay open until the child lane is actually complete
+1. [#981](https://github.com/tomacox74/js2il/issues/981) - module-mode conformance slice
+2. [#982](https://github.com/tomacox74/js2il/issues/982) - async and Promise conformance slice
+3. [#983](https://github.com/tomacox74/js2il/issues/983) - raw and harness-heavy conformance slice
+4. [#985](https://github.com/tomacox74/js2il/issues/985) - Intl and environment-sensitive suite strategy
+5. [#984](https://github.com/tomacox74/js2il/issues/984) - agent and CanBlock conformance slice
+6. [#934](https://github.com/tomacox74/js2il/issues/934) - close after the roadmap split lands; it no longer owns unique implementation work
+7. [#927](https://github.com/tomacox74/js2il/issues/927) - close after [#934](https://github.com/tomacox74/js2il/issues/934); the original phased program is now fully decomposed into concrete follow-ons
 
 **Recently delivered**
 - [#928](https://github.com/tomacox74/js2il/issues/928) - pinned intake/bootstrap
 - [#929](https://github.com/tomacox74/js2il/issues/929) - metadata/frontmatter parser
 - [#930](https://github.com/tomacox74/js2il/issues/930) - MVP runner for the narrow initial slice
 - [#931](https://github.com/tomacox74/js2il/issues/931) - classified MVP results, exclusions, and baseline outputs
+- [#932](https://github.com/tomacox74/js2il/issues/932) - CI workflow and machine-readable reporting
+- [#933](https://github.com/tomacox74/js2il/issues/933) - docs/backlog linkage for bounded `test262` evidence
 
 **Current caveat**
-- The current runner now has stable MVP verdict classification and a baseline artifact, but it is still not a broad official coverage claim. Keep CI/reporting/docs integration and suite expansion behind the remaining follow-ons rather than treating the landed slice as full-corpus conformance reporting.
+- The current runner now has stable MVP verdict classification, bounded CI suites, and docs linkage, but it is still not a broad official coverage claim. Keep future expansion work bounded to one of [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985) rather than treating the landed slice as full-corpus conformance reporting.
 
 ### Lane C - Issue Throughput + Reliability Hygiene
 
@@ -82,9 +88,10 @@ Goal: keep the issue queue actionable while preventing status-document drift.
 - Documentation drift risk
 
 **Current queue**
+- [#979](https://github.com/tomacox74/js2il/issues/979) - changelog archive layout and browse-only index
 - Keep `docs/tracking-issues` synchronized after each merge tranche
-- Backfill `priority:*` labels and future `lane:*` labels on the remaining 16 open issues
-- Keep [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956), and [#927](https://github.com/tomacox74/js2il/issues/927) / [#932](https://github.com/tomacox74/js2il/issues/932)-[#934](https://github.com/tomacox74/js2il/issues/934) scoped with crisp acceptance criteria
+- Backfill `priority:*` labels and future `lane:*` labels on the remaining 20 open issues
+- Keep [#949](https://github.com/tomacox74/js2il/issues/949), [#956](https://github.com/tomacox74/js2il/issues/956), [#979](https://github.com/tomacox74/js2il/issues/979), and [#981](https://github.com/tomacox74/js2il/issues/981)-[#985](https://github.com/tomacox74/js2il/issues/985) scoped with crisp acceptance criteria
 - Close or retag stale issues only when the replacement scope is clearly documented
 
 ## Mandatory PR Gate (Feature Work)

--- a/tests/test262/post-mvp-expansion.json
+++ b/tests/test262/post-mvp-expansion.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "sourceIssues": {
+    "decomposition": 934,
+    "umbrella": 927
+  },
+  "summary": "Post-MVP test262 work is tracked as bounded rollout areas keyed off existing blocker codes and path exclusions instead of one open-ended follow-up issue.",
+  "areas": [
+    {
+      "id": "modules",
+      "title": "Module-mode conformance",
+      "rolloutOrder": 1,
+      "issueNumber": 981,
+      "currentSignals": [
+        "module-flag",
+        "resolution-negative"
+      ],
+      "supportStrategy": "Start with module tests that can run against the existing loader/runtime surface, then widen to module-specific harness behavior and resolution-negative expectations once those results are attributable in summary output.",
+      "firstSlice": "Bounded positive and negative module cases that do not also require agents or async-specific host support."
+    },
+    {
+      "id": "async-promise",
+      "title": "Async and Promise-dependent conformance",
+      "rolloutOrder": 2,
+      "issueNumber": 982,
+      "currentSignals": [
+        "async-requirement"
+      ],
+      "supportStrategy": "Define an explicit async completion contract around Promise jobs and test262 completion helpers before widening the bounded suites beyond synchronous script execution.",
+      "firstSlice": "Async/Promise cases that need `doneprintHandle.js` or equivalent completion signaling but not agents."
+    },
+    {
+      "id": "raw-harness-heavy",
+      "title": "Raw and harness-heavy conformance",
+      "rolloutOrder": 3,
+      "issueNumber": 983,
+      "currentSignals": [
+        "raw-flag"
+      ],
+      "supportStrategy": "Separate default-harness execution from `flags:raw` and other richer include/define scenarios so harness growth stays reviewable and deliberate.",
+      "firstSlice": "A bounded set of raw or richer-harness cases that still run in a single-agent host without environment-sensitive assumptions."
+    },
+    {
+      "id": "intl-and-environment",
+      "title": "Intl and environment-sensitive suites",
+      "rolloutOrder": 4,
+      "issueNumber": 985,
+      "currentSignals": [
+        "path-excluded:test/intl402/**",
+        "path-excluded:test/annexB/**",
+        "path-excluded:test/staging/**"
+      ],
+      "supportStrategy": "Turn the current blanket path exclusions into explicit policy by defining deterministic environment contracts for the suites worth targeting first and documenting what remains intentionally excluded.",
+      "firstSlice": "A named deterministic environment-sensitive slice, starting with `intl402` or another host-sensitive suite that can run with documented locale/timezone/platform assumptions."
+    },
+    {
+      "id": "agents-and-canblock",
+      "title": "Agent and CanBlock conformance",
+      "rolloutOrder": 5,
+      "issueNumber": 984,
+      "currentSignals": [
+        "agent-requirement",
+        "can-block-requirement"
+      ],
+      "supportStrategy": "Treat agent-sensitive tests as a dedicated host-runtime expansion with explicit multi-agent and blocking semantics instead of letting them piggyback on the single-process MVP runner.",
+      "firstSlice": "A minimal agent-host contract plus a bounded first slice of agent-sensitive tests once the host/runtime model exists."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add ADR 0009 plus a checked-in `tests/test262/post-mvp-expansion.json` manifest for the post-MVP `test262` rollout
- create and reference the concrete follow-on issues #981-#985 for modules, async/Promise, raw+harness-heavy, agent/CanBlock, and Intl/environment-sensitive work
- refresh the directly affected tracking docs and changelog so the repo points at the new queue instead of the old single expansion bucket

## Notes
- no runtime or compiler behavior changes are included here; this PR closes the roadmap/planning work by turning the remaining post-MVP expansion into explicit, bounded follow-ons

Closes #934
Closes #927