### PR TITLE
feat(compiler): accept strict and non-strict scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler/cli/sdk/tests/docs: remove the top-level `"use strict"` requirement and its configurable warning/error flag so JS2IL accepts both strict and non-strict scripts by default.
 
 ## v0.9.13 - 2026-05-04
 

--- a/docs/ECMA262/11/Section11_2.json
+++ b/docs/ECMA262/11/Section11_2.json
@@ -38,10 +38,10 @@
     "entries": [
       {
         "clause": "11.2.1",
-        "feature": "Directive prologues; configurable enforcement of \"use strict\"",
+        "feature": "Directive prologues; optional top-level \"use strict\"",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive",
-        "notes": "JS2IL recognizes directive prologues and (by default) requires a top-level \"use strict\" directive. For third-party CommonJS modules that omit the directive, the compiler can downgrade the missing prologue to a warning via --strictMode=Warn (or suppress via --strictMode=Ignore). JS2IL still compiles using strict-mode semantics; this option only changes reporting severity for the missing directive prologue."
+        "notes": "JS2IL recognizes directive prologues and accepts scripts with or without a top-level \"use strict\" directive."
       }
     ]
   }

--- a/docs/ECMA262/11/Section11_2.md
+++ b/docs/ECMA262/11/Section11_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section11](Section11.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-05-06T09:50:24Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -21,11 +21,11 @@
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 11.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Directive prologues; configurable enforcement of "use strict" | Supported with Limitations |  | JS2IL recognizes directive prologues and (by default) requires a top-level "use strict" directive. For third-party CommonJS modules that omit the directive, the compiler can downgrade the missing prologue to a warning via --strictMode=Warn (or suppress via --strictMode=Ignore). JS2IL still compiles using strict-mode semantics; this option only changes reporting severity for the missing directive prologue. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Directive prologues; optional top-level "use strict" | Supported with Limitations |  |  | JS2IL recognizes directive prologues and accepts scripts with or without a top-level "use strict" directive. |
 

--- a/docs/ECMA262/20/Section20_1.json
+++ b/docs/ECMA262/20/Section20_1.json
@@ -535,7 +535,7 @@
           "tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js",
           "tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperty_NonExtensible_ReconfigureExisting.js"
         ],
