### PR TITLE
perf: add Okojo prime comparison

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -127,9 +127,11 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Build Jint Comparison Project
+      - name: Build Jint and Okojo comparison projects
         run: |
           cd tests/performance/JintComparison
+          dotnet build -c Release
+          cd ../OkojoComparison
           dotnet build -c Release
 
       - name: Shutdown build server

--- a/.github/workflows/performance-comparison.yml
+++ b/.github/workflows/performance-comparison.yml
@@ -41,9 +41,11 @@ jobs:
         run: |
           dotnet tool install --global --add-source ./src/Cli/bin/Release js2il
       
-      - name: Build Jint Comparison Project
+      - name: Build Jint and Okojo comparison projects
         run: |
           cd tests/performance/JintComparison
+          dotnet build -c Release
+          cd ../OkojoComparison
           dotnet build -c Release
       
       - name: Shutdown build server

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -139,11 +139,14 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Build Jint Comparison Project
+      - name: Build Jint and Okojo comparison projects
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           Set-Location tests/performance/JintComparison
+          dotnet build -c Release
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          Set-Location ..\OkojoComparison
           dotnet build -c Release
           if ($LASTEXITCODE -ne 0) { exit 1 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- tooling/perf/docs: add Okojo to the prime benchmark comparison harness, build the new comparison project in the Linux/Windows smoke and performance workflows, and refresh the performance comparison docs.
 
 ## v0.9.16 - 2026-05-12
 

--- a/tests/performance/OkojoComparison/OkojoComparison.csproj
+++ b/tests/performance/OkojoComparison/OkojoComparison.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Okojo" Version="0.1.2-preview.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\PrimeJavaScript.js" Link="PrimeJavaScript.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/performance/OkojoComparison/Program.cs
+++ b/tests/performance/OkojoComparison/Program.cs
@@ -1,0 +1,77 @@
+﻿using Okojo;
+using Okojo.Runtime;
+using System.Diagnostics;
+
+namespace OkojoComparison;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("=== Okojo Performance Test ===");
+        Console.WriteLine($"Running PrimeJavaScript.js with Okojo v{typeof(JsRuntime).Assembly.GetName().Version}");
+        Console.WriteLine();
+
+        var scriptPath = Path.Combine(AppContext.BaseDirectory, "PrimeJavaScript.js");
+        if (!File.Exists(scriptPath))
+        {
+            Console.Error.WriteLine($"Error: Could not find {scriptPath}");
+            return;
+        }
+
+        var script = File.ReadAllText(scriptPath);
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            using var runtime = JsRuntime.CreateBuilder()
+                .UseGlobals(globals => globals.Function("__hostLog", 1, info =>
+                {
+                    Console.WriteLine(info.GetArgumentStringOrDefault(0, string.Empty));
+                    return JsValue.Undefined;
+                }))
+                .Build();
+
+            var realm = runtime.MainRealm;
+            realm.Evaluate(
+                """
+                globalThis.console = {
+                    log: function() {
+                        var parts = [];
+                        for (var i = 0; i < arguments.length; i++) {
+                            parts.push(String(arguments[i]));
+                        }
+                        __hostLog(parts.join(' '));
+                    }
+                };
+                globalThis.process = { argv: ['okojo', 'verbose'] };
+                (function() {
+                    var _t0 = Date.now();
+                    globalThis.performance = {
+                        now: function() { return Date.now() - _t0; }
+                    };
+                })();
+                globalThis.require = function(mod) {
+                    if (mod === 'perf_hooks') {
+                        return { performance: globalThis.performance };
+                    }
+                    throw new Error("Module '" + mod + "' not found");
+                };
+                """
+            );
+
+            realm.Evaluate(script);
+
+            stopwatch.Stop();
+
+            Console.WriteLine();
+            Console.WriteLine($"=== Okojo Total Execution Time: {stopwatch.ElapsedMilliseconds}ms ({stopwatch.Elapsed.TotalSeconds:F2}s) ===");
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            Console.Error.WriteLine($"Error executing script: {ex.Message}");
+            Console.Error.WriteLine(ex.StackTrace);
+        }
+    }
+}

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -8,7 +8,7 @@ This directory provides two complementary performance testing approaches:
 
 ### 1. Quick Comparison Harness (Legacy)
 
