### PR TITLE
perf(benchmarks): expand cross-runtime scenario coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- tooling/perf/docs: expand the BenchmarkDotNet scenario catalog, make phased js2il benchmark failures surface explicitly instead of being skipped, and make benchmark runs exit non-zero when any benchmark case fails so broken perf scripts are not misreported as successful timings.
 
 ## v0.9.17 - 2026-05-14
 

--- a/tests/performance/Benchmarks/BenchmarkScenarioCatalog.cs
+++ b/tests/performance/Benchmarks/BenchmarkScenarioCatalog.cs
@@ -1,0 +1,26 @@
+namespace Benchmarks;
+
+internal sealed record BenchmarkScenario(string Key, string ScriptName, string Content);
+
+internal static class BenchmarkScenarioCatalog
+{
+    public static IReadOnlyList<BenchmarkScenario> LoadScenarios(string scenariosDir)
+    {
+        if (!Directory.Exists(scenariosDir))
+        {
+            return Array.Empty<BenchmarkScenario>();
+        }
+
+        return Directory.GetFiles(scenariosDir, "*.js", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .Select(path =>
+            {
+                var scriptName = Path.GetFileNameWithoutExtension(path);
+                return new BenchmarkScenario(
+                    Key: scriptName,
+                    ScriptName: scriptName,
+                    Content: File.ReadAllText(path));
+            })
+            .ToArray();
+    }
+}

--- a/tests/performance/Benchmarks/IMPLEMENTATION_SUMMARY.md
+++ b/tests/performance/Benchmarks/IMPLEMENTATION_SUMMARY.md
@@ -10,7 +10,7 @@ Successfully implemented a comprehensive BenchmarkDotNet-based performance bench
 
 ```
 tests/performance/Benchmarks/
-├── Scenarios/              # 5 JavaScript benchmark scripts
+├── Scenarios/              # Jint-derived JavaScript benchmark scripts
 │   ├── minimal.js
 │   ├── evaluation.js
 │   ├── evaluation-modern.js
@@ -42,7 +42,7 @@ Three runtime adapters implementing `IJavaScriptRuntime`:
 
 ### 3. Benchmark Scenarios
 
-5 scenarios ported from Jint benchmark suite (BSD-2-Clause licensed):
+The suite started with 5 scenarios ported from the Jint benchmark suite, and now benchmarks the full checked-in root scenario catalog (currently 19 scripts) for cross-runtime comparisons.
 
 1. **minimal.js** (21 chars) - Basic arithmetic (`1 + 1 === 2`)
 2. **evaluation.js** (252 chars) - Object properties, recursion (fibonacci)
@@ -56,7 +56,7 @@ All scenarios include "use strict" directive for js2il compatibility.
 
 - **JavaScriptRuntimeBenchmarks**: Cross-runtime comparison
   - Benchmarks: Node.js, Jint, js2il (compile+execute)
-  - Parameterized across all 5 scenarios
+  - Parameterized across the full checked-in root scenario catalog
   
 - **Js2ILPhasedBenchmarks**: Separate compile/execute phases
   - Benchmarks: js2il compile, js2il execute (pre-compiled)
@@ -120,7 +120,7 @@ Comprehensive validation test (`ValidationTest.cs`):
 - ✅ Jint: ~77ms execution
 - ✅ Node.js: ~31ms execution (fastest)
 - ✅ js2il: ~280-360ms compile + ~42-65ms execution
-- ✅ All 5 scenarios present and loadable
+- ✅ Representative scenarios across the expanded root catalog are present and loadable
 - ✅ Build successful (0 warnings, 0 errors)
 
 ## Technical Highlights
@@ -169,7 +169,7 @@ All benchmark scripts properly attributed:
 ### Validation Tests Passed
 
 - ✅ All runtime adapters execute minimal.js successfully
-- ✅ All 5 scenarios load without errors
+- ✅ Representative scenarios from the expanded catalog load without errors
 - ✅ Build succeeds in Release mode
 - ✅ No blocking issues found
 

--- a/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
+++ b/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
@@ -20,6 +20,7 @@ namespace Benchmarks;
 public class JavaScriptRuntimeBenchmarks
 {
     private readonly Dictionary<string, string> _scripts = new();
+    private readonly Dictionary<string, string> _scenarioKeyToScriptName = new(StringComparer.Ordinal);
     private readonly JintRuntime _jintRuntime = new();
     private readonly NodeJsRuntime _nodeRuntime = new();
     private readonly Js2ILRuntime _js2ilRuntime = new();
@@ -27,30 +28,12 @@ public class JavaScriptRuntimeBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        // Load all benchmark scripts
         var scriptsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Scenarios");
-        
-        var scriptFiles = new[]
-        {
-            "minimal.js",
-            "evaluation.js",
-            "evaluation-modern.js",
-            "stopwatch.js",
-            "array-stress.js"
-        };
 
-        foreach (var scriptFile in scriptFiles)
+        foreach (var scenario in BenchmarkScenarioCatalog.LoadScenarios(scriptsDir))
         {
-            var path = Path.Combine(scriptsDir, scriptFile);
-            if (File.Exists(path))
-            {
-                var scriptName = Path.GetFileNameWithoutExtension(scriptFile);
-                _scripts[scriptName] = File.ReadAllText(path);
-            }
-            else
-            {
-                Console.WriteLine($"Warning: Script not found: {path}");
-            }
+            _scripts[scenario.Key] = scenario.Content;
+            _scenarioKeyToScriptName[scenario.Key] = scenario.ScriptName;
         }
 
         if (_scripts.Count == 0)
@@ -66,26 +49,19 @@ public class JavaScriptRuntimeBenchmarks
     {
         if (_scripts.Count > 0)
         {
-            return _scripts.Keys;
+            return _scripts.Keys.OrderBy(name => name, StringComparer.Ordinal);
         }
 
         var scriptsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Scenarios");
-        if (!Directory.Exists(scriptsDir))
-        {
-            return Array.Empty<string>();
-        }
-
-        return Directory.GetFiles(scriptsDir, "*.js")
-            .Select(Path.GetFileNameWithoutExtension)
-            .Where(name => !string.IsNullOrWhiteSpace(name))
-            .OrderBy(name => name)!;
+        return BenchmarkScenarioCatalog.LoadScenarios(scriptsDir)
+            .Select(scenario => scenario.Key);
     }
 
     [Benchmark(Description = "Node.js")]
     public void NodeJs()
     {
         var script = _scripts[ScriptName];
-        var result = _nodeRuntime.Execute(script, $"{ScriptName}.js");
+        var result = _nodeRuntime.Execute(script, $"{ResolveScriptName(ScriptName)}.js");
         
         if (!result.Success)
         {
@@ -97,7 +73,7 @@ public class JavaScriptRuntimeBenchmarks
     public void Jint()
     {
         var script = _scripts[ScriptName];
-        var result = _jintRuntime.Execute(script, $"{ScriptName}.js");
+        var result = _jintRuntime.Execute(script, $"{ResolveScriptName(ScriptName)}.js");
         
         if (!result.Success)
         {
@@ -109,11 +85,18 @@ public class JavaScriptRuntimeBenchmarks
     public void Js2IL_Total()
     {
         var script = _scripts[ScriptName];
-        var result = _js2ilRuntime.Execute(script, $"{ScriptName}.js");
+        var result = _js2ilRuntime.Execute(script, $"{ResolveScriptName(ScriptName)}.js");
         
         if (!result.Success)
         {
             throw new Exception($"js2il execution failed: {result.Error}");
         }
+    }
+
+    private string ResolveScriptName(string scenarioKey)
+    {
+        return _scenarioKeyToScriptName.TryGetValue(scenarioKey, out var scriptName)
+            ? scriptName
+            : scenarioKey;
     }
 }

--- a/tests/performance/Benchmarks/Js2ILPhasedBenchmarks.cs
+++ b/tests/performance/Benchmarks/Js2ILPhasedBenchmarks.cs
@@ -45,21 +45,19 @@ public class Js2ILPhasedBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        // Load all benchmark scripts
         var scriptsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Scenarios");
-        
-        var scriptFiles = Directory.GetFiles(scriptsDir, "*.js")
-            .Where(path => !TemporarilyExcludedScriptNames.Contains(Path.GetFileNameWithoutExtension(path)))
-            .OrderBy(path => path, StringComparer.Ordinal)
+
+        var scenarios = BenchmarkScenarioCatalog.LoadScenarios(scriptsDir)
+            .Where(scenario => !TemporarilyExcludedScriptNames.Contains(scenario.ScriptName))
             .ToArray();
 
-        for (int i = 0; i < scriptFiles.Length; i++)
+        for (int i = 0; i < scenarios.Length; i++)
         {
-            var scriptPath = scriptFiles[i];
-            var scriptFile = Path.GetFileName(scriptPath);
-            var scriptName = Path.GetFileNameWithoutExtension(scriptFile);
-            var scenarioKey = scriptName;
-            var scriptContent = File.ReadAllText(scriptPath);
+            var scenario = scenarios[i];
+            var scenarioKey = scenario.Key;
+            var scriptName = scenario.ScriptName;
+            var scriptFile = scriptName + ".js";
+            var scriptContent = scenario.Content;
             _scripts[scenarioKey] = scriptContent;
             _scenarioKeyToScriptName[scenarioKey] = scriptName;
             _jintPreparedScripts[scenarioKey] = Engine.PrepareScript(scriptContent, scriptFile);
@@ -168,15 +166,10 @@ public class Js2ILPhasedBenchmarks
         }
 
         var scriptsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Scenarios");
-        if (!Directory.Exists(scriptsDir))
-        {
-            return Array.Empty<string>();
-        }
-
-        return Directory.GetFiles(scriptsDir, "*.js")
-            .Select(Path.GetFileNameWithoutExtension)
+        return BenchmarkScenarioCatalog.LoadScenarios(scriptsDir)
+            .Select(scenario => scenario.Key)
             .Where(name => !string.IsNullOrWhiteSpace(name) && !TemporarilyExcludedScriptNames.Contains(name))
-            .OrderBy(name => name)!;
+            .OrderBy(name => name, StringComparer.Ordinal);
     }
 
     [Benchmark(Description = "js2il compile")]

--- a/tests/performance/Benchmarks/Js2ILPhasedBenchmarks.cs
+++ b/tests/performance/Benchmarks/Js2ILPhasedBenchmarks.cs
@@ -33,13 +33,6 @@ public class Js2ILPhasedBenchmarks
     private readonly Dictionary<string, Assembly> _compiledAssemblies = new();
     private readonly Dictionary<string, string> _compiledModuleIds = new();
     private readonly Dictionary<string, string> _js2IlCompileFailures = new();
-    // TODO: Fix these scenarios for phased js2il benchmarks or delete them, then remove this temporary exclusion.
-    private static readonly HashSet<string> TemporarilyExcludedScriptNames = new(StringComparer.Ordinal)
-    {
-        "evaluation",
-        "evaluation-modern",
-        "linq-js"
-    };
     private string _tempDir = "";
 
     [GlobalSetup]
@@ -47,11 +40,9 @@ public class Js2ILPhasedBenchmarks
     {
         var scriptsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Scenarios");
 
-        var scenarios = BenchmarkScenarioCatalog.LoadScenarios(scriptsDir)
-            .Where(scenario => !TemporarilyExcludedScriptNames.Contains(scenario.ScriptName))
-            .ToArray();
+        var scenarios = BenchmarkScenarioCatalog.LoadScenarios(scriptsDir);
 
-        for (int i = 0; i < scenarios.Length; i++)
+        for (int i = 0; i < scenarios.Count; i++)
         {
             var scenario = scenarios[i];
             var scenarioKey = scenario.Key;
@@ -156,30 +147,19 @@ public class Js2ILPhasedBenchmarks
     {
         if (_scripts.Count > 0)
         {
-            var names = _scripts.Keys.AsEnumerable();
-            if (_js2IlCompileFailures.Count > 0)
-            {
-                names = names.Where(name => !_js2IlCompileFailures.ContainsKey(name));
-            }
-
-            return names.OrderBy(name => name, StringComparer.Ordinal);
+            return _scripts.Keys.OrderBy(name => name, StringComparer.Ordinal);
         }
 
         var scriptsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Scenarios");
         return BenchmarkScenarioCatalog.LoadScenarios(scriptsDir)
             .Select(scenario => scenario.Key)
-            .Where(name => !string.IsNullOrWhiteSpace(name) && !TemporarilyExcludedScriptNames.Contains(name))
+            .Where(name => !string.IsNullOrWhiteSpace(name))
             .OrderBy(name => name, StringComparer.Ordinal);
     }
 
     [Benchmark(Description = "js2il compile")]
     public void Js2IL_Compile()
     {
-        if (_js2IlCompileFailures.TryGetValue(ScriptName, out _))
-        {
-            return;
-        }
-
         var script = _scripts[ScriptName];
         var resolvedScriptName = ResolveScriptName(ScriptName);
         var tempScriptFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.js");
@@ -193,7 +173,10 @@ public class Js2ILPhasedBenchmarks
             var options = new CompilerOptions { OutputDirectory = tempOutputDir };
             var serviceProvider = CompilerServices.BuildServiceProvider(options);
             var compiler = serviceProvider.GetRequiredService<Compiler>();
-            compiler.Compile(tempScriptFile, resolvedScriptName);
+            if (!compiler.Compile(tempScriptFile, resolvedScriptName))
+            {
+                throw new InvalidOperationException($"js2il compile benchmark failed for scenario '{resolvedScriptName}'.");
+            }
         }
         finally
         {
@@ -214,9 +197,10 @@ public class Js2ILPhasedBenchmarks
     [Benchmark(Description = "js2il execute (pre-compiled)")]
     public void Js2IL_ExecuteOnly()
     {
-        if (_js2IlCompileFailures.TryGetValue(ScriptName, out _))
+        if (_js2IlCompileFailures.TryGetValue(ScriptName, out var failure))
         {
-            return;
+            throw new InvalidOperationException(
+                $"js2il phased setup failed for scenario '{ResolveScriptName(ScriptName)}': {failure}");
         }
 
         var assembly = _compiledAssemblies[ScriptName];

--- a/tests/performance/Benchmarks/Program.cs
+++ b/tests/performance/Benchmarks/Program.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
 using Benchmarks;
 
 // Run benchmarks based on command line arguments
@@ -14,7 +15,8 @@ else
     if (programArgs.Length > 0 && programArgs[0] == "--dispatch")
     {
         // Run the focused late-bound dispatch microbenchmarks without interactive benchmark selection.
-        BenchmarkRunner.Run<LateBoundDispatchBenchmarks>(args: programArgs.Skip(1).ToArray());
+        var summary = BenchmarkRunner.Run<LateBoundDispatchBenchmarks>(args: programArgs.Skip(1).ToArray());
+        SetExitCodeFromSummaries([summary]);
     }
     else
     {
@@ -39,7 +41,8 @@ else
             switcher = BenchmarkSwitcher.FromTypes([typeof(JavaScriptRuntimeBenchmarks)]);
         }
 
-        switcher.Run(benchmarkArgs);
+        var summaries = switcher.Run(benchmarkArgs);
+        SetExitCodeFromSummaries(summaries);
     }
 }
 
@@ -51,3 +54,40 @@ Console.WriteLine("  dotnet run -c Release --dispatch # Run late-bound dispatch 
 Console.WriteLine("  dotnet run -c Release --phased # Run js2il phased + Jint prepared comparison");
 Console.WriteLine("  dotnet run -c Release --all    # Run all benchmarks");
 Console.WriteLine("  dotnet run -c Release --validate # Run validation tests");
+
+static void SetExitCodeFromSummaries(IEnumerable<Summary> summaries)
+{
+    var summaryList = summaries.ToArray();
+    var failedBenchmarks = summaryList
+        .SelectMany(summary => summary.Reports
+            .Where(report => !report.Success)
+            .Select(report => report.BenchmarkCase.ToString()))
+        .Distinct(StringComparer.Ordinal)
+        .ToArray();
+
+    var hasValidationFailures = summaryList.Any(summary =>
+        summary.HasCriticalValidationErrors || summary.ValidationErrors.Any());
+
+    if (!hasValidationFailures && failedBenchmarks.Length == 0)
+    {
+        return;
+    }
+
+    if (failedBenchmarks.Length > 0)
+    {
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("Benchmark run failed. Cases with issues:");
+        foreach (var failedBenchmark in failedBenchmarks)
+        {
+            Console.Error.WriteLine($"  {failedBenchmark}");
+        }
+    }
+
+    if (hasValidationFailures)
+    {
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("Benchmark run failed due to BenchmarkDotNet validation errors.");
+    }
+
+    Environment.ExitCode = 1;
+}

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -98,6 +98,8 @@ Benchmarks js2il compile and execute phases separately, alongside Jint prepare a
 dotnet run -c Release -- --phased
 ```
 
+If any benchmark case fails, the run now exits non-zero and prints the failing benchmark cases instead of silently treating them as successful timings.
+
 #### Late-Bound Dispatch Comparison
 Runs a research-only microbenchmark that compares `JavaScriptRuntime.Object.CallMember*` against CLR-focused DLR call sites produced by C# `dynamic` and by a custom runtime-name `CallSiteBinder`:
 

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -41,7 +41,7 @@ Benchmarks/
 
 ### Core Scenarios
 
-Benchmark runners discover all `Scenarios/*.js` files at runtime (currently 19). The list below highlights the core scenarios.
+Benchmark runners discover the full root-level `Scenarios\*.js` catalog at runtime (currently 19 scenarios in the checked-in Jint-derived slice). The list below highlights a few representative scenarios.
 
 1. **minimal.js** - Simple arithmetic (`1 + 1 === 2`)
    - Purpose: Baseline minimal execution overhead
@@ -62,6 +62,8 @@ Benchmark runners discover all `Scenarios/*.js` files at runtime (currently 19).
 5. **array-stress.js** - Array manipulation stress test
    - Purpose: Array performance (push, pop, shift, unshift, splice, slice)
    - Tests: High-volume array operations
+
+Additional discovered scenarios include the broader Dromaeo-derived object/string/regexp/base64 cases, `linq-js`, and the modern stopwatch variants. The cross-runtime suite now runs this full file-backed catalog rather than the original five-script bootstrap subset.
 
 ## Running Benchmarks
 
@@ -153,8 +155,8 @@ dotnet run -c Release -- --exporters html,json,markdown
 
 When comparing runtimes, consider:
 
-1. **Jint vs js2il**: js2il typically 5-10x faster (AOT vs interpreted)
-2. **Node.js vs js2il**: Node.js typically 10-50x faster (mature JIT vs young AOT)
+1. **Jint vs js2il**: js2il should generally win on steady-state .NET execution, but the exact ratio is scenario-dependent
+2. **Node.js vs js2il**: Node.js often remains ahead on mature JIT-heavy workloads
 3. **Compile overhead**: js2il compile time can exceed execution for short-running scripts
 
 ## Output
@@ -270,10 +272,9 @@ Check js2il logs in `BenchmarkDotNet.Artifacts/logs/`.
 When adding new scenarios:
 
 1. Add JavaScript file to `Scenarios/`
-2. Update scenario list in benchmark classes
-3. Document provenance in `Compliance/PROVENANCE.md`
-4. Verify all three runtimes can execute the script
-5. Update this README with scenario description
+2. Document provenance in `Compliance/PROVENANCE.md`
+3. Verify all three runtimes can execute the script
+4. Update this README with scenario description if it adds a new workload family
 
 ## References
 

--- a/tests/performance/Benchmarks/ValidationTest.cs
+++ b/tests/performance/Benchmarks/ValidationTest.cs
@@ -11,8 +11,27 @@ public static class ValidationTest
     {
         // Test runtime adapters with minimal.js
         var script = "\"use strict\";\nvar x = 1 + 1 === 2;";
+        var scriptsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Scenarios");
+        var scenarios = BenchmarkScenarioCatalog.LoadScenarios(scriptsDir);
+        var requiredScenarios = new[]
+        {
+            "minimal",
+            "dromaeo-object-array",
+            "linq-js",
+            "stopwatch-modern"
+        };
 
         Console.WriteLine("Testing runtime adapters...\n");
+
+        Console.WriteLine($"Discovered {scenarios.Count} BenchmarkDotNet scenarios.");
+        foreach (var requiredScenario in requiredScenarios)
+        {
+            if (!scenarios.Any(scenario => string.Equals(scenario.Key, requiredScenario, StringComparison.Ordinal)))
+            {
+                throw new InvalidOperationException($"Expected benchmark scenario '{requiredScenario}' was not found.");
+            }
+        }
+        Console.WriteLine($"Verified representative scenario discovery: {string.Join(", ", requiredScenarios)}");
 
         // Test Jint
         Console.WriteLine("1. Testing Jint...");

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -158,6 +158,7 @@ The BenchmarkDotNet suite is integrated into CI via `.github/workflows/benchmark
 
 - **Quick Comparison**: Used in `.github/workflows/performance-comparison.yml` for informational PR comments
 - **BenchmarkDotNet**: Available as workflow_dispatch for detailed statistical reporting (informational-only, no PR gating)
+- The cross-runtime BenchmarkDotNet suite now benchmarks the full checked-in root scenario catalog under `tests/performance/Benchmarks/Scenarios`, not just the original five bootstrap scripts
 
 ## Adding New Benchmarks
 


### PR DESCRIPTION
## Summary
- benchmark the full checked-in BenchmarkDotNet root scenario catalog instead of the original five-script subset
- share scenario discovery between the cross-runtime and phased suites
- update validation and documentation to reflect the expanded coverage

## Validation
- dotnet build .\\tests\\performance\\Benchmarks\\Benchmarks.csproj -c Release
- dotnet run --project .\\tests\\performance\\Benchmarks\\Benchmarks.csproj -c Release -- --validate