-        "notes": "Marks ordinary objects non-extensible in runtime integrity state and blocks adding new properties through assignment and Object.defineProperty. Because JS2IL requires strict mode, failed additions surface as TypeError instead of silent no-op. Exotic object behavior remains partial."
+        "notes": "Marks ordinary objects non-extensible in runtime integrity state and blocks adding new properties through assignment and Object.defineProperty. Failed additions currently surface as TypeError. Exotic object behavior remains partial."
       },
       {
         "clause": "20.1.2.21",

--- a/docs/ECMA262/20/Section20_1.md
+++ b/docs/ECMA262/20/Section20_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-08T23:10:56Z
+> Last generated (UTC): 2026-05-06T09:50:24Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -63,251 +63,251 @@
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 20.1.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-object-value))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object(value) (callable semantics) | Supported with Limitations | [`IntrinsicCallables_Object_Callable_ReturnsObject.js`](../../../tests/Js2IL.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js) | Calls to Object(...) are lowered to JavaScriptRuntime.Object.Construct(...). Null/undefined return a new empty object; non-null values are returned unchanged (no ToObject boxing/wrapping of primitives). |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object(value) (callable semantics) | Supported with Limitations | [`IntrinsicCallables_Object_Callable_ReturnsObject.js`](../../../tests/Js2IL.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js) |  | Calls to Object(...) are lowered to JavaScriptRuntime.Object.Construct(...). Null/undefined return a new empty object; non-null values are returned unchanged (no ToObject boxing/wrapping of primitives). |
 
 ### 20.1.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-object.assign))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.assign | Supported with Limitations | [`Object_Assign_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Assign_Basic.js) | Implemented in JavaScriptRuntime.Object.assign. Copies enumerable own properties from source objects to the target using SpreadInto semantics. Returns the target object. Symbol-keyed properties, property descriptor copying, and full error handling are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.assign | Supported with Limitations | [`Object_Assign_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Assign_Basic.js) |  | Implemented in JavaScriptRuntime.Object.assign. Copies enumerable own properties from source objects to the target using SpreadInto semantics. Returns the target object. Symbol-keyed properties, property descriptor copying, and full error handling are not implemented. |
 
 ### 20.1.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-object.create))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.create | Supported with Limitations | [`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`Function_Prototype_ObjectCreate_ObjectPrototype.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js) | Implemented in JavaScriptRuntime.Object.create using the opt-in PrototypeChain side-table to set [[Prototype]] (including null-prototype objects via JS null). When a properties bag is provided, it is applied via defineProperties. This does not implement full OrdinaryObjectCreate invariants or exotic object behaviors. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.create | Supported with Limitations | [`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`Function_Prototype_ObjectCreate_ObjectPrototype.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js) |  | Implemented in JavaScriptRuntime.Object.create using the opt-in PrototypeChain side-table to set [[Prototype]] (including null-prototype objects via JS null). When a properties bag is provided, it is applied via defineProperties. This does not implement full OrdinaryObjectCreate invariants or exotic object behaviors. |
 
 ### 20.1.2.3 ([tc39.es](https://tc39.es/ecma262/#sec-object.defineproperties))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.defineProperties | Supported with Limitations | [`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js) | Implemented in JavaScriptRuntime.Object.defineProperties with a best-effort all-or-throw behavior (enumerates descriptor keys first, then applies). Supports defining data/accessor descriptors and enumerable filtering. Full validation, ordering rules, and invariant checks are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.defineProperties | Supported with Limitations | [`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js) |  | Implemented in JavaScriptRuntime.Object.defineProperties with a best-effort all-or-throw behavior (enumerates descriptor keys first, then applies). Supports defining data/accessor descriptors and enumerable filtering. Full validation, ordering rules, and invariant checks are not implemented. |
 
 ### 20.1.2.3.1 ([tc39.es](https://tc39.es/ecma262/#sec-objectdefineproperties))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| ObjectDefineProperties abstract operation | Supported with Limitations | [`Object_DefineProperties_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperties_Basic.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js) | Implemented via Object.defineProperties with a snapshot-then-apply flow. Supports common descriptor bags, but full validation and all invariant/redefinition edge cases are not fully modeled. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| ObjectDefineProperties abstract operation | Supported with Limitations | [`Object_DefineProperties_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperties_Basic.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js) |  | Implemented via Object.defineProperties with a snapshot-then-apply flow. Supports common descriptor bags, but full validation and all invariant/redefinition edge cases are not fully modeled. |
 
 ### 20.1.2.4 ([tc39.es](https://tc39.es/ecma262/#sec-object.defineproperty))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.defineProperty | Supported with Limitations | [`ObjectDefineProperty_Accessor.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectDefineProperty_Accessor.js)<br>[`ObjectDefineProperty_Enumerable_ForIn.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectDefineProperty_Enumerable_ForIn.js)<br>[`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`Object_DefineProperty_AccessorTransitions_And_Invariants.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperty_AccessorTransitions_And_Invariants.js)<br>[`Object_DefineProperty_NonExtensible_ReconfigureExisting.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperty_NonExtensible_ReconfigureExisting.js)<br>[`Object_Integrity_DefineProperty_And_StrictWrites.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js) | Implemented in JavaScriptRuntime.Object.defineProperty using a ConditionalWeakTable-backed descriptor store plus implicit descriptors for dictionary-backed ordinary properties. Ordinary-object redefinition checks cover data/accessor transitions, non-configurable and non-writable invariants, inherited descriptor fields, and non-extensible/sealed/frozen interactions for ordinary objects. Exotic arrays, typed arrays, host objects, and full proxy invariants remain partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.defineProperty | Supported with Limitations | [`ObjectDefineProperty_Accessor.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectDefineProperty_Accessor.js)<br>[`ObjectDefineProperty_Enumerable_ForIn.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectDefineProperty_Enumerable_ForIn.js)<br>[`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`Object_DefineProperty_AccessorTransitions_And_Invariants.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperty_AccessorTransitions_And_Invariants.js)<br>[`Object_DefineProperty_NonExtensible_ReconfigureExisting.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperty_NonExtensible_ReconfigureExisting.js)<br>[`Object_Integrity_DefineProperty_And_StrictWrites.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js) |  | Implemented in JavaScriptRuntime.Object.defineProperty using a ConditionalWeakTable-backed descriptor store plus implicit descriptors for dictionary-backed ordinary properties. Ordinary-object redefinition checks cover data/accessor transitions, non-configurable and non-writable invariants, inherited descriptor fields, and non-extensible/sealed/frozen interactions for ordinary objects. Exotic arrays, typed arrays, host objects, and full proxy invariants remain partial. |
 
 ### 20.1.2.5 ([tc39.es](https://tc39.es/ecma262/#sec-object.entries))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.entries | Supported with Limitations | [`Object_Entries_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Entries_Basic.js) | Implemented in JavaScriptRuntime.Object.entries. Returns an array of [key, value] pairs for own enumerable properties. Respects PropertyDescriptorStore for enumerable:false filtering. Symbol-keyed properties and full spec ordering guarantees are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.entries | Supported with Limitations | [`Object_Entries_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Entries_Basic.js) |  | Implemented in JavaScriptRuntime.Object.entries. Returns an array of [key, value] pairs for own enumerable properties. Respects PropertyDescriptorStore for enumerable:false filtering. Symbol-keyed properties and full spec ordering guarantees are not implemented. |
 
 ### 20.1.2.6 ([tc39.es](https://tc39.es/ecma262/#sec-object.freeze))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.freeze | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Object_Integrity_DefineProperty_And_StrictWrites.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js) | For ordinary objects, synthesizes descriptors for existing own properties, marks the object non-extensible, sets own properties non-configurable, and makes own data properties non-writable. Subsequent strict-mode writes, deletes, and incompatible Object.defineProperty redefinitions fail through the ordinary property paths with TypeError. Array and other exotic-object invariants remain partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.freeze | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Object_Integrity_DefineProperty_And_StrictWrites.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js) |  | For ordinary objects, synthesizes descriptors for existing own properties, marks the object non-extensible, sets own properties non-configurable, and makes own data properties non-writable. Subsequent strict-mode writes, deletes, and incompatible Object.defineProperty redefinitions fail through the ordinary property paths with TypeError. Array and other exotic-object invariants remain partial. |
 
 ### 20.1.2.7 ([tc39.es](https://tc39.es/ecma262/#sec-object.fromentries))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.fromEntries | Supported with Limitations | [`Object_FromEntries_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_FromEntries_Basic.js) | Implemented in JavaScriptRuntime.Object.fromEntries. Creates an object from an iterable of [key, value] pairs using GetIterator. Supports array-like entries. Symbol keys and full iterator protocol edge cases are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.fromEntries | Supported with Limitations | [`Object_FromEntries_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_FromEntries_Basic.js) |  | Implemented in JavaScriptRuntime.Object.fromEntries. Creates an object from an iterable of [key, value] pairs using GetIterator. Supports array-like entries. Symbol keys and full iterator protocol edge cases are not implemented. |
 
 ### 20.1.2.8 ([tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertydescriptor))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.getOwnPropertyDescriptor | Supported with Limitations | [`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) | Implemented in JavaScriptRuntime.Object.getOwnPropertyDescriptor. Returns descriptor objects for own string and symbol keys on ordinary js2il objects, with simplified fallbacks for plain dynamic-object properties. Full host-object descriptor fidelity remains limited. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.getOwnPropertyDescriptor | Supported with Limitations | [`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) |  | Implemented in JavaScriptRuntime.Object.getOwnPropertyDescriptor. Returns descriptor objects for own string and symbol keys on ordinary js2il objects, with simplified fallbacks for plain dynamic-object properties. Full host-object descriptor fidelity remains limited. |
 
 ### 20.1.2.9 ([tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertydescriptors))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.getOwnPropertyDescriptors | Supported with Limitations | [`Object_GetOwnPropertyDescriptors_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyDescriptors_Basic.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) | Returns descriptor objects for own string and symbol keys using descriptor store + dictionary fallbacks, and symbol keys round-trip through the returned descriptor bag. Full host-object descriptor fidelity remains limited. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.getOwnPropertyDescriptors | Supported with Limitations | [`Object_GetOwnPropertyDescriptors_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyDescriptors_Basic.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) |  | Returns descriptor objects for own string and symbol keys using descriptor store + dictionary fallbacks, and symbol keys round-trip through the returned descriptor bag. Full host-object descriptor fidelity remains limited. |
 
 ### 20.1.2.10 ([tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertynames))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.getOwnPropertyNames | Supported with Limitations | [`Object_GetOwnPropertyNames_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyNames_Basic.js)<br>[`Object_OwnPropertyKeyOrdering.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_OwnPropertyKeyOrdering.js) | Implemented in JavaScriptRuntime.Object.getOwnPropertyNames using ordered own-key helpers plus descriptor/dynamic stores. Returns only string keys, preserving ordinary-object numeric-then-string ordering while excluding symbol keys. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.getOwnPropertyNames | Supported with Limitations | [`Object_GetOwnPropertyNames_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyNames_Basic.js)<br>[`Object_OwnPropertyKeyOrdering.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_OwnPropertyKeyOrdering.js) |  | Implemented in JavaScriptRuntime.Object.getOwnPropertyNames using ordered own-key helpers plus descriptor/dynamic stores. Returns only string keys, preserving ordinary-object numeric-then-string ordering while excluding symbol keys. |
 
 ### 20.1.2.11 ([tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertysymbols))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.getOwnPropertySymbols | Supported with Limitations | [`Object_GetOwnPropertySymbols_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertySymbols_Basic.js)<br>[`Object_OwnPropertyKeyOrdering.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_OwnPropertyKeyOrdering.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) | Supported through js2il's encoded-symbol-key mapping. Returns only symbol keys, preserving ordinary-object symbol insertion order and keeping symbols out of the string-key enumeration APIs. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.getOwnPropertySymbols | Supported with Limitations | [`Object_GetOwnPropertySymbols_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertySymbols_Basic.js)<br>[`Object_OwnPropertyKeyOrdering.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_OwnPropertyKeyOrdering.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) |  | Supported through js2il's encoded-symbol-key mapping. Returns only symbol keys, preserving ordinary-object symbol insertion order and keeping symbols out of the string-key enumeration APIs. |
 
 ### 20.1.2.11.1 ([tc39.es](https://tc39.es/ecma262/#sec-getownpropertykeys))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| GetOwnPropertyKeys internal operation | Supported with Limitations | [`Object_GetOwnPropertyNames_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyNames_Basic.js)<br>[`Object_GetOwnPropertySymbols_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertySymbols_Basic.js)<br>[`Object_OwnPropertyKeyOrdering.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_OwnPropertyKeyOrdering.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) | Modeled through Object.getOwnPropertyNames/Object.getOwnPropertySymbols plus ordered-own-key helpers, preserving ordinary-object numeric/string ordering separately from symbol insertion order. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| GetOwnPropertyKeys internal operation | Supported with Limitations | [`Object_GetOwnPropertyNames_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertyNames_Basic.js)<br>[`Object_GetOwnPropertySymbols_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GetOwnPropertySymbols_Basic.js)<br>[`Object_OwnPropertyKeyOrdering.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_OwnPropertyKeyOrdering.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) |  | Modeled through Object.getOwnPropertyNames/Object.getOwnPropertySymbols plus ordered-own-key helpers, preserving ordinary-object numeric/string ordering separately from symbol insertion order. |
 
 ### 20.1.2.12 ([tc39.es](https://tc39.es/ecma262/#sec-object.getprototypeof))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.getPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) | Implemented in JavaScriptRuntime.Object.getPrototypeOf using an opt-in side-table prototype store (JavaScriptRuntime.PrototypeChain). This does not currently model default Object.prototype; if no prototype has been explicitly assigned, this returns undefined (null). |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.getPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) |  | Implemented in JavaScriptRuntime.Object.getPrototypeOf using an opt-in side-table prototype store (JavaScriptRuntime.PrototypeChain). This does not currently model default Object.prototype; if no prototype has been explicitly assigned, this returns undefined (null). |
 
 ### 20.1.2.13 ([tc39.es](https://tc39.es/ecma262/#sec-object.groupby))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.groupBy | Supported with Limitations | [`Object_GroupBy_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GroupBy_Basic.js) | Implemented for common iterable + callback usage, grouping values into array buckets on a plain object. Full callback/iterator abrupt completion corner cases are partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.groupBy | Supported with Limitations | [`Object_GroupBy_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_GroupBy_Basic.js) |  | Implemented for common iterable + callback usage, grouping values into array buckets on a plain object. Full callback/iterator abrupt completion corner cases are partial. |
 
 ### 20.1.2.14 ([tc39.es](https://tc39.es/ecma262/#sec-object.hasown))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.hasOwn | Supported with Limitations | [`Object_HasOwn_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_HasOwn_Basic.js) | Checks own properties via descriptor store and dynamic object dictionaries; host-object edge cases are best-effort. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.hasOwn | Supported with Limitations | [`Object_HasOwn_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_HasOwn_Basic.js) |  | Checks own properties via descriptor store and dynamic object dictionaries; host-object edge cases are best-effort. |
 
 ### 20.1.2.15 ([tc39.es](https://tc39.es/ecma262/#sec-object.is))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.is | Supported | [`Object_Is_SameValue.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Is_SameValue.js) | Implemented in JavaScriptRuntime.Object.is using Operators.SameValue, including NaN identity and +0/-0 distinction. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.is | Supported | [`Object_Is_SameValue.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Is_SameValue.js) |  | Implemented in JavaScriptRuntime.Object.is using Operators.SameValue, including NaN identity and +0/-0 distinction. |
 
 ### 20.1.2.16 ([tc39.es](https://tc39.es/ecma262/#sec-object.isextensible))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.isExtensible | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js) | Backed by a runtime integrity side-table; primitives return false. Ordinary objects transition to false after preventExtensions/seal/freeze and that state is consulted by assignment and Object.defineProperty paths. Exotic object behavior and complete realm invariants are partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.isExtensible | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js) |  | Backed by a runtime integrity side-table; primitives return false. Ordinary objects transition to false after preventExtensions/seal/freeze and that state is consulted by assignment and Object.defineProperty paths. Exotic object behavior and complete realm invariants are partial. |
 
 ### 20.1.2.17 ([tc39.es](https://tc39.es/ecma262/#sec-object.isfrozen))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.isFrozen | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js) | Computed from non-extensible state plus own descriptor configurability and writability for ordinary objects; empty non-extensible ordinary objects report true. Full array-index and other exotic-property semantics are partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.isFrozen | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js) |  | Computed from non-extensible state plus own descriptor configurability and writability for ordinary objects; empty non-extensible ordinary objects report true. Full array-index and other exotic-property semantics are partial. |
 
 ### 20.1.2.18 ([tc39.es](https://tc39.es/ecma262/#sec-object.issealed))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.isSealed | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js) | Computed from non-extensible state plus own descriptor configurability for ordinary objects; empty non-extensible ordinary objects report true. Exotic object semantics are partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.isSealed | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js) |  | Computed from non-extensible state plus own descriptor configurability for ordinary objects; empty non-extensible ordinary objects report true. Exotic object semantics are partial. |
 
 ### 20.1.2.19 ([tc39.es](https://tc39.es/ecma262/#sec-object.keys))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.keys | Supported with Limitations | [`Object_Keys_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Keys_Basic.js) | Implemented in JavaScriptRuntime.Object.keys. Returns an array of own enumerable string keys. Respects PropertyDescriptorStore for enumerable:false filtering. Symbol-keyed properties and full spec ordering guarantees are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.keys | Supported with Limitations | [`Object_Keys_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Keys_Basic.js) |  | Implemented in JavaScriptRuntime.Object.keys. Returns an array of own enumerable string keys. Respects PropertyDescriptorStore for enumerable:false filtering. Symbol-keyed properties and full spec ordering guarantees are not implemented. |
 
 ### 20.1.2.20 ([tc39.es](https://tc39.es/ecma262/#sec-object.preventextensions))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.preventExtensions | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Object_DefineProperty_NonExtensible_ReconfigureExisting.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperty_NonExtensible_ReconfigureExisting.js) | Marks ordinary objects non-extensible in runtime integrity state and blocks adding new properties through assignment and Object.defineProperty. Because JS2IL requires strict mode, failed additions surface as TypeError instead of silent no-op. Exotic object behavior remains partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.preventExtensions | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Object_DefineProperty_NonExtensible_ReconfigureExisting.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_DefineProperty_NonExtensible_ReconfigureExisting.js) |  | Marks ordinary objects non-extensible in runtime integrity state and blocks adding new properties through assignment and Object.defineProperty. Failed additions currently surface as TypeError. Exotic object behavior remains partial. |
 
 ### 20.1.2.21 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype (constructor property) | Supported with Limitations | [`Function_Prototype_ObjectCreate_ObjectPrototype.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js) | Object.prototype is available as a value via the global Object function value (JavaScriptRuntime.GlobalThis.Object). The runtime currently exposes a minimal placeholder object to support patterns like Object.create(Object.prototype, ...); the full Object.prototype API surface is not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype (constructor property) | Supported with Limitations | [`Function_Prototype_ObjectCreate_ObjectPrototype.js`](../../../tests/Js2IL.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js) |  | Object.prototype is available as a value via the global Object function value (JavaScriptRuntime.GlobalThis.Object). The runtime currently exposes a minimal placeholder object to support patterns like Object.create(Object.prototype, ...); the full Object.prototype API surface is not implemented. |
 
 ### 20.1.2.22 ([tc39.es](https://tc39.es/ecma262/#sec-object.seal))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.seal | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Object_Integrity_DefineProperty_And_StrictWrites.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js) | For ordinary objects, synthesizes descriptors for existing own properties, marks the object non-extensible, and sets own properties non-configurable while leaving writable data properties writable. delete and incompatible Object.defineProperty redefinitions then fail through ordinary descriptor enforcement. Full host and exotic-object invariants are partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.seal | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Object_Integrity_DefineProperty_And_StrictWrites.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js) |  | For ordinary objects, synthesizes descriptors for existing own properties, marks the object non-extensible, and sets own properties non-configurable while leaving writable data properties writable. delete and incompatible Object.defineProperty redefinitions then fail through ordinary descriptor enforcement. Full host and exotic-object invariants are partial. |
 
 ### 20.1.2.23 ([tc39.es](https://tc39.es/ecma262/#sec-object.setprototypeof))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.setPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) | Implemented in JavaScriptRuntime.Object.setPrototypeOf using an opt-in side-table prototype store. Rejects null/undefined targets; accepts object-like targets. Does not yet implement full invariant checks, extensibility, or exotic object behaviors. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.setPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) |  | Implemented in JavaScriptRuntime.Object.setPrototypeOf using an opt-in side-table prototype store. Rejects null/undefined targets; accepts object-like targets. Does not yet implement full invariant checks, extensibility, or exotic object behaviors. |
 
 ### 20.1.2.24 ([tc39.es](https://tc39.es/ecma262/#sec-object.values))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.values | Supported with Limitations | [`Object_Values_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Values_Basic.js) | Implemented in JavaScriptRuntime.Object.values. Returns an array of own enumerable property values. Respects PropertyDescriptorStore for enumerable:false filtering. Symbol-keyed properties and full spec ordering guarantees are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.values | Supported with Limitations | [`Object_Values_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Values_Basic.js) |  | Implemented in JavaScriptRuntime.Object.values. Returns an array of own enumerable property values. Respects PropertyDescriptorStore for enumerable:false filtering. Symbol-keyed properties and full spec ordering guarantees are not implemented. |
 
 ### 20.1.3.1 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.constructor))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.constructor | Supported with Limitations | [`Object_Prototype_Constructor_IsPrototypeOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_Constructor_IsPrototypeOf.js) | Provided on the runtime Object.prototype intrinsic surface. Default prototype wiring for every host/exotic value is not fully modeled. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.constructor | Supported with Limitations | [`Object_Prototype_Constructor_IsPrototypeOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_Constructor_IsPrototypeOf.js) |  | Provided on the runtime Object.prototype intrinsic surface. Default prototype wiring for every host/exotic value is not fully modeled. |
 
 ### 20.1.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.hasownproperty))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.hasOwnProperty | Supported with Limitations | [`Object_Prototype_HasOwnProperty_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_HasOwnProperty_Basic.js) | Seeded onto Object.prototype via JavaScriptRuntime.GlobalThis. Works when invoked via Object.prototype.hasOwnProperty (e.g., using apply/call). Default Object.prototype wiring for all object literals is incomplete. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.hasOwnProperty | Supported with Limitations | [`Object_Prototype_HasOwnProperty_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_HasOwnProperty_Basic.js) |  | Seeded onto Object.prototype via JavaScriptRuntime.GlobalThis. Works when invoked via Object.prototype.hasOwnProperty (e.g., using apply/call). Default Object.prototype wiring for all object literals is incomplete. |
 
 ### 20.1.3.3 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.isprototypeof))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.isPrototypeOf | Supported with Limitations | [`Object_Prototype_Constructor_IsPrototypeOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_Constructor_IsPrototypeOf.js) | Implemented by walking the opt-in PrototypeChain side-table. Behavior depends on prototype-feature enablement for a given compilation unit. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.isPrototypeOf | Supported with Limitations | [`Object_Prototype_Constructor_IsPrototypeOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_Constructor_IsPrototypeOf.js) |  | Implemented by walking the opt-in PrototypeChain side-table. Behavior depends on prototype-feature enablement for a given compilation unit. |
 
 ### 20.1.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.propertyIsEnumerable | Supported with Limitations | [`Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js) | Reads enumerability from descriptor store and dynamic dictionary fallbacks. Full host-object fidelity is partial. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.propertyIsEnumerable | Supported with Limitations | [`Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js) |  | Reads enumerability from descriptor store and dynamic dictionary fallbacks. Full host-object fidelity is partial. |
 
 ### 20.1.3.5 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.tolocalestring))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.toLocaleString | Supported with Limitations | [`Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js) | Implemented as an Object.prototype toString-based fallback path for core compatibility. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.toLocaleString | Supported with Limitations | [`Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js) |  | Implemented as an Object.prototype toString-based fallback path for core compatibility. |
 
 ### 20.1.3.6 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.tostring))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.toString | Supported with Limitations | [`Object_Prototype_ToString_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_ToString_Basic.js)<br>[`Object_Prototype_ToString_SymbolToStringTag_Custom.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_ToString_SymbolToStringTag_Custom.js)<br>[`Generator_Prototype_ToStringTag.js`](../../../tests/Js2IL.Tests/Generator/JavaScript/Generator_Prototype_ToStringTag.js) | Supports built-in tags plus Symbol.toStringTag lookup for ordinary objects, arrays, and key runtime types; full brand checks and all exotic cases are not exhaustive. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.toString | Supported with Limitations | [`Object_Prototype_ToString_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_ToString_Basic.js)<br>[`Object_Prototype_ToString_SymbolToStringTag_Custom.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_ToString_SymbolToStringTag_Custom.js)<br>[`Generator_Prototype_ToStringTag.js`](../../../tests/Js2IL.Tests/Generator/JavaScript/Generator_Prototype_ToStringTag.js) |  | Supports built-in tags plus Symbol.toStringTag lookup for ordinary objects, arrays, and key runtime types; full brand checks and all exotic cases are not exhaustive. |
 
 ### 20.1.3.7 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.valueof))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.valueOf | Supported with Limitations | [`Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js) | Returns the current this value after null/undefined checks in the runtime call path. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.valueOf | Supported with Limitations | [`Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.js) |  | Returns the current this value after null/undefined checks in the runtime call path. |
 
 ### 20.1.3.8 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__proto__))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Legacy __proto__ getter/setter | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) | Supported via special-casing the "__proto__" key in runtime property get/set helpers when prototype-chain mode is enabled. This approximates legacy accessor semantics but does not fully implement Object.prototype as an actual intrinsic object with accessor descriptors. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Legacy __proto__ getter/setter | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) |  | Supported via special-casing the "__proto__" key in runtime property get/set helpers when prototype-chain mode is enabled. This approximates legacy accessor semantics but does not fully implement Object.prototype as an actual intrinsic object with accessor descriptors. |
 
 ### 20.1.3.9 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype-legacy-accessor-methods))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Legacy Object.prototype accessor methods | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) | Legacy getter/setter lookup/definition APIs are available via Object.prototype.* call forms and descriptor store integration. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Legacy Object.prototype accessor methods | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) |  | Legacy getter/setter lookup/definition APIs are available via Object.prototype.* call forms and descriptor store integration. |
 
 ### 20.1.3.9.1 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.__defineGetter__ | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) | Defines accessor getter descriptors in the runtime descriptor store. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.__defineGetter__ | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) |  | Defines accessor getter descriptors in the runtime descriptor store. |
 
 ### 20.1.3.9.2 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.__defineSetter__ | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) | Defines accessor setter descriptors in the runtime descriptor store. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.__defineSetter__ | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) |  | Defines accessor setter descriptors in the runtime descriptor store. |
 
 ### 20.1.3.9.3 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.__lookupGetter__ | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) | Looks up getter accessors on own/prototype descriptor chain when available. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.__lookupGetter__ | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) |  | Looks up getter accessors on own/prototype descriptor chain when available. |
 
 ### 20.1.3.9.4 ([tc39.es](https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Object.prototype.__lookupSetter__ | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) | Looks up setter accessors on own/prototype descriptor chain when available. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object.prototype.__lookupSetter__ | Supported with Limitations | [`Object_Prototype_LegacyAccessors.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_LegacyAccessors.js) |  | Looks up setter accessors on own/prototype descriptor chain when available. |
 
 ### 20.1.4 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-object-instances))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Properties of Object instances | Supported with Limitations | [`Object_Prototype_Constructor_IsPrototypeOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_Constructor_IsPrototypeOf.js)<br>[`PrototypeChain_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) | Instance-level Object.prototype methods are available through the runtime intrinsic Object.prototype surface; default prototype linkage remains opt-in via runtime prototype-chain mode. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Properties of Object instances | Supported with Limitations | [`Object_Prototype_Constructor_IsPrototypeOf.js`](../../../tests/Js2IL.Tests/Object/JavaScript/Object_Prototype_Constructor_IsPrototypeOf.js)<br>[`PrototypeChain_Basic.js`](../../../tests/Js2IL.Tests/Object/JavaScript/PrototypeChain_Basic.js) |  | Instance-level Object.prototype methods are available through the runtime intrinsic Object.prototype surface; default prototype linkage remains opt-in via runtime prototype-chain mode. |
 

