### PR TITLE
fix(perf): Restore prime typed-array hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler/runtime/tests: fix the prime benchmark regression by restoring direct `Int32Array` numeric-index hot paths (including boxed numeric indexes) instead of falling back to generic item helpers, repairing the corresponding inline typed-array IL emission for verifier-safe direct reads, and adding a boxed-double `TypeUtilities.ToNumber(...)` fast path to reduce coercion overhead in hot loops.
 
 ## v0.9.11 - 2026-05-03
 

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Collections.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Collections.cs
@@ -360,7 +360,7 @@ internal sealed partial class LIRToILCompiler
                     }
 
                     // Index must be numeric double
-                    EmitLoadTemp(getI32.Index, ilEncoder, allocation, methodDescriptor);
+                    EmitLoadTempAsDouble(getI32.Index, ilEncoder, allocation, methodDescriptor);
 
                     var int32ArrayGetter = _memberRefRegistry.GetOrAddMethod(
                         typeof(JavaScriptRuntime.Int32Array),

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -914,7 +914,7 @@ internal sealed partial class LIRToILCompiler
                         ilEncoder.Token(_typeReferenceRegistry.GetOrAdd(typeof(JavaScriptRuntime.Int32Array)));
                     }
 
-                    EmitLoadTemp(getI32.Index, ilEncoder, allocation, methodDescriptor);
+                    EmitLoadTempAsDouble(getI32.Index, ilEncoder, allocation, methodDescriptor);
 
                     var int32ArrayGetter = _memberRefRegistry.GetOrAddMethod(
                         typeof(JavaScriptRuntime.Int32Array),

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -182,7 +182,7 @@ internal static class LIRIntrinsicNormalization
 
                 // Int32Array element access (numeric index).
                 if (receiverType == typeof(JavaScriptRuntime.Int32Array)
-                    && IsUnboxedDouble(methodBody, getItem.Index))
+                    && IsNumericDouble(methodBody, getItem.Index))
                 {
                     // Rewrite: GetItem(receiver, indexDouble, result) -> GetInt32ArrayElement(receiver, indexDouble, result)
                     methodBody.Instructions[i] = new LIRGetInt32ArrayElement(getItem.Object, getItem.Index, getItem.Result);
@@ -225,6 +225,18 @@ internal static class LIRIntrinsicNormalization
 
             if (instruction is LIRGetItemAsNumber getItemAsNumber)
             {
+                if (knownSpecializedReceiverClrTypes.TryGetValue(getItemAsNumber.Object.Index, out var receiverType)
+                    && receiverType == typeof(JavaScriptRuntime.Int32Array)
+                    && IsNumericDouble(methodBody, getItemAsNumber.Index))
+                {
+                    methodBody.Instructions[i] = new LIRGetInt32ArrayElement(
+                        getItemAsNumber.Object,
+                        getItemAsNumber.Index,
+                        getItemAsNumber.Result);
+                    methodBody.TempStorages[getItemAsNumber.Result.Index] = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double));
+                    continue;
+                }
+
                 if (IsTempStringReference(methodBody, getItemAsNumber.Index))
                 {
                     methodBody.Instructions[i] = new LIRGetItemAsNumberString(

--- a/src/JavaScriptRuntime/Operators.cs
+++ b/src/JavaScriptRuntime/Operators.cs
@@ -113,12 +113,17 @@ namespace JavaScriptRuntime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static object Add(object? a, object? b)
         {
-            a = ToPrimitiveForAddition(a);
-            b = ToPrimitiveForAddition(b);
-
             if (a is double leftDouble && b is double rightDouble)
             {
                 return leftDouble + rightDouble;
+            }
+
+            a = ToPrimitiveForAddition(a);
+            b = ToPrimitiveForAddition(b);
+
+            if (a is double leftPrimitiveDouble && b is double rightPrimitiveDouble)
+            {
+                return leftPrimitiveDouble + rightPrimitiveDouble;
             }
 
             // If either is a string, concatenate string representations
@@ -156,11 +161,16 @@ namespace JavaScriptRuntime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static object Add(double a, object? b)
         {
-            b = ToPrimitiveForAddition(b);
-
             if (b is double db)
             {
                 return a + db;
+            }
+
+            b = ToPrimitiveForAddition(b);
+
+            if (b is double primitiveDouble)
+            {
+                return a + primitiveDouble;
             }
 
             if (b is string)
@@ -186,11 +196,16 @@ namespace JavaScriptRuntime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static object Add(object? a, double b)
         {
-            a = ToPrimitiveForAddition(a);
-
             if (a is double da)
             {
                 return da + b;
+            }
+
+            a = ToPrimitiveForAddition(a);
+
+            if (a is double primitiveDouble)
+            {
+                return primitiveDouble + b;
             }
 
             if (a is string)

--- a/src/JavaScriptRuntime/TypeUtilities.cs
+++ b/src/JavaScriptRuntime/TypeUtilities.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Dynamic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace JavaScriptRuntime
 {
@@ -36,13 +37,20 @@ namespace JavaScriptRuntime
         }
 
         // JS ToNumber coercion used by codegen slow paths when operand type is uncertain
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double ToNumber(object? value)
         {
+            if (value is double d) return d;
             // JS ToNumber(undefined) => NaN (undefined is represented as CLR null)
             if (value == null) return double.NaN;
+
+            return ToNumberSlow(value);
+        }
+
+        private static double ToNumberSlow(object value)
+        {
             switch (value)
             {
-                case double d: return d;
                 case float f: return (double)f;
                 case int i: return i;
                 case long l: return l;

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f8d
+					// Method begins at RVA 0x2fa9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f84
+				// Method begins at RVA 0x2fa0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f96
+				// Method begins at RVA 0x2fb2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -412,7 +412,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e7f
+				// Method begins at RVA 0x2e9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -432,7 +432,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e88
+				// Method begins at RVA 0x2ea4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e91
+				// Method begins at RVA 0x2ead
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -480,7 +480,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2eac
+						// Method begins at RVA 0x2ec8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -504,7 +504,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2ebe
+							// Method begins at RVA 0x2eda
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -522,7 +522,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2eb5
+						// Method begins at RVA 0x2ed1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -540,7 +540,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ea3
+					// Method begins at RVA 0x2ebf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -568,7 +568,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2ed9
+							// Method begins at RVA 0x2ef5
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -586,7 +586,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ed0
+						// Method begins at RVA 0x2eec
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -604,7 +604,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ec7
+					// Method begins at RVA 0x2ee3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -628,7 +628,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2eeb
+						// Method begins at RVA 0x2f07
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -646,7 +646,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ee2
+					// Method begins at RVA 0x2efe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -664,7 +664,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e9a
+				// Method begins at RVA 0x2eb6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -684,7 +684,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ef4
+				// Method begins at RVA 0x2f10
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -708,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f06
+					// Method begins at RVA 0x2f22
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -726,7 +726,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2efd
+				// Method begins at RVA 0x2f19
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -803,7 +803,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28e4
+			// Method begins at RVA 0x2900
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -878,7 +878,7 @@
 			)
 			// Method begins at RVA 0x25bc
 			// Header size: 12
-			// Code size: 795 (0x31b)
+			// Code size: 822 (0x336)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26,
@@ -920,7 +920,7 @@
 			IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0024: ldloc.s 19
 			IL_0026: cgt
-			IL_0028: brfalse IL_01c7
+			IL_0028: brfalse IL_01d0
 
 			IL_002d: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26::.ctor()
 			IL_0032: stloc.0
@@ -997,7 +997,7 @@
 				IL_00d4: ldloc.s 19
 				IL_00d6: ldloc.s 21
 				IL_00d8: clt
-				IL_00da: brfalse IL_01c5
+				IL_00da: brfalse IL_01ce
 
 				IL_00df: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75::.ctor()
 				IL_00e4: stloc.s 7
@@ -1044,191 +1044,200 @@
 					IL_0148: ldarg.0
 					IL_0149: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
 					IL_014e: ldloc.s 8
-					IL_0150: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-					IL_0155: stloc.s 21
-					IL_0157: ldloc.s 21
-					IL_0159: conv.i4
-					IL_015a: ldloc.s 10
-					IL_015c: conv.i4
-					IL_015d: or
-					IL_015e: conv.r8
-					IL_015f: stloc.s 21
-					IL_0161: ldloc.s 21
-					IL_0163: box [System.Runtime]System.Double
-					IL_0168: stloc.s 22
-					IL_016a: ldarg.0
-					IL_016b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_0170: ldloc.s 8
-					IL_0172: unbox.any [System.Runtime]System.Double
-					IL_0177: ldloc.s 22
-					IL_0179: unbox.any [System.Runtime]System.Double
-					IL_017e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_0183: ldloc.s 8
-					IL_0185: unbox.any [System.Runtime]System.Double
-					IL_018a: ldarg.2
-					IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
-					IL_0190: stloc.s 20
-					IL_0192: ldloc.s 20
-					IL_0194: stloc.s 8
-					IL_0196: ldloc.s 8
-					IL_0198: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_019d: stloc.s 21
-					IL_019f: ldloc.s 21
-					IL_01a1: ldloc.s 5
-					IL_01a3: cgt
-					IL_01a5: ldc.i4.0
-					IL_01a6: ceq
-					IL_01a8: brfalse IL_01b2
+					IL_0150: unbox.any [System.Runtime]System.Double
+					IL_0155: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_015a: stloc.s 21
+					IL_015c: ldloc.s 21
+					IL_015e: stloc.s 21
+					IL_0160: ldloc.s 21
+					IL_0162: conv.i4
+					IL_0163: ldloc.s 10
+					IL_0165: conv.i4
+					IL_0166: or
+					IL_0167: conv.r8
+					IL_0168: stloc.s 21
+					IL_016a: ldloc.s 21
+					IL_016c: box [System.Runtime]System.Double
+					IL_0171: stloc.s 22
+					IL_0173: ldarg.0
+					IL_0174: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_0179: ldloc.s 8
+					IL_017b: unbox.any [System.Runtime]System.Double
+					IL_0180: ldloc.s 22
+					IL_0182: unbox.any [System.Runtime]System.Double
+					IL_0187: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_018c: ldloc.s 8
+					IL_018e: unbox.any [System.Runtime]System.Double
+					IL_0193: ldarg.2
+					IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
+					IL_0199: stloc.s 20
+					IL_019b: ldloc.s 20
+					IL_019d: stloc.s 8
+					IL_019f: ldloc.s 8
+					IL_01a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01a6: stloc.s 21
+					IL_01a8: ldloc.s 21
+					IL_01aa: ldloc.s 5
+					IL_01ac: cgt
+					IL_01ae: ldc.i4.0
+					IL_01af: ceq
+					IL_01b1: brfalse IL_01bb
 
-					IL_01ad: br IL_0141
+					IL_01b6: br IL_0141
 				// end loop
 
-				IL_01b2: ldloc.s 6
-				IL_01b4: ldarg.2
-				IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01ba: stloc.s 20
-				IL_01bc: ldloc.s 20
-				IL_01be: stloc.s 6
-				IL_01c0: br IL_00c3
+				IL_01bb: ldloc.s 6
+				IL_01bd: ldarg.2
+				IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01c3: stloc.s 20
+				IL_01c5: ldloc.s 20
+				IL_01c7: stloc.s 6
+				IL_01c9: br IL_00c3
 			// end loop
 
-			IL_01c5: ldnull
-			IL_01c6: ret
+			IL_01ce: ldnull
+			IL_01cf: ret
 
-			IL_01c7: ldarg.1
-			IL_01c8: stloc.s 12
-			IL_01ca: ldloc.s 12
-			IL_01cc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01d1: stloc.s 21
-			IL_01d3: ldloc.s 21
-			IL_01d5: conv.i4
-			IL_01d6: conv.u4
-			IL_01d7: ldc.r8 5
-			IL_01e0: conv.i4
-			IL_01e1: shr.un
-			IL_01e2: conv.r.un
-			IL_01e3: stloc.s 21
-			IL_01e5: ldloc.s 21
-			IL_01e7: box [System.Runtime]System.Double
-			IL_01ec: stloc.s 22
-			IL_01ee: ldloc.s 22
-			IL_01f0: stloc.s 13
-			IL_01f2: ldarg.0
-			IL_01f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_01f8: ldloc.s 13
-			IL_01fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_01ff: stloc.s 21
-			IL_0201: ldloc.s 21
-			IL_0203: stloc.s 14
-			// loop start (head: IL_0205)
-				IL_0205: ldloc.s 12
-				IL_0207: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_020c: stloc.s 21
-				IL_020e: ldloc.s 21
-				IL_0210: ldarg.3
-				IL_0211: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0216: clt
-				IL_0218: brfalse IL_02f7
+			IL_01d0: ldarg.1
+			IL_01d1: stloc.s 12
+			IL_01d3: ldloc.s 12
+			IL_01d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01da: stloc.s 21
+			IL_01dc: ldloc.s 21
+			IL_01de: conv.i4
+			IL_01df: conv.u4
+			IL_01e0: ldc.r8 5
+			IL_01e9: conv.i4
+			IL_01ea: shr.un
+			IL_01eb: conv.r.un
+			IL_01ec: stloc.s 21
+			IL_01ee: ldloc.s 21
+			IL_01f0: box [System.Runtime]System.Double
+			IL_01f5: stloc.s 22
+			IL_01f7: ldloc.s 22
+			IL_01f9: stloc.s 13
+			IL_01fb: ldarg.0
+			IL_01fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0201: ldloc.s 13
+			IL_0203: unbox.any [System.Runtime]System.Double
+			IL_0208: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_020d: stloc.s 21
+			IL_020f: ldloc.s 21
+			IL_0211: stloc.s 21
+			IL_0213: ldloc.s 21
+			IL_0215: stloc.s 14
+			// loop start (head: IL_0217)
+				IL_0217: ldloc.s 12
+				IL_0219: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_021e: stloc.s 21
+				IL_0220: ldloc.s 21
+				IL_0222: ldarg.3
+				IL_0223: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0228: clt
+				IL_022a: brfalse IL_0312
 
-				IL_021d: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
-				IL_0222: stloc.s 15
-				IL_0224: ldloc.s 12
-				IL_0226: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_022b: stloc.s 21
-				IL_022d: ldloc.s 21
-				IL_022f: conv.i4
-				IL_0230: ldc.r8 31
-				IL_0239: conv.i4
-				IL_023a: and
-				IL_023b: conv.r8
-				IL_023c: stloc.s 21
-				IL_023e: ldloc.s 21
-				IL_0240: stloc.s 16
-				IL_0242: ldc.r8 1
+				IL_022f: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
+				IL_0234: stloc.s 15
+				IL_0236: ldloc.s 12
+				IL_0238: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_023d: stloc.s 21
+				IL_023f: ldloc.s 21
+				IL_0241: conv.i4
+				IL_0242: ldc.r8 31
 				IL_024b: conv.i4
-				IL_024c: ldloc.s 16
-				IL_024e: conv.i4
-				IL_024f: shl
-				IL_0250: conv.r8
-				IL_0251: stloc.s 21
-				IL_0253: ldloc.s 14
-				IL_0255: conv.i4
-				IL_0256: ldloc.s 21
-				IL_0258: conv.i4
-				IL_0259: or
-				IL_025a: conv.r8
-				IL_025b: stloc.s 21
-				IL_025d: ldloc.s 21
-				IL_025f: stloc.s 14
-				IL_0261: ldloc.s 12
-				IL_0263: ldarg.2
-				IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0269: stloc.s 20
-				IL_026b: ldloc.s 20
-				IL_026d: stloc.s 12
-				IL_026f: ldloc.s 12
-				IL_0271: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0276: stloc.s 21
-				IL_0278: ldloc.s 21
-				IL_027a: conv.i4
-				IL_027b: conv.u4
-				IL_027c: ldc.r8 5
-				IL_0285: conv.i4
-				IL_0286: shr.un
-				IL_0287: conv.r.un
+				IL_024c: and
+				IL_024d: conv.r8
+				IL_024e: stloc.s 21
+				IL_0250: ldloc.s 21
+				IL_0252: stloc.s 16
+				IL_0254: ldc.r8 1
+				IL_025d: conv.i4
+				IL_025e: ldloc.s 16
+				IL_0260: conv.i4
+				IL_0261: shl
+				IL_0262: conv.r8
+				IL_0263: stloc.s 21
+				IL_0265: ldloc.s 14
+				IL_0267: conv.i4
+				IL_0268: ldloc.s 21
+				IL_026a: conv.i4
+				IL_026b: or
+				IL_026c: conv.r8
+				IL_026d: stloc.s 21
+				IL_026f: ldloc.s 21
+				IL_0271: stloc.s 14
+				IL_0273: ldloc.s 12
+				IL_0275: ldarg.2
+				IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_027b: stloc.s 20
+				IL_027d: ldloc.s 20
+				IL_027f: stloc.s 12
+				IL_0281: ldloc.s 12
+				IL_0283: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0288: stloc.s 21
 				IL_028a: ldloc.s 21
-				IL_028c: stloc.s 17
-				IL_028e: ldloc.s 17
-				IL_0290: box [System.Runtime]System.Double
-				IL_0295: stloc.s 22
-				IL_0297: ldloc.s 22
-				IL_0299: ldloc.s 13
-				IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-				IL_02a0: stloc.s 23
-				IL_02a2: ldloc.s 23
-				IL_02a4: brfalse IL_02f2
+				IL_028c: conv.i4
+				IL_028d: conv.u4
+				IL_028e: ldc.r8 5
+				IL_0297: conv.i4
+				IL_0298: shr.un
+				IL_0299: conv.r.un
+				IL_029a: stloc.s 21
+				IL_029c: ldloc.s 21
+				IL_029e: stloc.s 17
+				IL_02a0: ldloc.s 17
+				IL_02a2: box [System.Runtime]System.Double
+				IL_02a7: stloc.s 22
+				IL_02a9: ldloc.s 22
+				IL_02ab: ldloc.s 13
+				IL_02ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
+				IL_02b2: stloc.s 23
+				IL_02b4: ldloc.s 23
+				IL_02b6: brfalse IL_030d
 
-				IL_02a9: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36::.ctor()
-				IL_02ae: stloc.s 18
-				IL_02b0: ldloc.s 14
-				IL_02b2: box [System.Runtime]System.Double
-				IL_02b7: stloc.s 22
-				IL_02b9: ldarg.0
-				IL_02ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_02bf: ldloc.s 13
-				IL_02c1: unbox.any [System.Runtime]System.Double
-				IL_02c6: ldloc.s 22
-				IL_02c8: unbox.any [System.Runtime]System.Double
-				IL_02cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_02d2: ldloc.s 17
-				IL_02d4: box [System.Runtime]System.Double
-				IL_02d9: stloc.s 22
-				IL_02db: ldloc.s 22
-				IL_02dd: stloc.s 13
-				IL_02df: ldarg.0
-				IL_02e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_02e5: ldloc.s 13
-				IL_02e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_02ec: stloc.s 21
-				IL_02ee: ldloc.s 21
-				IL_02f0: stloc.s 14
+				IL_02bb: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36::.ctor()
+				IL_02c0: stloc.s 18
+				IL_02c2: ldloc.s 14
+				IL_02c4: box [System.Runtime]System.Double
+				IL_02c9: stloc.s 22
+				IL_02cb: ldarg.0
+				IL_02cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_02d1: ldloc.s 13
+				IL_02d3: unbox.any [System.Runtime]System.Double
+				IL_02d8: ldloc.s 22
+				IL_02da: unbox.any [System.Runtime]System.Double
+				IL_02df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_02e4: ldloc.s 17
+				IL_02e6: box [System.Runtime]System.Double
+				IL_02eb: stloc.s 22
+				IL_02ed: ldloc.s 22
+				IL_02ef: stloc.s 13
+				IL_02f1: ldarg.0
+				IL_02f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_02f7: ldloc.s 13
+				IL_02f9: unbox.any [System.Runtime]System.Double
+				IL_02fe: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0303: stloc.s 21
+				IL_0305: ldloc.s 21
+				IL_0307: stloc.s 21
+				IL_0309: ldloc.s 21
+				IL_030b: stloc.s 14
 
-				IL_02f2: br IL_0205
+				IL_030d: br IL_0217
 			// end loop
 
-			IL_02f7: ldloc.s 14
-			IL_02f9: box [System.Runtime]System.Double
-			IL_02fe: stloc.s 22
-			IL_0300: ldarg.0
-			IL_0301: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_0306: ldloc.s 13
-			IL_0308: unbox.any [System.Runtime]System.Double
-			IL_030d: ldloc.s 22
-			IL_030f: unbox.any [System.Runtime]System.Double
-			IL_0314: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_0319: ldnull
-			IL_031a: ret
+			IL_0312: ldloc.s 14
+			IL_0314: box [System.Runtime]System.Double
+			IL_0319: stloc.s 22
+			IL_031b: ldarg.0
+			IL_031c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0321: ldloc.s 13
+			IL_0323: unbox.any [System.Runtime]System.Double
+			IL_0328: ldloc.s 22
+			IL_032a: unbox.any [System.Runtime]System.Double
+			IL_032f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_0334: ldnull
+			IL_0335: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1239,7 +1248,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2950
+			// Method begins at RVA 0x296c
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1353,7 +1362,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f0f
+				// Method begins at RVA 0x2f2b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1373,7 +1382,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f18
+				// Method begins at RVA 0x2f34
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1397,7 +1406,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f2a
+					// Method begins at RVA 0x2f46
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1415,7 +1424,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f21
+				// Method begins at RVA 0x2f3d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1435,7 +1444,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f33
+				// Method begins at RVA 0x2f4f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1463,7 +1472,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f4e
+						// Method begins at RVA 0x2f6a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1481,7 +1490,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f45
+					// Method begins at RVA 0x2f61
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1499,7 +1508,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f3c
+				// Method begins at RVA 0x2f58
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1519,7 +1528,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f57
+				// Method begins at RVA 0x2f73
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1543,7 +1552,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f69
+					// Method begins at RVA 0x2f85
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1561,7 +1570,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f60
+				// Method begins at RVA 0x2f7c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1585,7 +1594,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f7b
+					// Method begins at RVA 0x2f97
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1603,7 +1612,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f72
+				// Method begins at RVA 0x2f8e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1697,7 +1706,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29ac
+			// Method begins at RVA 0x29c8
 			// Header size: 12
 			// Code size: 206 (0xce)
 			.maxstack 8
@@ -1795,7 +1804,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d10
+			// Method begins at RVA 0x2d2c
 			// Header size: 12
 			// Code size: 120 (0x78)
 			.maxstack 8
@@ -1862,7 +1871,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d94
+			// Method begins at RVA 0x2db0
 			// Header size: 12
 			// Code size: 214 (0xd6)
 			.maxstack 8
@@ -1961,7 +1970,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a88
+			// Method begins at RVA 0x2aa4
 			// Header size: 12
 			// Code size: 633 (0x279)
 			.maxstack 8
@@ -2208,7 +2217,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2e76
+			// Method begins at RVA 0x2e92
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2403,7 +2412,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2f9f
+		// Method begins at RVA 0x2fbb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Js2IL.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f45
+					// Method begins at RVA 0x2f61
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f3c
+				// Method begins at RVA 0x2f58
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f4e
+				// Method begins at RVA 0x2f6a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -370,7 +370,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e37
+				// Method begins at RVA 0x2e53
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -390,7 +390,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e40
+				// Method begins at RVA 0x2e5c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -410,7 +410,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e49
+				// Method begins at RVA 0x2e65
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -438,7 +438,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e64
+						// Method begins at RVA 0x2e80
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -462,7 +462,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2e76
+							// Method begins at RVA 0x2e92
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -480,7 +480,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e6d
+						// Method begins at RVA 0x2e89
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -498,7 +498,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e5b
+					// Method begins at RVA 0x2e77
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -526,7 +526,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2e91
+							// Method begins at RVA 0x2ead
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -544,7 +544,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e88
+						// Method begins at RVA 0x2ea4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -562,7 +562,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e7f
+					// Method begins at RVA 0x2e9b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -586,7 +586,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ea3
+						// Method begins at RVA 0x2ebf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -604,7 +604,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e9a
+					// Method begins at RVA 0x2eb6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -622,7 +622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e52
+				// Method begins at RVA 0x2e6e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -642,7 +642,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eac
+				// Method begins at RVA 0x2ec8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -666,7 +666,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ebe
+					// Method begins at RVA 0x2eda
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -684,7 +684,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eb5
+				// Method begins at RVA 0x2ed1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -761,7 +761,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x289c
+			// Method begins at RVA 0x28b8
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -836,7 +836,7 @@
 			)
 			// Method begins at RVA 0x2574
 			// Header size: 12
-			// Code size: 795 (0x31b)
+			// Code size: 822 (0x336)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26,
@@ -878,7 +878,7 @@
 			IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0024: ldloc.s 19
 			IL_0026: cgt
-			IL_0028: brfalse IL_01c7
+			IL_0028: brfalse IL_01d0
 
 			IL_002d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26::.ctor()
 			IL_0032: stloc.0
@@ -955,7 +955,7 @@
 				IL_00d4: ldloc.s 19
 				IL_00d6: ldloc.s 21
 				IL_00d8: clt
-				IL_00da: brfalse IL_01c5
+				IL_00da: brfalse IL_01ce
 
 				IL_00df: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75::.ctor()
 				IL_00e4: stloc.s 7
@@ -1002,191 +1002,200 @@
 					IL_0148: ldarg.0
 					IL_0149: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
 					IL_014e: ldloc.s 8
-					IL_0150: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-					IL_0155: stloc.s 21
-					IL_0157: ldloc.s 21
-					IL_0159: conv.i4
-					IL_015a: ldloc.s 10
-					IL_015c: conv.i4
-					IL_015d: or
-					IL_015e: conv.r8
-					IL_015f: stloc.s 21
-					IL_0161: ldloc.s 21
-					IL_0163: box [System.Runtime]System.Double
-					IL_0168: stloc.s 22
-					IL_016a: ldarg.0
-					IL_016b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_0170: ldloc.s 8
-					IL_0172: unbox.any [System.Runtime]System.Double
-					IL_0177: ldloc.s 22
-					IL_0179: unbox.any [System.Runtime]System.Double
-					IL_017e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_0183: ldloc.s 8
-					IL_0185: unbox.any [System.Runtime]System.Double
-					IL_018a: ldarg.2
-					IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
-					IL_0190: stloc.s 20
-					IL_0192: ldloc.s 20
-					IL_0194: stloc.s 8
-					IL_0196: ldloc.s 8
-					IL_0198: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_019d: stloc.s 21
-					IL_019f: ldloc.s 21
-					IL_01a1: ldloc.s 5
-					IL_01a3: cgt
-					IL_01a5: ldc.i4.0
-					IL_01a6: ceq
-					IL_01a8: brfalse IL_01b2
+					IL_0150: unbox.any [System.Runtime]System.Double
+					IL_0155: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_015a: stloc.s 21
+					IL_015c: ldloc.s 21
+					IL_015e: stloc.s 21
+					IL_0160: ldloc.s 21
+					IL_0162: conv.i4
+					IL_0163: ldloc.s 10
+					IL_0165: conv.i4
+					IL_0166: or
+					IL_0167: conv.r8
+					IL_0168: stloc.s 21
+					IL_016a: ldloc.s 21
+					IL_016c: box [System.Runtime]System.Double
+					IL_0171: stloc.s 22
+					IL_0173: ldarg.0
+					IL_0174: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_0179: ldloc.s 8
+					IL_017b: unbox.any [System.Runtime]System.Double
+					IL_0180: ldloc.s 22
+					IL_0182: unbox.any [System.Runtime]System.Double
+					IL_0187: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_018c: ldloc.s 8
+					IL_018e: unbox.any [System.Runtime]System.Double
+					IL_0193: ldarg.2
+					IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
+					IL_0199: stloc.s 20
+					IL_019b: ldloc.s 20
+					IL_019d: stloc.s 8
+					IL_019f: ldloc.s 8
+					IL_01a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01a6: stloc.s 21
+					IL_01a8: ldloc.s 21
+					IL_01aa: ldloc.s 5
+					IL_01ac: cgt
+					IL_01ae: ldc.i4.0
+					IL_01af: ceq
+					IL_01b1: brfalse IL_01bb
 
-					IL_01ad: br IL_0141
+					IL_01b6: br IL_0141
 				// end loop
 
-				IL_01b2: ldloc.s 6
-				IL_01b4: ldarg.2
-				IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01ba: stloc.s 20
-				IL_01bc: ldloc.s 20
-				IL_01be: stloc.s 6
-				IL_01c0: br IL_00c3
+				IL_01bb: ldloc.s 6
+				IL_01bd: ldarg.2
+				IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01c3: stloc.s 20
+				IL_01c5: ldloc.s 20
+				IL_01c7: stloc.s 6
+				IL_01c9: br IL_00c3
 			// end loop
 
-			IL_01c5: ldnull
-			IL_01c6: ret
+			IL_01ce: ldnull
+			IL_01cf: ret
 
-			IL_01c7: ldarg.1
-			IL_01c8: stloc.s 12
-			IL_01ca: ldloc.s 12
-			IL_01cc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01d1: stloc.s 21
-			IL_01d3: ldloc.s 21
-			IL_01d5: conv.i4
-			IL_01d6: conv.u4
-			IL_01d7: ldc.r8 5
-			IL_01e0: conv.i4
-			IL_01e1: shr.un
-			IL_01e2: conv.r.un
-			IL_01e3: stloc.s 21
-			IL_01e5: ldloc.s 21
-			IL_01e7: box [System.Runtime]System.Double
-			IL_01ec: stloc.s 22
-			IL_01ee: ldloc.s 22
-			IL_01f0: stloc.s 13
-			IL_01f2: ldarg.0
-			IL_01f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_01f8: ldloc.s 13
-			IL_01fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_01ff: stloc.s 21
-			IL_0201: ldloc.s 21
-			IL_0203: stloc.s 14
-			// loop start (head: IL_0205)
-				IL_0205: ldloc.s 12
-				IL_0207: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_020c: stloc.s 21
-				IL_020e: ldloc.s 21
-				IL_0210: ldarg.3
-				IL_0211: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0216: clt
-				IL_0218: brfalse IL_02f7
+			IL_01d0: ldarg.1
+			IL_01d1: stloc.s 12
+			IL_01d3: ldloc.s 12
+			IL_01d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01da: stloc.s 21
+			IL_01dc: ldloc.s 21
+			IL_01de: conv.i4
+			IL_01df: conv.u4
+			IL_01e0: ldc.r8 5
+			IL_01e9: conv.i4
+			IL_01ea: shr.un
+			IL_01eb: conv.r.un
+			IL_01ec: stloc.s 21
+			IL_01ee: ldloc.s 21
+			IL_01f0: box [System.Runtime]System.Double
+			IL_01f5: stloc.s 22
+			IL_01f7: ldloc.s 22
+			IL_01f9: stloc.s 13
+			IL_01fb: ldarg.0
+			IL_01fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0201: ldloc.s 13
+			IL_0203: unbox.any [System.Runtime]System.Double
+			IL_0208: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_020d: stloc.s 21
+			IL_020f: ldloc.s 21
+			IL_0211: stloc.s 21
+			IL_0213: ldloc.s 21
+			IL_0215: stloc.s 14
+			// loop start (head: IL_0217)
+				IL_0217: ldloc.s 12
+				IL_0219: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_021e: stloc.s 21
+				IL_0220: ldloc.s 21
+				IL_0222: ldarg.3
+				IL_0223: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0228: clt
+				IL_022a: brfalse IL_0312
 
-				IL_021d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
-				IL_0222: stloc.s 15
-				IL_0224: ldloc.s 12
-				IL_0226: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_022b: stloc.s 21
-				IL_022d: ldloc.s 21
-				IL_022f: conv.i4
-				IL_0230: ldc.r8 31
-				IL_0239: conv.i4
-				IL_023a: and
-				IL_023b: conv.r8
-				IL_023c: stloc.s 21
-				IL_023e: ldloc.s 21
-				IL_0240: stloc.s 16
-				IL_0242: ldc.r8 1
+				IL_022f: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
+				IL_0234: stloc.s 15
+				IL_0236: ldloc.s 12
+				IL_0238: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_023d: stloc.s 21
+				IL_023f: ldloc.s 21
+				IL_0241: conv.i4
+				IL_0242: ldc.r8 31
 				IL_024b: conv.i4
-				IL_024c: ldloc.s 16
-				IL_024e: conv.i4
-				IL_024f: shl
-				IL_0250: conv.r8
-				IL_0251: stloc.s 21
-				IL_0253: ldloc.s 14
-				IL_0255: conv.i4
-				IL_0256: ldloc.s 21
-				IL_0258: conv.i4
-				IL_0259: or
-				IL_025a: conv.r8
-				IL_025b: stloc.s 21
-				IL_025d: ldloc.s 21
-				IL_025f: stloc.s 14
-				IL_0261: ldloc.s 12
-				IL_0263: ldarg.2
-				IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0269: stloc.s 20
-				IL_026b: ldloc.s 20
-				IL_026d: stloc.s 12
-				IL_026f: ldloc.s 12
-				IL_0271: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0276: stloc.s 21
-				IL_0278: ldloc.s 21
-				IL_027a: conv.i4
-				IL_027b: conv.u4
-				IL_027c: ldc.r8 5
-				IL_0285: conv.i4
-				IL_0286: shr.un
-				IL_0287: conv.r.un
+				IL_024c: and
+				IL_024d: conv.r8
+				IL_024e: stloc.s 21
+				IL_0250: ldloc.s 21
+				IL_0252: stloc.s 16
+				IL_0254: ldc.r8 1
+				IL_025d: conv.i4
+				IL_025e: ldloc.s 16
+				IL_0260: conv.i4
+				IL_0261: shl
+				IL_0262: conv.r8
+				IL_0263: stloc.s 21
+				IL_0265: ldloc.s 14
+				IL_0267: conv.i4
+				IL_0268: ldloc.s 21
+				IL_026a: conv.i4
+				IL_026b: or
+				IL_026c: conv.r8
+				IL_026d: stloc.s 21
+				IL_026f: ldloc.s 21
+				IL_0271: stloc.s 14
+				IL_0273: ldloc.s 12
+				IL_0275: ldarg.2
+				IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_027b: stloc.s 20
+				IL_027d: ldloc.s 20
+				IL_027f: stloc.s 12
+				IL_0281: ldloc.s 12
+				IL_0283: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0288: stloc.s 21
 				IL_028a: ldloc.s 21
-				IL_028c: stloc.s 17
-				IL_028e: ldloc.s 17
-				IL_0290: box [System.Runtime]System.Double
-				IL_0295: stloc.s 22
-				IL_0297: ldloc.s 22
-				IL_0299: ldloc.s 13
-				IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-				IL_02a0: stloc.s 23
-				IL_02a2: ldloc.s 23
-				IL_02a4: brfalse IL_02f2
+				IL_028c: conv.i4
+				IL_028d: conv.u4
+				IL_028e: ldc.r8 5
+				IL_0297: conv.i4
+				IL_0298: shr.un
+				IL_0299: conv.r.un
+				IL_029a: stloc.s 21
+				IL_029c: ldloc.s 21
+				IL_029e: stloc.s 17
+				IL_02a0: ldloc.s 17
+				IL_02a2: box [System.Runtime]System.Double
+				IL_02a7: stloc.s 22
+				IL_02a9: ldloc.s 22
+				IL_02ab: ldloc.s 13
+				IL_02ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
+				IL_02b2: stloc.s 23
+				IL_02b4: ldloc.s 23
+				IL_02b6: brfalse IL_030d
 
-				IL_02a9: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36::.ctor()
-				IL_02ae: stloc.s 18
-				IL_02b0: ldloc.s 14
-				IL_02b2: box [System.Runtime]System.Double
-				IL_02b7: stloc.s 22
-				IL_02b9: ldarg.0
-				IL_02ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_02bf: ldloc.s 13
-				IL_02c1: unbox.any [System.Runtime]System.Double
-				IL_02c6: ldloc.s 22
-				IL_02c8: unbox.any [System.Runtime]System.Double
-				IL_02cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_02d2: ldloc.s 17
-				IL_02d4: box [System.Runtime]System.Double
-				IL_02d9: stloc.s 22
-				IL_02db: ldloc.s 22
-				IL_02dd: stloc.s 13
-				IL_02df: ldarg.0
-				IL_02e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_02e5: ldloc.s 13
-				IL_02e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_02ec: stloc.s 21
-				IL_02ee: ldloc.s 21
-				IL_02f0: stloc.s 14
+				IL_02bb: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36::.ctor()
+				IL_02c0: stloc.s 18
+				IL_02c2: ldloc.s 14
+				IL_02c4: box [System.Runtime]System.Double
+				IL_02c9: stloc.s 22
+				IL_02cb: ldarg.0
+				IL_02cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_02d1: ldloc.s 13
+				IL_02d3: unbox.any [System.Runtime]System.Double
+				IL_02d8: ldloc.s 22
+				IL_02da: unbox.any [System.Runtime]System.Double
+				IL_02df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_02e4: ldloc.s 17
+				IL_02e6: box [System.Runtime]System.Double
+				IL_02eb: stloc.s 22
+				IL_02ed: ldloc.s 22
+				IL_02ef: stloc.s 13
+				IL_02f1: ldarg.0
+				IL_02f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_02f7: ldloc.s 13
+				IL_02f9: unbox.any [System.Runtime]System.Double
+				IL_02fe: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0303: stloc.s 21
+				IL_0305: ldloc.s 21
+				IL_0307: stloc.s 21
+				IL_0309: ldloc.s 21
+				IL_030b: stloc.s 14
 
-				IL_02f2: br IL_0205
+				IL_030d: br IL_0217
 			// end loop
 
-			IL_02f7: ldloc.s 14
-			IL_02f9: box [System.Runtime]System.Double
-			IL_02fe: stloc.s 22
-			IL_0300: ldarg.0
-			IL_0301: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_0306: ldloc.s 13
-			IL_0308: unbox.any [System.Runtime]System.Double
-			IL_030d: ldloc.s 22
-			IL_030f: unbox.any [System.Runtime]System.Double
-			IL_0314: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_0319: ldnull
-			IL_031a: ret
+			IL_0312: ldloc.s 14
+			IL_0314: box [System.Runtime]System.Double
+			IL_0319: stloc.s 22
+			IL_031b: ldarg.0
+			IL_031c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0321: ldloc.s 13
+			IL_0323: unbox.any [System.Runtime]System.Double
+			IL_0328: ldloc.s 22
+			IL_032a: unbox.any [System.Runtime]System.Double
+			IL_032f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_0334: ldnull
+			IL_0335: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1197,7 +1206,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2908
+			// Method begins at RVA 0x2924
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1311,7 +1320,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ec7
+				// Method begins at RVA 0x2ee3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1331,7 +1340,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ed0
+				// Method begins at RVA 0x2eec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1355,7 +1364,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ee2
+					// Method begins at RVA 0x2efe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1373,7 +1382,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ed9
+				// Method begins at RVA 0x2ef5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1393,7 +1402,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eeb
+				// Method begins at RVA 0x2f07
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1421,7 +1430,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f06
+						// Method begins at RVA 0x2f22
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1439,7 +1448,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2efd
+					// Method begins at RVA 0x2f19
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1457,7 +1466,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ef4
+				// Method begins at RVA 0x2f10
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1477,7 +1486,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f0f
+				// Method begins at RVA 0x2f2b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1501,7 +1510,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f21
+					// Method begins at RVA 0x2f3d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1519,7 +1528,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f18
+				// Method begins at RVA 0x2f34
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1543,7 +1552,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f33
+					// Method begins at RVA 0x2f4f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1561,7 +1570,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f2a
+				// Method begins at RVA 0x2f46
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1655,7 +1664,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2964
+			// Method begins at RVA 0x2980
 			// Header size: 12
 			// Code size: 206 (0xce)
 			.maxstack 8
@@ -1753,7 +1762,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cc8
+			// Method begins at RVA 0x2ce4
 			// Header size: 12
 			// Code size: 120 (0x78)
 			.maxstack 8
@@ -1820,7 +1829,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d4c
+			// Method begins at RVA 0x2d68
 			// Header size: 12
 			// Code size: 214 (0xd6)
 			.maxstack 8
@@ -1919,7 +1928,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a40
+			// Method begins at RVA 0x2a5c
 			// Header size: 12
 			// Code size: 633 (0x279)
 			.maxstack 8
@@ -2163,7 +2172,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2e2e
+			// Method begins at RVA 0x2e4a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2358,7 +2367,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2f57
+		// Method begins at RVA 0x2f73
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_FromArray_CopyAndCoerce.verified.txt
+++ b/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_FromArray_CopyAndCoerce.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213e
+			// Method begins at RVA 0x2148
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -34,7 +34,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2147
+			// Method begins at RVA 0x2151
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -60,7 +60,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 226 (0xe2)
+		// Code size: 236 (0xec)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_FromArray_CopyAndCoerce/Scope,
@@ -119,30 +119,32 @@
 			IL_009f: ldloc.s 6
 			IL_00a1: ldloc.s 5
 			IL_00a3: clt
-			IL_00a5: brfalse IL_00e1
+			IL_00a5: brfalse IL_00eb
 
 			IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_00af: ldloc.1
 			IL_00b0: ldloc.2
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bb: pop
-			IL_00bc: ldloc.2
-			IL_00bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c2: stloc.s 5
-			IL_00c4: ldloc.s 5
-			IL_00c6: ldc.r8 1
-			IL_00cf: add
-			IL_00d0: stloc.s 5
-			IL_00d2: ldloc.s 5
-			IL_00d4: box [System.Runtime]System.Double
-			IL_00d9: stloc.3
-			IL_00da: ldloc.3
-			IL_00db: stloc.2
-			IL_00dc: br IL_008f
+			IL_00b1: unbox.any [System.Runtime]System.Double
+			IL_00b6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00bb: box [System.Runtime]System.Double
+			IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00c5: pop
+			IL_00c6: ldloc.2
+			IL_00c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00cc: stloc.s 5
+			IL_00ce: ldloc.s 5
+			IL_00d0: ldc.r8 1
+			IL_00d9: add
+			IL_00da: stloc.s 5
+			IL_00dc: ldloc.s 5
+			IL_00de: box [System.Runtime]System.Double
+			IL_00e3: stloc.3
+			IL_00e4: ldloc.3
+			IL_00e5: stloc.2
+			IL_00e6: br IL_008f
 		// end loop
 
-		IL_00e1: ret
+		IL_00eb: ret
 	} // end of method Int32Array_FromArray_CopyAndCoerce::__js_module_init__
 
 } // end of class Modules.Int32Array_FromArray_CopyAndCoerce
@@ -154,7 +156,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2150
+		// Method begins at RVA 0x215a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
+++ b/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2411
+				// Method begins at RVA 0x2425
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241a
+				// Method begins at RVA 0x242e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2423
+				// Method begins at RVA 0x2437
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x2440
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23e4
+			// Method begins at RVA 0x23f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f6
+				// Method begins at RVA 0x240a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ed
+			// Method begins at RVA 0x2401
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2408
+				// Method begins at RVA 0x241c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +180,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ff
+			// Method begins at RVA 0x2413
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -206,7 +206,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 875 (0x36b)
+		// Code size: 895 (0x37f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_BoundsChecks/Scope,
@@ -289,230 +289,234 @@
 			IL_00d1: ldloc.s 20
 			IL_00d3: ldloc.s 19
 			IL_00d5: clt
-			IL_00d7: brfalse IL_011b
+			IL_00d7: brfalse IL_0125
 
 			IL_00dc: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope_For_L5C5/Block_L5C40::.ctor()
 			IL_00e1: stloc.3
 			IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_00e7: ldloc.1
 			IL_00e8: ldloc.2
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00f3: pop
-			IL_00f4: ldloc.2
-			IL_00f5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00fa: stloc.s 19
-			IL_00fc: ldloc.s 19
-			IL_00fe: ldc.r8 1
-			IL_0107: add
-			IL_0108: stloc.s 19
-			IL_010a: ldloc.s 19
-			IL_010c: box [System.Runtime]System.Double
-			IL_0111: stloc.s 21
-			IL_0113: ldloc.s 21
-			IL_0115: stloc.2
-			IL_0116: br IL_00c1
+			IL_00e9: unbox.any [System.Runtime]System.Double
+			IL_00ee: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00f3: box [System.Runtime]System.Double
+			IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00fd: pop
+			IL_00fe: ldloc.2
+			IL_00ff: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0104: stloc.s 19
+			IL_0106: ldloc.s 19
+			IL_0108: ldc.r8 1
+			IL_0111: add
+			IL_0112: stloc.s 19
+			IL_0114: ldloc.s 19
+			IL_0116: box [System.Runtime]System.Double
+			IL_011b: stloc.s 21
+			IL_011d: ldloc.s 21
+			IL_011f: stloc.2
+			IL_0120: br IL_00c1
 		// end loop
 
-		IL_011b: ldloc.1
-		IL_011c: ldstr "subarray"
-		IL_0121: ldc.r8 1
-		IL_012a: box [System.Runtime]System.Double
-		IL_012f: ldc.r8 3
-		IL_0138: box [System.Runtime]System.Double
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0142: stloc.s 22
-		IL_0144: ldloc.s 22
-		IL_0146: stloc.s 4
-		IL_0148: ldloc.1
-		IL_0149: ldstr "set"
-		IL_014e: ldloc.s 4
-		IL_0150: ldc.r8 0.0
-		IL_0159: box [System.Runtime]System.Double
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0163: pop
-		IL_0164: ldc.r8 0.0
-		IL_016d: box [System.Runtime]System.Double
-		IL_0172: stloc.s 5
-		// loop start (head: IL_0174)
-			IL_0174: ldloc.1
-			IL_0175: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_017a: stloc.s 19
-			IL_017c: ldloc.s 5
-			IL_017e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0183: stloc.s 20
-			IL_0185: ldloc.s 20
-			IL_0187: ldloc.s 19
-			IL_0189: clt
-			IL_018b: brfalse IL_01d3
+		IL_0125: ldloc.1
+		IL_0126: ldstr "subarray"
+		IL_012b: ldc.r8 1
+		IL_0134: box [System.Runtime]System.Double
+		IL_0139: ldc.r8 3
+		IL_0142: box [System.Runtime]System.Double
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_014c: stloc.s 22
+		IL_014e: ldloc.s 22
+		IL_0150: stloc.s 4
+		IL_0152: ldloc.1
+		IL_0153: ldstr "set"
+		IL_0158: ldloc.s 4
+		IL_015a: ldc.r8 0.0
+		IL_0163: box [System.Runtime]System.Double
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_016d: pop
+		IL_016e: ldc.r8 0.0
+		IL_0177: box [System.Runtime]System.Double
+		IL_017c: stloc.s 5
+		// loop start (head: IL_017e)
+			IL_017e: ldloc.1
+			IL_017f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_0184: stloc.s 19
+			IL_0186: ldloc.s 5
+			IL_0188: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_018d: stloc.s 20
+			IL_018f: ldloc.s 20
+			IL_0191: ldloc.s 19
+			IL_0193: clt
+			IL_0195: brfalse IL_01e7
 
-			IL_0190: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope_For_L11C5/Block_L11C40::.ctor()
-			IL_0195: stloc.s 6
-			IL_0197: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_019c: ldloc.1
-			IL_019d: ldloc.s 5
-			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_01a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01a9: pop
-			IL_01aa: ldloc.s 5
-			IL_01ac: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01b1: stloc.s 19
-			IL_01b3: ldloc.s 19
-			IL_01b5: ldc.r8 1
-			IL_01be: add
-			IL_01bf: stloc.s 19
-			IL_01c1: ldloc.s 19
-			IL_01c3: box [System.Runtime]System.Double
-			IL_01c8: stloc.s 21
-			IL_01ca: ldloc.s 21
-			IL_01cc: stloc.s 5
-			IL_01ce: br IL_0174
+			IL_019a: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope_For_L11C5/Block_L11C40::.ctor()
+			IL_019f: stloc.s 6
+			IL_01a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01a6: ldloc.1
+			IL_01a7: ldloc.s 5
+			IL_01a9: unbox.any [System.Runtime]System.Double
+			IL_01ae: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_01b3: box [System.Runtime]System.Double
+			IL_01b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01bd: pop
+			IL_01be: ldloc.s 5
+			IL_01c0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01c5: stloc.s 19
+			IL_01c7: ldloc.s 19
+			IL_01c9: ldc.r8 1
+			IL_01d2: add
+			IL_01d3: stloc.s 19
+			IL_01d5: ldloc.s 19
+			IL_01d7: box [System.Runtime]System.Double
+			IL_01dc: stloc.s 21
+			IL_01de: ldloc.s 21
+			IL_01e0: stloc.s 5
+			IL_01e2: br IL_017e
 		// end loop
 		.try
 		{
-			IL_01d3: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L15C4::.ctor()
-			IL_01d8: stloc.s 7
-			IL_01da: ldc.i4.3
-			IL_01db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01e0: dup
-			IL_01e1: ldc.r8 7
-			IL_01ea: box [System.Runtime]System.Double
-			IL_01ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01e7: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L15C4::.ctor()
+			IL_01ec: stloc.s 7
+			IL_01ee: ldc.i4.3
+			IL_01ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_01f4: dup
-			IL_01f5: ldc.r8 6
+			IL_01f5: ldc.r8 7
 			IL_01fe: box [System.Runtime]System.Double
 			IL_0203: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0208: dup
-			IL_0209: ldc.r8 5
+			IL_0209: ldc.r8 6
 			IL_0212: box [System.Runtime]System.Double
 			IL_0217: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_021c: stloc.s 18
-			IL_021e: ldloc.1
-			IL_021f: ldstr "set"
-			IL_0224: ldloc.s 18
-			IL_0226: ldc.r8 2
-			IL_022f: box [System.Runtime]System.Double
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0239: pop
-			IL_023a: leave IL_02b2
+			IL_021c: dup
+			IL_021d: ldc.r8 5
+			IL_0226: box [System.Runtime]System.Double
+			IL_022b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0230: stloc.s 18
+			IL_0232: ldloc.1
+			IL_0233: ldstr "set"
+			IL_0238: ldloc.s 18
+			IL_023a: ldc.r8 2
+			IL_0243: box [System.Runtime]System.Double
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_024d: pop
+			IL_024e: leave IL_02c6
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_023f: stloc.s 8
-			IL_0241: ldloc.s 8
-			IL_0243: dup
-			IL_0244: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0249: dup
-			IL_024a: brtrue IL_0260
+			IL_0253: stloc.s 8
+			IL_0255: ldloc.s 8
+			IL_0257: dup
+			IL_0258: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_025d: dup
+			IL_025e: brtrue IL_0274
 
-			IL_024f: pop
-			IL_0250: dup
-			IL_0251: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0256: dup
-			IL_0257: brtrue IL_026d
+			IL_0263: pop
+			IL_0264: dup
+			IL_0265: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_026a: dup
+			IL_026b: brtrue IL_0281
 
-			IL_025c: pop
-			IL_025d: pop
-			IL_025e: rethrow
+			IL_0270: pop
+			IL_0271: pop
+			IL_0272: rethrow
 
-			IL_0260: pop
-			IL_0261: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0266: stloc.s 9
-			IL_0268: br IL_0270
+			IL_0274: pop
+			IL_0275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_027a: stloc.s 9
+			IL_027c: br IL_0284
 
-			IL_026d: pop
-			IL_026e: stloc.s 9
+			IL_0281: pop
+			IL_0282: stloc.s 9
 
-			IL_0270: ldloc.s 9
-			IL_0272: stloc.s 22
-			IL_0274: ldloc.s 22
-			IL_0276: stloc.s 10
-			IL_0278: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L17C12::.ctor()
-			IL_027d: stloc.s 11
-			IL_027f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0284: ldloc.s 10
-			IL_0286: ldstr "name"
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0290: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0295: pop
-			IL_0296: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_029b: ldloc.s 10
-			IL_029d: ldstr "message"
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02ac: pop
-			IL_02ad: leave IL_02b2
+			IL_0284: ldloc.s 9
+			IL_0286: stloc.s 22
+			IL_0288: ldloc.s 22
+			IL_028a: stloc.s 10
+			IL_028c: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L17C12::.ctor()
+			IL_0291: stloc.s 11
+			IL_0293: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0298: ldloc.s 10
+			IL_029a: ldstr "name"
+			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02a9: pop
+			IL_02aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02af: ldloc.s 10
+			IL_02b1: ldstr "message"
+			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02c0: pop
+			IL_02c1: leave IL_02c6
 		} // end handler
 		.try
 		{
-			IL_02b2: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L22C4::.ctor()
-			IL_02b7: stloc.s 12
-			IL_02b9: ldc.i4.1
-			IL_02ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02bf: dup
-			IL_02c0: ldc.r8 1
-			IL_02c9: box [System.Runtime]System.Double
-			IL_02ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02d3: stloc.s 18
-			IL_02d5: ldloc.1
-			IL_02d6: ldstr "set"
-			IL_02db: ldloc.s 18
-			IL_02dd: ldc.r8 1
-			IL_02e6: neg
-			IL_02e7: box [System.Runtime]System.Double
-			IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02f1: pop
-			IL_02f2: leave IL_036a
+			IL_02c6: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L22C4::.ctor()
+			IL_02cb: stloc.s 12
+			IL_02cd: ldc.i4.1
+			IL_02ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02d3: dup
+			IL_02d4: ldc.r8 1
+			IL_02dd: box [System.Runtime]System.Double
+			IL_02e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02e7: stloc.s 18
+			IL_02e9: ldloc.1
+			IL_02ea: ldstr "set"
+			IL_02ef: ldloc.s 18
+			IL_02f1: ldc.r8 1
+			IL_02fa: neg
+			IL_02fb: box [System.Runtime]System.Double
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0305: pop
+			IL_0306: leave IL_037e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02f7: stloc.s 13
-			IL_02f9: ldloc.s 13
-			IL_02fb: dup
-			IL_02fc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0301: dup
-			IL_0302: brtrue IL_0318
+			IL_030b: stloc.s 13
+			IL_030d: ldloc.s 13
+			IL_030f: dup
+			IL_0310: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0315: dup
+			IL_0316: brtrue IL_032c
 
-			IL_0307: pop
-			IL_0308: dup
-			IL_0309: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_030e: dup
-			IL_030f: brtrue IL_0325
+			IL_031b: pop
+			IL_031c: dup
+			IL_031d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0322: dup
+			IL_0323: brtrue IL_0339
 
-			IL_0314: pop
-			IL_0315: pop
-			IL_0316: rethrow
+			IL_0328: pop
+			IL_0329: pop
+			IL_032a: rethrow
 
-			IL_0318: pop
-			IL_0319: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_031e: stloc.s 14
-			IL_0320: br IL_0328
+			IL_032c: pop
+			IL_032d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0332: stloc.s 14
+			IL_0334: br IL_033c
 
-			IL_0325: pop
-			IL_0326: stloc.s 14
+			IL_0339: pop
+			IL_033a: stloc.s 14
 
-			IL_0328: ldloc.s 14
-			IL_032a: stloc.s 22
-			IL_032c: ldloc.s 22
-			IL_032e: stloc.s 15
-			IL_0330: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L24C12::.ctor()
-			IL_0335: stloc.s 16
-			IL_0337: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_033c: ldloc.s 15
-			IL_033e: ldstr "name"
-			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0348: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_034d: pop
-			IL_034e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0353: ldloc.s 15
-			IL_0355: ldstr "message"
-			IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_035f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0364: pop
-			IL_0365: leave IL_036a
+			IL_033c: ldloc.s 14
+			IL_033e: stloc.s 22
+			IL_0340: ldloc.s 22
+			IL_0342: stloc.s 15
+			IL_0344: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L24C12::.ctor()
+			IL_0349: stloc.s 16
+			IL_034b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0350: ldloc.s 15
+			IL_0352: ldstr "name"
+			IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_035c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0361: pop
+			IL_0362: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0367: ldloc.s 15
+			IL_0369: ldstr "message"
+			IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0373: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0378: pop
+			IL_0379: leave IL_037e
 		} // end handler
 
-		IL_036a: ret
+		IL_037e: ret
 	} // end of method Int32Array_Set_BoundsChecks::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_BoundsChecks
@@ -524,7 +528,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2435
+		// Method begins at RVA 0x2449
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_FromArray_WithOffset.verified.txt
+++ b/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_FromArray_WithOffset.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2141
+			// Method begins at RVA 0x214b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -34,7 +34,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x214a
+			// Method begins at RVA 0x2154
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -60,7 +60,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 229 (0xe5)
+		// Code size: 239 (0xef)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_FromArray_WithOffset/Scope,
@@ -119,30 +119,32 @@
 			IL_00a0: ldloc.s 7
 			IL_00a2: ldloc.s 6
 			IL_00a4: clt
-			IL_00a6: brfalse IL_00e4
+			IL_00a6: brfalse IL_00ee
 
 			IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_00b0: ldloc.1
 			IL_00b1: ldloc.3
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bc: pop
-			IL_00bd: ldloc.3
-			IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c3: stloc.s 6
-			IL_00c5: ldloc.s 6
-			IL_00c7: ldc.r8 1
-			IL_00d0: add
-			IL_00d1: stloc.s 6
-			IL_00d3: ldloc.s 6
-			IL_00d5: box [System.Runtime]System.Double
-			IL_00da: stloc.s 5
-			IL_00dc: ldloc.s 5
-			IL_00de: stloc.3
-			IL_00df: br IL_0090
+			IL_00b2: unbox.any [System.Runtime]System.Double
+			IL_00b7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00bc: box [System.Runtime]System.Double
+			IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00c6: pop
+			IL_00c7: ldloc.3
+			IL_00c8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00cd: stloc.s 6
+			IL_00cf: ldloc.s 6
+			IL_00d1: ldc.r8 1
+			IL_00da: add
+			IL_00db: stloc.s 6
+			IL_00dd: ldloc.s 6
+			IL_00df: box [System.Runtime]System.Double
+			IL_00e4: stloc.s 5
+			IL_00e6: ldloc.s 5
+			IL_00e8: stloc.3
+			IL_00e9: br IL_0090
 		// end loop
 
-		IL_00e4: ret
+		IL_00ee: ret
 	} // end of method Int32Array_Set_FromArray_WithOffset::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_FromArray_WithOffset
@@ -154,7 +156,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2153
+		// Method begins at RVA 0x215d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- restore direct `Int32Array::get_Item(double)` lowering when numeric indexes are boxed doubles
- make the `Int32Array` getter emitter coerce numeric index temps with `EmitLoadTempAsDouble`, matching the setter
- add safe primitive-double fast paths to `Operators.Add(...)` so boxed numeric `+=` hot loops skip the generic ToPrimitive path
- update the prime generator snapshot to lock in the restored typed-array reads

## Root cause
The latest patch-release lowering kept some prime loop indexes object-typed after the recursive assignment/type-inference correctness changes. That caused hot `Int32Array` reads to be fused into `ObjectRuntime.GetItemAsNumber(object, object)` and hot `+=` operations to go through the slower generic addition path with boxed doubles.

## Validation
- `dotnet test .\tests\Js2IL.Tests\Js2IL.Tests.csproj -c Release /p:IsTestProject=true --no-build --filter "FullyQualifiedName~Js2IL.Tests.Integration.GeneratorTests.Compile_Performance_PrimeJavaScript|FullyQualifiedName~Js2IL.Tests.TypedArray.GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign|FullyQualifiedName~Js2IL.Tests.TypedArray.ExecutionTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign|FullyQualifiedName~Js2IL.Tests.BinaryOperator" --nologo`
- Sequential local prime sample on the same machine: current master output `65` passes / ~5s, fixed output `114` passes / ~5s, v0.9.10 output `220` passes / ~5s
