### PR TITLE
fix(release): align coordinated publish validation

### DIFF
--- a/.github/workflows/publish-tool.yml
+++ b/.github/workflows/publish-tool.yml
@@ -1,10 +1,16 @@
 name: Publish coordinated packages
-run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.release.tag_name || github.event.inputs.branch || github.head_ref || github.ref_name }}
+run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.inputs.ref || github.event.release.tag_name || github.head_ref || github.ref_name }}
 
 on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Release tag to publish (for example v0.9.17)'
+        required: false
+        default: ''
 
 jobs:
   build-and-publish:
@@ -14,11 +20,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install npm dependencies
+        run: npm ci
 
       - name: Restore .NET tools
         run: dotnet tool restore
@@ -26,7 +42,23 @@ jobs:
       - name: Compute version from tag
         shell: pwsh
         run: |
-          $tag = "$env:GITHUB_REF_NAME"
+          $ref = "${{ github.event.inputs.ref }}"
+          if ([string]::IsNullOrWhiteSpace($ref)) {
+            $ref = "$env:GITHUB_REF_NAME"
+          }
+
+          $tag = $ref.Trim()
+          if ($tag.StartsWith('refs/tags/')) {
+            $tag = $tag.Substring('refs/tags/'.Length)
+          }
+          if ($tag.Contains('/')) {
+            Write-Error "Publish coordinated packages expects a release tag like v0.9.17, but got '$ref'."
+            exit 1
+          }
+          if ($tag -notmatch '^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$') {
+            Write-Error "Publish coordinated packages expects a semver tag like v0.9.17, but got '$tag'."
+            exit 1
+          }
           if ($tag.StartsWith('v')) { $version = $tag.Substring(1) } else { $version = $tag }
           echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
@@ -36,8 +68,8 @@ jobs:
       - name: Build
         run: dotnet build js2il.sln -c Release --no-restore
 
-      - name: Test
-        run: dotnet test js2il.sln -c Release --no-build --verbosity normal
+      - name: Validate coordinated release package set
+        run: npm run release:validate
 
       - name: Pack coordinated packages
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ dotnet publish -c Release
 ## Release pipeline
 
 
-When a tag beginning with `v` is pushed, GitHub Actions runs `.github/workflows/publish-tool.yml` to build/test the solution, then pack and publish the coordinated NuGet package set: `Js2IL.Runtime`, `js2il`, `Js2IL.Core`, and `Js2IL.SDK`.
+When a tag beginning with `v` is pushed, GitHub Actions runs `.github/workflows/publish-tool.yml` to build the solution, run the coordinated `npm run release:validate` gate, then pack and publish the coordinated NuGet package set: `Js2IL.Runtime`, `js2il`, `Js2IL.Core`, and `Js2IL.SDK`. The same workflow also supports manual dispatch with a release-tag input so a failed tagged publish can be retried without moving the release tag.
 
 The legacy `.github/workflows/release.yml` workflow still produces a published artifact bundle, but NuGet publishing happens in `.github/workflows/publish-tool.yml`.
 


### PR DESCRIPTION
## Summary
- use the documented release validation gate in the coordinated publish workflow
- add workflow_dispatch tag retry support for failed tagged publishes
- update the release pipeline README text to match

## Validation
- npm ci
- npm run release:validate