--- a/docs/Js2IL.SDK.NuGet.README.md
+++ b/docs/Js2IL.SDK.NuGet.README.md
@@ -80,8 +80,6 @@ You can set metadata per item or apply defaults with properties:
   - Defaults to `true` for Debug builds and `false` otherwise.
 - `Verbose` / `Js2ILVerbose`
 - `AnalyzeUnused` / `Js2ILAnalyzeUnused`
-- `StrictMode` / `Js2ILStrictMode`
-  - `Error`, `Warn`, or `Ignore`
 - `DiagnosticFilePath` / `Js2ILDiagnosticFilePath`
 
 ## MSBuild outputs

--- a/samples/Hosting.Domino/host/Hosting.Domino.csproj
+++ b/samples/Hosting.Domino/host/Hosting.Domino.csproj
@@ -8,7 +8,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <ModuleOutputDirectory>obj\$(Configuration)\$(TargetFramework)\js2il\domino</ModuleOutputDirectory>
-    <Js2ILStrictMode>Ignore</Js2ILStrictMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/test262/runMvp.js
+++ b/scripts/test262/runMvp.js
@@ -1109,7 +1109,6 @@ function evaluateCase(rootPath, outputRoot, testCase, js2il, args) {
 
   const compositeSourcePath = path.join(caseDirectory, 'input.js');
   fs.writeFileSync(compositeSourcePath, buildCompositeSource(rootPath, testCase), 'utf8');
-  const compilerArgs = ['--strictMode', 'Ignore'];
   const diagnosticContext = createDiagnosticContext(rootPath, outputRoot);
 
   const compileResult = compileWithJs2IL(
@@ -1117,7 +1116,7 @@ function evaluateCase(rootPath, outputRoot, testCase, js2il, args) {
     path.join(caseDirectory, 'compile'),
     js2il,
     args.compileTimeoutSeconds * 1000,
-    compilerArgs,
+    [],
   );
 
   const negative = testCase.metadata.negative;

--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -39,10 +39,6 @@ public class Js2ILArgs
     [ArgShortcut("--pdb")]
     public bool EmitPdb { get; set; }
 
-    [ArgDescription("Strict-mode directive prologue enforcement: Error, Warn, or Ignore")]
-    [ArgShortcut("--strictMode")]
-    public StrictModeDirectivePrologueMode StrictMode { get; set; } = StrictModeDirectivePrologueMode.Error;
-
     [ArgDescription("Show version information and exit")]
     [ArgShortcut("--version")]
     public bool Version { get; set; }
@@ -86,8 +82,7 @@ class Program
                 Verbose = parsed.Verbose,
                 DiagnosticFilePath = diagnosticFilePath,
                 AnalyzeUnused = parsed.AnalyzeUnused,
-                EmitPdb = parsed.EmitPdb,
-                StrictMode = parsed.StrictMode
+                EmitPdb = parsed.EmitPdb
             });
             var logger = servicesProvider.GetRequiredService<ICompilerOutput>();
 
