### PR TITLE
fix(compiler): capture shadowed global names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler/packaging/tests: fix the v0.9.8 Linux and Windows release smoke regression by capturing module-local bindings that shadow runtime global intrinsic names (for example `URL`) when nested CommonJS function expressions close over them, restoring the packaged Hosting.Domino sample build.
 
 ## v0.9.8 - 2026-04-27
 

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.cs
@@ -630,12 +630,14 @@ namespace Js2IL.SymbolTables
                 // Convert FunctionDeclaration to use its body like FunctionExpression
                 if (funcDecl.Body is BlockStatement body)
                 {
-                    scope.ReferencesParentScopeVariables = CheckBodyReferencesParentVariables(body, scope);
+                    scope.ReferencesParentScopeVariables =
+                        ScopeReferencesAncestorVariables(scope) || CheckBodyReferencesParentVariables(body, scope);
                 }
             }
             else if (scope.Kind == ScopeKind.Function && scope.AstNode is ArrowFunctionExpression arrowExpr)
             {
-                scope.ReferencesParentScopeVariables = CheckArrowFunctionReferencesParentVariables(arrowExpr, scope);
+                scope.ReferencesParentScopeVariables =
+                    ScopeReferencesAncestorVariables(scope) || CheckArrowFunctionReferencesParentVariables(arrowExpr, scope);
             }
 
             var hasDescendantCallableReferencingParentScopeVariables = scope.Children.Any(child =>
@@ -1651,8 +1653,12 @@ namespace Js2IL.SymbolTables
         private bool CheckFunctionReferencesParentVariables(FunctionExpression funcExpr, Scope functionScope)
         {
             if (funcExpr.Body is not BlockStatement body) return false;
-            return CheckBodyReferencesParentVariables(body, functionScope);
+            return ScopeReferencesAncestorVariables(functionScope)
+                || CheckBodyReferencesParentVariables(body, functionScope);
         }
+
+        private bool ScopeReferencesAncestorVariables(Scope scope)
+            => scope.Parent != null && CollectReferencedParentVariables(scope, scope.Parent).Count > 0;
 
         /// <summary>
         /// Recursively collects identifiers that are not in localVariables but are in targetVariables.
@@ -1664,10 +1670,8 @@ namespace Js2IL.SymbolTables
             switch (node)
             {
                 case Identifier id:
-                    // If this identifier is not local, not a global intrinsic, and is in target scope
-                    if (!localVariables.Contains(id.Name) && 
-                        !IsKnownGlobalIntrinsic(id.Name) && 
-                        targetVariables.Contains(id.Name))
+                    // If an ancestor declares this name, that binding shadows any runtime global intrinsic.
+                    if (!localVariables.Contains(id.Name) && targetVariables.Contains(id.Name))
                     {
                         result.Add(id.Name);
                     }

--- a/tests/Js2IL.Tests/CommonJS/ExecutionTests.cs
+++ b/tests/Js2IL.Tests/CommonJS/ExecutionTests.cs
@@ -241,6 +241,16 @@ namespace Js2IL.Tests.CommonJS
         }
 
         [Fact]
+        public Task CommonJS_Require_Captures_Shadowed_Global_URL()
+        {
+            // Repro for the v0.9.8 smoke failure compiling @mixmark-io/domino:
+            // a module-local `URL` require must shadow the runtime global URL inside nested closures.
+            return ExecutionTest(
+                nameof(CommonJS_Require_Captures_Shadowed_Global_URL),
+                additionalScripts: new[] { "CommonJS_Require_Captures_Shadowed_Global_URL_Lib" });
+        }
+
+        [Fact]
         public Task CommonJS_Module_Exports_ClassExpression_ExtendsArray()
         {
             // Issue #552 repro: IR pipeline crash compiling a CommonJS module that exports a class expression.

--- a/tests/Js2IL.Tests/CommonJS/GeneratorTests.cs
+++ b/tests/Js2IL.Tests/CommonJS/GeneratorTests.cs
@@ -216,6 +216,16 @@ namespace Js2IL.Tests.CommonJS
         }
 
         [Fact]
+        public Task CommonJS_Require_Captures_Shadowed_Global_URL()
+        {
+            // Repro for the v0.9.8 smoke failure compiling @mixmark-io/domino:
+            // a module-local `URL` require must shadow the runtime global URL inside nested closures.
+            return GenerateTest(
+                nameof(CommonJS_Require_Captures_Shadowed_Global_URL),
+                new[] { "CommonJS_Require_Captures_Shadowed_Global_URL_Lib" });
+        }
+
+        [Fact]
         public Task CommonJS_Module_Exports_ClassExpression_ExtendsArray()
         {
             // Issue #552 repro: IR pipeline crash compiling a CommonJS module that exports a class expression.

--- a/tests/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Require_Captures_Shadowed_Global_URL.js
+++ b/tests/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Require_Captures_Shadowed_Global_URL.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var URL = require("./CommonJS_Require_Captures_Shadowed_Global_URL_Lib");
+
+var descriptor = {
+    value: function(href) {
+        return new URL("base").resolve(href);
+    }
+};
+
+console.log(descriptor.value("child"));

--- a/tests/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Require_Captures_Shadowed_Global_URL_Lib.js
+++ b/tests/Js2IL.Tests/CommonJS/JavaScript/CommonJS_Require_Captures_Shadowed_Global_URL_Lib.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function LocalURL(base) {
+    this.base = base;
+}
+
+LocalURL.prototype.resolve = function(href) {
+    return this.base + "/" + href;
+};
+
+module.exports = LocalURL;

--- a/tests/Js2IL.Tests/CommonJS/Snapshots/ExecutionTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Js2IL.Tests/CommonJS/Snapshots/ExecutionTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -1,0 +1,1 @@
+﻿base/child

--- a/tests/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -1,0 +1,387 @@
+﻿// IL code: CommonJS_Require_Captures_Shadowed_Global_URL
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.CommonJS_Require_Captures_Shadowed_Global_URL
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_descriptor
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21b1
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope scope,
+				object newTarget,
+				object href
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 07 00 00 02
+			)
+			// Method begins at RVA 0x212c
+			// Header size: 12
+			// Code size: 43 (0x2b)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope::URL
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldc.i4.1
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldstr "base"
+			IL_0015: stelem.ref
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_001b: stloc.0
+			IL_001c: ldloc.0
+			IL_001d: ldstr "resolve"
+			IL_0022: ldarg.2
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0028: stloc.0
+			IL_0029: ldloc.0
+			IL_002a: ret
+		} // end of method FunctionExpression_descriptor::__js_call__
+
+	} // end of class FunctionExpression_descriptor
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 0f 53 63 6f 70 65 20 55 52 4c 3d 7b 55 52
+			4c 7d 00 00
+		)
+		// Fields
+		.field public object URL
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x21a8
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 109 (0x6d)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope,
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[2] object,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		)
+
+		IL_0000: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.1
+		IL_0007: ldstr "./CommonJS_Require_Captures_Shadowed_Global_URL_Lib"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.2
+		IL_0012: ldloc.0
+		IL_0013: ldloc.2
+		IL_0014: stfld object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope::URL
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: ldc.i4.0
+		IL_0024: ldelem.ref
+		IL_0025: castclass Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope
+		IL_002a: ldftn object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor::__js_call__(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope, object, object)
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object)
+		IL_003a: stloc.2
+		IL_003b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0040: dup
+		IL_0041: ldstr "value"
+		IL_0046: ldloc.2
+		IL_0047: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_004c: stloc.3
+		IL_004d: ldloc.3
+		IL_004e: stloc.1
+		IL_004f: ldloc.1
+		IL_0050: ldstr "value"
+		IL_0055: ldstr "child"
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_005f: stloc.2
+		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0065: ldloc.2
+		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006b: pop
+		IL_006c: ret
+	} // end of method CommonJS_Require_Captures_Shadowed_Global_URL::__js_module_init__
+
+} // end of class Modules.CommonJS_Require_Captures_Shadowed_Global_URL
+
+.class private auto ansi beforefieldinit Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit LocalURL
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21c3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object base
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2163
+			// Header size: 1
+			// Code size: 19 (0x13)
+			.maxstack 8
+
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldstr "base"
+			IL_000a: ldarg.1
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
+		} // end of method LocalURL::__js_call__
+
+	} // end of class LocalURL
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L7C29
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested private auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21cc
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object href
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2178
+			// Header size: 12
+			// Code size: 36 (0x24)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldstr "base"
+			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000f: ldstr "/"
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0019: stloc.0
+			IL_001a: ldloc.0
+			IL_001b: ldarg.1
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0021: stloc.0
+			IL_0022: ldloc.0
+			IL_0023: ret
+		} // end of method FunctionExpression_L7C29::__js_call__
+
+	} // end of class FunctionExpression_L7C29
+
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 19 53 63 6f 70 65 20 4c 6f 63 61 6c 55 52
+			4c 3d 7b 4c 6f 63 61 6c 55 52 4c 7d 00 00
+		)
+		// Fields
+		.field public object LocalURL
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x21ba
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x20cc
+		// Header size: 12
+		// Code size: 81 (0x51)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/Scope,
+			[1] object,
+			[2] object
+		)
+
+		IL_0000: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL::__js_call__(object, object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object)
+		IL_0017: stloc.2
+		IL_0018: ldloc.2
+		IL_0019: stloc.1
+		IL_001a: ldnull
+		IL_001b: ldftn object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29::__js_call__(object, object)
+		IL_0021: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object)
+		IL_002b: stloc.2
+		IL_002c: ldloc.1
+		IL_002d: ldstr "prototype"
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0037: ldstr "resolve"
+		IL_003c: ldloc.2
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_0042: pop
+		IL_0043: ldarg.2
+		IL_0044: ldstr "exports"
+		IL_0049: ldloc.1
+		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object)
+		IL_004f: pop
+		IL_0050: ret
+	} // end of method CommonJS_Require_Captures_Shadowed_Global_URL_Lib::__js_module_init__
+
+} // end of class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x21d5
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.CommonJS_Require_Captures_Shadowed_Global_URL::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary
- Fixes the v0.9.8 Linux/Windows release smoke failure in `samples/Hosting.Domino`.
- Updates closure/free-variable analysis so module-local bindings named like runtime globals (for example `URL`) still shadow the global and are captured by nested CommonJS function expressions.
- Adds focused CommonJS execution/generator coverage and an Unreleased changelog entry.

## Root cause
The smoke jobs failed while compiling `@mixmark-io/domino` because `Document.js` declares `var URL = require('./URL')`, then a nested function expression closes over `URL`. The symbol-table capture analysis ignored the reference because `URL` is also a known global intrinsic name, so later LIR lowering could not find storage for that binding.

This is a product regression, so the changelog is updated and a patch release should be cut after merge.

## Validation
- `dotnet test .\tests\Js2IL.Tests\Js2IL.Tests.csproj -c Release /p:IsTestProject=true --filter "FullyQualifiedName~Js2IL.Tests.CommonJS.ExecutionTests.CommonJS_Require_Captures_Shadowed_Global_URL|FullyQualifiedName~Js2IL.Tests.CommonJS.GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL" --nologo`
- `dotnet test .\tests\Js2IL.Tests\Js2IL.Tests.csproj -c Release /p:IsTestProject=true --no-build --filter "FullyQualifiedName~Js2IL.Tests.CommonJS." --nologo`
- packed local `Js2IL.SDK`/`Js2IL.Runtime`/`Js2IL.Core` prerelease packages and ran `samples\Hosting.Domino\host\Hosting.Domino.csproj` with the local feed; output included `title=JS2IL Domino Sample` and `links=2`.
