### PR TITLE
fix(ci): wait for published packages in benchmark suite

### DIFF
--- a/.github/workflows/benchmarkdotnet-suite.yml
+++ b/.github/workflows/benchmarkdotnet-suite.yml
@@ -23,6 +23,7 @@ jobs:
   benchmarkdotnet-suite:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: write
     
@@ -68,6 +69,54 @@ jobs:
             echo "USE_PUBLISHED_JS2IL_PACKAGES=false" >> "$GITHUB_ENV"
           fi
 
+      - name: Wait for published Js2IL packages
+        if: env.USE_PUBLISHED_JS2IL_PACKAGES == 'true' && github.event_name == 'release'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflowId = 'publish-tool.yml';
+            const targetSha = process.env.GITHUB_SHA;
+            const targetRef = process.env.GITHUB_REF_NAME;
+            const deadlineMs = 20 * 60 * 1000;
+            const pollMs = 15 * 1000;
+            const startedAt = Date.now();
+
+            while (Date.now() - startedAt < deadlineMs) {
+              const response = await github.request('GET /repos/{owner}/{repo}/actions/runs', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                event: 'push',
+                per_page: 50
+              });
+
+              const run = response.data.workflow_runs.find(candidate =>
+                candidate.path === '.github/workflows/publish-tool.yml' &&
+                candidate.head_sha === targetSha &&
+                candidate.head_branch === targetRef);
+
+              if (!run) {
+                core.info(`Waiting for ${workflowId} run for ${targetRef} (${targetSha}) to appear...`);
+                await new Promise(resolve => setTimeout(resolve, pollMs));
+                continue;
+              }
+
+              core.info(`Found ${workflowId} run ${run.id} with status=${run.status} conclusion=${run.conclusion ?? 'n/a'}`);
+
+              if (run.status !== 'completed') {
+                await new Promise(resolve => setTimeout(resolve, pollMs));
+                continue;
+              }
+
+              if (run.conclusion !== 'success') {
+                throw new Error(`${workflowId} run ${run.id} completed with conclusion=${run.conclusion}`);
+              }
+
+              core.info(`${workflowId} completed successfully; proceeding to package restore.`);
+              return;
+            }
+
+            throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
+
       - name: Restore benchmark project
         shell: bash
         run: |
@@ -79,7 +128,10 @@ jobs:
             delay=30
 
             for i in $(seq 1 $tries); do
+              dotnet nuget locals http-cache --clear || true
+
               if dotnet restore Benchmarks.csproj \
+                --no-cache \
                 -p:UsePublishedJs2ILPackages=true \
                 -p:Js2ILPackageVersion="${JS2IL_PACKAGE_VERSION}"; then
                 echo "Restored Js2IL benchmark packages ${JS2IL_PACKAGE_VERSION}"

--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -10,6 +10,7 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     env:
       DOTNET_NOLOGO: true
@@ -36,6 +37,54 @@ jobs:
           echo "Using tool version: $version"
           echo "TOOL_VERSION=$version" >> "$GITHUB_ENV"
 
+      - name: Wait for published Js2IL packages
+        if: github.event_name == 'release'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflowId = 'publish-tool.yml';
+            const targetSha = process.env.GITHUB_SHA;
+            const targetRef = process.env.GITHUB_REF_NAME;
+            const deadlineMs = 20 * 60 * 1000;
+            const pollMs = 15 * 1000;
+            const startedAt = Date.now();
+
+            while (Date.now() - startedAt < deadlineMs) {
+              const response = await github.request('GET /repos/{owner}/{repo}/actions/runs', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                event: 'push',
+                per_page: 50
+              });
+
+              const run = response.data.workflow_runs.find(candidate =>
+                candidate.path === '.github/workflows/publish-tool.yml' &&
+                candidate.head_sha === targetSha &&
+                candidate.head_branch === targetRef);
+
+              if (!run) {
+                core.info(`Waiting for ${workflowId} run for ${targetRef} (${targetSha}) to appear...`);
+                await new Promise(resolve => setTimeout(resolve, pollMs));
+                continue;
+              }
+
+              core.info(`Found ${workflowId} run ${run.id} with status=${run.status} conclusion=${run.conclusion ?? 'n/a'}`);
+
+              if (run.status !== 'completed') {
+                await new Promise(resolve => setTimeout(resolve, pollMs));
+                continue;
+              }
+
+              if (run.conclusion !== 'success') {
+                throw new Error(`${workflowId} run ${run.id} completed with conclusion=${run.conclusion}`);
+              }
+
+              core.info(`${workflowId} completed successfully; proceeding to tool install.`);
+              return;
+            }
+
+            throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
+
       - name: Install js2il tool from NuGet (specific version with retry)
         run: |
           set -euo pipefail