@@ -168,7 +163,6 @@ class Program
         logger.WriteLineError("--diagnostic-file <path> Write diagnostics output to a text file");
         logger.WriteLineError("-a, --analyzeunused    Analyze and report unused properties and methods");
         logger.WriteLineError("--pdb                  Emit Portable PDB debug symbols (.pdb)");
-        logger.WriteLineError("--strictMode           Strict-mode directive prologue enforcement: Error, Warn, or Ignore");
         logger.WriteLineError("--version              Show version information and exit");
         logger.WriteLineError("-h, -?, --help         Show help and exit");
     }

--- a/src/Compiler/CompilerOptions.cs
+++ b/src/Compiler/CompilerOptions.cs
@@ -1,21 +1,3 @@
-public enum StrictModeDirectivePrologueMode
-{
-    /// <summary>
-    /// Missing "use strict" is a validation error.
-    /// </summary>
-    Error = 0,
-
-    /// <summary>
-    /// Missing "use strict" is downgraded to a warning.
-    /// </summary>
-    Warn = 1,
-
-    /// <summary>
-    /// Missing "use strict" is ignored (no error/warning).
-    /// </summary>
-    Ignore = 2
-}
-
 public class CompilerOptions
 {
     public string? OutputDirectory { get; set; } = null;
@@ -23,12 +5,6 @@ public class CompilerOptions
     public string? DiagnosticFilePath { get; set; } = null;
     public bool AnalyzeUnused { get; set; } = false;    
     public bool DiagnosticsEnabled => Verbose || !string.IsNullOrWhiteSpace(DiagnosticFilePath);
-
-    /// <summary>
-    /// Controls how missing strict-mode directive prologues ("use strict"; at the start of a module/script)
-    /// are reported.
-    /// </summary>
-    public StrictModeDirectivePrologueMode StrictMode { get; set; } = StrictModeDirectivePrologueMode.Error;
 
     /// <summary>
     /// When true, emits Portable PDB debug symbols alongside the generated assembly.

--- a/src/Compiler/ModuleLoader.cs
+++ b/src/Compiler/ModuleLoader.cs
@@ -36,7 +36,7 @@ public class ModuleLoader
         Microsoft.Extensions.Logging.ILogger<ModuleLoader>? diagnosticLogger = null)
     {
         _diagnosticsEnabled = options.DiagnosticsEnabled;
-        _validator = new JavaScriptAstValidator(options.StrictMode);
+        _validator = new JavaScriptAstValidator();
         _fileSystem = fileSystem;
         _moduleResolver = moduleResolver;
         _ux = ux;

--- a/src/Compiler/Validation/JavaScriptAstValidator.cs
+++ b/src/Compiler/Validation/JavaScriptAstValidator.cs
@@ -12,8 +12,6 @@ namespace Js2IL.Validation;
 
 public class JavaScriptAstValidator : IAstValidator
 {
-    private readonly StrictModeDirectivePrologueMode _strictModeDirectivePrologueMode;
-
     private static readonly Lazy<HashSet<string>> SupportedRequireModules = new(() =>
     {
         var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -31,18 +29,9 @@ public class JavaScriptAstValidator : IAstValidator
         return set;
     });
 
-    public JavaScriptAstValidator(StrictModeDirectivePrologueMode strictModeDirectivePrologueMode = StrictModeDirectivePrologueMode.Error)
-    {
-        _strictModeDirectivePrologueMode = strictModeDirectivePrologueMode;
-    }
-
     public ValidationResult Validate(Acornima.Ast.Program ast)
     {
         var result = new ValidationResult { IsValid = true };
-
-        // JS2IL currently only supports strict-mode semantics.
-        // Require every module/script to include a directive prologue containing "use strict".
-        ValidateUseStrictDirectivePrologue(ast, result, _strictModeDirectivePrologueMode);
 
         // Validate spec-level early errors that Acornima may parse but considers static errors.
         // In particular, break/continue target rules are specified under iteration statements.
@@ -976,57 +965,6 @@ public class JavaScriptAstValidator : IAstValidator
 
                 nodeStack.Pop();
             });
-    }
-
-    private static void ValidateUseStrictDirectivePrologue(
-        Acornima.Ast.Program ast,
-        ValidationResult result,
-        StrictModeDirectivePrologueMode strictModeDirectivePrologueMode)
-    {
-        var hasUseStrict = false;
-
-        foreach (var statement in ast.Body)
-        {
-            if (statement is ExpressionStatement { Expression: StringLiteral str })
-            {
-                if (string.Equals(str.Value, "use strict", StringComparison.Ordinal))
-                {
-                    hasUseStrict = true;
-                    break;
-                }
-                continue;
-            }
-
-            // Directive prologue ends at the first non-string-literal expression statement.
-            break;
-        }
-
-        if (!hasUseStrict)
-        {
-            switch (strictModeDirectivePrologueMode)
-            {
-                case StrictModeDirectivePrologueMode.Error:
-                    AddError(
-                        result,
-                        "JS2IL requires strict mode: add a \"use strict\"; directive prologue at the start of the module",
-                        ast);
-                    break;
-                case StrictModeDirectivePrologueMode.Warn:
-                    AddWarning(
-                        result,
-                        "JS2IL requires strict mode: add a \"use strict\"; directive prologue at the start of the module",
-                        ast);
-                    break;
-                case StrictModeDirectivePrologueMode.Ignore:
-                    break;
-                default:
-                    AddError(
-                        result,
-                        "JS2IL requires strict mode: add a \"use strict\"; directive prologue at the start of the module",
-                        ast);
-                    break;
-            }
-        }
     }
 
     private static void ValidateIterationStatementEarlyErrors(Acornima.Ast.Program ast, ValidationResult result)

