### PR TITLE
refactor(runtime): reduce duplicated helper logic

### DIFF
--- a/src/JavaScriptRuntime/Math.cs
+++ b/src/JavaScriptRuntime/Math.cs
@@ -254,52 +254,10 @@ namespace JavaScriptRuntime
             return (double)count;
         }
 
-        private static double ToNumber(object? x)
-        {
-            if (x is null) return double.NaN; // undefined => NaN
-            switch (x)
-            {
-                case JsNull: return 0d; // null => +0
-                case double dd: return dd;
-                case float ff: return ff;
-                case int ii: return ii;
-                case long ll: return ll;
-                case short ss: return ss;
-                case byte bb: return bb;
-                case bool b: return b ? 1d : 0d;
-                case string s:
-                    if (double.TryParse(s, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
-                        return parsed;
-                    return double.NaN;
-            }
-            try { return Convert.ToDouble(x, System.Globalization.CultureInfo.InvariantCulture); }
-            catch { return double.NaN; }
-        }
+        private static double ToNumber(object? x) => TypeUtilities.ToNumber(x);
 
-        private static int ToInt32(object? x)
-        {
-            double d = ToNumber(x);
-            if (double.IsNaN(d) || double.IsInfinity(d) || d == 0) return 0;
-            // ECMAScript ToInt32: modulo 2^32 into the signed range [-2^31, 2^31-1]
-            double two32 = 4294967296.0; // 2^32
-            double two31 = 2147483648.0; // 2^31
-            double n = System.Math.Floor(System.Math.Abs(d));
-            double int32bit = System.Math.IEEERemainder(n, two32);
-            if (int32bit < 0) int32bit += two32;
-            if (d < 0) int32bit = -int32bit;
-            double signed = int32bit >= two31 ? int32bit - two32 : int32bit;
-            return (int)signed;
-        }
+        private static int ToInt32(object? x) => TypeUtilities.ToInt32(x);
 
-        private static uint ToUint32(object? x)
-        {
-            double d = ToNumber(x);
-            if (double.IsNaN(d) || double.IsInfinity(d) || d == 0) return 0u;
-            double two32 = 4294967296.0; // 2^32
-            double n = System.Math.Floor(System.Math.Abs(d));
-            double uint32bit = n % two32;
-            if (d < 0) uint32bit = two32 - uint32bit;
-            return (uint)uint32bit;
-        }
+        private static uint ToUint32(object? x) => TypeUtilities.ToUint32(x);
     }
 }

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -68,38 +68,65 @@ namespace JavaScriptRuntime
         public static object DefineObjectLiteralDataProperty(object target, object? prop, object? value)
         {
             ConfigureFunctionNameFromPropertyKey(prop, value);
-            return DefineObjectLiteralDataPropertyCore(
+            return DefineDataPropertyCore(
                 target,
                 Object.ToPropertyKeyString(prop),
                 value,
-                static (jsObject, key, objectValue) => jsObject.SetObject(key, objectValue));
+                static (jsObject, key, objectValue) => jsObject.SetObject(key, objectValue),
+                enumerable: true);
         }
 
         public static object DefineObjectLiteralDataProperty(object target, string prop, double value)
-            => DefineObjectLiteralDataPropertyCore(
+            => DefineDataPropertyCore(
                 target,
                 prop,
                 value,
-                static (jsObject, key, numberValue) => jsObject.SetNumber(key, numberValue));
+                static (jsObject, key, numberValue) => jsObject.SetNumber(key, numberValue),
+                enumerable: true);
 
         public static object DefineObjectLiteralDataProperty(object target, string prop, bool value)
-            => DefineObjectLiteralDataPropertyCore(
+            => DefineDataPropertyCore(
                 target,
                 prop,
                 value,
-                static (jsObject, key, boolValue) => jsObject.SetBoolean(key, boolValue));
+                static (jsObject, key, boolValue) => jsObject.SetBoolean(key, boolValue),
+                enumerable: true);
 
         public static object DefineObjectLiteralDataProperty(object target, string prop, object? value)
         {
             ConfigureFunctionNameFromPropertyKey(prop, value);
-            return DefineObjectLiteralDataPropertyCore(
+            return DefineDataPropertyCore(
                 target,
                 prop,
                 value,
-                static (jsObject, key, objectValue) => jsObject.SetObject(key, objectValue));
+                static (jsObject, key, objectValue) => jsObject.SetObject(key, objectValue),
+                enumerable: true);
         }
 
         public static object DefineObjectLiteralAccessorProperty(object target, object? prop, object? getter, object? setter)
