### PR TITLE
fix(compiler): allow dynamic new on unknown globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - tooling/perf/docs: expand the BenchmarkDotNet scenario catalog, make phased js2il benchmark failures surface explicitly instead of being skipped, and make benchmark runs exit non-zero when any benchmark case fails so broken perf scripts are not misreported as successful timings.
+- compiler/tests/perf: fix issue #1068 by allowing unknown global constructor identifiers in `new` expressions to lower through the dynamic `ConstructValue` path, restoring `linq-js` benchmark compilation and adding focused try/catch regression coverage for the parser gap.
 
 ## v0.9.17 - 2026-05-14
 

--- a/src/Compiler/IR/HIR/HIRBuilder.cs
+++ b/src/Compiler/IR/HIR/HIRBuilder.cs
@@ -2684,6 +2684,16 @@ class HIRMethodBuilder
                     && (typeof(Delegate).IsAssignableFrom(globalThisProperty.PropertyType)
                         || typeof(Type).IsAssignableFrom(globalThisProperty.PropertyType));
 
+                var newArgExprs = new List<HIRExpression>();
+                foreach (var arg in newExpr.Arguments)
+                {
+                    if (!TryParseExpression(arg, out var argHirExpr))
+                    {
+                        return false;
+                    }
+                    newArgExprs.Add(argHirExpr!);
+                }
+
                 if (!isBuiltInError
                     && !isArrayCtor
                     && !isStringCtor
@@ -2693,17 +2703,10 @@ class HIRMethodBuilder
                     && intrinsicType == null
                     && !isConstructibleGlobalThisProperty)
                 {
-                    return false;
-                }
-
-                var newArgExprs = new List<HIRExpression>();
-                foreach (var arg in newExpr.Arguments)
-                {
-                    if (!TryParseExpression(arg, out var argHirExpr))
-                    {
-                        return false;
-                    }
-                    newArgExprs.Add(argHirExpr!);
+                    // Unknown global constructor values (for example legacy host globals like Enumerator)
+                    // should lower through the dynamic ConstructValue path rather than being rejected.
+                    hirExpr = new HIRNewExpression(new HIRVariableExpression(newCalleeSymbol), newArgExprs);
+                    return true;
                 }
 
                 if (isBuiltInError && newArgExprs.Count > 1)

--- a/tests/Js2IL.Tests/TryCatch/ExecutionTests.cs
+++ b/tests/Js2IL.Tests/TryCatch/ExecutionTests.cs
@@ -36,5 +36,8 @@ namespace Js2IL.Tests.TryCatch
 
         [Fact]
         public Task TryCatch_CallMember_MissingMethod_IsTypeError() { var testName = nameof(TryCatch_CallMember_MissingMethod_IsTypeError); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task TryCatch_NewExpression_UnknownGlobalIdentifier() { var testName = nameof(TryCatch_NewExpression_UnknownGlobalIdentifier); return ExecutionTest(testName); }
     }
 }

--- a/tests/Js2IL.Tests/TryCatch/GeneratorTests.cs
+++ b/tests/Js2IL.Tests/TryCatch/GeneratorTests.cs
@@ -36,5 +36,8 @@ namespace Js2IL.Tests.TryCatch
 
         [Fact]
         public Task TryCatch_NewExpression_BuiltInErrors() { var testName = nameof(TryCatch_NewExpression_BuiltInErrors); return GenerateTest(testName); }
+
+        [Fact]
+        public Task TryCatch_NewExpression_UnknownGlobalIdentifier() { var testName = nameof(TryCatch_NewExpression_UnknownGlobalIdentifier); return GenerateTest(testName); }
     }
 }

--- a/tests/Js2IL.Tests/TryCatch/JavaScript/TryCatch_NewExpression_UnknownGlobalIdentifier.js
+++ b/tests/Js2IL.Tests/TryCatch/JavaScript/TryCatch_NewExpression_UnknownGlobalIdentifier.js
@@ -1,0 +1,10 @@
+"use strict";
+
+try {
+    new Enumerator(123);
+    console.log("unreachable");
+} catch (e) {
+    console.log("caught");
+}
+
+console.log("done");