--- a/src/Js2IL.SDK/Js2ILCompileTask.cs
+++ b/src/Js2IL.SDK/Js2ILCompileTask.cs
@@ -82,11 +82,6 @@ public sealed class Js2ILCompileTask : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        if (!TryGetStrictMode(source, out var strictMode))
-        {
-            return false;
-        }
-
         var diagnosticFilePath = source.GetMetadata("ResolvedDiagnosticFilePath");
         if (!EnsureDiagnosticDirectoryExists(diagnosticFilePath))
         {
@@ -99,8 +94,7 @@ public sealed class Js2ILCompileTask : Microsoft.Build.Utilities.Task
             Verbose = verbose,
             DiagnosticFilePath = string.IsNullOrWhiteSpace(diagnosticFilePath) ? null : diagnosticFilePath,
             AnalyzeUnused = analyzeUnused,
-            EmitPdb = emitPdb,
-            StrictMode = strictMode
+            EmitPdb = emitPdb
         };
 
         var logger = new MsBuildCompilerOutput(Log, sourcePath);
@@ -264,24 +258,6 @@ public sealed class Js2ILCompileTask : Microsoft.Build.Utilities.Task
             Log.LogError($"Cannot create the diagnostic output directory for '{diagnosticFilePath}': {ex.Message}");
             return false;
         }