+            => DefineAccessorProperty(target, prop, getter, setter, enumerable: true, createDictionarySlot: true);
+
+        public static object DefineClassElementDataProperty(object target, object? prop, object? value)
+        {
+            ConfigureFunctionNameFromPropertyKey(prop, value);
+            return DefineDataPropertyCore(
+                target,
+                Object.ToPropertyKeyString(prop),
+                value,
+                static (jsObject, key, objectValue) => jsObject.SetObject(key, objectValue),
+                enumerable: false);
+        }
+
+        public static object DefineClassElementAccessorProperty(object target, object? prop, object? getter, object? setter)
+            => DefineAccessorProperty(target, prop, getter, setter, enumerable: false, createDictionarySlot: false);
+
+        private static object DefineAccessorProperty(
+            object target,
+            object? prop,
+            object? getter,
+            object? setter,
+            bool enumerable,
+            bool createDictionarySlot)
         {
             if (target is null || target is JsNull)
             {
@@ -130,13 +157,13 @@ namespace JavaScriptRuntime
             PropertyDescriptorStore.DefineOrUpdate(target, key, new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Accessor,
-                Enumerable = true,
+                Enumerable = enumerable,
                 Configurable = true,
                 Get = getter is null || getter is JsNull ? existingGetter : getter,
                 Set = setter is null || setter is JsNull ? existingSetter : setter
             });
 
-            if (target is IDictionary<string, object?> dict && !dict.ContainsKey(key))
+            if (createDictionarySlot && target is IDictionary<string, object?> dict && !dict.ContainsKey(key))
             {
                 dict[key] = null;
             }
@@ -144,83 +171,12 @@ namespace JavaScriptRuntime
             return target;
         }
 
-        public static object DefineClassElementDataProperty(object target, object? prop, object? value)
-        {
-            if (target is null || target is JsNull)
-            {
-                throw new TypeError("Cannot convert undefined or null to object");
-            }
-
-            var key = Object.ToPropertyKeyString(prop);
-            Object.InvalidateRegExpWellKnownSymbolFastPath(target, key);
-            ConfigureFunctionNameFromPropertyKey(prop, value);
-
-            if (target is JsObject jsObject)
-            {
-                jsObject.SetObject(key, value);
-            }
-            else if (target is IDictionary<string, object?> dict)
-            {
-                dict[key] = value;
-            }
-
-            PropertyDescriptorStore.DefineOrUpdate(target, key, new JsPropertyDescriptor
-            {
-                Kind = JsPropertyDescriptorKind.Data,
-                Value = value,
-                Writable = true,
-                Enumerable = false,
-                Configurable = true
-            });
-
-            return target;
-        }
-
-        public static object DefineClassElementAccessorProperty(object target, object? prop, object? getter, object? setter)
-        {
-            if (target is null || target is JsNull)
-            {
-                throw new TypeError("Cannot convert undefined or null to object");
-            }
-
-            if (getter is not null && getter is not JsNull && getter is not Delegate)
-            {
-                throw new TypeError("Getter must be a function");
-            }
-
-            if (setter is not null && setter is not JsNull && setter is not Delegate)
-            {
-                throw new TypeError("Setter must be a function");
-            }
-
-            var key = Object.ToPropertyKeyString(prop);
-            Object.InvalidateRegExpWellKnownSymbolFastPath(target, key);
-
-            object? existingGetter = null;
-            object? existingSetter = null;
-            if (PropertyDescriptorStore.TryGetOwn(target, key, out var existing) && existing.Kind == JsPropertyDescriptorKind.Accessor)
-            {
-                existingGetter = existing.Get;
-                existingSetter = existing.Set;
-            }
-
-            PropertyDescriptorStore.DefineOrUpdate(target, key, new JsPropertyDescriptor
-            {
-                Kind = JsPropertyDescriptorKind.Accessor,
-                Enumerable = false,
-                Configurable = true,
-                Get = getter is null || getter is JsNull ? existingGetter : getter,
-                Set = setter is null || setter is JsNull ? existingSetter : setter
-            });
-
-            return target;
-        }
-
-        private static object DefineObjectLiteralDataPropertyCore<TValue>(
+        private static object DefineDataPropertyCore<TValue>(
             object target,
             string key,
             TValue value,
-            Action<JsObject, string, TValue> setJsObjectValue)
+            Action<JsObject, string, TValue> setJsObjectValue,
+            bool enumerable)
         {
             if (target is null || target is JsNull)
             {
@@ -243,7 +199,7 @@ namespace JavaScriptRuntime
                 Kind = JsPropertyDescriptorKind.Data,
                 Value = value,
                 Writable = true,
-                Enumerable = true,
+                Enumerable = enumerable,
                 Configurable = true
             });
 

--- a/src/JavaScriptRuntime/TypeUtilities.cs
+++ b/src/JavaScriptRuntime/TypeUtilities.cs
@@ -140,6 +140,28 @@ namespace JavaScriptRuntime
             return unchecked((int)(long)number);
         }
 
+        /// <summary>
+        /// ECMA-262 §7.1.7 ToUint32 ( argument ).
+        /// Converts argument to an unsigned 32-bit integer in the range [0, 2^32-1].
+        /// </summary>
+        public static uint ToUint32(object? value)
+        {
+            var number = ToNumber(value);
+            if (double.IsNaN(number) || double.IsInfinity(number) || number == 0.0)
+            {
+                return 0;
+            }
+
+            const double two32 = 4294967296.0;
+            var uint32bit = global::System.Math.Floor(global::System.Math.Abs(number)) % two32;
+            if (number < 0)
+            {
+                uint32bit = two32 - uint32bit;
+            }
+
+            return (uint)uint32bit;
+        }
+
         // JS ToBoolean coercion used in conditional tests and logical contexts
         public static bool ToBoolean(double value)
         {


### PR DESCRIPTION
## Summary
- consolidate duplicated object literal and class element property-definition helpers in `ObjectRuntime`
- centralize `ToUint32` in `TypeUtilities` and route `Math` coercion helpers through the shared utilities
- reduce `JavaScriptRuntime` line count without changing the public surface area

## Testing
- not run locally (per request)