-**Location:** `RunComparison.js`, `JintComparison/`, `YantraJSComparison/`
+**Location:** `RunComparison.js`, `JintComparison/`, `OkojoComparison/`, `YantraJSComparison/`
 
 **Purpose:** Fast, simple throughput comparisons for smoke testing
 
@@ -76,9 +76,20 @@ dotnet run -c Release
 Node.js script that:
 1. Runs the Node.js benchmark
 2. Runs the Jint benchmark
-3. Compiles the JavaScript using JS2IL
-4. Runs the JS2IL-compiled native code
-5. Compares all three results with detailed statistics
+3. Runs the Okojo benchmark
+4. Runs the YantraJS benchmark
+5. Compiles the JavaScript using JS2IL
+6. Runs the JS2IL-compiled native code
+7. Compares all results with detailed statistics
+
+### OkojoComparison/
+A C# console application that uses the fully managed Okojo JavaScript engine to execute the benchmark with lightweight host shims for `console`, `process.argv`, and `perf_hooks`.
+
+**Build & Run:**
+```powershell
+cd OkojoComparison
+dotnet run -c Release
+```
 
 **Run:**
 ```bash

--- a/tests/performance/RunComparison.js
+++ b/tests/performance/RunComparison.js
@@ -1,5 +1,5 @@
 // Performance Comparison Script
-// Compares Node.js vs Jint vs JS2IL performance on PrimeJavaScript.js
+// Compares Node.js vs Jint vs Okojo vs YantraJS vs JS2IL performance on PrimeJavaScript.js
 
 const { execSync } = require('child_process');
 const fs = require('fs');
@@ -159,9 +159,48 @@ try {
 console.log();
 
 // ============================================================================
-// 4. JS2IL Benchmark
+// 4. Okojo Benchmark
 // ============================================================================
-log("4. Compiling with JS2IL...", 'yellow');
+log("4. Running Okojo benchmark...", 'yellow');
+try {
+    const okojoDir = path.join(__dirname, 'OkojoComparison');
+    const okojoResult = execSync('dotnet run -c Release', {
+        cwd: okojoDir,
+        encoding: 'utf8',
+        stdio: 'pipe'
+    });
+
+    const okojoTimeMatch = okojoResult.match(/=== Okojo Total Execution Time: (\d+)ms \(([\d.]+)s\) ===/);
+    let okojoMs = 0;
+    if (okojoTimeMatch) {
+        okojoMs = parseInt(okojoTimeMatch[1]);
+    }
+
+    const okojoMatch = okojoResult.match(/rogiervandam-okojo;(\d+);([\d.]+);/);
+    if (okojoMatch) {
+        const okojoPasses = parseInt(okojoMatch[1]);
+        const okojoDuration = parseFloat(okojoMatch[2]);
+        log(`   [OK] Okojo completed: ${okojoMs} ms total`, 'green');
+        log(`        Passes: ${okojoPasses} in ${okojoDuration} s`, 'gray');
+
+        results.push({
+            runtime: "Okojo",
+            totalTimeMs: okojoMs,
+            passes: okojoPasses,
+            passDuration: okojoDuration,
+            passesPerSecond: Math.round((okojoPasses / okojoDuration) * 100) / 100
+        });
+    }
+} catch (error) {
+    log(`   [ERROR] Okojo failed: ${error.message}`, 'red');
+}
+
+console.log();
+
+// ============================================================================
+// 5. JS2IL Benchmark
+// ============================================================================
+log("5. Compiling with JS2IL...", 'yellow');
 try {
     const compileStart = Date.now();
     execSync(`js2il "${path.join(__dirname, 'PrimeJavaScript.js')}" "${path.join(js2ilOutput, 'PrimeJavaScript')}"`, {
@@ -173,7 +212,7 @@ try {
     log(`   [OK] Compilation completed in: ${compileDuration} ms`, 'green');
 
     console.log();
-    log("5. Running JS2IL compiled benchmark...", 'yellow');
+    log("6. Running JS2IL compiled benchmark...", 'yellow');
     const js2ilStart = Date.now();
     const js2ilResult = execSync(`dotnet "${path.join(js2ilOutput, 'PrimeJavaScript', 'PrimeJavaScript.dll')}"`, {
         encoding: 'utf8',
@@ -246,12 +285,23 @@ header("KEY FINDINGS");
 // Calculate comparisons
 const nodeResult = results.find(r => r.runtime === "Node.js");
 const jintResult = results.find(r => r.runtime === "Jint");
+const okojoResult = results.find(r => r.runtime === "Okojo");
 const yantraResult = results.find(r => r.runtime === "YantraJS");
 const js2ilResult = results.find(r => r.runtime === "JS2IL");
 
 if (js2ilResult && jintResult) {
     const js2ilVsJint = Math.round((js2ilResult.passes / jintResult.passes) * 100) / 100;
     log(`  * JS2IL is ${js2ilVsJint}x faster than Jint (interpreted .NET)`, 'green');
+}
+
+if (js2ilResult && okojoResult) {
+    if (js2ilResult.passes > okojoResult.passes) {
+        const js2ilVsOkojo = Math.round((js2ilResult.passes / okojoResult.passes) * 100) / 100;
+        log(`  * JS2IL is ${js2ilVsOkojo}x faster than Okojo`, 'green');
+    } else {
+        const okojoVsJs2il = Math.round((okojoResult.passes / js2ilResult.passes) * 100) / 100;
+        log(`  * Okojo is ${okojoVsJs2il}x faster than JS2IL`, 'yellow');
+    }
 }
 
 if (js2ilResult && yantraResult) {
@@ -279,6 +329,11 @@ if (nodeResult && jintResult) {
     log(`  * Node.js is ${nodeVsJint}x faster than Jint`, 'cyan');
 }
 
+if (nodeResult && okojoResult) {
+    const nodeVsOkojo = Math.round((nodeResult.passes / okojoResult.passes) * 100) / 100;
+    log(`  * Node.js is ${nodeVsOkojo}x faster than Okojo`, 'cyan');
+}
+
 if (nodeResult && yantraResult) {
     const nodeVsYantra = Math.round((nodeResult.passes / yantraResult.passes) * 100) / 100;
     log(`  * Node.js is ${nodeVsYantra}x faster than YantraJS`, 'cyan');
@@ -298,10 +353,12 @@ const jsonOutput = {
     results: {
         node: nodeResult ? { passes: nodeResult.passes, passesPerSecond: nodeResult.passesPerSecond } : null,
         js2il: js2ilResult ? { passes: js2ilResult.passes, passesPerSecond: js2ilResult.passesPerSecond, compileDuration: js2ilResult.compileDuration } : null,
+        okojo: okojoResult ? { passes: okojoResult.passes, passesPerSecond: okojoResult.passesPerSecond } : null,
         yantraJS: yantraResult ? { passes: yantraResult.passes, passesPerSecond: yantraResult.passesPerSecond } : null,
         jint: jintResult ? { passes: jintResult.passes, passesPerSecond: jintResult.passesPerSecond } : null
     },
     comparisons: {
+        vsOkojo: js2ilResult && okojoResult ? Math.round((js2ilResult.passes / okojoResult.passes) * 100) / 100 : null,
         vsYantraJS: js2ilResult && yantraResult ? Math.round((js2ilResult.passes / yantraResult.passes) * 100) / 100 : null,
         vsJint: js2ilResult && jintResult ? Math.round((js2ilResult.passes / jintResult.passes) * 100) / 100 : null,
         vsNode: js2ilResult && nodeResult ? Math.round((nodeResult.passes / js2ilResult.passes) * 100) / 100 : null


### PR DESCRIPTION
## Summary
- add an `OkojoComparison` performance runner for the prime sieve quick-comparison harness
- include Okojo in `RunComparison.js` output, JSON results, and the perf README
- update the Linux smoke and performance comparison workflows to build the Okojo comparison project before running the harness

## Validation
- `dotnet run --project .\tests\performance\OkojoComparison\OkojoComparison.csproj -c Release`
- `node .\tests\performance\RunComparison.js`