-    }
-
-    private bool TryGetStrictMode(ITaskItem source, out StrictModeDirectivePrologueMode strictMode)
-    {
-        var raw = source.GetMetadata("StrictMode");
-        if (string.IsNullOrWhiteSpace(raw))
-        {
-            strictMode = StrictModeDirectivePrologueMode.Error;
-            return true;
-        }
-
-        if (Enum.TryParse(raw, ignoreCase: true, out strictMode))
-        {
-            return true;
-        }
-
-        Log.LogError($"Invalid StrictMode value '{raw}' for Js2IL source '{source.ItemSpec}'. Use Error, Warn, or Ignore.");
-        return false;
     }
 
     private bool TryGetBooleanMetadata(ITaskItem item, string metadataName, out bool value)

--- a/src/Js2IL.SDK/build/Js2IL.SDK.props
+++ b/src/Js2IL.SDK/build/Js2IL.SDK.props
@@ -11,7 +11,6 @@
     <Js2ILEmitPdb Condition="'$(Js2ILEmitPdb)' == ''">false</Js2ILEmitPdb>
     <Js2ILAnalyzeUnused Condition="'$(Js2ILAnalyzeUnused)' == ''">false</Js2ILAnalyzeUnused>
     <Js2ILVerbose Condition="'$(Js2ILVerbose)' == ''">false</Js2ILVerbose>