@@ -43,6 +92,7 @@ jobs:
           tries=20
           delay=30
           for i in $(seq 1 $tries); do
+            dotnet nuget locals http-cache --clear || true
             if dotnet tool install --global js2il --version "$TOOL_VERSION"; then
               echo "Installed js2il $TOOL_VERSION"
               exit 0

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -10,6 +10,7 @@ jobs:
   smoke:
     runs-on: windows-latest
     permissions:
+      actions: read
       contents: write
     env:
       DOTNET_NOLOGO: true
@@ -38,6 +39,54 @@ jobs:
           "Using tool version: $version" | Write-Output
           "TOOL_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Wait for published Js2IL packages
+        if: github.event_name == 'release'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflowId = 'publish-tool.yml';
+            const targetSha = process.env.GITHUB_SHA;
+            const targetRef = process.env.GITHUB_REF_NAME;
+            const deadlineMs = 20 * 60 * 1000;
+            const pollMs = 15 * 1000;
+            const startedAt = Date.now();
+
+            while (Date.now() - startedAt < deadlineMs) {
+              const response = await github.request('GET /repos/{owner}/{repo}/actions/runs', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                event: 'push',
+                per_page: 50
+              });
+
+              const run = response.data.workflow_runs.find(candidate =>
+                candidate.path === '.github/workflows/publish-tool.yml' &&
+                candidate.head_sha === targetSha &&
+                candidate.head_branch === targetRef);
+
+              if (!run) {
+                core.info(`Waiting for ${workflowId} run for ${targetRef} (${targetSha}) to appear...`);
+                await new Promise(resolve => setTimeout(resolve, pollMs));
+                continue;
+              }
+
+              core.info(`Found ${workflowId} run ${run.id} with status=${run.status} conclusion=${run.conclusion ?? 'n/a'}`);
+
+              if (run.status !== 'completed') {
+                await new Promise(resolve => setTimeout(resolve, pollMs));
+                continue;
+              }
+
+              if (run.conclusion !== 'success') {
+                throw new Error(`${workflowId} run ${run.id} completed with conclusion=${run.conclusion}`);
+              }
+
+              core.info(`${workflowId} completed successfully; proceeding to tool install.`);
+              return;
+            }
+
+            throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
+
       - name: Install js2il tool from NuGet (specific version with retry)
         shell: pwsh
         run: |
@@ -48,6 +97,7 @@ jobs:
           $delaySeconds = 30
 
           for ($i = 1; $i -le $tries; $i++) {
+            dotnet nuget locals http-cache --clear | Write-Output
             dotnet tool install --global js2il --version $env:TOOL_VERSION
             if ($LASTEXITCODE -eq 0) {
               "Installed js2il $env:TOOL_VERSION" | Write-Output


### PR DESCRIPTION
## Summary
- wait for the release-triggered BenchmarkDotNet workflow to see the matching publish-tool run before restoring published packages
- clear NuGet HTTP metadata and restore with --no-cache so repeated retries can observe freshly published package versions
- keep the existing published-package retry loop while making the release benchmark path resilient to publish/indexing races

## Validation
- restored and built tests/performance/Benchmarks against published Js2IL packages version 0.9.11 locally