--- a/tests/Js2IL.Tests/TryCatch/Snapshots/ExecutionTests.TryCatch_NewExpression_UnknownGlobalIdentifier.verified.txt
+++ b/tests/Js2IL.Tests/TryCatch/Snapshots/ExecutionTests.TryCatch_NewExpression_UnknownGlobalIdentifier.verified.txt
@@ -1,0 +1,2 @@
+caught
+done

--- a/tests/Js2IL.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_UnknownGlobalIdentifier.verified.txt
+++ b/tests/Js2IL.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_UnknownGlobalIdentifier.verified.txt
@@ -1,0 +1,193 @@
+﻿// IL code: TryCatch_NewExpression_UnknownGlobalIdentifier
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.TryCatch_NewExpression_UnknownGlobalIdentifier
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested private auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L3C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2125
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L3C4::.ctor
+
+		} // end of class Block_L3C4
+
+		.class nested public auto ansi beforefieldinit Block_L6C12
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x212e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L6C12::.ctor
+
+		} // end of class Block_L6C12
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x211c
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 173 (0xad)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope,
+			[1] class Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope/Block_L3C4,
+			[2] class [System.Runtime]System.Exception,
+			[3] object,
+			[4] object,
+			[5] class Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope/Block_L6C12,
+			[6] object
+		)
+
+		IL_0000: newobj instance void Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope::.ctor()
+		IL_0005: stloc.0
+		.try
+		{
+			IL_0006: newobj instance void Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope/Block_L3C4::.ctor()
+			IL_000b: stloc.1
+			IL_000c: ldstr "Enumerator"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0016: stloc.s 6
+			IL_0018: ldloc.s 6
+			IL_001a: ldc.i4.1
+			IL_001b: newarr [System.Runtime]System.Object
+			IL_0020: dup
+			IL_0021: ldc.i4.0
+			IL_0022: ldc.r8 123
+			IL_002b: box [System.Runtime]System.Double
+			IL_0030: stelem.ref
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0036: pop
+			IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_003c: ldstr "unreachable"
+			IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0046: pop
+			IL_0047: leave IL_009c
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_004c: stloc.2
+			IL_004d: ldloc.2
+			IL_004e: dup
+			IL_004f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0054: dup
+			IL_0055: brtrue IL_006b
+
+			IL_005a: pop
+			IL_005b: dup
+			IL_005c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0061: dup
+			IL_0062: brtrue IL_0077
+
+			IL_0067: pop
+			IL_0068: pop
+			IL_0069: rethrow
+
+			IL_006b: pop
+			IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0071: stloc.3
+			IL_0072: br IL_0079
+
+			IL_0077: pop
+			IL_0078: stloc.3
+
+			IL_0079: ldloc.3
+			IL_007a: stloc.s 6
+			IL_007c: ldloc.s 6
+			IL_007e: stloc.s 4
+			IL_0080: newobj instance void Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope/Block_L6C12::.ctor()
+			IL_0085: stloc.s 5
+			IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_008c: ldstr "caught"
+			IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0096: pop
+			IL_0097: leave IL_009c
+		} // end handler
+
+		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a1: ldstr "done"
+		IL_00a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ab: pop
+		IL_00ac: ret
+	} // end of method TryCatch_NewExpression_UnknownGlobalIdentifier::__js_module_init__
+
+} // end of class Modules.TryCatch_NewExpression_UnknownGlobalIdentifier
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2137
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.TryCatch_NewExpression_UnknownGlobalIdentifier::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary
- fix the `linq-js` benchmark compile failure from issue #1068
- allow unknown global identifier constructors in `new` expressions to lower through the dynamic `ConstructValue` path
- add focused try/catch execution and generator regression coverage for that parser gap

## Root cause
The failing `linq-js` callable was valid JavaScript, not dead or invalid code that other runtimes were skipping. The compiler failed in HIR parsing on `new Enumerator(b);` because `HIRBuilder` only allowed dynamic `new` fallback for non-identifier callees or non-global bindings, and incorrectly rejected unknown global identifier constructors.

## Validation
- direct compile of `tests\\performance\\Benchmarks\\Scenarios\\linq-js.js`
- `Js2IL.Tests.TryCatch.ExecutionTests.TryCatch_NewExpression_UnknownGlobalIdentifier`
- `Js2IL.Tests.TryCatch.GeneratorTests.TryCatch_NewExpression_UnknownGlobalIdentifier`