-    <Js2ILStrictMode Condition="'$(Js2ILStrictMode)' == ''">Error</Js2ILStrictMode>
     <Js2ILDiagnosticFilePath Condition="'$(Js2ILDiagnosticFilePath)' == ''"></Js2ILDiagnosticFilePath>
   </PropertyGroup>
 

--- a/src/Js2IL.SDK/build/Js2IL.SDK.targets
+++ b/src/Js2IL.SDK/build/Js2IL.SDK.targets
@@ -26,8 +26,6 @@
         <AnalyzeUnused Condition="'%(Js2ILCompile.AnalyzeUnused)' != ''">%(Js2ILCompile.AnalyzeUnused)</AnalyzeUnused>
         <Verbose Condition="'%(Js2ILCompile.Verbose)' == ''">$(Js2ILVerbose)</Verbose>
         <Verbose Condition="'%(Js2ILCompile.Verbose)' != ''">%(Js2ILCompile.Verbose)</Verbose>
-        <StrictMode Condition="'%(Js2ILCompile.StrictMode)' == ''">$(Js2ILStrictMode)</StrictMode>
-        <StrictMode Condition="'%(Js2ILCompile.StrictMode)' != ''">%(Js2ILCompile.StrictMode)</StrictMode>
       </_Js2ILCompile>
     </ItemGroup>
   </Target>

--- a/tests/Js2IL.Testing/TestCompiler.cs
+++ b/tests/Js2IL.Testing/TestCompiler.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.IO;
 using System.Reflection;
-using System.Text.RegularExpressions;
 
 namespace Js2IL.Tests
 {
@@ -13,10 +12,6 @@ namespace Js2IL.Tests
     /// </summary>
     public static class TestCompiler
     {
-        private static readonly Regex NoStrictFlagRegex = new(
-            @"flags\s*:\s*\[[^\]]*\bnoStrict\b[^\]]*\]",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
         /// <summary>
         /// Compiles JavaScript test code to a .NET assembly.
         /// </summary>
@@ -86,12 +81,6 @@ namespace Js2IL.Tests
                 || testCategory.StartsWith("built-ins.", StringComparison.OrdinalIgnoreCase)
                 || testCategory.StartsWith("built_ins.", StringComparison.OrdinalIgnoreCase))
             {
-                options.StrictMode = StrictModeDirectivePrologueMode.Warn;
-
-                if (NoStrictFlagRegex.IsMatch(js))
-                {
-                    options.StrictMode = StrictModeDirectivePrologueMode.Ignore;
-                }
             }
 
             var testLogger = new TestLogger();

--- a/tests/Js2IL.Tests/CliTests.cs
+++ b/tests/Js2IL.Tests/CliTests.cs
@@ -241,7 +241,7 @@ namespace Js2IL.Tests
         }
 
         [Fact]
-        public void Convert_NonStrictJs_DefaultStrictMode_Fails()
+        public void Convert_NonStrictJs_Succeeds()
         {
             var tempRoot = Path.Combine(Path.GetTempPath(), "js2il_cli_test_" + Guid.NewGuid().ToString("n"));
             Directory.CreateDirectory(tempRoot);
@@ -252,31 +252,9 @@ namespace Js2IL.Tests
             try
             {
                 var (code, stdout, stderr) = RunOutOfProc(jsFile, "-o", outDir);
-                Assert.NotEqual(0, code);
-                Assert.Contains("requires strict mode", stdout + stderr, StringComparison.OrdinalIgnoreCase);
-            }
-            finally
-            {
-                try { Directory.Delete(tempRoot, recursive: true); } catch { /* ignore */ }
-            }
-        }
-
-        [Fact]
-        public void Convert_NonStrictJs_StrictModeWarn_Succeeds()
-        {
-            var tempRoot = Path.Combine(Path.GetTempPath(), "js2il_cli_test_" + Guid.NewGuid().ToString("n"));
-            Directory.CreateDirectory(tempRoot);
-            var jsFile = Path.Combine(tempRoot, "nonstrict.js");
-            File.WriteAllText(jsFile, "console.log('hello');\n");
-            var outDir = Path.Combine(tempRoot, "out");
-
-            try
-            {
-                var (code, stdout, stderr) = RunOutOfProc(jsFile, "-o", outDir, "--strictMode", "warn");
-
                 Assert.Equal(0, code);
                 Assert.True(string.IsNullOrWhiteSpace(stderr), $"Unexpected stderr: {stderr}");
-                Assert.Contains("strict", stdout, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("Compilation succeeded", stdout, StringComparison.OrdinalIgnoreCase);
 
                 var baseName = Path.GetFileNameWithoutExtension(jsFile);
                 var dllPath = Path.Combine(outDir, baseName + ".dll");

--- a/tests/Js2IL.Tests/ModuleLoaderTests.cs
+++ b/tests/Js2IL.Tests/ModuleLoaderTests.cs
@@ -27,7 +27,7 @@ public class ModuleLoaderTests
     }
 
     [Fact]
-    public void LoadModules_DependencyMissingUseStrict_ReturnsNullAndLogsErrors()
+    public void LoadModules_DependencyMissingUseStrict_LoadsSuccessfully()
     {
         var fileSystem = new MockFileSystem();
         var logger = new TestLogger();
@@ -43,13 +43,13 @@ public class ModuleLoaderTests
 
         var modules = loader.LoadModules(rootPath);
 
-        Assert.Null(modules);
-        Assert.Contains("Validation Errors", logger.Errors);
-        Assert.Contains("requires strict mode", logger.Errors, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(modules);
+        Assert.True(string.IsNullOrWhiteSpace(logger.Errors));
+        Assert.True(string.IsNullOrWhiteSpace(logger.Warnings));
     }
 
     [Fact]
-    public void LoadModules_MultipleDependenciesMissingUseStrict_ReturnsNullAndLogsAllErrorsWithModuleNames()
+    public void LoadModules_MultipleDependenciesMissingUseStrict_LoadsSuccessfully()
     {
         var fileSystem = new MockFileSystem();
         var logger = new TestLogger();
@@ -67,35 +67,9 @@ public class ModuleLoaderTests
 
         var modules = loader.LoadModules(rootPath);
 
-        Assert.Null(modules);
-        Assert.Contains("Validation Errors", logger.Errors);
-
-        // Both dependencies should be reported (fail-fast hides one of these).
-        Assert.Contains("requires strict mode", logger.Errors, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(Path.GetFileName(depAPath), logger.Errors, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(Path.GetFileName(depBPath), logger.Errors, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void LoadModules_DependencyMissingUseStrict_StrictModeWarn_LoadsAndLogsWarning()
-    {
-        var fileSystem = new MockFileSystem();
-        var logger = new TestLogger();
-        var options = new CompilerOptions { Verbose = false, StrictMode = StrictModeDirectivePrologueMode.Warn };
-        var resolver = new NodeModuleResolver(fileSystem);
-        var loader = new ModuleLoader(options, fileSystem, resolver, logger);
-
-        var rootPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "js2il-tests", Guid.NewGuid().ToString("N"), "root.js"));
-        var depPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(rootPath)!, "dep.js"));
-
-        fileSystem.AddFile(rootPath, "\"use strict\";\nconst d = require('./dep');\nconsole.log(d);\n");
-        fileSystem.AddFile(depPath, "module.exports = 1;\n");
-
-        var modules = loader.LoadModules(rootPath);
-
         Assert.NotNull(modules);
         Assert.True(string.IsNullOrWhiteSpace(logger.Errors));
-        Assert.Contains("requires strict mode", logger.Warnings, StringComparison.OrdinalIgnoreCase);
+        Assert.True(string.IsNullOrWhiteSpace(logger.Warnings));
     }
 
     [Fact]
@@ -117,7 +91,7 @@ public class ModuleLoaderTests
             + "require('./missingA');\n"
             + "require('./missingB');\n"
         );
-        fileSystem.AddFile(okPath, "module.exports = 1;\n");
+        fileSystem.AddFile(okPath, "module.exports = ;\n");
 
         var modules = loader.LoadModules(rootPath);
 
@@ -125,7 +99,6 @@ public class ModuleLoaderTests
         Assert.Contains("require('./missingA')", logger.Errors);
         Assert.Contains("require('./missingB')", logger.Errors);
         Assert.Contains(Path.GetFileName(okPath), logger.Errors, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("requires strict mode", logger.Errors, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Js2IL.Tests/ValidatorTests.cs
+++ b/tests/Js2IL.Tests/ValidatorTests.cs
@@ -22,26 +22,14 @@ public class ValidatorTests
         => _parser.ParseJavaScript("\"use strict\";\n" + js, "test.js");
 
     [Fact]
-    public void Validate_MissingUseStrict_ReportsError()
+    public void Validate_MissingUseStrict_ReturnsValid()
     {
         var js = "var x = 1;";
         var ast = _parser.ParseJavaScript(js, "test.js");
         var result = _validator.Validate(ast);
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Contains("requires strict mode", StringComparison.OrdinalIgnoreCase));
-    }
-
-    [Fact]
-    public void Validate_MissingUseStrict_StrictModeWarn_ReportsWarning()
-    {
-        var js = "var x = 1;";
-        var ast = _parser.ParseJavaScript(js, "test.js");
-        var warnValidator = new JavaScriptAstValidator(StrictModeDirectivePrologueMode.Warn);
-        var result = warnValidator.Validate(ast);
-
         Assert.True(result.IsValid);
         Assert.Empty(result.Errors);
-        Assert.Contains(result.Warnings, w => w.Contains("requires strict mode", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(result.Warnings);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- remove the top-level `"use strict"` requirement so JS2IL accepts both strict and non-strict scripts by default
- delete the configurable strict-mode enforcement surface from the compiler, CLI, and SDK/MSBuild integration
- update validator, module-loader, CLI, SDK/docs, and ECMA docs coverage to match the new behavior

## Validation

- `dotnet test .\tests\Js2IL.Tests\Js2IL.Tests.csproj -c Release /p:IsTestProject=true --filter "FullyQualifiedName~ValidatorTests|FullyQualifiedName~CliTests|FullyQualifiedName~ModuleLoaderTests" --nologo`
- `dotnet test .\tests\Js2IL.Tests\Js2IL.Tests.csproj -c Release /p:IsTestProject=true --filter "FullyQualifiedName~ValidatorTests|FullyQualifiedName~CliTests|FullyQualifiedName~ModuleLoaderTests|FullyQualifiedName~Js2ILSdkPackageTests" --nologo`
