### PR TITLE
fix: restore prime benchmark lowering

### DIFF
--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -958,7 +958,7 @@ public partial class SymbolTableBuilder
                     continue;
                 }
 
-                var inferredType = InferExpressionClrType(variableDeclarator.Init, scope, proposedClrTypes, scope);
+                var inferredType = InferExpressionClrType(variableDeclarator.Init, scope, proposedClrTypes, binding);
                 if (inferredType != null)
                 {
                     proposedClrTypes[binding.Name] = inferredType;
@@ -994,7 +994,7 @@ public partial class SymbolTableBuilder
                     if (proposedClrTypes.TryGetValue(identifier.Name, out var inferredType))
                     {
                         // If any assignment conflicts with the inferred type, remove the proposed type.
-                        var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope);
+                        var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope.Bindings[identifier.Name]);
                         if (rightType != inferredType)
                         {
                             changed |= proposedClrTypes.Remove(identifier.Name);
@@ -1003,7 +1003,7 @@ public partial class SymbolTableBuilder
                     else if (unitializedClrTypes.Contains(identifier.Name))
                     {
                         // An uninitialized variable can still be a nullable/reference type.
-                        var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope);
+                        var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope.Bindings[identifier.Name]);
                         if (rightType?.IsValueType == false)
                         {
                             if (!proposedClrTypes.TryGetValue(identifier.Name, out var existingType) || existingType != rightType)
@@ -1164,7 +1164,7 @@ public partial class SymbolTableBuilder
             return true;
         }
 
-        var initializerType = InferExpressionClrType(declarator.Init, declaringScope, proposedClrTypes, declaringScope);
+        var initializerType = InferExpressionClrType(declarator.Init, declaringScope, proposedClrTypes, binding);
         if (initializerType == null || initializerType.IsValueType)
         {
             return false;
@@ -1237,7 +1237,7 @@ public partial class SymbolTableBuilder
                         return;
                     }
 
-                    var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope);
+                    var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, targetBinding);
                     if (rightType == null || rightType.IsValueType)
                     {
                         isCompatible = false;
@@ -1341,7 +1341,7 @@ public partial class SymbolTableBuilder
                         return;
                     }
 
-                    var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope);
+                    var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, targetBinding);
                     if (rightType != expectedType)
                     {
                         isCompatible = false;
@@ -2116,7 +2116,7 @@ public partial class SymbolTableBuilder
         }
     }
 
-    Type? InferExpressionClrType(Node expr, Scope? scope = null, Dictionary<string, Type>? proposedTypes = null, Scope? inferenceRootScope = null)
+    Type? InferExpressionClrType(Node expr, Scope? scope = null, Dictionary<string, Type>? proposedTypes = null, BindingInfo? excludedBinding = null)
     {
         static bool IsSupportedNumberLike(Type? t) =>
             t == typeof(double) || t == typeof(bool) || t == typeof(JavaScriptRuntime.JsNull);
@@ -2244,8 +2244,8 @@ public partial class SymbolTableBuilder
                         if (currentScope.Bindings.TryGetValue(id.Name, out var binding))
                         {
                             if (proposedTypes != null
-                                && inferenceRootScope != null
-                                && ReferenceEquals(binding.DeclaringScope, inferenceRootScope))
+                                && excludedBinding != null
+                                && ReferenceEquals(binding, excludedBinding))
                             {
                                 return null;
                             }
@@ -2257,7 +2257,7 @@ public partial class SymbolTableBuilder
 
                             if (binding.DeclarationNode is VariableDeclarator { Init: not null } declarator)
                             {
-                                var initializerType = InferExpressionClrType(declarator.Init, currentScope, proposedTypes, inferenceRootScope);
+                                var initializerType = InferExpressionClrType(declarator.Init, currentScope, proposedTypes, excludedBinding);
                                 if (initializerType != null)
                                 {
                                     return initializerType;
@@ -2520,7 +2520,7 @@ public partial class SymbolTableBuilder
                 switch (binExpr.Operator)
                 {
                     case Operator.Addition:
-                        return InferAddOperatorType(binExpr, scope, proposedTypes, inferenceRootScope);
+                        return InferAddOperatorType(binExpr, scope, proposedTypes, excludedBinding);
                     case Operator.Subtraction:
                     case Operator.Multiplication:
                     case Operator.Division:
@@ -2550,10 +2550,10 @@ public partial class SymbolTableBuilder
         return null;
     }
 
-    Type? InferAddOperatorType(NonLogicalBinaryExpression binaryExpression, Scope? scope, Dictionary<string, Type>? proposedTypes, Scope? inferenceRootScope = null)
+    Type? InferAddOperatorType(NonLogicalBinaryExpression binaryExpression, Scope? scope, Dictionary<string, Type>? proposedTypes, BindingInfo? excludedBinding = null)
     {
-        var leftType = InferExpressionClrType(binaryExpression.Left, scope, proposedTypes, inferenceRootScope);
-        var rightType = InferExpressionClrType(binaryExpression.Right, scope, proposedTypes, inferenceRootScope);
+        var leftType = InferExpressionClrType(binaryExpression.Left, scope, proposedTypes, excludedBinding);
+        var rightType = InferExpressionClrType(binaryExpression.Right, scope, proposedTypes, excludedBinding);
 
         // If either side is a string, + performs string concatenation
         if (leftType == typeof(string) || rightType == typeof(string))

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -958,7 +958,7 @@ public partial class SymbolTableBuilder
                     continue;
                 }
 
-                var inferredType = InferExpressionClrType(variableDeclarator.Init, scope, proposedClrTypes, binding);
+                var inferredType = InferExpressionClrType(variableDeclarator.Init, scope, proposedClrTypes, binding, scope);
                 if (inferredType != null)
                 {
                     proposedClrTypes[binding.Name] = inferredType;
@@ -994,7 +994,7 @@ public partial class SymbolTableBuilder
                     if (proposedClrTypes.TryGetValue(identifier.Name, out var inferredType))
                     {
                         // If any assignment conflicts with the inferred type, remove the proposed type.
-                        var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope.Bindings[identifier.Name]);
+                        var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope.Bindings[identifier.Name], scope);
                         if (rightType != inferredType)
                         {
                             changed |= proposedClrTypes.Remove(identifier.Name);
@@ -1003,7 +1003,7 @@ public partial class SymbolTableBuilder
                     else if (unitializedClrTypes.Contains(identifier.Name))
                     {
                         // An uninitialized variable can still be a nullable/reference type.
-                        var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope.Bindings[identifier.Name]);
+                        var rightType = InferExpressionClrType(assignExpr.Right, currentScope, proposedClrTypes, scope.Bindings[identifier.Name], scope);
                         if (rightType?.IsValueType == false)
                         {
                             if (!proposedClrTypes.TryGetValue(identifier.Name, out var existingType) || existingType != rightType)
@@ -2116,7 +2116,7 @@ public partial class SymbolTableBuilder
         }
     }
 
-    Type? InferExpressionClrType(Node expr, Scope? scope = null, Dictionary<string, Type>? proposedTypes = null, BindingInfo? excludedBinding = null)
+    Type? InferExpressionClrType(Node expr, Scope? scope = null, Dictionary<string, Type>? proposedTypes = null, BindingInfo? excludedBinding = null, Scope? inferenceRootScope = null)
     {
         static bool IsSupportedNumberLike(Type? t) =>
             t == typeof(double) || t == typeof(bool) || t == typeof(JavaScriptRuntime.JsNull);
@@ -2255,9 +2255,16 @@ public partial class SymbolTableBuilder
                                 return binding.ClrType;
                             }
 
+                            if (proposedTypes != null
+                                && inferenceRootScope != null
+                                && ReferenceEquals(currentScope, inferenceRootScope))
+                            {
+                                return null;
+                            }
+
                             if (binding.DeclarationNode is VariableDeclarator { Init: not null } declarator)
                             {
-                                var initializerType = InferExpressionClrType(declarator.Init, currentScope, proposedTypes, excludedBinding);
+                                var initializerType = InferExpressionClrType(declarator.Init, currentScope, proposedTypes, excludedBinding, inferenceRootScope);
                                 if (initializerType != null)
                                 {
                                     return initializerType;
@@ -2326,7 +2333,7 @@ public partial class SymbolTableBuilder
                 // <expr>.length
                 if (!me.Computed && me.Property is Identifier propId && string.Equals(propId.Name, "length", StringComparison.Ordinal))
                 {
-                    var receiverType = InferExpressionClrType(me.Object, scope, proposedTypes);
+                    var receiverType = InferExpressionClrType(me.Object, scope, proposedTypes, inferenceRootScope: inferenceRootScope);
                     if (receiverType == typeof(JavaScriptRuntime.Array)
                         || (receiverType != null && typeof(JavaScriptRuntime.TypedArrayBase).IsAssignableFrom(receiverType)))
                     {
@@ -2337,10 +2344,10 @@ public partial class SymbolTableBuilder
                 // <typedArray>[index]
                 if (me.Computed)
                 {
-                    var receiverType = InferExpressionClrType(me.Object, scope, proposedTypes);
+                    var receiverType = InferExpressionClrType(me.Object, scope, proposedTypes, inferenceRootScope: inferenceRootScope);
                     if (receiverType != null && typeof(JavaScriptRuntime.TypedArrayBase).IsAssignableFrom(receiverType))
                     {
-                        var indexType = InferExpressionClrType(me.Property, scope, proposedTypes);
+                        var indexType = InferExpressionClrType(me.Property, scope, proposedTypes, inferenceRootScope: inferenceRootScope);
                         // Numeric index required (JS will ToNumber, but we only infer when it's already clearly number-like).
                         if (IsSupportedNumberLike(indexType))
                         {
@@ -2350,7 +2357,7 @@ public partial class SymbolTableBuilder
 
                     if (receiverType == typeof(JavaScriptRuntime.Array))
                     {
-                        var indexType = InferExpressionClrType(me.Property, scope, proposedTypes);
+                        var indexType = InferExpressionClrType(me.Property, scope, proposedTypes, inferenceRootScope: inferenceRootScope);
                         if (IsSupportedNumberLike(indexType))
                         {
                             return InferExpressionArrayElementClrType(me.Object, scope, proposedTypes);
@@ -2481,7 +2488,7 @@ public partial class SymbolTableBuilder
                 // Array instance methods - use reflection to get return type
                 if (ce.Callee is MemberExpression instanceMe && instanceMe.Property is Identifier methodId)
                 {
-                    var receiverType = InferExpressionClrType(instanceMe.Object, scope, proposedTypes);
+                    var receiverType = InferExpressionClrType(instanceMe.Object, scope, proposedTypes, inferenceRootScope: inferenceRootScope);
                     if (receiverType == typeof(JavaScriptRuntime.Array))
                     {
                         // Use reflection to determine return type of Array methods
@@ -2520,7 +2527,7 @@ public partial class SymbolTableBuilder
                 switch (binExpr.Operator)
                 {
                     case Operator.Addition:
-                        return InferAddOperatorType(binExpr, scope, proposedTypes, excludedBinding);
+                        return InferAddOperatorType(binExpr, scope, proposedTypes, excludedBinding, inferenceRootScope);
                     case Operator.Subtraction:
                     case Operator.Multiplication:
                     case Operator.Division:
@@ -2550,10 +2557,10 @@ public partial class SymbolTableBuilder
         return null;
     }
 
-    Type? InferAddOperatorType(NonLogicalBinaryExpression binaryExpression, Scope? scope, Dictionary<string, Type>? proposedTypes, BindingInfo? excludedBinding = null)
+    Type? InferAddOperatorType(NonLogicalBinaryExpression binaryExpression, Scope? scope, Dictionary<string, Type>? proposedTypes, BindingInfo? excludedBinding = null, Scope? inferenceRootScope = null)
     {
-        var leftType = InferExpressionClrType(binaryExpression.Left, scope, proposedTypes, excludedBinding);
-        var rightType = InferExpressionClrType(binaryExpression.Right, scope, proposedTypes, excludedBinding);
+        var leftType = InferExpressionClrType(binaryExpression.Left, scope, proposedTypes, excludedBinding, inferenceRootScope);
+        var rightType = InferExpressionClrType(binaryExpression.Right, scope, proposedTypes, excludedBinding, inferenceRootScope);
 
         // If either side is a string, + performs string concatenation
         if (leftType == typeof(string) || rightType == typeof(string))

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.TemporalDeadZone.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.TemporalDeadZone.cs
@@ -11,8 +11,7 @@ public partial class SymbolTableBuilder
             binding.RequiresRuntimeTemporalDeadZoneChecks =
                 binding.RequiresTemporalDeadZoneChecks
                 && binding.IsCaptured
-                && (binding.Kind == BindingKind.Const
-                    || MayCapturedBindingBeObservedBeforeInitialization(scope, binding));
+                && MayCapturedBindingBeObservedBeforeInitialization(scope, binding);
         }
 
         foreach (var child in scope.Children)
@@ -93,14 +92,6 @@ public partial class SymbolTableBuilder
             return false;
         }
 
-        // Function declarations are hoisted, but they are inert until pre-init code actually
-        // references the callable binding (for example, an initializer calling the function).
-        if (candidateScope.AstNode is FunctionDeclaration
-            && TryGetFunctionScopeBinding(scopeContext, candidateScope, out var functionBinding))
-        {
-            return IsBindingReferencedBeforeBoundary(scopeContext, functionBinding, initializationBoundary);
-        }
-
         return candidateScope.AstNode.Start < initializationBoundary;
     }
 
@@ -112,82 +103,6 @@ public partial class SymbolTableBuilder
         }
 
         return CollectReferencedParentVariables(candidateScope, scopeContext).Contains(targetBinding.Name);
-    }
-
-    private bool IsBindingReferencedBeforeBoundary(Scope scope, BindingInfo targetBinding, int boundary)
-    {
-        bool referenced = false;
-        WalkScope(scope);
-        return referenced;
-
-        void WalkScope(Scope currentScope)
-        {
-            if (referenced)
-            {
-                return;
-            }
-
-            if (!ReferenceEquals(TryResolveBinding(currentScope, targetBinding.Name), targetBinding))
-            {
-                return;
-            }
-
-            WalkNode(GetExecutedScopeBodyRoot(currentScope), currentScope);
-        }
-
-        void WalkNode(Node? node, Scope currentScope)
-        {
-            if (node == null || referenced || node.Start >= boundary)
-            {
-                return;
-            }
-
-            if (ReferenceEquals(node, targetBinding.DeclarationNode))
-            {
-                return;
-            }
-
-            if (!ReferenceEquals(node, currentScope.AstNode)
-                && TryGetDirectChildScope(currentScope, node, out var childScope))
-            {
-                if (childScope.Kind == ScopeKind.Block
-                    && childScope.AstNode.Start < boundary
-                    && !childScope.Bindings.ContainsKey(targetBinding.Name))
-                {
-                    WalkScope(childScope);
-                }
-
-                return;
-            }
-
-            if (node is Identifier identifier
-                && ReferenceEquals(TryResolveBinding(currentScope, identifier.Name), targetBinding))
-            {
-                referenced = true;
-                return;
-            }
-
-            foreach (var childNode in node.ChildNodes)
-            {
-                WalkNode(childNode, currentScope);
-                if (referenced)
-                {
-                    return;
-                }
-            }
-        }
-    }
-
-    private static Node GetExecutedScopeBodyRoot(Scope scope)
-    {
-        return scope.AstNode switch
-        {
-            FunctionDeclaration fd when fd.Body is BlockStatement body => body,
-            FunctionExpression fe when fe.Body is BlockStatement body => body,
-            ArrowFunctionExpression af when af.Body is BlockStatement body => body,
-            ArrowFunctionExpression af => af.Body,
-            _ => scope.AstNode
-        };
     }
 
     private static bool TryGetBindingInitializationBoundary(BindingInfo binding, out int boundary)
@@ -225,26 +140,5 @@ public partial class SymbolTableBuilder
 
         childScope = null!;
         return false;
-    }
-
-    private static bool TryGetFunctionScopeBinding(Scope scope, Scope functionScope, out BindingInfo binding)
-    {
-        binding = null!;
-
-        if (functionScope.AstNode is not FunctionDeclaration functionDeclaration
-            || functionDeclaration.Id is not Identifier functionId)
-        {
-            return false;
-        }
-
-        if (!scope.Bindings.TryGetValue(functionId.Name, out var resolvedBinding)
-            || resolvedBinding == null
-            || !ReferenceEquals(resolvedBinding.DeclarationNode, functionDeclaration))
-        {
-            return false;
-        }
-
-        binding = resolvedBinding;
-        return true;
     }
 }

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f81
+				// Method begins at RVA 0x4e7c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f9c
+						// Method begins at RVA 0x4e97
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4fa5
+						// Method begins at RVA 0x4ea0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4fae
+						// Method begins at RVA 0x4ea9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4fb7
+						// Method begins at RVA 0x4eb2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4fc0
+						// Method begins at RVA 0x4ebb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4fc9
+						// Method begins at RVA 0x4ec4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f93
+					// Method begins at RVA 0x4e8e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f8a
+				// Method begins at RVA 0x4e85
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -503,7 +503,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fd2
+				// Method begins at RVA 0x4ecd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -604,7 +604,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fdb
+				// Method begins at RVA 0x4ed6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -632,7 +632,7 @@
 			)
 			// Method begins at RVA 0x2aac
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 76 (0x4c)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -640,42 +640,40 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: ldstr "Cannot access 'path' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "resolve"
-			IL_0017: ldc.i4.6
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::__dirname
-			IL_0025: stelem.ref
-			IL_0026: dup
-			IL_0027: ldc.i4.1
-			IL_0028: ldstr ".."
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.2
-			IL_0030: ldstr ".."
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.3
-			IL_0038: ldstr "tests"
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.4
-			IL_0040: ldstr "test262"
-			IL_0045: stelem.ref
-			IL_0046: dup
-			IL_0047: ldc.i4.5
-			IL_0048: ldstr "test262.pin.json"
-			IL_004d: stelem.ref
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0053: stloc.0
-			IL_0054: ldloc.0
-			IL_0055: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "resolve"
+			IL_000d: ldc.i4.6
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::__dirname
+			IL_001b: stelem.ref
+			IL_001c: dup
+			IL_001d: ldc.i4.1
+			IL_001e: ldstr ".."
+			IL_0023: stelem.ref
+			IL_0024: dup
+			IL_0025: ldc.i4.2
+			IL_0026: ldstr ".."
+			IL_002b: stelem.ref
+			IL_002c: dup
+			IL_002d: ldc.i4.3
+			IL_002e: ldstr "tests"
+			IL_0033: stelem.ref
+			IL_0034: dup
+			IL_0035: ldc.i4.4
+			IL_0036: ldstr "test262"
+			IL_003b: stelem.ref
+			IL_003c: dup
+			IL_003d: ldc.i4.5
+			IL_003e: ldstr "test262.pin.json"
+			IL_0043: stelem.ref
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0049: stloc.0
+			IL_004a: ldloc.0
+			IL_004b: ret
 		} // end of method defaultPinPath::__js_call__
 
 	} // end of class defaultPinPath
@@ -695,7 +693,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fed
+					// Method begins at RVA 0x4ee8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -713,7 +711,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fe4
+				// Method begins at RVA 0x4edf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -740,9 +738,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2b10
+			// Method begins at RVA 0x2b04
 			// Header size: 12
-			// Code size: 133 (0x85)
+			// Code size: 111 (0x6f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/Scope/Block_L80C14,
@@ -767,44 +765,38 @@
 
 			IL_001c: ldarg.0
 			IL_001d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0022: ldstr "Cannot access 'path' before initialization"
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_002c: stloc.3
-			IL_002d: ldloc.3
-			IL_002e: ldstr "isAbsolute"
-			IL_0033: ldarg.2
-			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0039: stloc.3
-			IL_003a: ldloc.3
-			IL_003b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0040: stloc.2
-			IL_0041: ldloc.2
-			IL_0042: brfalse IL_004e
+			IL_0022: ldstr "isAbsolute"
+			IL_0027: ldarg.2
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002d: stloc.3
+			IL_002e: ldloc.3
+			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0034: stloc.2
+			IL_0035: ldloc.2
+			IL_0036: brfalse IL_0042
 
-			IL_0047: ldarg.2
-			IL_0048: stloc.1
-			IL_0049: br IL_0083
+			IL_003b: ldarg.2
+			IL_003c: stloc.1
+			IL_003d: br IL_006d
 
-			IL_004e: ldarg.0
-			IL_004f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0054: ldstr "Cannot access 'path' before initialization"
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_005e: stloc.3
-			IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0064: ldstr "cwd"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_006e: stloc.s 4
-			IL_0070: ldloc.3
-			IL_0071: ldstr "resolve"
-			IL_0076: ldloc.s 4
-			IL_0078: ldarg.2
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_007e: stloc.s 4
-			IL_0080: ldloc.s 4
-			IL_0082: stloc.1
+			IL_0042: ldarg.0
+			IL_0043: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0048: stloc.3
+			IL_0049: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_004e: ldstr "cwd"
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0058: stloc.s 4
+			IL_005a: ldloc.3
+			IL_005b: ldstr "resolve"
+			IL_0060: ldloc.s 4
+			IL_0062: ldarg.2
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0068: stloc.s 4
+			IL_006a: ldloc.s 4
+			IL_006c: stloc.1
 
-			IL_0083: ldloc.1
-			IL_0084: ret
+			IL_006d: ldloc.1
+			IL_006e: ret
 		} // end of method resolvePathFromCwd::__js_call__
 
 	} // end of class resolvePathFromCwd
@@ -820,7 +812,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ff6
+				// Method begins at RVA 0x4ef1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -844,7 +836,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ba4
+			// Method begins at RVA 0x2b80
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -880,7 +872,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fff
+				// Method begins at RVA 0x4efa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -907,7 +899,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2bd4
+			// Method begins at RVA 0x2bb0
 			// Header size: 12
 			// Code size: 78 (0x4e)
 			.maxstack 8
@@ -961,7 +953,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5011
+					// Method begins at RVA 0x4f0c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -979,7 +971,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5008
+				// Method begins at RVA 0x4f03
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1004,7 +996,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c30
+			// Method begins at RVA 0x2c0c
 			// Header size: 12
 			// Code size: 172 (0xac)
 			.maxstack 8
@@ -1106,7 +1098,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5023
+					// Method begins at RVA 0x4f1e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1124,7 +1116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x501a
+				// Method begins at RVA 0x4f15
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1152,7 +1144,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x503e
+						// Method begins at RVA 0x4f39
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1170,7 +1162,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5035
+					// Method begins at RVA 0x4f30
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1188,7 +1180,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x502c
+				// Method begins at RVA 0x4f27
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1213,7 +1205,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ce8
+			// Method begins at RVA 0x2cc4
 			// Header size: 12
 			// Code size: 476 (0x1dc)
 			.maxstack 8
@@ -1439,7 +1431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5047
+				// Method begins at RVA 0x4f42
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1467,7 +1459,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5062
+						// Method begins at RVA 0x4f5d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1485,7 +1477,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5059
+					// Method begins at RVA 0x4f54
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1503,7 +1495,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5050
+				// Method begins at RVA 0x4f4b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1530,7 +1522,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2ee0
+			// Method begins at RVA 0x2ebc
 			// Header size: 12
 			// Code size: 190 (0xbe)
 			.maxstack 8
@@ -1651,7 +1643,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5074
+					// Method begins at RVA 0x4f6f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1671,7 +1663,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x507d
+					// Method begins at RVA 0x4f78
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1691,7 +1683,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5086
+					// Method begins at RVA 0x4f81
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1709,7 +1701,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x506b
+				// Method begins at RVA 0x4f66
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1736,7 +1728,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2fbc
+			// Method begins at RVA 0x2f98
 			// Header size: 12
 			// Code size: 885 (0x375)
 			.maxstack 8
@@ -2080,7 +2072,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x508f
+				// Method begins at RVA 0x4f8a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2107,9 +2099,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3340
+			// Method begins at RVA 0x331c
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 72 (0x48)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2119,39 +2111,35 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: ldstr "Cannot access 'fs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.2
-			IL_0011: ldloc.2
-			IL_0012: ldstr "readFileSync"
-			IL_0017: ldarg.2
-			IL_0018: ldstr "utf8"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.0
-			IL_0025: ldloc.0
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldc.i4.1
-			IL_002f: newarr [System.Runtime]System.Object
-			IL_0034: dup
-			IL_0035: ldc.i4.0
-			IL_0036: ldarg.0
-			IL_0037: stelem.ref
-			IL_0038: ldc.i4.0
-			IL_0039: ldelem.ref
-			IL_003a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_003f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_004a: ldnull
-			IL_004b: ldloc.1
-			IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0051: pop
-			IL_0052: ldloc.1
-			IL_0053: ret
+			IL_0006: ldstr "readFileSync"
+			IL_000b: ldarg.2
+			IL_000c: ldstr "utf8"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: stloc.0
+			IL_0019: ldloc.0
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_001f: stloc.2
+			IL_0020: ldloc.2
+			IL_0021: stloc.1
+			IL_0022: ldc.i4.1
+			IL_0023: newarr [System.Runtime]System.Object
+			IL_0028: dup
+			IL_0029: ldc.i4.0
+			IL_002a: ldarg.0
+			IL_002b: stelem.ref
+			IL_002c: ldc.i4.0
+			IL_002d: ldelem.ref
+			IL_002e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0033: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0039: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_003e: ldnull
+			IL_003f: ldloc.1
+			IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0045: pop
+			IL_0046: ldloc.1
+			IL_0047: ret
 		} // end of method loadPin::__js_call__
 
 	} // end of class loadPin
@@ -2167,7 +2155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5098
+				// Method begins at RVA 0x4f93
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2195,9 +2183,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x33a0
+			// Method begins at RVA 0x3370
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 76 (0x4c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2207,38 +2195,32 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: ldstr "Cannot access 'path' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: ldstr "dirname"
-			IL_0017: ldarg.2
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001d: stloc.1
-			IL_001e: ldloc.1
-			IL_001f: stloc.0
-			IL_0020: ldarg.0
-			IL_0021: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0026: ldstr "Cannot access 'path' before initialization"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0030: stloc.1
-			IL_0031: ldarg.3
-			IL_0032: ldstr "managedRoot"
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "resolve"
-			IL_0043: ldloc.0
-			IL_0044: ldloc.2
-			IL_0045: ldarg.3
-			IL_0046: ldstr "upstream"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0050: ldstr "commit"
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_005f: stloc.2
-			IL_0060: ldloc.2
-			IL_0061: ret
+			IL_0006: ldstr "dirname"
+			IL_000b: ldarg.2
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0011: stloc.1
+			IL_0012: ldloc.1
+			IL_0013: stloc.0
+			IL_0014: ldarg.0
+			IL_0015: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_001a: stloc.1
+			IL_001b: ldarg.3
+			IL_001c: ldstr "managedRoot"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0026: stloc.2
+			IL_0027: ldloc.1
+			IL_0028: ldstr "resolve"
+			IL_002d: ldloc.0
+			IL_002e: ldloc.2
+			IL_002f: ldarg.3
+			IL_0030: ldstr "upstream"
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003a: ldstr "commit"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0049: stloc.2
+			IL_004a: ldloc.2
+			IL_004b: ret
 		} // end of method resolveManagedCheckoutRoot::__js_call__
 
 	} // end of class resolveManagedCheckoutRoot
@@ -2254,7 +2236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50a1
+				// Method begins at RVA 0x4f9c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2281,9 +2263,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3410
+			// Method begins at RVA 0x33c8
 			// Header size: 12
-			// Code size: 121 (0x79)
+			// Code size: 109 (0x6d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2292,48 +2274,44 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: ldstr "Cannot access 'path' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0006: ldstr "posix"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "posix"
+			IL_0011: ldarg.2
+			IL_0012: ldstr "managedRoot"
 			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldarg.2
-			IL_001e: ldstr "managedRoot"
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0028: stloc.1
-			IL_0029: ldc.i4.1
-			IL_002a: newarr [System.Runtime]System.Object
-			IL_002f: dup
-			IL_0030: ldc.i4.0
-			IL_0031: ldarg.0
-			IL_0032: stelem.ref
-			IL_0033: ldc.i4.0
-			IL_0034: ldelem.ref
-			IL_0035: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_003a: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0045: ldnull
-			IL_0046: ldloc.1
-			IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_004c: stloc.1
-			IL_004d: ldloc.0
-			IL_004e: ldstr "join"
-			IL_0053: ldloc.1
-			IL_0054: ldarg.2
-			IL_0055: ldstr "upstream"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: ldstr "commit"
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_006e: stloc.1
-			IL_006f: ldnull
-			IL_0070: ldloc.1
-			IL_0071: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_0076: stloc.1
-			IL_0077: ldloc.1
-			IL_0078: ret
+			IL_001c: stloc.1
+			IL_001d: ldc.i4.1
+			IL_001e: newarr [System.Runtime]System.Object
+			IL_0023: dup
+			IL_0024: ldc.i4.0
+			IL_0025: ldarg.0
+			IL_0026: stelem.ref
+			IL_0027: ldc.i4.0
+			IL_0028: ldelem.ref
+			IL_0029: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_002e: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0039: ldnull
+			IL_003a: ldloc.1
+			IL_003b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0040: stloc.1
+			IL_0041: ldloc.0
+			IL_0042: ldstr "join"
+			IL_0047: ldloc.1
+			IL_0048: ldarg.2
+			IL_0049: ldstr "upstream"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0053: ldstr "commit"
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0062: stloc.1
+			IL_0063: ldnull
+			IL_0064: ldloc.1
+			IL_0065: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_006a: stloc.1
+			IL_006b: ldloc.1
+			IL_006c: ret
 		} // end of method resolveManagedCheckoutLabel::__js_call__
 
 	} // end of class resolveManagedCheckoutLabel
@@ -2353,7 +2331,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50b3
+					// Method begins at RVA 0x4fae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2371,7 +2349,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50aa
+				// Method begins at RVA 0x4fa5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2399,7 +2377,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3498
+			// Method begins at RVA 0x3444
 			// Header size: 12
 			// Code size: 252 (0xfc)
 			.maxstack 8
@@ -2530,7 +2508,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50c5
+					// Method begins at RVA 0x4fc0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2548,7 +2526,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50bc
+				// Method begins at RVA 0x4fb7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2576,7 +2554,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x35a0
+			// Method begins at RVA 0x354c
 			// Header size: 12
 			// Code size: 1017 (0x3f9)
 			.maxstack 8
@@ -2940,7 +2918,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ce
+				// Method begins at RVA 0x4fc9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2967,9 +2945,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x39a8
+			// Method begins at RVA 0x3954
 			// Header size: 12
-			// Code size: 49 (0x31)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2977,21 +2955,19 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: ldstr "Cannot access 'fs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "mkdirSync"
-			IL_0017: ldarg.2
-			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001d: dup
-			IL_001e: ldstr "recursive"
-			IL_0023: ldc.i4.1
-			IL_0024: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002e: pop
-			IL_002f: ldnull
-			IL_0030: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "mkdirSync"
+			IL_000d: ldarg.2
+			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0013: dup
+			IL_0014: ldstr "recursive"
+			IL_0019: ldc.i4.1
+			IL_001a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0024: pop
+			IL_0025: ldnull
+			IL_0026: ret
 		} // end of method ensureDir::__js_call__
 
 	} // end of class ensureDir
@@ -3011,7 +2987,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50e0
+					// Method begins at RVA 0x4fdb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3029,7 +3005,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50d7
+				// Method begins at RVA 0x4fd2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3056,9 +3032,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x39e8
+			// Method begins at RVA 0x3988
 			// Header size: 12
-			// Code size: 115 (0x73)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/removeDir/Scope/Block_L215C37,
@@ -3068,48 +3044,42 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: ldstr "Cannot access 'fs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: ldstr "existsSync"
-			IL_0017: ldarg.2
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001d: stloc.1
-			IL_001e: ldloc.1
-			IL_001f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0024: ldc.i4.0
-			IL_0025: ceq
-			IL_0027: stloc.2
-			IL_0028: ldloc.2
-			IL_0029: brfalse IL_0036
+			IL_0006: ldstr "existsSync"
+			IL_000b: ldarg.2
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0011: stloc.1
+			IL_0012: ldloc.1
+			IL_0013: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0018: ldc.i4.0
+			IL_0019: ceq
+			IL_001b: stloc.2
+			IL_001c: ldloc.2
+			IL_001d: brfalse IL_002a
 
-			IL_002e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/removeDir/Scope/Block_L215C37::.ctor()
-			IL_0033: stloc.0
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0022: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/removeDir/Scope/Block_L215C37::.ctor()
+			IL_0027: stloc.0
+			IL_0028: ldnull
+			IL_0029: ret
 
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_003c: ldstr "Cannot access 'fs' before initialization"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0046: stloc.1
-			IL_0047: ldloc.1
-			IL_0048: ldstr "rmSync"
-			IL_004d: ldarg.2
-			IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0053: dup
-			IL_0054: ldstr "recursive"
-			IL_0059: ldc.i4.1
-			IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_005f: dup
-			IL_0060: ldstr "force"
-			IL_0065: ldc.i4.1
-			IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0070: pop
-			IL_0071: ldnull
-			IL_0072: ret
+			IL_002a: ldarg.0
+			IL_002b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0030: stloc.1
+			IL_0031: ldloc.1
+			IL_0032: ldstr "rmSync"
+			IL_0037: ldarg.2
+			IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003d: dup
+			IL_003e: ldstr "recursive"
+			IL_0043: ldc.i4.1
+			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0049: dup
+			IL_004a: ldstr "force"
+			IL_004f: ldc.i4.1
+			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method removeDir::__js_call__
 
 	} // end of class removeDir
@@ -3129,7 +3099,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50f2
+					// Method begins at RVA 0x4fed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3149,7 +3119,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50fb
+					// Method begins at RVA 0x4ff6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3167,7 +3137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50e9
+				// Method begins at RVA 0x4fe4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3195,9 +3165,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3a68
+			// Method begins at RVA 0x39f4
 			// Header size: 12
-			// Code size: 667 (0x29b)
+			// Code size: 657 (0x291)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3221,237 +3191,235 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
-			IL_0006: ldstr "Cannot access 'childProcess' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.s 7
-			IL_0012: ldc.r8 4
-			IL_001b: ldc.r8 1024
-			IL_0024: mul
-			IL_0025: stloc.s 8
-			IL_0027: ldloc.s 8
-			IL_0029: ldc.r8 1024
-			IL_0032: mul
-			IL_0033: stloc.s 8
-			IL_0035: ldloc.s 7
-			IL_0037: ldstr "spawnSync"
-			IL_003c: ldstr "git"
-			IL_0041: ldarg.2
-			IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0047: dup
-			IL_0048: ldstr "cwd"
-			IL_004d: ldarg.3
-			IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0053: dup
-			IL_0054: ldstr "encoding"
-			IL_0059: ldstr "utf8"
-			IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0063: dup
-			IL_0064: ldstr "maxBuffer"
-			IL_0069: ldloc.s 8
-			IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0070: dup
-			IL_0071: ldstr "shell"
-			IL_0076: ldc.i4.0
-			IL_0077: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0081: stloc.s 7
-			IL_0083: ldloc.s 7
-			IL_0085: stloc.0
-			IL_0086: ldloc.0
-			IL_0087: ldstr "error"
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0096: stloc.s 9
-			IL_0098: ldloc.s 9
-			IL_009a: brfalse IL_00d1
+			IL_0006: stloc.s 7
+			IL_0008: ldc.r8 4
+			IL_0011: ldc.r8 1024
+			IL_001a: mul
+			IL_001b: stloc.s 8
+			IL_001d: ldloc.s 8
+			IL_001f: ldc.r8 1024
+			IL_0028: mul
+			IL_0029: stloc.s 8
+			IL_002b: ldloc.s 7
+			IL_002d: ldstr "spawnSync"
+			IL_0032: ldstr "git"
+			IL_0037: ldarg.2
+			IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003d: dup
+			IL_003e: ldstr "cwd"
+			IL_0043: ldarg.3
+			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0049: dup
+			IL_004a: ldstr "encoding"
+			IL_004f: ldstr "utf8"
+			IL_0054: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0059: dup
+			IL_005a: ldstr "maxBuffer"
+			IL_005f: ldloc.s 8
+			IL_0061: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0066: dup
+			IL_0067: ldstr "shell"
+			IL_006c: ldc.i4.0
+			IL_006d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0077: stloc.s 7
+			IL_0079: ldloc.s 7
+			IL_007b: stloc.0
+			IL_007c: ldloc.0
+			IL_007d: ldstr "error"
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_008c: stloc.s 9
+			IL_008e: ldloc.s 9
+			IL_0090: brfalse IL_00c7
 
-			IL_009f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L230C20::.ctor()
-			IL_00a4: stloc.1
-			IL_00a5: ldloc.0
-			IL_00a6: ldstr "error"
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b0: pop
-			IL_00b1: ldloc.0
-			IL_00b2: ldstr "error"
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00bc: dup
-			IL_00bd: isinst [System.Runtime]System.Exception
-			IL_00c2: dup
-			IL_00c3: brtrue IL_00cf
+			IL_0095: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L230C20::.ctor()
+			IL_009a: stloc.1
+			IL_009b: ldloc.0
+			IL_009c: ldstr "error"
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a6: pop
+			IL_00a7: ldloc.0
+			IL_00a8: ldstr "error"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b2: dup
+			IL_00b3: isinst [System.Runtime]System.Exception
+			IL_00b8: dup
+			IL_00b9: brtrue IL_00c5
 
-			IL_00c8: pop
-			IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00ce: throw
+			IL_00be: pop
+			IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00c4: throw
 
-			IL_00cf: pop
-			IL_00d0: throw
+			IL_00c5: pop
+			IL_00c6: throw
 
-			IL_00d1: ldloc.0
-			IL_00d2: ldstr "status"
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00dc: stloc.s 7
-			IL_00de: ldloc.s 7
-			IL_00e0: ldc.r8 0.0
-			IL_00e9: box [System.Runtime]System.Double
-			IL_00ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00f3: stloc.s 9
-			IL_00f5: ldloc.s 9
-			IL_00f7: brfalse IL_026b
+			IL_00c7: ldloc.0
+			IL_00c8: ldstr "status"
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d2: stloc.s 7
+			IL_00d4: ldloc.s 7
+			IL_00d6: ldc.r8 0.0
+			IL_00df: box [System.Runtime]System.Double
+			IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00e9: stloc.s 9
+			IL_00eb: ldloc.s 9
+			IL_00ed: brfalse IL_0261
 
-			IL_00fc: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L234C27::.ctor()
-			IL_0101: stloc.2
-			IL_0102: ldloc.0
-			IL_0103: ldstr "stderr"
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010d: stloc.s 7
-			IL_010f: ldloc.s 7
-			IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0116: stloc.s 9
-			IL_0118: ldloc.s 9
-			IL_011a: brtrue IL_012b
+			IL_00f2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L234C27::.ctor()
+			IL_00f7: stloc.2
+			IL_00f8: ldloc.0
+			IL_00f9: ldstr "stderr"
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0103: stloc.s 7
+			IL_0105: ldloc.s 7
+			IL_0107: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_010c: stloc.s 9
+			IL_010e: ldloc.s 9
+			IL_0110: brtrue IL_0121
 
-			IL_011f: ldstr ""
-			IL_0124: stloc.s 11
-			IL_0126: br IL_012f
+			IL_0115: ldstr ""
+			IL_011a: stloc.s 11
+			IL_011c: br IL_0125
 
-			IL_012b: ldloc.s 7
-			IL_012d: stloc.s 11
+			IL_0121: ldloc.s 7
+			IL_0123: stloc.s 11
 
-			IL_012f: ldloc.s 11
-			IL_0131: castclass [System.Runtime]System.String
-			IL_0136: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_013b: stloc.s 12
-			IL_013d: ldloc.s 12
-			IL_013f: stloc.3
-			IL_0140: ldloc.0
-			IL_0141: ldstr "stdout"
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_014b: stloc.s 7
-			IL_014d: ldloc.s 7
-			IL_014f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0154: stloc.s 9
-			IL_0156: ldloc.s 9
-			IL_0158: brtrue IL_0169
+			IL_0125: ldloc.s 11
+			IL_0127: castclass [System.Runtime]System.String
+			IL_012c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0131: stloc.s 12
+			IL_0133: ldloc.s 12
+			IL_0135: stloc.3
+			IL_0136: ldloc.0
+			IL_0137: ldstr "stdout"
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0141: stloc.s 7
+			IL_0143: ldloc.s 7
+			IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_014a: stloc.s 9
+			IL_014c: ldloc.s 9
+			IL_014e: brtrue IL_015f
 
-			IL_015d: ldstr ""
-			IL_0162: stloc.s 13
-			IL_0164: br IL_016d
+			IL_0153: ldstr ""
+			IL_0158: stloc.s 13
+			IL_015a: br IL_0163
 
-			IL_0169: ldloc.s 7
-			IL_016b: stloc.s 13
+			IL_015f: ldloc.s 7
+			IL_0161: stloc.s 13
 
-			IL_016d: ldloc.s 13
-			IL_016f: castclass [System.Runtime]System.String
-			IL_0174: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0179: stloc.s 12
-			IL_017b: ldloc.s 12
-			IL_017d: stloc.s 4
-			IL_017f: ldc.i4.2
-			IL_0180: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0185: dup
-			IL_0186: ldloc.3
-			IL_0187: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_018c: dup
-			IL_018d: ldloc.s 4
-			IL_018f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0194: stloc.s 14
-			IL_0196: ldloc.s 14
-			IL_0198: ldc.i4.1
-			IL_0199: newarr [System.Runtime]System.Object
-			IL_019e: dup
-			IL_019f: ldc.i4.0
-			IL_01a0: call class [System.Runtime]System.Func`3<object[], object, bool> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Boolean()
-			IL_01a5: stelem.ref
-			IL_01a6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
-			IL_01ab: stloc.s 14
-			IL_01ad: ldloc.s 14
-			IL_01af: ldc.i4.1
-			IL_01b0: newarr [System.Runtime]System.Object
-			IL_01b5: dup
-			IL_01b6: ldc.i4.0
-			IL_01b7: ldstr "\n"
-			IL_01bc: stelem.ref
-			IL_01bd: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01c2: stloc.s 12
-			IL_01c4: ldloc.s 12
-			IL_01c6: stloc.s 5
-			IL_01c8: ldarg.2
-			IL_01c9: ldstr "join"
-			IL_01ce: ldstr " "
-			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01d8: stloc.s 7
-			IL_01da: ldloc.s 7
-			IL_01dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01e1: stloc.s 12
-			IL_01e3: ldstr "git "
-			IL_01e8: ldloc.s 12
-			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ef: stloc.s 12
-			IL_01f1: ldloc.s 12
-			IL_01f3: ldstr " failed"
-			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01fd: stloc.s 12
-			IL_01ff: ldloc.s 5
-			IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0206: stloc.s 9
-			IL_0208: ldloc.s 9
-			IL_020a: brfalse IL_022f
+			IL_0163: ldloc.s 13
+			IL_0165: castclass [System.Runtime]System.String
+			IL_016a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_016f: stloc.s 12
+			IL_0171: ldloc.s 12
+			IL_0173: stloc.s 4
+			IL_0175: ldc.i4.2
+			IL_0176: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_017b: dup
+			IL_017c: ldloc.3
+			IL_017d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0182: dup
+			IL_0183: ldloc.s 4
+			IL_0185: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_018a: stloc.s 14
+			IL_018c: ldloc.s 14
+			IL_018e: ldc.i4.1
+			IL_018f: newarr [System.Runtime]System.Object
+			IL_0194: dup
+			IL_0195: ldc.i4.0
+			IL_0196: call class [System.Runtime]System.Func`3<object[], object, bool> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Boolean()
+			IL_019b: stelem.ref
+			IL_019c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
+			IL_01a1: stloc.s 14
+			IL_01a3: ldloc.s 14
+			IL_01a5: ldc.i4.1
+			IL_01a6: newarr [System.Runtime]System.Object
+			IL_01ab: dup
+			IL_01ac: ldc.i4.0
+			IL_01ad: ldstr "\n"
+			IL_01b2: stelem.ref
+			IL_01b3: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01b8: stloc.s 12
+			IL_01ba: ldloc.s 12
+			IL_01bc: stloc.s 5
+			IL_01be: ldarg.2
+			IL_01bf: ldstr "join"
+			IL_01c4: ldstr " "
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01ce: stloc.s 7
+			IL_01d0: ldloc.s 7
+			IL_01d2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d7: stloc.s 12
+			IL_01d9: ldstr "git "
+			IL_01de: ldloc.s 12
+			IL_01e0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e5: stloc.s 12
+			IL_01e7: ldloc.s 12
+			IL_01e9: ldstr " failed"
+			IL_01ee: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f3: stloc.s 12
+			IL_01f5: ldloc.s 5
+			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01fc: stloc.s 9
+			IL_01fe: ldloc.s 9
+			IL_0200: brfalse IL_0225
 
-			IL_020f: ldloc.s 5
-			IL_0211: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0216: stloc.s 15
-			IL_0218: ldstr ":\n"
-			IL_021d: ldloc.s 15
-			IL_021f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0224: stloc.s 15
-			IL_0226: ldloc.s 15
-			IL_0228: stloc.s 6
-			IL_022a: br IL_0236
+			IL_0205: ldloc.s 5
+			IL_0207: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_020c: stloc.s 15
+			IL_020e: ldstr ":\n"
+			IL_0213: ldloc.s 15
+			IL_0215: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021a: stloc.s 15
+			IL_021c: ldloc.s 15
+			IL_021e: stloc.s 6
+			IL_0220: br IL_022c
 
-			IL_022f: ldstr "."
-			IL_0234: stloc.s 6
+			IL_0225: ldstr "."
+			IL_022a: stloc.s 6
 
-			IL_0236: ldloc.s 6
-			IL_0238: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_023d: stloc.s 15
-			IL_023f: ldloc.s 12
-			IL_0241: ldloc.s 15
-			IL_0243: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0248: stloc.s 15
-			IL_024a: ldloc.s 15
-			IL_024c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0251: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0256: dup
-			IL_0257: isinst [System.Runtime]System.Exception
-			IL_025c: dup
-			IL_025d: brtrue IL_0269
+			IL_022c: ldloc.s 6
+			IL_022e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0233: stloc.s 15
+			IL_0235: ldloc.s 12
+			IL_0237: ldloc.s 15
+			IL_0239: call string [System.Runtime]System.String::Concat(string, string)
+			IL_023e: stloc.s 15
+			IL_0240: ldloc.s 15
+			IL_0242: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0247: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_024c: dup
+			IL_024d: isinst [System.Runtime]System.Exception
+			IL_0252: dup
+			IL_0253: brtrue IL_025f
 
-			IL_0262: pop
-			IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0268: throw
+			IL_0258: pop
+			IL_0259: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_025e: throw
 
-			IL_0269: pop
-			IL_026a: throw
+			IL_025f: pop
+			IL_0260: throw
 
-			IL_026b: ldloc.0
-			IL_026c: ldstr "stdout"
-			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0276: stloc.s 7
-			IL_0278: ldloc.s 7
-			IL_027a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_027f: stloc.s 9
-			IL_0281: ldloc.s 9
-			IL_0283: brtrue IL_0294
+			IL_0261: ldloc.0
+			IL_0262: ldstr "stdout"
+			IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026c: stloc.s 7
+			IL_026e: ldloc.s 7
+			IL_0270: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0275: stloc.s 9
+			IL_0277: ldloc.s 9
+			IL_0279: brtrue IL_028a
 
-			IL_0288: ldstr ""
-			IL_028d: stloc.s 16
-			IL_028f: br IL_0298
+			IL_027e: ldstr ""
+			IL_0283: stloc.s 16
+			IL_0285: br IL_028e
 
-			IL_0294: ldloc.s 7
-			IL_0296: stloc.s 16
+			IL_028a: ldloc.s 7
+			IL_028c: stloc.s 16
 
-			IL_0298: ldloc.s 16
-			IL_029a: ret
+			IL_028e: ldloc.s 16
+			IL_0290: ret
 		} // end of method runGit::__js_call__
 
 	} // end of class runGit
@@ -3467,7 +3435,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5104
+				// Method begins at RVA 0x4fff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3491,7 +3459,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5116
+					// Method begins at RVA 0x5011
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3509,7 +3477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x510d
+				// Method begins at RVA 0x5008
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3533,7 +3501,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5128
+					// Method begins at RVA 0x5023
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3551,7 +3519,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x511f
+				// Method begins at RVA 0x501a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3578,7 +3546,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3d10
+			// Method begins at RVA 0x3c94
 			// Header size: 12
 			// Code size: 441 (0x1b9)
 			.maxstack 8
@@ -3809,7 +3777,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5179
+						// Method begins at RVA 0x5074
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3829,7 +3797,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5182
+						// Method begins at RVA 0x507d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3847,7 +3815,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5170
+					// Method begins at RVA 0x506b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3867,7 +3835,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x518b
+					// Method begins at RVA 0x5086
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3885,7 +3853,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5131
+				// Method begins at RVA 0x502c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3913,7 +3881,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x514c
+						// Method begins at RVA 0x5047
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3931,7 +3899,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5143
+					// Method begins at RVA 0x503e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3949,7 +3917,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x513a
+				// Method begins at RVA 0x5035
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3977,7 +3945,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5167
+						// Method begins at RVA 0x5062
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3995,7 +3963,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x515e
+					// Method begins at RVA 0x5059
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4013,7 +3981,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5155
+				// Method begins at RVA 0x5050
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4041,9 +4009,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3ef4
+			// Method begins at RVA 0x3e78
 			// Header size: 12
-			// Code size: 1651 (0x673)
+			// Code size: 1547 (0x60b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4113,7 +4081,7 @@
 					IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0033: stloc.s 25
 					IL_0035: ldloc.s 25
-					IL_0037: brtrue IL_019c
+					IL_0037: brtrue IL_0176
 
 					IL_003c: ldloc.s 24
 					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -4124,570 +4092,542 @@
 					IL_004e: stloc.s 6
 					IL_0050: ldarg.0
 					IL_0051: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_0056: ldstr "Cannot access 'path' before initialization"
-					IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0060: stloc.s 24
-					IL_0062: ldc.i4.1
-					IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0068: dup
-					IL_0069: ldarg.2
-					IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_006f: stloc.s 26
-					IL_0071: ldc.i4.1
-					IL_0072: newarr [System.Runtime]System.Object
-					IL_0077: dup
-					IL_0078: ldc.i4.0
-					IL_0079: ldarg.0
-					IL_007a: stelem.ref
-					IL_007b: ldc.i4.0
-					IL_007c: ldelem.ref
-					IL_007d: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_0082: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_008d: ldnull
-					IL_008e: ldloc.s 5
-					IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_0095: stloc.s 27
-					IL_0097: ldloc.s 27
-					IL_0099: ldstr "split"
-					IL_009e: ldstr "/"
-					IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00a8: stloc.s 27
-					IL_00aa: ldloc.s 26
-					IL_00ac: ldloc.s 27
-					IL_00ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_00b3: ldloc.s 26
-					IL_00b5: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_00ba: stloc.s 28
-					IL_00bc: ldloc.s 24
-					IL_00be: ldstr "join"
-					IL_00c3: ldloc.s 28
-					IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_00ca: stloc.s 24
-					IL_00cc: ldloc.s 24
-					IL_00ce: stloc.s 7
-					IL_00d0: ldarg.0
-					IL_00d1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_00d6: ldstr "Cannot access 'fs' before initialization"
-					IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_00e0: stloc.s 24
-					IL_00e2: ldloc.s 24
-					IL_00e4: ldstr "existsSync"
-					IL_00e9: ldloc.s 7
-					IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00f0: stloc.s 24
-					IL_00f2: ldloc.s 24
-					IL_00f4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_00f9: ldc.i4.0
-					IL_00fa: ceq
-					IL_00fc: stloc.s 25
-					IL_00fe: ldloc.s 25
-					IL_0100: box [System.Runtime]System.Boolean
-					IL_0105: stloc.s 29
-					IL_0107: ldloc.s 29
-					IL_0109: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_010e: stloc.s 25
-					IL_0110: ldloc.s 25
-					IL_0112: brtrue IL_0165
+					IL_0056: stloc.s 24
+					IL_0058: ldc.i4.1
+					IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_005e: dup
+					IL_005f: ldarg.2
+					IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_0065: stloc.s 26
+					IL_0067: ldc.i4.1
+					IL_0068: newarr [System.Runtime]System.Object
+					IL_006d: dup
+					IL_006e: ldc.i4.0
+					IL_006f: ldarg.0
+					IL_0070: stelem.ref
+					IL_0071: ldc.i4.0
+					IL_0072: ldelem.ref
+					IL_0073: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_0078: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_007e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_0083: ldnull
+					IL_0084: ldloc.s 5
+					IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+					IL_008b: stloc.s 27
+					IL_008d: ldloc.s 27
+					IL_008f: ldstr "split"
+					IL_0094: ldstr "/"
+					IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_009e: stloc.s 27
+					IL_00a0: ldloc.s 26
+					IL_00a2: ldloc.s 27
+					IL_00a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00a9: ldloc.s 26
+					IL_00ab: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00b0: stloc.s 28
+					IL_00b2: ldloc.s 24
+					IL_00b4: ldstr "join"
+					IL_00b9: ldloc.s 28
+					IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_00c0: stloc.s 24
+					IL_00c2: ldloc.s 24
+					IL_00c4: stloc.s 7
+					IL_00c6: ldarg.0
+					IL_00c7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00cc: ldstr "existsSync"
+					IL_00d1: ldloc.s 7
+					IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00d8: stloc.s 24
+					IL_00da: ldloc.s 24
+					IL_00dc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_00e1: ldc.i4.0
+					IL_00e2: ceq
+					IL_00e4: stloc.s 25
+					IL_00e6: ldloc.s 25
+					IL_00e8: box [System.Runtime]System.Boolean
+					IL_00ed: stloc.s 29
+					IL_00ef: ldloc.s 29
+					IL_00f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00f6: stloc.s 25
+					IL_00f8: ldloc.s 25
+					IL_00fa: brtrue IL_013f
 
-					IL_0117: ldarg.0
-					IL_0118: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_011d: ldstr "Cannot access 'fs' before initialization"
-					IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0127: stloc.s 24
-					IL_0129: ldloc.s 24
-					IL_012b: ldstr "statSync"
-					IL_0130: ldloc.s 7
-					IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0137: stloc.s 24
-					IL_0139: ldloc.s 24
-					IL_013b: ldstr "isFile"
-					IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0145: stloc.s 24
-					IL_0147: ldloc.s 24
-					IL_0149: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_014e: ldc.i4.0
-					IL_014f: ceq
-					IL_0151: stloc.s 25
-					IL_0153: ldloc.s 25
-					IL_0155: box [System.Runtime]System.Boolean
-					IL_015a: stloc.s 30
-					IL_015c: ldloc.s 30
-					IL_015e: stloc.s 32
-					IL_0160: br IL_0169
+					IL_00ff: ldarg.0
+					IL_0100: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0105: ldstr "statSync"
+					IL_010a: ldloc.s 7
+					IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0111: stloc.s 24
+					IL_0113: ldloc.s 24
+					IL_0115: ldstr "isFile"
+					IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_011f: stloc.s 24
+					IL_0121: ldloc.s 24
+					IL_0123: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0128: ldc.i4.0
+					IL_0129: ceq
+					IL_012b: stloc.s 25
+					IL_012d: ldloc.s 25
+					IL_012f: box [System.Runtime]System.Boolean
+					IL_0134: stloc.s 30
+					IL_0136: ldloc.s 30
+					IL_0138: stloc.s 32
+					IL_013a: br IL_0143
 
-					IL_0165: ldloc.s 29
-					IL_0167: stloc.s 32
+					IL_013f: ldloc.s 29
+					IL_0141: stloc.s 32
 
-					IL_0169: ldloc.s 32
-					IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0170: stloc.s 25
-					IL_0172: ldloc.s 25
-					IL_0174: brfalse IL_0189
+					IL_0143: ldloc.s 32
+					IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_014a: stloc.s 25
+					IL_014c: ldloc.s 25
+					IL_014e: brfalse IL_0163
 
-					IL_0179: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44/Block_L266C69::.ctor()
-					IL_017e: stloc.s 8
-					IL_0180: ldloc.0
-					IL_0181: ldloc.s 5
-					IL_0183: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0188: pop
+					IL_0153: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44/Block_L266C69::.ctor()
+					IL_0158: stloc.s 8
+					IL_015a: ldloc.0
+					IL_015b: ldloc.s 5
+					IL_015d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0162: pop
 
-					IL_0189: br IL_0024
+					IL_0163: br IL_0024
 				// end loop
-				IL_018e: ldloc.2
-				IL_018f: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0194: ldc.i4.1
-				IL_0195: stloc.s 4
-				IL_0197: leave IL_01b7
+				IL_0168: ldloc.2
+				IL_0169: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_016e: ldc.i4.1
+				IL_016f: stloc.s 4
+				IL_0171: leave IL_0191
 
-				IL_019c: ldc.i4.1
-				IL_019d: stloc.3
-				IL_019e: leave IL_01b7
+				IL_0176: ldc.i4.1
+				IL_0177: stloc.3
+				IL_0178: leave IL_0191
 			} // end .try
 			finally
 			{
-				IL_01a3: ldloc.3
-				IL_01a4: brtrue IL_01b6
+				IL_017d: ldloc.3
+				IL_017e: brtrue IL_0190
 
-				IL_01a9: ldloc.s 4
-				IL_01ab: brtrue IL_01b6
+				IL_0183: ldloc.s 4
+				IL_0185: brtrue IL_0190
 
-				IL_01b0: ldloc.2
-				IL_01b1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_018a: ldloc.2
+				IL_018b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
 
-				IL_01b6: endfinally
+				IL_0190: endfinally
 			} // end handler
 
-			IL_01b7: ldarg.3
-			IL_01b8: ldstr "requiredDirectories"
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_01c7: stloc.s 9
-			IL_01c9: ldc.i4.0
-			IL_01ca: stloc.s 10
-			IL_01cc: ldc.i4.0
-			IL_01cd: stloc.s 11
+			IL_0191: ldarg.3
+			IL_0192: ldstr "requiredDirectories"
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019c: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_01a1: stloc.s 9
+			IL_01a3: ldc.i4.0
+			IL_01a4: stloc.s 10
+			IL_01a6: ldc.i4.0
+			IL_01a7: stloc.s 11
 			.try
 			{
-				// loop start (head: IL_01cf)
-					IL_01cf: ldloc.s 9
-					IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_01d6: stloc.s 24
-					IL_01d8: ldloc.s 24
-					IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_01df: stloc.s 25
-					IL_01e1: ldloc.s 25
-					IL_01e3: brtrue IL_0349
+				// loop start (head: IL_01a9)
+					IL_01a9: ldloc.s 9
+					IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_01b0: stloc.s 24
+					IL_01b2: ldloc.s 24
+					IL_01b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_01b9: stloc.s 25
+					IL_01bb: ldloc.s 25
+					IL_01bd: brtrue IL_02fd
 
-					IL_01e8: ldloc.s 24
-					IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_01ef: stloc.s 24
-					IL_01f1: ldloc.s 24
-					IL_01f3: stloc.s 12
-					IL_01f5: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
-					IL_01fa: stloc.s 13
-					IL_01fc: ldarg.0
-					IL_01fd: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_0202: ldstr "Cannot access 'path' before initialization"
-					IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_020c: stloc.s 24
-					IL_020e: ldc.i4.1
-					IL_020f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0214: dup
-					IL_0215: ldarg.2
-					IL_0216: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_021b: stloc.s 26
-					IL_021d: ldc.i4.1
-					IL_021e: newarr [System.Runtime]System.Object
-					IL_0223: dup
-					IL_0224: ldc.i4.0
-					IL_0225: ldarg.0
-					IL_0226: stelem.ref
-					IL_0227: ldc.i4.0
-					IL_0228: ldelem.ref
-					IL_0229: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_022e: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_0234: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_0239: ldnull
-					IL_023a: ldloc.s 12
-					IL_023c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_0241: stloc.s 27
-					IL_0243: ldloc.s 27
-					IL_0245: ldstr "split"
-					IL_024a: ldstr "/"
-					IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0254: stloc.s 27
-					IL_0256: ldloc.s 26
-					IL_0258: ldloc.s 27
-					IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_025f: ldloc.s 26
-					IL_0261: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_0266: stloc.s 28
-					IL_0268: ldloc.s 24
-					IL_026a: ldstr "join"
-					IL_026f: ldloc.s 28
-					IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_0276: stloc.s 24
-					IL_0278: ldloc.s 24
-					IL_027a: stloc.s 14
-					IL_027c: ldarg.0
-					IL_027d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0282: ldstr "Cannot access 'fs' before initialization"
-					IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_028c: stloc.s 24
-					IL_028e: ldloc.s 24
-					IL_0290: ldstr "existsSync"
-					IL_0295: ldloc.s 14
-					IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_029c: stloc.s 24
-					IL_029e: ldloc.s 24
-					IL_02a0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_02a5: ldc.i4.0
-					IL_02a6: ceq
-					IL_02a8: stloc.s 25
-					IL_02aa: ldloc.s 25
-					IL_02ac: box [System.Runtime]System.Boolean
-					IL_02b1: stloc.s 29
-					IL_02b3: ldloc.s 29
-					IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02ba: stloc.s 25
-					IL_02bc: ldloc.s 25
-					IL_02be: brtrue IL_0311
+					IL_01c2: ldloc.s 24
+					IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_01c9: stloc.s 24
+					IL_01cb: ldloc.s 24
+					IL_01cd: stloc.s 12
+					IL_01cf: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
+					IL_01d4: stloc.s 13
+					IL_01d6: ldarg.0
+					IL_01d7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_01dc: stloc.s 24
+					IL_01de: ldc.i4.1
+					IL_01df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_01e4: dup
+					IL_01e5: ldarg.2
+					IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_01eb: stloc.s 26
+					IL_01ed: ldc.i4.1
+					IL_01ee: newarr [System.Runtime]System.Object
+					IL_01f3: dup
+					IL_01f4: ldc.i4.0
+					IL_01f5: ldarg.0
+					IL_01f6: stelem.ref
+					IL_01f7: ldc.i4.0
+					IL_01f8: ldelem.ref
+					IL_01f9: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_01fe: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_0204: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_0209: ldnull
+					IL_020a: ldloc.s 12
+					IL_020c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+					IL_0211: stloc.s 27
+					IL_0213: ldloc.s 27
+					IL_0215: ldstr "split"
+					IL_021a: ldstr "/"
+					IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0224: stloc.s 27
+					IL_0226: ldloc.s 26
+					IL_0228: ldloc.s 27
+					IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_022f: ldloc.s 26
+					IL_0231: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_0236: stloc.s 28
+					IL_0238: ldloc.s 24
+					IL_023a: ldstr "join"
+					IL_023f: ldloc.s 28
+					IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_0246: stloc.s 24
+					IL_0248: ldloc.s 24
+					IL_024a: stloc.s 14
+					IL_024c: ldarg.0
+					IL_024d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0252: ldstr "existsSync"
+					IL_0257: ldloc.s 14
+					IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_025e: stloc.s 24
+					IL_0260: ldloc.s 24
+					IL_0262: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0267: ldc.i4.0
+					IL_0268: ceq
+					IL_026a: stloc.s 25
+					IL_026c: ldloc.s 25
+					IL_026e: box [System.Runtime]System.Boolean
+					IL_0273: stloc.s 29
+					IL_0275: ldloc.s 29
+					IL_0277: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_027c: stloc.s 25
+					IL_027e: ldloc.s 25
+					IL_0280: brtrue IL_02c5
 
-					IL_02c3: ldarg.0
-					IL_02c4: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_02c9: ldstr "Cannot access 'fs' before initialization"
-					IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_02d3: stloc.s 24
-					IL_02d5: ldloc.s 24
-					IL_02d7: ldstr "statSync"
-					IL_02dc: ldloc.s 14
-					IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_02e3: stloc.s 24
-					IL_02e5: ldloc.s 24
-					IL_02e7: ldstr "isDirectory"
-					IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02f1: stloc.s 24
-					IL_02f3: ldloc.s 24
-					IL_02f5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_02fa: ldc.i4.0
-					IL_02fb: ceq
-					IL_02fd: stloc.s 25
-					IL_02ff: ldloc.s 25
-					IL_0301: box [System.Runtime]System.Boolean
-					IL_0306: stloc.s 30
-					IL_0308: ldloc.s 30
-					IL_030a: stloc.s 33
-					IL_030c: br IL_0315
+					IL_0285: ldarg.0
+					IL_0286: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_028b: ldstr "statSync"
+					IL_0290: ldloc.s 14
+					IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0297: stloc.s 24
+					IL_0299: ldloc.s 24
+					IL_029b: ldstr "isDirectory"
+					IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02a5: stloc.s 24
+					IL_02a7: ldloc.s 24
+					IL_02a9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_02ae: ldc.i4.0
+					IL_02af: ceq
+					IL_02b1: stloc.s 25
+					IL_02b3: ldloc.s 25
+					IL_02b5: box [System.Runtime]System.Boolean
+					IL_02ba: stloc.s 30
+					IL_02bc: ldloc.s 30
+					IL_02be: stloc.s 33
+					IL_02c0: br IL_02c9
 
-					IL_0311: ldloc.s 29
-					IL_0313: stloc.s 33
+					IL_02c5: ldloc.s 29
+					IL_02c7: stloc.s 33
 
-					IL_0315: ldloc.s 33
-					IL_0317: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_031c: stloc.s 25
-					IL_031e: ldloc.s 25
-					IL_0320: brfalse IL_0335
+					IL_02c9: ldloc.s 33
+					IL_02cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02d0: stloc.s 25
+					IL_02d2: ldloc.s 25
+					IL_02d4: brfalse IL_02e9
 
-					IL_0325: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55/Block_L273C74::.ctor()
-					IL_032a: stloc.s 15
-					IL_032c: ldloc.1
-					IL_032d: ldloc.s 12
-					IL_032f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0334: pop
+					IL_02d9: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55/Block_L273C74::.ctor()
+					IL_02de: stloc.s 15
+					IL_02e0: ldloc.1
+					IL_02e1: ldloc.s 12
+					IL_02e3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02e8: pop
 
-					IL_0335: br IL_01cf
+					IL_02e9: br IL_01a9
 				// end loop
-				IL_033a: ldloc.s 9
-				IL_033c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0341: ldc.i4.1
-				IL_0342: stloc.s 11
-				IL_0344: leave IL_0367
+				IL_02ee: ldloc.s 9
+				IL_02f0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_02f5: ldc.i4.1
+				IL_02f6: stloc.s 11
+				IL_02f8: leave IL_031b
 
-				IL_0349: ldc.i4.1
-				IL_034a: stloc.s 10
-				IL_034c: leave IL_0367
+				IL_02fd: ldc.i4.1
+				IL_02fe: stloc.s 10
+				IL_0300: leave IL_031b
 			} // end .try
 			finally
 			{
-				IL_0351: ldloc.s 10
-				IL_0353: brtrue IL_0366
+				IL_0305: ldloc.s 10
+				IL_0307: brtrue IL_031a
 
-				IL_0358: ldloc.s 11
-				IL_035a: brtrue IL_0366
+				IL_030c: ldloc.s 11
+				IL_030e: brtrue IL_031a
 
-				IL_035f: ldloc.s 9
-				IL_0361: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0313: ldloc.s 9
+				IL_0315: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
 
-				IL_0366: endfinally
+				IL_031a: endfinally
 			} // end handler
 
-			IL_0367: ldloc.0
-			IL_0368: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_036d: conv.r8
-			IL_036e: ldc.r8 0.0
-			IL_0377: cgt
-			IL_0379: box [System.Runtime]System.Boolean
-			IL_037e: stloc.s 29
-			IL_0380: ldloc.s 29
-			IL_0382: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0387: stloc.s 25
-			IL_0389: ldloc.s 25
-			IL_038b: brtrue IL_03ae
+			IL_031b: ldloc.0
+			IL_031c: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0321: conv.r8
+			IL_0322: ldc.r8 0.0
+			IL_032b: cgt
+			IL_032d: box [System.Runtime]System.Boolean
+			IL_0332: stloc.s 29
+			IL_0334: ldloc.s 29
+			IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_033b: stloc.s 25
+			IL_033d: ldloc.s 25
+			IL_033f: brtrue IL_0362
 
-			IL_0390: ldloc.1
-			IL_0391: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0396: conv.r8
-			IL_0397: ldc.r8 0.0
-			IL_03a0: cgt
-			IL_03a2: box [System.Runtime]System.Boolean
-			IL_03a7: stloc.s 34
-			IL_03a9: br IL_03b2
+			IL_0344: ldloc.1
+			IL_0345: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_034a: conv.r8
+			IL_034b: ldc.r8 0.0
+			IL_0354: cgt
+			IL_0356: box [System.Runtime]System.Boolean
+			IL_035b: stloc.s 34
+			IL_035d: br IL_0366
 
-			IL_03ae: ldloc.s 29
-			IL_03b0: stloc.s 34
+			IL_0362: ldloc.s 29
+			IL_0364: stloc.s 34
 
-			IL_03b2: ldloc.s 34
-			IL_03b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03b9: stloc.s 25
-			IL_03bb: ldloc.s 25
-			IL_03bd: brfalse IL_04b5
+			IL_0366: ldloc.s 34
+			IL_0368: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_036d: stloc.s 25
+			IL_036f: ldloc.s 25
+			IL_0371: brfalse IL_0469
 
-			IL_03c2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
-			IL_03c7: stloc.s 16
-			IL_03c9: ldc.i4.0
-			IL_03ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03cf: stloc.s 17
-			IL_03d1: ldloc.0
-			IL_03d2: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_03d7: conv.r8
-			IL_03d8: ldc.r8 0.0
-			IL_03e1: cgt
-			IL_03e3: brfalse IL_0426
+			IL_0376: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
+			IL_037b: stloc.s 16
+			IL_037d: ldc.i4.0
+			IL_037e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0383: stloc.s 17
+			IL_0385: ldloc.0
+			IL_0386: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_038b: conv.r8
+			IL_038c: ldc.r8 0.0
+			IL_0395: cgt
+			IL_0397: brfalse IL_03da
 
-			IL_03e8: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L280C33::.ctor()
-			IL_03ed: stloc.s 18
-			IL_03ef: ldloc.0
-			IL_03f0: ldc.i4.1
-			IL_03f1: newarr [System.Runtime]System.Object
-			IL_03f6: dup
-			IL_03f7: ldc.i4.0
-			IL_03f8: ldstr ", "
-			IL_03fd: stelem.ref
-			IL_03fe: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0403: stloc.s 35
-			IL_0405: ldloc.s 35
-			IL_0407: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_039c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L280C33::.ctor()
+			IL_03a1: stloc.s 18
+			IL_03a3: ldloc.0
+			IL_03a4: ldc.i4.1
+			IL_03a5: newarr [System.Runtime]System.Object
+			IL_03aa: dup
+			IL_03ab: ldc.i4.0
+			IL_03ac: ldstr ", "
+			IL_03b1: stelem.ref
+			IL_03b2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03b7: stloc.s 35
+			IL_03b9: ldloc.s 35
+			IL_03bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03c0: stloc.s 35
+			IL_03c2: ldstr "missing files: "
+			IL_03c7: ldloc.s 35
+			IL_03c9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03ce: stloc.s 35
+			IL_03d0: ldloc.s 17
+			IL_03d2: ldloc.s 35
+			IL_03d4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03d9: pop
+
+			IL_03da: ldloc.1
+			IL_03db: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_03e0: conv.r8
+			IL_03e1: ldc.r8 0.0
+			IL_03ea: cgt
+			IL_03ec: brfalse IL_042f
+
+			IL_03f1: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L283C39::.ctor()
+			IL_03f6: stloc.s 19
+			IL_03f8: ldloc.1
+			IL_03f9: ldc.i4.1
+			IL_03fa: newarr [System.Runtime]System.Object
+			IL_03ff: dup
+			IL_0400: ldc.i4.0
+			IL_0401: ldstr ", "
+			IL_0406: stelem.ref
+			IL_0407: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
 			IL_040c: stloc.s 35
-			IL_040e: ldstr "missing files: "
-			IL_0413: ldloc.s 35
-			IL_0415: call string [System.Runtime]System.String::Concat(string, string)
-			IL_041a: stloc.s 35
-			IL_041c: ldloc.s 17
-			IL_041e: ldloc.s 35
-			IL_0420: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0425: pop
+			IL_040e: ldloc.s 35
+			IL_0410: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0415: stloc.s 35
+			IL_0417: ldstr "missing directories: "
+			IL_041c: ldloc.s 35
+			IL_041e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0423: stloc.s 35
+			IL_0425: ldloc.s 17
+			IL_0427: ldloc.s 35
+			IL_0429: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_042e: pop
 
-			IL_0426: ldloc.1
-			IL_0427: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_042c: conv.r8
-			IL_042d: ldc.r8 0.0
-			IL_0436: cgt
-			IL_0438: brfalse IL_047b
-
-			IL_043d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L283C39::.ctor()
-			IL_0442: stloc.s 19
-			IL_0444: ldloc.1
-			IL_0445: ldc.i4.1
-			IL_0446: newarr [System.Runtime]System.Object
+			IL_042f: ldloc.s 17
+			IL_0431: ldc.i4.1
+			IL_0432: newarr [System.Runtime]System.Object
+			IL_0437: dup
+			IL_0438: ldc.i4.0
+			IL_0439: ldstr "; "
+			IL_043e: stelem.ref
+			IL_043f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0444: stloc.s 35
+			IL_0446: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_044b: dup
-			IL_044c: ldc.i4.0
-			IL_044d: ldstr ", "
-			IL_0452: stelem.ref
-			IL_0453: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0458: stloc.s 35
-			IL_045a: ldloc.s 35
-			IL_045c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0461: stloc.s 35
-			IL_0463: ldstr "missing directories: "
-			IL_0468: ldloc.s 35
-			IL_046a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_046f: stloc.s 35
-			IL_0471: ldloc.s 17
-			IL_0473: ldloc.s 35
-			IL_0475: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_047a: pop
+			IL_044c: ldstr "ok"
+			IL_0451: ldc.i4.0
+			IL_0452: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0457: dup
+			IL_0458: ldstr "message"
+			IL_045d: ldloc.s 35
+			IL_045f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0464: stloc.s 36
+			IL_0466: ldloc.s 36
+			IL_0468: ret
 
-			IL_047b: ldloc.s 17
-			IL_047d: ldc.i4.1
-			IL_047e: newarr [System.Runtime]System.Object
-			IL_0483: dup
-			IL_0484: ldc.i4.0
-			IL_0485: ldstr "; "
-			IL_048a: stelem.ref
-			IL_048b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0490: stloc.s 35
-			IL_0492: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0497: dup
-			IL_0498: ldstr "ok"
-			IL_049d: ldc.i4.0
-			IL_049e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04a3: dup
-			IL_04a4: ldstr "message"
-			IL_04a9: ldloc.s 35
-			IL_04ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04b0: stloc.s 36
-			IL_04b2: ldloc.s 36
-			IL_04b4: ret
+			IL_0469: ldarg.0
+			IL_046a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_046f: ldstr "join"
+			IL_0474: ldarg.2
+			IL_0475: ldstr "package.json"
+			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_047f: stloc.s 24
+			IL_0481: ldloc.s 24
+			IL_0483: stloc.s 20
+			IL_0485: ldarg.0
+			IL_0486: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_048b: ldstr "readFileSync"
+			IL_0490: ldloc.s 20
+			IL_0492: ldstr "utf8"
+			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_049c: stloc.s 24
+			IL_049e: ldloc.s 24
+			IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_04a5: stloc.s 24
+			IL_04a7: ldloc.s 24
+			IL_04a9: stloc.s 21
+			IL_04ab: ldloc.s 21
+			IL_04ad: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04b2: ldc.i4.0
+			IL_04b3: ceq
+			IL_04b5: stloc.s 25
+			IL_04b7: ldloc.s 25
+			IL_04b9: box [System.Runtime]System.Boolean
+			IL_04be: stloc.s 29
+			IL_04c0: ldloc.s 29
+			IL_04c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04c7: stloc.s 25
+			IL_04c9: ldloc.s 25
+			IL_04cb: brtrue IL_050e
 
-			IL_04b5: ldarg.0
-			IL_04b6: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_04bb: ldstr "Cannot access 'path' before initialization"
-			IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_04c5: stloc.s 24
-			IL_04c7: ldloc.s 24
-			IL_04c9: ldstr "join"
-			IL_04ce: ldarg.2
-			IL_04cf: ldstr "package.json"
-			IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04d9: stloc.s 24
-			IL_04db: ldloc.s 24
-			IL_04dd: stloc.s 20
-			IL_04df: ldarg.0
-			IL_04e0: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_04e5: ldstr "Cannot access 'fs' before initialization"
-			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_04ef: stloc.s 24
-			IL_04f1: ldloc.s 24
-			IL_04f3: ldstr "readFileSync"
-			IL_04f8: ldloc.s 20
-			IL_04fa: ldstr "utf8"
-			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0504: stloc.s 24
-			IL_0506: ldloc.s 24
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_050d: stloc.s 24
-			IL_050f: ldloc.s 24
-			IL_0511: stloc.s 21
-			IL_0513: ldloc.s 21
-			IL_0515: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_051a: ldc.i4.0
-			IL_051b: ceq
-			IL_051d: stloc.s 25
-			IL_051f: ldloc.s 25
-			IL_0521: box [System.Runtime]System.Boolean
-			IL_0526: stloc.s 29
-			IL_0528: ldloc.s 29
-			IL_052a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_052f: stloc.s 25
-			IL_0531: ldloc.s 25
-			IL_0533: brtrue IL_0576
+			IL_04d0: ldloc.s 21
+			IL_04d2: ldstr "version"
+			IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04dc: stloc.s 24
+			IL_04de: ldloc.s 24
+			IL_04e0: ldarg.3
+			IL_04e1: ldstr "upstream"
+			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04eb: ldstr "packageVersion"
+			IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_04fa: stloc.s 25
+			IL_04fc: ldloc.s 25
+			IL_04fe: box [System.Runtime]System.Boolean
+			IL_0503: stloc.s 30
+			IL_0505: ldloc.s 30
+			IL_0507: stloc.s 37
+			IL_0509: br IL_0512
 
-			IL_0538: ldloc.s 21
-			IL_053a: ldstr "version"
-			IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0544: stloc.s 24
-			IL_0546: ldloc.s 24
-			IL_0548: ldarg.3
-			IL_0549: ldstr "upstream"
-			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0553: ldstr "packageVersion"
-			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_055d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0562: stloc.s 25
-			IL_0564: ldloc.s 25
-			IL_0566: box [System.Runtime]System.Boolean
-			IL_056b: stloc.s 30
-			IL_056d: ldloc.s 30
-			IL_056f: stloc.s 37
-			IL_0571: br IL_057a
+			IL_050e: ldloc.s 29
+			IL_0510: stloc.s 37
 
-			IL_0576: ldloc.s 29
-			IL_0578: stloc.s 37
+			IL_0512: ldloc.s 37
+			IL_0514: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0519: stloc.s 25
+			IL_051b: ldloc.s 25
+			IL_051d: brfalse IL_05e9
 
-			IL_057a: ldloc.s 37
-			IL_057c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0581: stloc.s 25
-			IL_0583: ldloc.s 25
-			IL_0585: brfalse IL_0651
+			IL_0522: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L291C75::.ctor()
+			IL_0527: stloc.s 22
+			IL_0529: ldarg.3
+			IL_052a: ldstr "upstream"
+			IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0534: ldstr "packageVersion"
+			IL_0539: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_053e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0543: stloc.s 35
+			IL_0545: ldstr "package.json version mismatch: expected "
+			IL_054a: ldloc.s 35
+			IL_054c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0551: stloc.s 35
+			IL_0553: ldloc.s 35
+			IL_0555: ldstr ", got "
+			IL_055a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_055f: stloc.s 35
+			IL_0561: ldloc.s 21
+			IL_0563: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0568: stloc.s 25
+			IL_056a: ldloc.s 25
+			IL_056c: brfalse IL_0584
 
-			IL_058a: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L291C75::.ctor()
-			IL_058f: stloc.s 22
-			IL_0591: ldarg.3
-			IL_0592: ldstr "upstream"
-			IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_059c: ldstr "packageVersion"
-			IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05a6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05ab: stloc.s 35
-			IL_05ad: ldstr "package.json version mismatch: expected "
-			IL_05b2: ldloc.s 35
-			IL_05b4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05b9: stloc.s 35
+			IL_0571: ldloc.s 21
+			IL_0573: ldstr "version"
+			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057d: stloc.s 38
+			IL_057f: br IL_0588
+
+			IL_0584: ldloc.s 21
+			IL_0586: stloc.s 38
+
+			IL_0588: ldloc.s 38
+			IL_058a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_058f: stloc.s 25
+			IL_0591: ldloc.s 25
+			IL_0593: brfalse IL_05ab
+
+			IL_0598: ldloc.s 21
+			IL_059a: ldstr "version"
+			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05a4: stloc.s 23
+			IL_05a6: br IL_05b2
+
+			IL_05ab: ldstr "<missing>"
+			IL_05b0: stloc.s 23
+
+			IL_05b2: ldloc.s 23
+			IL_05b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05b9: stloc.s 39
 			IL_05bb: ldloc.s 35
-			IL_05bd: ldstr ", got "
-			IL_05c2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05c7: stloc.s 35
-			IL_05c9: ldloc.s 21
-			IL_05cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05d0: stloc.s 25
-			IL_05d2: ldloc.s 25
-			IL_05d4: brfalse IL_05ec
+			IL_05bd: ldloc.s 39
+			IL_05bf: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05c4: stloc.s 39
+			IL_05c6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05cb: dup
+			IL_05cc: ldstr "ok"
+			IL_05d1: ldc.i4.0
+			IL_05d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05d7: dup
+			IL_05d8: ldstr "message"
+			IL_05dd: ldloc.s 39
+			IL_05df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05e4: stloc.s 36
+			IL_05e6: ldloc.s 36
+			IL_05e8: ret
 
-			IL_05d9: ldloc.s 21
-			IL_05db: ldstr "version"
-			IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e5: stloc.s 38
-			IL_05e7: br IL_05f0
-
-			IL_05ec: ldloc.s 21
-			IL_05ee: stloc.s 38
-
-			IL_05f0: ldloc.s 38
-			IL_05f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05f7: stloc.s 25
-			IL_05f9: ldloc.s 25
-			IL_05fb: brfalse IL_0613
-
-			IL_0600: ldloc.s 21
-			IL_0602: ldstr "version"
-			IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_060c: stloc.s 23
-			IL_060e: br IL_061a
-
-			IL_0613: ldstr "<missing>"
-			IL_0618: stloc.s 23
-
-			IL_061a: ldloc.s 23
-			IL_061c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0621: stloc.s 39
-			IL_0623: ldloc.s 35
-			IL_0625: ldloc.s 39
-			IL_0627: call string [System.Runtime]System.String::Concat(string, string)
-			IL_062c: stloc.s 39
-			IL_062e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0633: dup
-			IL_0634: ldstr "ok"
-			IL_0639: ldc.i4.0
-			IL_063a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_063f: dup
-			IL_0640: ldstr "message"
-			IL_0645: ldloc.s 39
-			IL_0647: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_064c: stloc.s 36
-			IL_064e: ldloc.s 36
-			IL_0650: ret
-
-			IL_0651: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0656: dup
-			IL_0657: ldstr "ok"
-			IL_065c: ldc.i4.1
-			IL_065d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0662: dup
-			IL_0663: ldstr "message"
-			IL_0668: ldstr ""
-			IL_066d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0672: ret
+			IL_05e9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05ee: dup
+			IL_05ef: ldstr "ok"
+			IL_05f4: ldc.i4.1
+			IL_05f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05fa: dup
+			IL_05fb: ldstr "message"
+			IL_0600: ldstr ""
+			IL_0605: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_060a: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -4711,7 +4651,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x51a6
+						// Method begins at RVA 0x50a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4729,7 +4669,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x519d
+					// Method begins at RVA 0x5098
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4749,7 +4689,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51af
+					// Method begins at RVA 0x50aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4767,7 +4707,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5194
+				// Method begins at RVA 0x508f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4796,7 +4736,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x45a8
+			// Method begins at RVA 0x44c4
 			// Header size: 12
 			// Code size: 1134 (0x46e)
 			.maxstack 8
@@ -5245,7 +5185,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x51ca
+						// Method begins at RVA 0x50c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5263,7 +5203,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51c1
+					// Method begins at RVA 0x50bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5281,7 +5221,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51b8
+				// Method begins at RVA 0x50b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5310,7 +5250,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4a24
+			// Method begins at RVA 0x4940
 			// Header size: 12
 			// Code size: 426 (0x1aa)
 			.maxstack 8
@@ -5504,7 +5444,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51dc
+					// Method begins at RVA 0x50d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5522,7 +5462,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51d3
+				// Method begins at RVA 0x50ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5551,7 +5491,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4bdc
+			// Method begins at RVA 0x4af8
 			// Header size: 12
 			// Code size: 356 (0x164)
 			.maxstack 8
@@ -5708,7 +5648,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51ee
+					// Method begins at RVA 0x50e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5728,7 +5668,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51f7
+					// Method begins at RVA 0x50f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5746,7 +5686,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51e5
+				// Method begins at RVA 0x50e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5772,7 +5712,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4d4c
+			// Method begins at RVA 0x4c68
 			// Header size: 12
 			// Code size: 511 (0x1ff)
 			.maxstack 8
@@ -6027,7 +5967,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5209
+					// Method begins at RVA 0x5104
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6047,7 +5987,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5212
+					// Method begins at RVA 0x510d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6065,7 +6005,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5200
+				// Method begins at RVA 0x50fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6113,24 +6053,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4f57
+			// Method begins at RVA 0x4e73
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -6823,7 +6754,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x521b
+		// Method begins at RVA 0x5116
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Js2IL.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63a3
+				// Method begins at RVA 0x6343
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +121,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63b5
+					// Method begins at RVA 0x6355
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -141,7 +141,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63be
+					// Method begins at RVA 0x635e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -161,7 +161,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63c7
+					// Method begins at RVA 0x6367
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -179,7 +179,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63ac
+				// Method begins at RVA 0x634c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -285,7 +285,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63d9
+					// Method begins at RVA 0x6379
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -303,7 +303,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63d0
+				// Method begins at RVA 0x6370
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -429,7 +429,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63eb
+					// Method begins at RVA 0x638b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -447,7 +447,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63e2
+				// Method begins at RVA 0x6382
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -596,7 +596,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63f4
+				// Method begins at RVA 0x6394
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2197,7 +2197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x639a
+			// Method begins at RVA 0x633a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2532,7 +2532,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x643d
+				// Method begins at RVA 0x63a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2613,7 +2613,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6458
+						// Method begins at RVA 0x63c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2631,7 +2631,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x644f
+					// Method begins at RVA 0x63b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2649,7 +2649,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6446
+				// Method begins at RVA 0x63af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2781,7 +2781,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6473
+						// Method begins at RVA 0x63dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2799,7 +2799,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x646a
+					// Method begins at RVA 0x63d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2817,7 +2817,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6461
+				// Method begins at RVA 0x63ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2997,7 +2997,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6485
+					// Method begins at RVA 0x63ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3015,7 +3015,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x647c
+				// Method begins at RVA 0x63e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3043,7 +3043,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64a0
+						// Method begins at RVA 0x6409
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3061,7 +3061,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6497
+					// Method begins at RVA 0x6400
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3079,7 +3079,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x648e
+				// Method begins at RVA 0x63f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3242,7 +3242,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64b2
+					// Method begins at RVA 0x641b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3260,7 +3260,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64a9
+				// Method begins at RVA 0x6412
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3388,7 +3388,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64bb
+				// Method begins at RVA 0x6424
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3416,7 +3416,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64d6
+						// Method begins at RVA 0x643f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3436,7 +3436,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64df
+						// Method begins at RVA 0x6448
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3456,7 +3456,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64e8
+						// Method begins at RVA 0x6451
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3476,7 +3476,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64f1
+						// Method begins at RVA 0x645a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3494,7 +3494,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64cd
+					// Method begins at RVA 0x6436
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3512,7 +3512,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64c4
+				// Method begins at RVA 0x642d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3693,7 +3693,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x650c
+						// Method begins at RVA 0x6475
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3713,7 +3713,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6515
+						// Method begins at RVA 0x647e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3733,7 +3733,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x651e
+						// Method begins at RVA 0x6487
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3751,7 +3751,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6503
+					// Method begins at RVA 0x646c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3769,7 +3769,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64fa
+				// Method begins at RVA 0x6463
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4016,7 +4016,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6530
+					// Method begins at RVA 0x6499
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4036,7 +4036,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6539
+					// Method begins at RVA 0x64a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4056,7 +4056,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6542
+					// Method begins at RVA 0x64ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4074,7 +4074,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6527
+				// Method begins at RVA 0x6490
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4312,7 +4312,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x655d
+						// Method begins at RVA 0x64c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4332,7 +4332,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6566
+						// Method begins at RVA 0x64cf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4352,7 +4352,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x656f
+						// Method begins at RVA 0x64d8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4372,7 +4372,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6578
+						// Method begins at RVA 0x64e1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4392,7 +4392,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6581
+						// Method begins at RVA 0x64ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4412,7 +4412,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x658a
+						// Method begins at RVA 0x64f3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4432,7 +4432,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6593
+						// Method begins at RVA 0x64fc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4450,7 +4450,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6554
+					// Method begins at RVA 0x64bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4468,7 +4468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x654b
+				// Method begins at RVA 0x64b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4886,7 +4886,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x659c
+				// Method begins at RVA 0x6505
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4979,7 +4979,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65ae
+					// Method begins at RVA 0x6517
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4999,7 +4999,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65b7
+					// Method begins at RVA 0x6520
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5019,7 +5019,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65c0
+					// Method begins at RVA 0x6529
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5037,7 +5037,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65a5
+				// Method begins at RVA 0x650e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5197,7 +5197,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65c9
+				// Method begins at RVA 0x6532
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5277,7 +5277,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65db
+					// Method begins at RVA 0x6544
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5295,7 +5295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65d2
+				// Method begins at RVA 0x653b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5396,7 +5396,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65e4
+				// Method begins at RVA 0x654d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5466,7 +5466,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65ed
+				// Method begins at RVA 0x6556
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5536,7 +5536,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65ff
+					// Method begins at RVA 0x6568
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5556,7 +5556,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6608
+					// Method begins at RVA 0x6571
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5574,7 +5574,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65f6
+				// Method begins at RVA 0x655f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5602,7 +5602,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6623
+						// Method begins at RVA 0x658c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5620,7 +5620,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x661a
+					// Method begins at RVA 0x6583
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5638,7 +5638,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6611
+				// Method begins at RVA 0x657a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5861,7 +5861,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6635
+					// Method begins at RVA 0x659e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5881,7 +5881,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x663e
+					// Method begins at RVA 0x65a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5899,7 +5899,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x662c
+				// Method begins at RVA 0x6595
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6054,7 +6054,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6650
+					// Method begins at RVA 0x65b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6074,7 +6074,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6659
+					// Method begins at RVA 0x65c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6094,7 +6094,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6662
+					// Method begins at RVA 0x65cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6114,7 +6114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6686
+					// Method begins at RVA 0x65ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6132,7 +6132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6647
+				// Method begins at RVA 0x65b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6160,7 +6160,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x667d
+						// Method begins at RVA 0x65e6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6178,7 +6178,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6674
+					// Method begins at RVA 0x65dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6196,7 +6196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x666b
+				// Method begins at RVA 0x65d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6659,7 +6659,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66bc
+						// Method begins at RVA 0x6625
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6679,7 +6679,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66c5
+						// Method begins at RVA 0x662e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6699,7 +6699,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66ce
+						// Method begins at RVA 0x6637
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6717,7 +6717,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66b3
+					// Method begins at RVA 0x661c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6737,7 +6737,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66d7
+					// Method begins at RVA 0x6640
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6757,7 +6757,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66e0
+					// Method begins at RVA 0x6649
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6775,7 +6775,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x668f
+				// Method begins at RVA 0x65f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6803,7 +6803,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66aa
+						// Method begins at RVA 0x6613
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6821,7 +6821,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66a1
+					// Method begins at RVA 0x660a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6839,7 +6839,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6698
+				// Method begins at RVA 0x6601
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6867,7 +6867,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66fb
+						// Method begins at RVA 0x6664
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6885,7 +6885,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66f2
+					// Method begins at RVA 0x665b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6903,7 +6903,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66e9
+				// Method begins at RVA 0x6652
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6934,7 +6934,7 @@
 			)
 			// Method begins at RVA 0x53c0
 			// Header size: 12
-			// Code size: 1478 (0x5c6)
+			// Code size: 1425 (0x591)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6976,13 +6976,14 @@
 				[36] object,
 				[37] object,
 				[38] object,
-				[39] object,
+				[39] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[40] object,
-				[41] bool,
-				[42] object,
+				[41] object,
+				[42] bool,
 				[43] object,
 				[44] object,
-				[45] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[45] object,
+				[46] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldnull
@@ -7206,310 +7207,297 @@
 			IL_0271: ldc.i4.0
 			IL_0272: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0277: stloc.s 19
-			IL_0279: br IL_02a2
+			IL_0279: br IL_028f
 
 			IL_027e: ldarg.0
-			IL_027f: ldfld object Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
-			IL_0284: ldstr "Cannot access 'DEFAULT_HARNESS_INCLUDES' before initialization"
-			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_028e: stloc.s 31
-			IL_0290: ldloc.s 31
-			IL_0292: ldstr "slice"
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_029c: stloc.s 31
-			IL_029e: ldloc.s 31
-			IL_02a0: stloc.s 19
+			IL_027f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
+			IL_0284: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_0289: stloc.s 39
+			IL_028b: ldloc.s 39
+			IL_028d: stloc.s 19
 
-			IL_02a2: ldloc.s 19
-			IL_02a4: stloc.s 20
-			IL_02a6: ldloc.s 20
-			IL_02a8: ldstr "slice"
-			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02b2: stloc.s 31
-			IL_02b4: ldloc.s 31
-			IL_02b6: stloc.s 21
-			IL_02b8: ldloc.2
-			IL_02b9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02be: stloc.s 33
-			IL_02c0: ldloc.s 33
-			IL_02c2: brfalse IL_02e4
+			IL_028f: ldloc.s 19
+			IL_0291: stloc.s 20
+			IL_0293: ldloc.s 20
+			IL_0295: ldstr "slice"
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_029f: stloc.s 31
+			IL_02a1: ldloc.s 31
+			IL_02a3: stloc.s 21
+			IL_02a5: ldloc.2
+			IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02ab: stloc.s 33
+			IL_02ad: ldloc.s 33
+			IL_02af: brfalse IL_02d1
 
-			IL_02c7: ldloc.1
-			IL_02c8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02cd: ldc.i4.0
-			IL_02ce: ceq
-			IL_02d0: stloc.s 33
-			IL_02d2: ldloc.s 33
-			IL_02d4: box [System.Runtime]System.Boolean
-			IL_02d9: stloc.s 35
-			IL_02db: ldloc.s 35
-			IL_02dd: stloc.s 39
-			IL_02df: br IL_02e7
+			IL_02b4: ldloc.1
+			IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02ba: ldc.i4.0
+			IL_02bb: ceq
+			IL_02bd: stloc.s 33
+			IL_02bf: ldloc.s 33
+			IL_02c1: box [System.Runtime]System.Boolean
+			IL_02c6: stloc.s 35
+			IL_02c8: ldloc.s 35
+			IL_02ca: stloc.s 40
+			IL_02cc: br IL_02d4
 
-			IL_02e4: ldloc.2
-			IL_02e5: stloc.s 39
+			IL_02d1: ldloc.2
+			IL_02d2: stloc.s 40
 
-			IL_02e7: ldloc.s 39
-			IL_02e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02ee: stloc.s 33
-			IL_02f0: ldloc.s 33
-			IL_02f2: brfalse IL_0333
+			IL_02d4: ldloc.s 40
+			IL_02d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02db: stloc.s 33
+			IL_02dd: ldloc.s 33
+			IL_02df: brfalse IL_0316
 
-			IL_02f7: ldarg.0
-			IL_02f8: ldfld object Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_02fd: ldstr "Cannot access 'ASYNC_HARNESS_INCLUDE' before initialization"
-			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0307: stloc.s 31
-			IL_0309: ldnull
-			IL_030a: ldloc.s 21
-			IL_030c: ldloc.s 31
-			IL_030e: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_0313: stloc.s 31
-			IL_0315: ldloc.s 31
-			IL_0317: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_031c: ldc.i4.0
-			IL_031d: ceq
-			IL_031f: stloc.s 33
-			IL_0321: ldloc.s 33
-			IL_0323: box [System.Runtime]System.Boolean
-			IL_0328: stloc.s 35
-			IL_032a: ldloc.s 35
-			IL_032c: stloc.s 39
-			IL_032e: br IL_0333
+			IL_02e4: ldarg.0
+			IL_02e5: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_02ea: stloc.s 31
+			IL_02ec: ldnull
+			IL_02ed: ldloc.s 21
+			IL_02ef: ldloc.s 31
+			IL_02f1: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_02f6: stloc.s 31
+			IL_02f8: ldloc.s 31
+			IL_02fa: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02ff: ldc.i4.0
+			IL_0300: ceq
+			IL_0302: stloc.s 33
+			IL_0304: ldloc.s 33
+			IL_0306: box [System.Runtime]System.Boolean
+			IL_030b: stloc.s 35
+			IL_030d: ldloc.s 35
+			IL_030f: stloc.s 40
+			IL_0311: br IL_0316
 
-			IL_0333: ldloc.s 39
-			IL_0335: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_033a: stloc.s 33
-			IL_033c: ldloc.s 33
-			IL_033e: brfalse IL_036b
+			IL_0316: ldloc.s 40
+			IL_0318: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_031d: stloc.s 33
+			IL_031f: ldloc.s 33
+			IL_0321: brfalse IL_0340
 
-			IL_0343: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L360C78::.ctor()
-			IL_0348: stloc.s 22
-			IL_034a: ldarg.0
-			IL_034b: ldfld object Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0350: ldstr "Cannot access 'ASYNC_HARNESS_INCLUDE' before initialization"
-			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_035a: stloc.s 31
-			IL_035c: ldloc.s 21
-			IL_035e: ldstr "push"
-			IL_0363: ldloc.s 31
-			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_036a: pop
+			IL_0326: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L360C78::.ctor()
+			IL_032b: stloc.s 22
+			IL_032d: ldloc.s 21
+			IL_032f: ldstr "push"
+			IL_0334: ldarg.0
+			IL_0335: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_033f: pop
 
-			IL_036b: ldc.r8 0.0
-			IL_0374: stloc.s 23
-			// loop start (head: IL_0376)
-				IL_0376: ldloc.s 23
-				IL_0378: ldarg.3
-				IL_0379: ldstr "length"
-				IL_037e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0383: clt
-				IL_0385: brfalse IL_03e9
+			IL_0340: ldc.r8 0.0
+			IL_0349: stloc.s 23
+			// loop start (head: IL_034b)
+				IL_034b: ldloc.s 23
+				IL_034d: ldarg.3
+				IL_034e: ldstr "length"
+				IL_0353: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0358: clt
+				IL_035a: brfalse IL_03be
 
-				IL_038a: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44::.ctor()
-				IL_038f: stloc.s 24
-				IL_0391: ldarg.3
-				IL_0392: ldloc.s 23
-				IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0399: stloc.s 31
-				IL_039b: ldnull
-				IL_039c: ldloc.s 21
-				IL_039e: ldloc.s 31
-				IL_03a0: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-				IL_03a5: stloc.s 31
-				IL_03a7: ldloc.s 31
-				IL_03a9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_03ae: ldc.i4.0
-				IL_03af: ceq
-				IL_03b1: stloc.s 33
-				IL_03b3: ldloc.s 33
-				IL_03b5: brfalse IL_03d6
+				IL_035f: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44::.ctor()
+				IL_0364: stloc.s 24
+				IL_0366: ldarg.3
+				IL_0367: ldloc.s 23
+				IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_036e: stloc.s 31
+				IL_0370: ldnull
+				IL_0371: ldloc.s 21
+				IL_0373: ldloc.s 31
+				IL_0375: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+				IL_037a: stloc.s 31
+				IL_037c: ldloc.s 31
+				IL_037e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0383: ldc.i4.0
+				IL_0384: ceq
+				IL_0386: stloc.s 33
+				IL_0388: ldloc.s 33
+				IL_038a: brfalse IL_03ab
 
-				IL_03ba: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44/Block_L365C49::.ctor()
-				IL_03bf: stloc.s 25
-				IL_03c1: ldloc.s 21
-				IL_03c3: ldstr "push"
-				IL_03c8: ldarg.3
-				IL_03c9: ldloc.s 23
-				IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_03d5: pop
+				IL_038f: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44/Block_L365C49::.ctor()
+				IL_0394: stloc.s 25
+				IL_0396: ldloc.s 21
+				IL_0398: ldstr "push"
+				IL_039d: ldarg.3
+				IL_039e: ldloc.s 23
+				IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_03aa: pop
 
-				IL_03d6: ldloc.s 23
-				IL_03d8: ldc.r8 1
-				IL_03e1: add
-				IL_03e2: stloc.s 23
-				IL_03e4: br IL_0376
+				IL_03ab: ldloc.s 23
+				IL_03ad: ldc.r8 1
+				IL_03b6: add
+				IL_03b7: stloc.s 23
+				IL_03b9: br IL_034b
 			// end loop
 
-			IL_03e9: ldnull
-			IL_03ea: ldarg.3
-			IL_03eb: ldstr "agent.js"
-			IL_03f0: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_03f5: stloc.s 31
-			IL_03f7: ldloc.s 31
-			IL_03f9: stloc.s 26
-			IL_03fb: ldnull
-			IL_03fc: ldarg.2
-			IL_03fd: ldstr "CanBlockIsFalse"
-			IL_0402: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_0407: stloc.s 31
-			IL_0409: ldloc.s 31
-			IL_040b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0410: stloc.s 33
-			IL_0412: ldloc.s 33
-			IL_0414: brfalse IL_0425
+			IL_03be: ldnull
+			IL_03bf: ldarg.3
+			IL_03c0: ldstr "agent.js"
+			IL_03c5: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_03ca: stloc.s 31
+			IL_03cc: ldloc.s 31
+			IL_03ce: stloc.s 26
+			IL_03d0: ldnull
+			IL_03d1: ldarg.2
+			IL_03d2: ldstr "CanBlockIsFalse"
+			IL_03d7: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_03dc: stloc.s 31
+			IL_03de: ldloc.s 31
+			IL_03e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03e5: stloc.s 33
+			IL_03e7: ldloc.s 33
+			IL_03e9: brfalse IL_03fa
 
-			IL_0419: ldstr "false"
-			IL_041e: stloc.s 27
-			IL_0420: br IL_045a
+			IL_03ee: ldstr "false"
+			IL_03f3: stloc.s 27
+			IL_03f5: br IL_042f
 
-			IL_0425: ldnull
-			IL_0426: ldarg.2
-			IL_0427: ldstr "CanBlockIsTrue"
-			IL_042c: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_0431: stloc.s 31
-			IL_0433: ldloc.s 31
-			IL_0435: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_043a: stloc.s 33
-			IL_043c: ldloc.s 33
-			IL_043e: brfalse IL_044f
+			IL_03fa: ldnull
+			IL_03fb: ldarg.2
+			IL_03fc: ldstr "CanBlockIsTrue"
+			IL_0401: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_0406: stloc.s 31
+			IL_0408: ldloc.s 31
+			IL_040a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_040f: stloc.s 33
+			IL_0411: ldloc.s 33
+			IL_0413: brfalse IL_0424
 
-			IL_0443: ldstr "true"
-			IL_0448: stloc.s 28
-			IL_044a: br IL_0456
+			IL_0418: ldstr "true"
+			IL_041d: stloc.s 28
+			IL_041f: br IL_042b
 
-			IL_044f: ldstr "unspecified"
-			IL_0454: stloc.s 28
+			IL_0424: ldstr "unspecified"
+			IL_0429: stloc.s 28
 
-			IL_0456: ldloc.s 28
-			IL_0458: stloc.s 27
+			IL_042b: ldloc.s 28
+			IL_042d: stloc.s 27
 
-			IL_045a: ldloc.s 27
-			IL_045c: stloc.s 29
-			IL_045e: ldloc.0
-			IL_045f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0464: stloc.s 33
-			IL_0466: ldloc.s 33
-			IL_0468: brfalse IL_0479
+			IL_042f: ldloc.s 27
+			IL_0431: stloc.s 29
+			IL_0433: ldloc.0
+			IL_0434: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0439: stloc.s 33
+			IL_043b: ldloc.s 33
+			IL_043d: brfalse IL_044e
 
-			IL_046d: ldstr "module"
-			IL_0472: stloc.s 30
-			IL_0474: br IL_0480
+			IL_0442: ldstr "module"
+			IL_0447: stloc.s 30
+			IL_0449: br IL_0455
 
-			IL_0479: ldstr "script"
-			IL_047e: stloc.s 30
+			IL_044e: ldstr "script"
+			IL_0453: stloc.s 30
 
-			IL_0480: ldloc.s 20
-			IL_0482: ldstr "length"
-			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_048c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0491: ldc.r8 0.0
-			IL_049a: cgt
-			IL_049c: stloc.s 33
+			IL_0455: ldloc.s 20
+			IL_0457: ldstr "length"
+			IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0461: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0466: ldc.r8 0.0
+			IL_046f: cgt
+			IL_0471: stloc.s 33
+			IL_0473: ldloc.2
+			IL_0474: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0479: stloc.s 42
+			IL_047b: ldloc.s 42
+			IL_047d: brtrue IL_049e
+
+			IL_0482: ldarg.0
+			IL_0483: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_0488: stloc.s 31
+			IL_048a: ldnull
+			IL_048b: ldarg.3
+			IL_048c: ldloc.s 31
+			IL_048e: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_0493: stloc.s 31
+			IL_0495: ldloc.s 31
+			IL_0497: stloc.s 43
+			IL_0499: br IL_04a1
+
 			IL_049e: ldloc.2
-			IL_049f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04a4: stloc.s 41
-			IL_04a6: ldloc.s 41
-			IL_04a8: brtrue IL_04d3
+			IL_049f: stloc.s 43
 
-			IL_04ad: ldarg.0
-			IL_04ae: ldfld object Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_04b3: ldstr "Cannot access 'ASYNC_HARNESS_INCLUDE' before initialization"
-			IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_04bd: stloc.s 31
-			IL_04bf: ldnull
-			IL_04c0: ldarg.3
-			IL_04c1: ldloc.s 31
-			IL_04c3: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_04c8: stloc.s 31
-			IL_04ca: ldloc.s 31
-			IL_04cc: stloc.s 42
-			IL_04ce: br IL_04d6
+			IL_04a1: ldloc.s 26
+			IL_04a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04a8: stloc.s 42
+			IL_04aa: ldloc.s 42
+			IL_04ac: brtrue IL_04d1
 
-			IL_04d3: ldloc.2
-			IL_04d4: stloc.s 42
+			IL_04b1: ldloc.s 29
+			IL_04b3: ldstr "unspecified"
+			IL_04b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_04bd: stloc.s 42
+			IL_04bf: ldloc.s 42
+			IL_04c1: box [System.Runtime]System.Boolean
+			IL_04c6: stloc.s 35
+			IL_04c8: ldloc.s 35
+			IL_04ca: stloc.s 45
+			IL_04cc: br IL_04d5
 
-			IL_04d6: ldloc.s 26
-			IL_04d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04dd: stloc.s 41
-			IL_04df: ldloc.s 41
-			IL_04e1: brtrue IL_0506
+			IL_04d1: ldloc.s 26
+			IL_04d3: stloc.s 45
 
-			IL_04e6: ldloc.s 29
-			IL_04e8: ldstr "unspecified"
-			IL_04ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_04f2: stloc.s 41
-			IL_04f4: ldloc.s 41
-			IL_04f6: box [System.Runtime]System.Boolean
-			IL_04fb: stloc.s 35
-			IL_04fd: ldloc.s 35
-			IL_04ff: stloc.s 44
-			IL_0501: br IL_050a
-
-			IL_0506: ldloc.s 26
-			IL_0508: stloc.s 44
-
-			IL_050a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_050f: dup
-			IL_0510: ldstr "sourceType"
-			IL_0515: ldloc.s 30
-			IL_0517: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_051c: dup
-			IL_051d: ldstr "strictMode"
-			IL_0522: ldloc.s 12
-			IL_0524: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0529: dup
-			IL_052a: ldstr "defaultHarnessIncludes"
-			IL_052f: ldloc.s 20
-			IL_0531: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0536: dup
-			IL_0537: ldstr "harnessIncludes"
-			IL_053c: ldloc.s 21
-			IL_053e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0543: dup
-			IL_0544: ldstr "requiresDefaultHarness"
-			IL_0549: ldloc.s 33
-			IL_054b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0550: dup
-			IL_0551: ldstr "requiresAsyncHarness"
-			IL_0556: ldloc.s 42
-			IL_0558: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_055d: dup
-			IL_055e: ldstr "requiresAgent"
-			IL_0563: ldloc.s 44
-			IL_0565: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_056a: dup
-			IL_056b: ldstr "canBlock"
-			IL_0570: ldloc.s 29
-			IL_0572: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0577: dup
-			IL_0578: ldstr "isModule"
-			IL_057d: ldloc.0
-			IL_057e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0583: dup
-			IL_0584: ldstr "isRaw"
-			IL_0589: ldloc.1
-			IL_058a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_058f: dup
-			IL_0590: ldstr "isAsync"
-			IL_0595: ldloc.2
-			IL_0596: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_059b: dup
-			IL_059c: ldstr "isGenerated"
-			IL_05a1: ldloc.3
-			IL_05a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05a7: dup
-			IL_05a8: ldstr "isNonDeterministic"
-			IL_05ad: ldloc.s 4
-			IL_05af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05b4: dup
-			IL_05b5: ldstr "isFixture"
-			IL_05ba: ldloc.s 5
-			IL_05bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05c1: stloc.s 45
-			IL_05c3: ldloc.s 45
-			IL_05c5: ret
+			IL_04d5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04da: dup
+			IL_04db: ldstr "sourceType"
+			IL_04e0: ldloc.s 30
+			IL_04e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04e7: dup
+			IL_04e8: ldstr "strictMode"
+			IL_04ed: ldloc.s 12
+			IL_04ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04f4: dup
+			IL_04f5: ldstr "defaultHarnessIncludes"
+			IL_04fa: ldloc.s 20
+			IL_04fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0501: dup
+			IL_0502: ldstr "harnessIncludes"
+			IL_0507: ldloc.s 21
+			IL_0509: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_050e: dup
+			IL_050f: ldstr "requiresDefaultHarness"
+			IL_0514: ldloc.s 33
+			IL_0516: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_051b: dup
+			IL_051c: ldstr "requiresAsyncHarness"
+			IL_0521: ldloc.s 43
+			IL_0523: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0528: dup
+			IL_0529: ldstr "requiresAgent"
+			IL_052e: ldloc.s 45
+			IL_0530: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0535: dup
+			IL_0536: ldstr "canBlock"
+			IL_053b: ldloc.s 29
+			IL_053d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0542: dup
+			IL_0543: ldstr "isModule"
+			IL_0548: ldloc.0
+			IL_0549: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_054e: dup
+			IL_054f: ldstr "isRaw"
+			IL_0554: ldloc.1
+			IL_0555: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_055a: dup
+			IL_055b: ldstr "isAsync"
+			IL_0560: ldloc.2
+			IL_0561: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0566: dup
+			IL_0567: ldstr "isGenerated"
+			IL_056c: ldloc.3
+			IL_056d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0572: dup
+			IL_0573: ldstr "isNonDeterministic"
+			IL_0578: ldloc.s 4
+			IL_057a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_057f: dup
+			IL_0580: ldstr "isFixture"
+			IL_0585: ldloc.s 5
+			IL_0587: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_058c: stloc.s 46
+			IL_058e: ldloc.s 46
+			IL_0590: ret
 		} // end of method buildExecutionMetadata::__js_call__
 
 	} // end of class buildExecutionMetadata
@@ -7529,7 +7517,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x670d
+					// Method begins at RVA 0x6676
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7549,7 +7537,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6716
+					// Method begins at RVA 0x667f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7569,7 +7557,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x671f
+					// Method begins at RVA 0x6688
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7589,7 +7577,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6728
+					// Method begins at RVA 0x6691
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7609,7 +7597,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6731
+					// Method begins at RVA 0x669a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7629,7 +7617,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x673a
+					// Method begins at RVA 0x66a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7649,7 +7637,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6743
+					// Method begins at RVA 0x66ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7667,7 +7655,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6704
+				// Method begins at RVA 0x666d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7696,7 +7684,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5994
+			// Method begins at RVA 0x5960
 			// Header size: 12
 			// Code size: 549 (0x225)
 			.maxstack 8
@@ -7925,7 +7913,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x678b
+					// Method begins at RVA 0x66f4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7943,7 +7931,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x674c
+				// Method begins at RVA 0x66b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7971,7 +7959,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6767
+						// Method begins at RVA 0x66d0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7989,7 +7977,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x675e
+					// Method begins at RVA 0x66c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8007,7 +7995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6755
+				// Method begins at RVA 0x66be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8035,7 +8023,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6782
+						// Method begins at RVA 0x66eb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8053,7 +8041,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6779
+					// Method begins at RVA 0x66e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8071,7 +8059,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6770
+				// Method begins at RVA 0x66d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8099,9 +8087,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5bc8
+			// Method begins at RVA 0x5b94
 			// Header size: 12
-			// Code size: 1883 (0x75b)
+			// Code size: 1849 (0x739)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -8136,8 +8124,8 @@
 				[29] object,
 				[30] float64,
 				[31] string,
-				[32] string,
-				[33] object,
+				[32] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[33] string,
 				[34] object,
 				[35] object,
 				[36] object,
@@ -8146,7 +8134,8 @@
 				[39] object,
 				[40] object,
 				[41] object,
-				[42] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[42] object,
+				[43] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -8263,7 +8252,7 @@
 				IL_010d: ldstr "length"
 				IL_0112: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_0117: clt
-				IL_0119: brfalse IL_01c8
+				IL_0119: brfalse IL_01b5
 
 				IL_011e: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48::.ctor()
 				IL_0123: stloc.s 11
@@ -8272,555 +8261,551 @@
 				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_012e: stloc.s 12
 				IL_0130: ldarg.0
-				IL_0131: ldfld object Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
-				IL_0136: ldstr "Cannot access 'KNOWN_FRONTMATTER_KEYS' before initialization"
-				IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0140: stloc.s 28
-				IL_0142: ldloc.s 28
-				IL_0144: ldstr "indexOf"
-				IL_0149: ldloc.s 12
-				IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0150: stloc.s 28
-				IL_0152: ldloc.s 28
-				IL_0154: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0159: stloc.s 30
-				IL_015b: ldloc.s 30
-				IL_015d: ldc.r8 0.0
-				IL_0166: clt
-				IL_0168: brfalse IL_01b5
+				IL_0131: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
+				IL_0136: ldc.i4.1
+				IL_0137: newarr [System.Runtime]System.Object
+				IL_013c: dup
+				IL_013d: ldc.i4.0
+				IL_013e: ldloc.s 12
+				IL_0140: stelem.ref
+				IL_0141: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_0146: stloc.s 30
+				IL_0148: ldloc.s 30
+				IL_014a: ldc.r8 0.0
+				IL_0153: clt
+				IL_0155: brfalse IL_01a2
 
-				IL_016d: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49::.ctor()
-				IL_0172: stloc.s 13
-				IL_0174: ldloc.s 9
-				IL_0176: ldloc.s 12
-				IL_0178: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_017d: pop
-				IL_017e: ldloc.s 12
-				IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0185: stloc.s 31
-				IL_0187: ldstr "Unsupported frontmatter key '"
-				IL_018c: ldloc.s 31
-				IL_018e: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0193: stloc.s 31
-				IL_0195: ldloc.s 31
-				IL_0197: ldstr "'."
-				IL_019c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01a1: stloc.s 31
-				IL_01a3: ldnull
-				IL_01a4: ldloc.s 4
-				IL_01a6: ldstr "unknown-frontmatter-key"
-				IL_01ab: ldloc.s 12
-				IL_01ad: ldloc.s 31
-				IL_01af: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_01b4: pop
+				IL_015a: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49::.ctor()
+				IL_015f: stloc.s 13
+				IL_0161: ldloc.s 9
+				IL_0163: ldloc.s 12
+				IL_0165: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_016a: pop
+				IL_016b: ldloc.s 12
+				IL_016d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0172: stloc.s 31
+				IL_0174: ldstr "Unsupported frontmatter key '"
+				IL_0179: ldloc.s 31
+				IL_017b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0180: stloc.s 31
+				IL_0182: ldloc.s 31
+				IL_0184: ldstr "'."
+				IL_0189: call string [System.Runtime]System.String::Concat(string, string)
+				IL_018e: stloc.s 31
+				IL_0190: ldnull
+				IL_0191: ldloc.s 4
+				IL_0193: ldstr "unknown-frontmatter-key"
+				IL_0198: ldloc.s 12
+				IL_019a: ldloc.s 31
+				IL_019c: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+				IL_01a1: pop
 
-				IL_01b5: ldloc.s 10
-				IL_01b7: ldc.r8 1
-				IL_01c0: add
-				IL_01c1: stloc.s 10
-				IL_01c3: br IL_0109
+				IL_01a2: ldloc.s 10
+				IL_01a4: ldc.r8 1
+				IL_01ad: add
+				IL_01ae: stloc.s 10
+				IL_01b0: br IL_0109
 			// end loop
 
-			IL_01c8: ldloc.s 7
-			IL_01ca: ldstr "includes"
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d4: stloc.s 28
-			IL_01d6: ldc.i4.1
-			IL_01d7: newarr [System.Runtime]System.Object
-			IL_01dc: dup
-			IL_01dd: ldc.i4.0
-			IL_01de: ldarg.0
-			IL_01df: stelem.ref
-			IL_01e0: ldc.i4.0
-			IL_01e1: ldelem.ref
-			IL_01e2: castclass Modules.test262_metadataParser/Scope
-			IL_01e7: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_01f2: ldnull
-			IL_01f3: ldloc.s 28
-			IL_01f5: ldstr "includes"
-			IL_01fa: ldloc.s 4
-			IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0201: stloc.s 28
-			IL_0203: ldloc.s 28
-			IL_0205: stloc.s 14
-			IL_0207: ldloc.s 7
-			IL_0209: ldstr "flags"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0213: stloc.s 28
-			IL_0215: ldc.i4.1
-			IL_0216: newarr [System.Runtime]System.Object
-			IL_021b: dup
-			IL_021c: ldc.i4.0
-			IL_021d: ldarg.0
-			IL_021e: stelem.ref
-			IL_021f: ldc.i4.0
-			IL_0220: ldelem.ref
-			IL_0221: castclass Modules.test262_metadataParser/Scope
-			IL_0226: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_022c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0231: ldnull
-			IL_0232: ldloc.s 28
-			IL_0234: ldstr "flags"
-			IL_0239: ldloc.s 4
-			IL_023b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0240: stloc.s 28
-			IL_0242: ldloc.s 28
-			IL_0244: stloc.s 15
-			IL_0246: ldloc.s 7
-			IL_0248: ldstr "features"
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0252: stloc.s 28
-			IL_0254: ldc.i4.1
-			IL_0255: newarr [System.Runtime]System.Object
-			IL_025a: dup
-			IL_025b: ldc.i4.0
-			IL_025c: ldarg.0
-			IL_025d: stelem.ref
-			IL_025e: ldc.i4.0
-			IL_025f: ldelem.ref
-			IL_0260: castclass Modules.test262_metadataParser/Scope
-			IL_0265: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_026b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0270: ldnull
-			IL_0271: ldloc.s 28
-			IL_0273: ldstr "features"
-			IL_0278: ldloc.s 4
-			IL_027a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_027f: stloc.s 28
-			IL_0281: ldloc.s 28
-			IL_0283: stloc.s 16
-			IL_0285: ldloc.s 7
-			IL_0287: ldstr "locale"
-			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0291: stloc.s 28
-			IL_0293: ldc.i4.1
-			IL_0294: newarr [System.Runtime]System.Object
-			IL_0299: dup
-			IL_029a: ldc.i4.0
-			IL_029b: ldarg.0
-			IL_029c: stelem.ref
-			IL_029d: ldc.i4.0
-			IL_029e: ldelem.ref
-			IL_029f: castclass Modules.test262_metadataParser/Scope
-			IL_02a4: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_02aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_02af: ldnull
-			IL_02b0: ldloc.s 28
-			IL_02b2: ldstr "locale"
-			IL_02b7: ldloc.s 4
-			IL_02b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_02be: stloc.s 28
-			IL_02c0: ldloc.s 28
-			IL_02c2: stloc.s 17
-			IL_02c4: ldloc.s 7
-			IL_02c6: ldstr "defines"
-			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02d0: stloc.s 28
-			IL_02d2: ldc.i4.1
-			IL_02d3: newarr [System.Runtime]System.Object
-			IL_02d8: dup
-			IL_02d9: ldc.i4.0
-			IL_02da: ldarg.0
-			IL_02db: stelem.ref
-			IL_02dc: ldc.i4.0
-			IL_02dd: ldelem.ref
-			IL_02de: castclass Modules.test262_metadataParser/Scope
-			IL_02e3: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_02e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_02ee: ldnull
-			IL_02ef: ldloc.s 28
-			IL_02f1: ldstr "defines"
-			IL_02f6: ldloc.s 4
-			IL_02f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_02fd: stloc.s 28
-			IL_02ff: ldloc.s 28
-			IL_0301: stloc.s 18
-			IL_0303: ldloc.s 7
-			IL_0305: ldstr "negative"
-			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_030f: stloc.s 28
-			IL_0311: ldc.i4.1
-			IL_0312: newarr [System.Runtime]System.Object
-			IL_0317: dup
-			IL_0318: ldc.i4.0
-			IL_0319: ldarg.0
-			IL_031a: stelem.ref
-			IL_031b: ldc.i4.0
-			IL_031c: ldelem.ref
-			IL_031d: castclass Modules.test262_metadataParser/Scope
-			IL_0322: ldftn object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-			IL_0328: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_032d: ldnull
-			IL_032e: ldloc.s 28
-			IL_0330: ldloc.s 4
-			IL_0332: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0337: stloc.s 28
-			IL_0339: ldloc.s 28
-			IL_033b: stloc.s 19
-			IL_033d: ldc.r8 0.0
-			IL_0346: stloc.s 20
-			// loop start (head: IL_0348)
-				IL_0348: ldloc.s 20
-				IL_034a: ldloc.s 15
-				IL_034c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_0351: clt
-				IL_0353: brfalse IL_0419
+			IL_01b5: ldloc.s 7
+			IL_01b7: ldstr "includes"
+			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c1: stloc.s 28
+			IL_01c3: ldc.i4.1
+			IL_01c4: newarr [System.Runtime]System.Object
+			IL_01c9: dup
+			IL_01ca: ldc.i4.0
+			IL_01cb: ldarg.0
+			IL_01cc: stelem.ref
+			IL_01cd: ldc.i4.0
+			IL_01ce: ldelem.ref
+			IL_01cf: castclass Modules.test262_metadataParser/Scope
+			IL_01d4: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_01da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_01df: ldnull
+			IL_01e0: ldloc.s 28
+			IL_01e2: ldstr "includes"
+			IL_01e7: ldloc.s 4
+			IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_01ee: stloc.s 28
+			IL_01f0: ldloc.s 28
+			IL_01f2: stloc.s 14
+			IL_01f4: ldloc.s 7
+			IL_01f6: ldstr "flags"
+			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0200: stloc.s 28
+			IL_0202: ldc.i4.1
+			IL_0203: newarr [System.Runtime]System.Object
+			IL_0208: dup
+			IL_0209: ldc.i4.0
+			IL_020a: ldarg.0
+			IL_020b: stelem.ref
+			IL_020c: ldc.i4.0
+			IL_020d: ldelem.ref
+			IL_020e: castclass Modules.test262_metadataParser/Scope
+			IL_0213: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_021e: ldnull
+			IL_021f: ldloc.s 28
+			IL_0221: ldstr "flags"
+			IL_0226: ldloc.s 4
+			IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_022d: stloc.s 28
+			IL_022f: ldloc.s 28
+			IL_0231: stloc.s 15
+			IL_0233: ldloc.s 7
+			IL_0235: ldstr "features"
+			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023f: stloc.s 28
+			IL_0241: ldc.i4.1
+			IL_0242: newarr [System.Runtime]System.Object
+			IL_0247: dup
+			IL_0248: ldc.i4.0
+			IL_0249: ldarg.0
+			IL_024a: stelem.ref
+			IL_024b: ldc.i4.0
+			IL_024c: ldelem.ref
+			IL_024d: castclass Modules.test262_metadataParser/Scope
+			IL_0252: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0258: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_025d: ldnull
+			IL_025e: ldloc.s 28
+			IL_0260: ldstr "features"
+			IL_0265: ldloc.s 4
+			IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_026c: stloc.s 28
+			IL_026e: ldloc.s 28
+			IL_0270: stloc.s 16
+			IL_0272: ldloc.s 7
+			IL_0274: ldstr "locale"
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027e: stloc.s 28
+			IL_0280: ldc.i4.1
+			IL_0281: newarr [System.Runtime]System.Object
+			IL_0286: dup
+			IL_0287: ldc.i4.0
+			IL_0288: ldarg.0
+			IL_0289: stelem.ref
+			IL_028a: ldc.i4.0
+			IL_028b: ldelem.ref
+			IL_028c: castclass Modules.test262_metadataParser/Scope
+			IL_0291: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0297: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_029c: ldnull
+			IL_029d: ldloc.s 28
+			IL_029f: ldstr "locale"
+			IL_02a4: ldloc.s 4
+			IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_02ab: stloc.s 28
+			IL_02ad: ldloc.s 28
+			IL_02af: stloc.s 17
+			IL_02b1: ldloc.s 7
+			IL_02b3: ldstr "defines"
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02bd: stloc.s 28
+			IL_02bf: ldc.i4.1
+			IL_02c0: newarr [System.Runtime]System.Object
+			IL_02c5: dup
+			IL_02c6: ldc.i4.0
+			IL_02c7: ldarg.0
+			IL_02c8: stelem.ref
+			IL_02c9: ldc.i4.0
+			IL_02ca: ldelem.ref
+			IL_02cb: castclass Modules.test262_metadataParser/Scope
+			IL_02d0: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_02d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_02db: ldnull
+			IL_02dc: ldloc.s 28
+			IL_02de: ldstr "defines"
+			IL_02e3: ldloc.s 4
+			IL_02e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_02ea: stloc.s 28
+			IL_02ec: ldloc.s 28
+			IL_02ee: stloc.s 18
+			IL_02f0: ldloc.s 7
+			IL_02f2: ldstr "negative"
+			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fc: stloc.s 28
+			IL_02fe: ldc.i4.1
+			IL_02ff: newarr [System.Runtime]System.Object
+			IL_0304: dup
+			IL_0305: ldc.i4.0
+			IL_0306: ldarg.0
+			IL_0307: stelem.ref
+			IL_0308: ldc.i4.0
+			IL_0309: ldelem.ref
+			IL_030a: castclass Modules.test262_metadataParser/Scope
+			IL_030f: ldftn object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
+			IL_0315: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_031a: ldnull
+			IL_031b: ldloc.s 28
+			IL_031d: ldloc.s 4
+			IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0324: stloc.s 28
+			IL_0326: ldloc.s 28
+			IL_0328: stloc.s 19
+			IL_032a: ldc.r8 0.0
+			IL_0333: stloc.s 20
+			// loop start (head: IL_0335)
+				IL_0335: ldloc.s 20
+				IL_0337: ldloc.s 15
+				IL_0339: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_033e: clt
+				IL_0340: brfalse IL_03f7
 
-				IL_0358: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
-				IL_035d: stloc.s 21
-				IL_035f: ldarg.0
-				IL_0360: ldfld object Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
-				IL_0365: ldstr "Cannot access 'KNOWN_FLAG_VALUES' before initialization"
-				IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_036f: stloc.s 28
-				IL_0371: ldloc.s 28
-				IL_0373: ldstr "indexOf"
-				IL_0378: ldloc.s 15
-				IL_037a: ldloc.s 20
-				IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0386: stloc.s 28
-				IL_0388: ldloc.s 28
-				IL_038a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_038f: stloc.s 30
-				IL_0391: ldloc.s 30
-				IL_0393: ldc.r8 0.0
-				IL_039c: clt
-				IL_039e: brfalse IL_0406
+				IL_0345: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
+				IL_034a: stloc.s 21
+				IL_034c: ldarg.0
+				IL_034d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
+				IL_0352: stloc.s 32
+				IL_0354: ldloc.s 32
+				IL_0356: ldc.i4.1
+				IL_0357: newarr [System.Runtime]System.Object
+				IL_035c: dup
+				IL_035d: ldc.i4.0
+				IL_035e: ldloc.s 15
+				IL_0360: ldloc.s 20
+				IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0367: stelem.ref
+				IL_0368: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_036d: stloc.s 30
+				IL_036f: ldloc.s 30
+				IL_0371: ldc.r8 0.0
+				IL_037a: clt
+				IL_037c: brfalse IL_03e4
 
-				IL_03a3: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
-				IL_03a8: stloc.s 22
-				IL_03aa: ldloc.s 15
-				IL_03ac: ldloc.s 20
-				IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_03b3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_03b8: stloc.s 31
-				IL_03ba: ldstr "flags:"
-				IL_03bf: ldloc.s 31
-				IL_03c1: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03c6: stloc.s 31
-				IL_03c8: ldloc.s 15
-				IL_03ca: ldloc.s 20
-				IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_03d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_03d6: stloc.s 32
-				IL_03d8: ldstr "Unsupported flag '"
-				IL_03dd: ldloc.s 32
-				IL_03df: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03e4: stloc.s 32
-				IL_03e6: ldloc.s 32
-				IL_03e8: ldstr "'."
-				IL_03ed: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03f2: stloc.s 32
-				IL_03f4: ldnull
-				IL_03f5: ldloc.s 4
-				IL_03f7: ldstr "unknown-flag"
-				IL_03fc: ldloc.s 31
-				IL_03fe: ldloc.s 32
-				IL_0400: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_0405: pop
+				IL_0381: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
+				IL_0386: stloc.s 22
+				IL_0388: ldloc.s 15
+				IL_038a: ldloc.s 20
+				IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0391: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0396: stloc.s 31
+				IL_0398: ldstr "flags:"
+				IL_039d: ldloc.s 31
+				IL_039f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03a4: stloc.s 31
+				IL_03a6: ldloc.s 15
+				IL_03a8: ldloc.s 20
+				IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_03af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_03b4: stloc.s 33
+				IL_03b6: ldstr "Unsupported flag '"
+				IL_03bb: ldloc.s 33
+				IL_03bd: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03c2: stloc.s 33
+				IL_03c4: ldloc.s 33
+				IL_03c6: ldstr "'."
+				IL_03cb: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03d0: stloc.s 33
+				IL_03d2: ldnull
+				IL_03d3: ldloc.s 4
+				IL_03d5: ldstr "unknown-flag"
+				IL_03da: ldloc.s 31
+				IL_03dc: ldloc.s 33
+				IL_03de: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+				IL_03e3: pop
 
-				IL_0406: ldloc.s 20
-				IL_0408: ldc.r8 1
-				IL_0411: add
-				IL_0412: stloc.s 20
-				IL_0414: br IL_0348
+				IL_03e4: ldloc.s 20
+				IL_03e6: ldc.r8 1
+				IL_03ef: add
+				IL_03f0: stloc.s 20
+				IL_03f2: br IL_0335
 			// end loop
 
-			IL_0419: ldc.i4.1
-			IL_041a: newarr [System.Runtime]System.Object
-			IL_041f: dup
-			IL_0420: ldc.i4.0
-			IL_0421: ldarg.0
-			IL_0422: stelem.ref
-			IL_0423: ldc.i4.0
-			IL_0424: ldelem.ref
-			IL_0425: castclass Modules.test262_metadataParser/Scope
-			IL_042a: ldftn object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0430: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0435: ldnull
-			IL_0436: ldloc.s 15
-			IL_0438: ldloc.s 14
-			IL_043a: ldloc.2
-			IL_043b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0440: stloc.s 28
-			IL_0442: ldloc.s 28
-			IL_0444: stloc.s 23
-			IL_0446: ldloc.s 23
-			IL_0448: ldstr "strictMode"
-			IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0452: ldstr "conflicting-flags"
-			IL_0457: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_045c: stloc.s 25
-			IL_045e: ldloc.s 25
-			IL_0460: brfalse IL_0484
+			IL_03f7: ldc.i4.1
+			IL_03f8: newarr [System.Runtime]System.Object
+			IL_03fd: dup
+			IL_03fe: ldc.i4.0
+			IL_03ff: ldarg.0
+			IL_0400: stelem.ref
+			IL_0401: ldc.i4.0
+			IL_0402: ldelem.ref
+			IL_0403: castclass Modules.test262_metadataParser/Scope
+			IL_0408: ldftn object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_040e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0413: ldnull
+			IL_0414: ldloc.s 15
+			IL_0416: ldloc.s 14
+			IL_0418: ldloc.2
+			IL_0419: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_041e: stloc.s 28
+			IL_0420: ldloc.s 28
+			IL_0422: stloc.s 23
+			IL_0424: ldloc.s 23
+			IL_0426: ldstr "strictMode"
+			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0430: ldstr "conflicting-flags"
+			IL_0435: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_043a: stloc.s 25
+			IL_043c: ldloc.s 25
+			IL_043e: brfalse IL_0462
 
-			IL_0465: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
-			IL_046a: stloc.s 24
-			IL_046c: ldnull
-			IL_046d: ldloc.s 4
-			IL_046f: ldstr "conflicting-strictness-flags"
-			IL_0474: ldstr "flags"
-			IL_0479: ldstr "Multiple strictness/source-type flags were declared together."
-			IL_047e: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_0483: pop
+			IL_0443: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
+			IL_0448: stloc.s 24
+			IL_044a: ldnull
+			IL_044b: ldloc.s 4
+			IL_044d: ldstr "conflicting-strictness-flags"
+			IL_0452: ldstr "flags"
+			IL_0457: ldstr "Multiple strictness/source-type flags were declared together."
+			IL_045c: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+			IL_0461: pop
 
-			IL_0484: ldloc.1
-			IL_0485: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_048a: stloc.s 25
-			IL_048c: ldloc.s 25
-			IL_048e: brtrue IL_04a0
+			IL_0462: ldloc.1
+			IL_0463: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0468: stloc.s 25
+			IL_046a: ldloc.s 25
+			IL_046c: brtrue IL_047e
 
-			IL_0493: ldc.i4.0
-			IL_0494: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0499: stloc.s 33
-			IL_049b: br IL_04a3
+			IL_0471: ldc.i4.0
+			IL_0472: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0477: stloc.s 34
+			IL_0479: br IL_0481
 
-			IL_04a0: ldloc.1
-			IL_04a1: stloc.s 33
+			IL_047e: ldloc.1
+			IL_047f: stloc.s 34
 
-			IL_04a3: ldloc.2
-			IL_04a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04a9: stloc.s 25
-			IL_04ab: ldloc.s 25
-			IL_04ad: brtrue IL_04bf
+			IL_0481: ldloc.2
+			IL_0482: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0487: stloc.s 25
+			IL_0489: ldloc.s 25
+			IL_048b: brtrue IL_049d
 
-			IL_04b2: ldc.i4.0
-			IL_04b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04b8: stloc.s 35
-			IL_04ba: br IL_04c2
+			IL_0490: ldc.i4.0
+			IL_0491: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0496: stloc.s 36
+			IL_0498: br IL_04a0
 
-			IL_04bf: ldloc.2
-			IL_04c0: stloc.s 35
+			IL_049d: ldloc.2
+			IL_049e: stloc.s 36
 
-			IL_04c2: ldloc.s 7
-			IL_04c4: ldstr "description"
-			IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04ce: stloc.s 28
-			IL_04d0: ldc.i4.1
-			IL_04d1: newarr [System.Runtime]System.Object
-			IL_04d6: dup
-			IL_04d7: ldc.i4.0
-			IL_04d8: ldarg.0
-			IL_04d9: stelem.ref
-			IL_04da: ldc.i4.0
-			IL_04db: ldelem.ref
-			IL_04dc: castclass Modules.test262_metadataParser/Scope
-			IL_04e1: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_04e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_04ec: ldnull
-			IL_04ed: ldloc.s 28
-			IL_04ef: ldstr "description"
-			IL_04f4: ldloc.s 4
-			IL_04f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_04fb: stloc.s 28
-			IL_04fd: ldloc.s 7
-			IL_04ff: ldstr "info"
-			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0509: stloc.s 36
-			IL_050b: ldc.i4.1
-			IL_050c: newarr [System.Runtime]System.Object
-			IL_0511: dup
-			IL_0512: ldc.i4.0
-			IL_0513: ldarg.0
-			IL_0514: stelem.ref
-			IL_0515: ldc.i4.0
-			IL_0516: ldelem.ref
-			IL_0517: castclass Modules.test262_metadataParser/Scope
-			IL_051c: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0522: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0527: ldnull
-			IL_0528: ldloc.s 36
-			IL_052a: ldstr "info"
-			IL_052f: ldloc.s 4
-			IL_0531: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0536: stloc.s 36
-			IL_0538: ldloc.s 7
-			IL_053a: ldstr "esid"
-			IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0544: stloc.s 37
-			IL_0546: ldc.i4.1
-			IL_0547: newarr [System.Runtime]System.Object
-			IL_054c: dup
-			IL_054d: ldc.i4.0
-			IL_054e: ldarg.0
-			IL_054f: stelem.ref
-			IL_0550: ldc.i4.0
-			IL_0551: ldelem.ref
-			IL_0552: castclass Modules.test262_metadataParser/Scope
-			IL_0557: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_055d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0562: ldnull
-			IL_0563: ldloc.s 37
-			IL_0565: ldstr "esid"
-			IL_056a: ldloc.s 4
-			IL_056c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0571: stloc.s 37
-			IL_0573: ldloc.s 7
-			IL_0575: ldstr "es5id"
-			IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_057f: stloc.s 38
-			IL_0581: ldc.i4.1
-			IL_0582: newarr [System.Runtime]System.Object
-			IL_0587: dup
-			IL_0588: ldc.i4.0
-			IL_0589: ldarg.0
-			IL_058a: stelem.ref
-			IL_058b: ldc.i4.0
-			IL_058c: ldelem.ref
-			IL_058d: castclass Modules.test262_metadataParser/Scope
-			IL_0592: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0598: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_059d: ldnull
-			IL_059e: ldloc.s 38
-			IL_05a0: ldstr "es5id"
-			IL_05a5: ldloc.s 4
-			IL_05a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_05ac: stloc.s 38
-			IL_05ae: ldloc.s 7
-			IL_05b0: ldstr "es6id"
-			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ba: stloc.s 39
-			IL_05bc: ldc.i4.1
-			IL_05bd: newarr [System.Runtime]System.Object
-			IL_05c2: dup
-			IL_05c3: ldc.i4.0
-			IL_05c4: ldarg.0
-			IL_05c5: stelem.ref
-			IL_05c6: ldc.i4.0
-			IL_05c7: ldelem.ref
-			IL_05c8: castclass Modules.test262_metadataParser/Scope
-			IL_05cd: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_05d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_05d8: ldnull
-			IL_05d9: ldloc.s 39
-			IL_05db: ldstr "es6id"
-			IL_05e0: ldloc.s 4
-			IL_05e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_05e7: stloc.s 39
-			IL_05e9: ldloc.s 7
-			IL_05eb: ldstr "author"
-			IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05f5: stloc.s 40
-			IL_05f7: ldc.i4.1
-			IL_05f8: newarr [System.Runtime]System.Object
-			IL_05fd: dup
-			IL_05fe: ldc.i4.0
-			IL_05ff: ldarg.0
-			IL_0600: stelem.ref
-			IL_0601: ldc.i4.0
-			IL_0602: ldelem.ref
-			IL_0603: castclass Modules.test262_metadataParser/Scope
-			IL_0608: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_060e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0613: ldnull
-			IL_0614: ldloc.s 40
-			IL_0616: ldstr "author"
-			IL_061b: ldloc.s 4
-			IL_061d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0622: stloc.s 40
-			IL_0624: ldc.i4.1
-			IL_0625: newarr [System.Runtime]System.Object
-			IL_062a: dup
-			IL_062b: ldc.i4.0
-			IL_062c: ldarg.0
-			IL_062d: stelem.ref
-			IL_062e: ldc.i4.0
-			IL_062f: ldelem.ref
-			IL_0630: castclass Modules.test262_metadataParser/Scope
-			IL_0635: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_063b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0640: ldnull
-			IL_0641: ldloc.1
-			IL_0642: ldloc.s 19
-			IL_0644: ldloc.s 23
-			IL_0646: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_064b: stloc.s 41
-			IL_064d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0652: dup
-			IL_0653: ldstr "filePath"
-			IL_0658: ldloc.s 33
-			IL_065a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_065f: dup
-			IL_0660: ldstr "fileName"
-			IL_0665: ldloc.s 35
-			IL_0667: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_066c: dup
-			IL_066d: ldstr "hasFrontmatter"
-			IL_0672: ldloc.s 5
-			IL_0674: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0679: dup
-			IL_067a: ldstr "frontmatter"
-			IL_067f: ldloc.s 7
-			IL_0681: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0686: dup
-			IL_0687: ldstr "unknownKeys"
-			IL_068c: ldloc.s 9
-			IL_068e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0693: dup
-			IL_0694: ldstr "description"
-			IL_0699: ldloc.s 28
-			IL_069b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06a0: dup
-			IL_06a1: ldstr "info"
-			IL_06a6: ldloc.s 36
-			IL_06a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06ad: dup
-			IL_06ae: ldstr "esid"
-			IL_06b3: ldloc.s 37
-			IL_06b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06ba: dup
-			IL_06bb: ldstr "es5id"
-			IL_06c0: ldloc.s 38
-			IL_06c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06c7: dup
-			IL_06c8: ldstr "es6id"
-			IL_06cd: ldloc.s 39
-			IL_06cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06d4: dup
-			IL_06d5: ldstr "author"
-			IL_06da: ldloc.s 40
-			IL_06dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06e1: dup
-			IL_06e2: ldstr "includes"
-			IL_06e7: ldloc.s 14
-			IL_06e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06ee: dup
-			IL_06ef: ldstr "flags"
-			IL_06f4: ldloc.s 15
-			IL_06f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06fb: dup
-			IL_06fc: ldstr "features"
-			IL_0701: ldloc.s 16
-			IL_0703: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0708: dup
-			IL_0709: ldstr "locale"
-			IL_070e: ldloc.s 17
-			IL_0710: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0715: dup
-			IL_0716: ldstr "defines"
-			IL_071b: ldloc.s 18
-			IL_071d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0722: dup
-			IL_0723: ldstr "negative"
-			IL_0728: ldloc.s 19
-			IL_072a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_072f: dup
-			IL_0730: ldstr "execution"
-			IL_0735: ldloc.s 23
-			IL_0737: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_073c: dup
-			IL_073d: ldstr "mvpBlockers"
-			IL_0742: ldloc.s 41
-			IL_0744: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0749: dup
-			IL_074a: ldstr "unsupported"
-			IL_074f: ldloc.s 4
-			IL_0751: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0756: stloc.s 42
-			IL_0758: ldloc.s 42
-			IL_075a: ret
+			IL_04a0: ldloc.s 7
+			IL_04a2: ldstr "description"
+			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04ac: stloc.s 28
+			IL_04ae: ldc.i4.1
+			IL_04af: newarr [System.Runtime]System.Object
+			IL_04b4: dup
+			IL_04b5: ldc.i4.0
+			IL_04b6: ldarg.0
+			IL_04b7: stelem.ref
+			IL_04b8: ldc.i4.0
+			IL_04b9: ldelem.ref
+			IL_04ba: castclass Modules.test262_metadataParser/Scope
+			IL_04bf: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_04c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_04ca: ldnull
+			IL_04cb: ldloc.s 28
+			IL_04cd: ldstr "description"
+			IL_04d2: ldloc.s 4
+			IL_04d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_04d9: stloc.s 28
+			IL_04db: ldloc.s 7
+			IL_04dd: ldstr "info"
+			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04e7: stloc.s 37
+			IL_04e9: ldc.i4.1
+			IL_04ea: newarr [System.Runtime]System.Object
+			IL_04ef: dup
+			IL_04f0: ldc.i4.0
+			IL_04f1: ldarg.0
+			IL_04f2: stelem.ref
+			IL_04f3: ldc.i4.0
+			IL_04f4: ldelem.ref
+			IL_04f5: castclass Modules.test262_metadataParser/Scope
+			IL_04fa: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0500: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0505: ldnull
+			IL_0506: ldloc.s 37
+			IL_0508: ldstr "info"
+			IL_050d: ldloc.s 4
+			IL_050f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_0514: stloc.s 37
+			IL_0516: ldloc.s 7
+			IL_0518: ldstr "esid"
+			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0522: stloc.s 38
+			IL_0524: ldc.i4.1
+			IL_0525: newarr [System.Runtime]System.Object
+			IL_052a: dup
+			IL_052b: ldc.i4.0
+			IL_052c: ldarg.0
+			IL_052d: stelem.ref
+			IL_052e: ldc.i4.0
+			IL_052f: ldelem.ref
+			IL_0530: castclass Modules.test262_metadataParser/Scope
+			IL_0535: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_053b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0540: ldnull
+			IL_0541: ldloc.s 38
+			IL_0543: ldstr "esid"
+			IL_0548: ldloc.s 4
+			IL_054a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_054f: stloc.s 38
+			IL_0551: ldloc.s 7
+			IL_0553: ldstr "es5id"
+			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_055d: stloc.s 39
+			IL_055f: ldc.i4.1
+			IL_0560: newarr [System.Runtime]System.Object
+			IL_0565: dup
+			IL_0566: ldc.i4.0
+			IL_0567: ldarg.0
+			IL_0568: stelem.ref
+			IL_0569: ldc.i4.0
+			IL_056a: ldelem.ref
+			IL_056b: castclass Modules.test262_metadataParser/Scope
+			IL_0570: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0576: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_057b: ldnull
+			IL_057c: ldloc.s 39
+			IL_057e: ldstr "es5id"
+			IL_0583: ldloc.s 4
+			IL_0585: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_058a: stloc.s 39
+			IL_058c: ldloc.s 7
+			IL_058e: ldstr "es6id"
+			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0598: stloc.s 40
+			IL_059a: ldc.i4.1
+			IL_059b: newarr [System.Runtime]System.Object
+			IL_05a0: dup
+			IL_05a1: ldc.i4.0
+			IL_05a2: ldarg.0
+			IL_05a3: stelem.ref
+			IL_05a4: ldc.i4.0
+			IL_05a5: ldelem.ref
+			IL_05a6: castclass Modules.test262_metadataParser/Scope
+			IL_05ab: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_05b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_05b6: ldnull
+			IL_05b7: ldloc.s 40
+			IL_05b9: ldstr "es6id"
+			IL_05be: ldloc.s 4
+			IL_05c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_05c5: stloc.s 40
+			IL_05c7: ldloc.s 7
+			IL_05c9: ldstr "author"
+			IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05d3: stloc.s 41
+			IL_05d5: ldc.i4.1
+			IL_05d6: newarr [System.Runtime]System.Object
+			IL_05db: dup
+			IL_05dc: ldc.i4.0
+			IL_05dd: ldarg.0
+			IL_05de: stelem.ref
+			IL_05df: ldc.i4.0
+			IL_05e0: ldelem.ref
+			IL_05e1: castclass Modules.test262_metadataParser/Scope
+			IL_05e6: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_05ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_05f1: ldnull
+			IL_05f2: ldloc.s 41
+			IL_05f4: ldstr "author"
+			IL_05f9: ldloc.s 4
+			IL_05fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_0600: stloc.s 41
+			IL_0602: ldc.i4.1
+			IL_0603: newarr [System.Runtime]System.Object
+			IL_0608: dup
+			IL_0609: ldc.i4.0
+			IL_060a: ldarg.0
+			IL_060b: stelem.ref
+			IL_060c: ldc.i4.0
+			IL_060d: ldelem.ref
+			IL_060e: castclass Modules.test262_metadataParser/Scope
+			IL_0613: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0619: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_061e: ldnull
+			IL_061f: ldloc.1
+			IL_0620: ldloc.s 19
+			IL_0622: ldloc.s 23
+			IL_0624: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
+			IL_0629: stloc.s 42
+			IL_062b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0630: dup
+			IL_0631: ldstr "filePath"
+			IL_0636: ldloc.s 34
+			IL_0638: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_063d: dup
+			IL_063e: ldstr "fileName"
+			IL_0643: ldloc.s 36
+			IL_0645: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_064a: dup
+			IL_064b: ldstr "hasFrontmatter"
+			IL_0650: ldloc.s 5
+			IL_0652: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0657: dup
+			IL_0658: ldstr "frontmatter"
+			IL_065d: ldloc.s 7
+			IL_065f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0664: dup
+			IL_0665: ldstr "unknownKeys"
+			IL_066a: ldloc.s 9
+			IL_066c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0671: dup
+			IL_0672: ldstr "description"
+			IL_0677: ldloc.s 28
+			IL_0679: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_067e: dup
+			IL_067f: ldstr "info"
+			IL_0684: ldloc.s 37
+			IL_0686: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_068b: dup
+			IL_068c: ldstr "esid"
+			IL_0691: ldloc.s 38
+			IL_0693: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0698: dup
+			IL_0699: ldstr "es5id"
+			IL_069e: ldloc.s 39
+			IL_06a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06a5: dup
+			IL_06a6: ldstr "es6id"
+			IL_06ab: ldloc.s 40
+			IL_06ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06b2: dup
+			IL_06b3: ldstr "author"
+			IL_06b8: ldloc.s 41
+			IL_06ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06bf: dup
+			IL_06c0: ldstr "includes"
+			IL_06c5: ldloc.s 14
+			IL_06c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06cc: dup
+			IL_06cd: ldstr "flags"
+			IL_06d2: ldloc.s 15
+			IL_06d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06d9: dup
+			IL_06da: ldstr "features"
+			IL_06df: ldloc.s 16
+			IL_06e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06e6: dup
+			IL_06e7: ldstr "locale"
+			IL_06ec: ldloc.s 17
+			IL_06ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06f3: dup
+			IL_06f4: ldstr "defines"
+			IL_06f9: ldloc.s 18
+			IL_06fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0700: dup
+			IL_0701: ldstr "negative"
+			IL_0706: ldloc.s 19
+			IL_0708: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_070d: dup
+			IL_070e: ldstr "execution"
+			IL_0713: ldloc.s 23
+			IL_0715: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_071a: dup
+			IL_071b: ldstr "mvpBlockers"
+			IL_0720: ldloc.s 42
+			IL_0722: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0727: dup
+			IL_0728: ldstr "unsupported"
+			IL_072d: ldloc.s 4
+			IL_072f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0734: stloc.s 43
+			IL_0736: ldloc.s 43
+			IL_0738: ret
 		} // end of method parseTest262Metadata::__js_call__
 
 	} // end of class parseTest262Metadata
@@ -8836,7 +8821,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6794
+				// Method begins at RVA 0x66fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8863,9 +8848,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x6330
+			// Method begins at RVA 0x62dc
 			// Header size: 12
-			// Code size: 94 (0x5e)
+			// Code size: 82 (0x52)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -8875,41 +8860,37 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.test262_metadataParser/Scope::fs
-			IL_0006: ldstr "Cannot access 'fs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: ldstr "readFileSync"
-			IL_0017: ldarg.2
-			IL_0018: ldstr "utf8"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0022: stloc.1
-			IL_0023: ldloc.1
-			IL_0024: stloc.0
-			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002a: dup
-			IL_002b: ldstr "filePath"
-			IL_0030: ldarg.2
-			IL_0031: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0036: stloc.2
-			IL_0037: ldc.i4.1
-			IL_0038: newarr [System.Runtime]System.Object
-			IL_003d: dup
-			IL_003e: ldc.i4.0
-			IL_003f: ldarg.0
-			IL_0040: stelem.ref
-			IL_0041: ldc.i4.0
-			IL_0042: ldelem.ref
-			IL_0043: castclass Modules.test262_metadataParser/Scope
-			IL_0048: ldftn object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-			IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0053: ldnull
-			IL_0054: ldloc.0
-			IL_0055: ldloc.2
-			IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_005b: stloc.1
-			IL_005c: ldloc.1
-			IL_005d: ret
+			IL_0006: ldstr "readFileSync"
+			IL_000b: ldarg.2
+			IL_000c: ldstr "utf8"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0016: stloc.1
+			IL_0017: ldloc.1
+			IL_0018: stloc.0
+			IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001e: dup
+			IL_001f: ldstr "filePath"
+			IL_0024: ldarg.2
+			IL_0025: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_002a: stloc.2
+			IL_002b: ldc.i4.1
+			IL_002c: newarr [System.Runtime]System.Object
+			IL_0031: dup
+			IL_0032: ldc.i4.0
+			IL_0033: ldarg.0
+			IL_0034: stelem.ref
+			IL_0035: ldc.i4.0
+			IL_0036: ldelem.ref
+			IL_0037: castclass Modules.test262_metadataParser/Scope
+			IL_003c: ldftn object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
+			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0047: ldnull
+			IL_0048: ldloc.0
+			IL_0049: ldloc.2
+			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_004f: stloc.1
+			IL_0050: ldloc.1
+			IL_0051: ret
 		} // end of method parseTest262File::__js_call__
 
 	} // end of class parseTest262File
@@ -8940,10 +8921,10 @@
 		)
 		// Fields
 		.field public object fs
-		.field public object DEFAULT_HARNESS_INCLUDES
-		.field public object ASYNC_HARNESS_INCLUDE
-		.field public object KNOWN_FRONTMATTER_KEYS
-		.field public object KNOWN_FLAG_VALUES
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array DEFAULT_HARNESS_INCLUDES
+		.field public string ASYNC_HARNESS_INCLUDE
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array KNOWN_FRONTMATTER_KEYS
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array KNOWN_FLAG_VALUES
 		.field public object normalizeLineEndings
 		.field public object countIndent
 		.field public object unquote
@@ -8971,30 +8952,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x63fd
+			// Method begins at RVA 0x639d
 			// Header size: 1
-			// Code size: 63 (0x3f)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.test262_metadataParser/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
-			IL_0032: ldarg.0
-			IL_0033: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0038: stfld object Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
-			IL_003d: nop
-			IL_003e: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -9416,10 +9382,10 @@
 		IL_03f6: dup
 		IL_03f7: ldstr "sta.js"
 		IL_03fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0401: stfld object Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
+		IL_0401: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
 		IL_0406: ldloc.0
 		IL_0407: ldstr "doneprintHandle.js"
-		IL_040c: stfld object Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+		IL_040c: stfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
 		IL_0411: ldloc.0
 		IL_0412: ldc.i4.s 12
 		IL_0414: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
@@ -9459,7 +9425,7 @@
 		IL_0492: dup
 		IL_0493: ldstr "negative"
 		IL_0498: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_049d: stfld object Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
+		IL_049d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
 		IL_04a2: ldloc.0
 		IL_04a3: ldc.i4.s 9
 		IL_04a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
@@ -9490,7 +9456,7 @@
 		IL_0502: dup
 		IL_0503: ldstr "non-deterministic"
 		IL_0508: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_050d: stfld object Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
+		IL_050d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
 		IL_0512: ldloc.0
 		IL_0513: ldfld object Modules.test262_metadataParser/Scope::parseTest262Frontmatter
 		IL_0518: stloc.2
@@ -9532,7 +9498,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x679d
+		// Method begins at RVA 0x6706
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Test262.Tests/language/statements/for-of/ExecutionTests.cs
+++ b/tests/Js2IL.Test262.Tests/language/statements/for-of/ExecutionTests.cs
@@ -68,7 +68,7 @@ public class ExecutionTests : ExecutionTestsBase
 
     [Fact(DisplayName = "array-expand")]
     public Task array_expand()
-        => ExecutionTest("array-expand");
+        => ExecutionTest("array-expand", preferOutOfProc: true);
 
     [Fact(DisplayName = "array-key-get-error")]
     public Task array_key_get_error()

--- a/tests/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
+++ b/tests/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213c
+				// Method begins at RVA 0x2116
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,37 +51,23 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20f0
+			// Method begins at RVA 0x20ec
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 21 (0x15)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] float64,
-				[3] object
+				[0] float64
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.ArrowFunction_CapturesOuterVariable/Scope::n
-			IL_0006: ldstr "Cannot access 'n' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldarg.2
-			IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0017: stloc.1
-			IL_0018: ldloc.0
-			IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001e: stloc.2
-			IL_001f: ldloc.1
-			IL_0020: ldloc.2
-			IL_0021: mul
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: box [System.Runtime]System.Double
-			IL_0029: stloc.3
-			IL_002a: ldloc.3
-			IL_002b: ret
+			IL_0001: ldfld float64 Modules.ArrowFunction_CapturesOuterVariable/Scope::n
+			IL_0006: stloc.0
+			IL_0007: ldarg.2
+			IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000d: ldloc.0
+			IL_000e: mul
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: ret
 		} // end of method ArrowFunction_L4C13::__js_call__
 
 	} // end of class ArrowFunction_L4C13
@@ -93,24 +79,21 @@
 			01 00 0b 53 63 6f 70 65 20 6e 3d 7b 6e 7d 00 00
 		)
 		// Fields
-		.field public object n
+		.field public float64 n
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2128
+			// Method begins at RVA 0x210d
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.ArrowFunction_CapturesOuterVariable/Scope::n
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -128,7 +111,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 147 (0x93)
+		// Code size: 142 (0x8e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_CapturesOuterVariable/Scope,
@@ -141,52 +124,51 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldc.r8 5
-		IL_0010: box [System.Runtime]System.Double
-		IL_0015: stfld object Modules.ArrowFunction_CapturesOuterVariable/Scope::n
-		IL_001a: ldc.i4.1
-		IL_001b: newarr [System.Runtime]System.Object
-		IL_0020: dup
-		IL_0021: ldc.i4.0
-		IL_0022: ldloc.0
-		IL_0023: stelem.ref
-		IL_0024: ldc.i4.0
-		IL_0025: ldelem.ref
-		IL_0026: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
-		IL_002b: ldftn object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, object)
-		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0036: ldc.i4.1
-		IL_0037: newarr [System.Runtime]System.Object
-		IL_003c: dup
-		IL_003d: ldc.i4.0
-		IL_003e: ldloc.0
-		IL_003f: stelem.ref
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_004a: ldc.i4.1
-		IL_004b: conv.r8
-		IL_004c: ldstr ""
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0056: stloc.2
-		IL_0057: ldloc.2
-		IL_0058: ldstr "mul"
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0062: stloc.2
-		IL_0063: ldloc.2
-		IL_0064: stloc.1
-		IL_0065: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006a: stloc.3
-		IL_006b: ldloc.1
-		IL_006c: ldloc.3
-		IL_006d: ldc.r8 3
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_0080: stloc.2
-		IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0086: ldstr "product is "
-		IL_008b: ldloc.2
-		IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0091: pop
-		IL_0092: ret
+		IL_0010: stfld float64 Modules.ArrowFunction_CapturesOuterVariable/Scope::n
+		IL_0015: ldc.i4.1
+		IL_0016: newarr [System.Runtime]System.Object
+		IL_001b: dup
+		IL_001c: ldc.i4.0
+		IL_001d: ldloc.0
+		IL_001e: stelem.ref
+		IL_001f: ldc.i4.0
+		IL_0020: ldelem.ref
+		IL_0021: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
+		IL_0026: ldftn object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, object)
+		IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0031: ldc.i4.1
+		IL_0032: newarr [System.Runtime]System.Object
+		IL_0037: dup
+		IL_0038: ldc.i4.0
+		IL_0039: ldloc.0
+		IL_003a: stelem.ref
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0045: ldc.i4.1
+		IL_0046: conv.r8
+		IL_0047: ldstr ""
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0051: stloc.2
+		IL_0052: ldloc.2
+		IL_0053: ldstr "mul"
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_005d: stloc.2
+		IL_005e: ldloc.2
+		IL_005f: stloc.1
+		IL_0060: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0065: stloc.3
+		IL_0066: ldloc.1
+		IL_0067: ldloc.3
+		IL_0068: ldc.r8 3
+		IL_0071: box [System.Runtime]System.Double
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_007b: stloc.2
+		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0081: ldstr "product is "
+		IL_0086: ldloc.2
+		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008c: pop
+		IL_008d: ret
 	} // end of method ArrowFunction_CapturesOuterVariable::__js_module_init__
 
 } // end of class Modules.ArrowFunction_CapturesOuterVariable
@@ -198,7 +180,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2145
+		// Method begins at RVA 0x211f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/tests/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219e
+				// Method begins at RVA 0x2179
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a7
+				// Method begins at RVA 0x2182
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -95,13 +95,10 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x213c
-			// Header size: 12
-			// Code size: 66 (0x42)
+			// Method begins at RVA 0x2139
+			// Header size: 1
+			// Code size: 54 (0x36)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: ldstr "This is a proxy function."
@@ -111,20 +108,16 @@
 			IL_001d: pop
 			IL_001e: ldarg.0
 			IL_001f: ldfld object Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
-			IL_0024: ldstr "Cannot access 'helloWorld' before initialization"
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_002e: stloc.0
-			IL_002f: ldloc.0
-			IL_0030: ldc.i4.1
-			IL_0031: newarr [System.Runtime]System.Object
-			IL_0036: dup
-			IL_0037: ldc.i4.0
-			IL_0038: ldarg.0
-			IL_0039: stelem.ref
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
-			IL_003f: pop
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0024: ldc.i4.1
+			IL_0025: newarr [System.Runtime]System.Object
+			IL_002a: dup
+			IL_002b: ldc.i4.0
+			IL_002c: ldarg.0
+			IL_002d: stelem.ref
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
+			IL_0033: pop
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method ArrowFunction_L8C25::__js_call__
 
 	} // end of class ArrowFunction_L8C25
@@ -144,18 +137,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218a
+			// Method begins at RVA 0x2170
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -258,7 +248,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b0
+		// Method begins at RVA 0x218b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Js2IL.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d7
+					// Method begins at RVA 0x21a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,48 +48,39 @@
 				)
 				// Method begins at RVA 0x2138
 				// Header size: 12
-				// Code size: 107 (0x6b)
+				// Code size: 83 (0x53)
 				.maxstack 8
 				.locals init (
-					[0] string,
-					[1] object
+					[0] string
 				)
 
 				IL_0000: ldstr "inner"
 				IL_0005: stloc.0
-				IL_0006: ldarg.0
-				IL_0007: ldc.i4.0
-				IL_0008: ldelem.ref
-				IL_0009: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
-				IL_000e: ldfld object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
-				IL_0013: ldstr "Cannot access 'globalVar' before initialization"
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001d: stloc.1
-				IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0023: ldstr "Global:"
-				IL_0028: ldloc.1
-				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_002e: pop
-				IL_002f: ldarg.0
-				IL_0030: ldc.i4.1
-				IL_0031: ldelem.ref
-				IL_0032: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope
-				IL_0037: ldfld object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
-				IL_003c: ldstr "Cannot access 'outerVar' before initialization"
-				IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0046: stloc.1
-				IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_004c: ldstr "Outer:"
-				IL_0051: ldloc.1
-				IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0057: pop
-				IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_005d: ldstr "Inner:"
-				IL_0062: ldloc.0
-				IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0068: pop
-				IL_0069: ldnull
-				IL_006a: ret
+				IL_0006: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_000b: ldstr "Global:"
+				IL_0010: ldarg.0
+				IL_0011: ldc.i4.0
+				IL_0012: ldelem.ref
+				IL_0013: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
+				IL_0018: ldfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
+				IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0022: pop
+				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0028: ldstr "Outer:"
+				IL_002d: ldarg.0
+				IL_002e: ldc.i4.1
+				IL_002f: ldelem.ref
+				IL_0030: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope
+				IL_0035: ldfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
+				IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_003f: pop
+				IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0045: ldstr "Inner:"
+				IL_004a: ldloc.0
+				IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0050: pop
+				IL_0051: ldnull
+				IL_0052: ret
 			} // end of method ArrowFunction_L8C28::__js_call__
 
 		} // end of class ArrowFunction_L8C28
@@ -102,24 +93,21 @@
 				72 3d 7b 6f 75 74 65 72 56 61 72 7d 00 00
 			)
 			// Fields
-			.field public object outerVar
+			.field public string outerVar
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c3
+				// Method begins at RVA 0x21a0
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -151,7 +139,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "outer"
-			IL_000c: stfld object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
+			IL_000c: stfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
 			IL_0011: ldnull
 			IL_0012: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
 			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
@@ -201,24 +189,21 @@
 			61 72 3d 7b 67 6c 6f 62 61 6c 56 61 72 7d 00 00
 		)
 		// Fields
-		.field public object globalVar
+		.field public string globalVar
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21af
+			// Method begins at RVA 0x2197
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -248,7 +233,7 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldstr "global"
-		IL_000c: stfld object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
+		IL_000c: stfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
 		IL_0011: ldc.i4.1
 		IL_0012: newarr [System.Runtime]System.Object
 		IL_0017: dup
@@ -295,7 +280,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e0
+		// Method begins at RVA 0x21b2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
+++ b/tests/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x263a
+					// Method begins at RVA 0x2623
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2550
+				// Method begins at RVA 0x2544
 				// Header size: 12
 				// Code size: 122 (0x7a)
 				.maxstack 8
@@ -112,7 +112,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2643
+					// Method begins at RVA 0x262c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -136,7 +136,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25d8
+				// Method begins at RVA 0x25cc
 				// Header size: 12
 				// Code size: 57 (0x39)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2631
+				// Method begins at RVA 0x261a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -298,7 +298,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x264c
+				// Method begins at RVA 0x2635
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -326,7 +326,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2667
+						// Method begins at RVA 0x2650
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -344,7 +344,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x265e
+					// Method begins at RVA 0x2647
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -362,7 +362,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2655
+				// Method begins at RVA 0x263e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -388,7 +388,7 @@
 			)
 			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 872 (0x368)
+			// Code size: 858 (0x35a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope,
@@ -486,302 +486,298 @@
 
 			IL_00a4: ldloc.0
 			IL_00a5: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00aa: switch (IL_00c3, IL_01ee, IL_028c, IL_0175, IL_0280)
+			IL_00aa: switch (IL_00c3, IL_01e0, IL_027e, IL_0167, IL_0272)
 
 			IL_00c3: ldarg.0
 			IL_00c4: ldc.i4.1
 			IL_00c5: ldelem.ref
 			IL_00c6: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope
 			IL_00cb: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::iterable
-			IL_00d0: ldstr "Cannot access 'iterable' before initialization"
-			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00da: stloc.s 9
-			IL_00dc: ldloc.s 9
-			IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_00e3: stloc.1
-			IL_00e4: ldc.i4.0
-			IL_00e5: stloc.2
-			IL_00e6: ldc.i4.0
-			IL_00e7: stloc.3
+			IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_00d5: stloc.1
+			IL_00d6: ldc.i4.0
+			IL_00d7: stloc.2
+			IL_00d8: ldc.i4.0
+			IL_00d9: stloc.3
+			IL_00da: ldloc.0
+			IL_00db: ldc.i4.0
+			IL_00dc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00e1: ldloc.0
+			IL_00e2: ldc.i4.0
+			IL_00e3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
 			IL_00e8: ldloc.0
 			IL_00e9: ldc.i4.0
-			IL_00ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00ea: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
 			IL_00ef: ldloc.0
 			IL_00f0: ldc.i4.0
-			IL_00f1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_00f6: ldloc.0
-			IL_00f7: ldc.i4.0
-			IL_00f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_00fd: ldloc.0
-			IL_00fe: ldc.i4.0
-			IL_00ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_0104: ldloc.1
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_010a: stloc.s 9
-			IL_010c: ldloc.0
-			IL_010d: ldc.i4.3
-			IL_010e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0113: ldloc.0
-			IL_0114: ldloc.s 9
-			IL_0116: ldarg.0
-			IL_0117: ldc.i4.1
-			IL_0118: ldloc.0
-			IL_0119: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_011e: ldc.i4.1
-			IL_011f: ldstr "_pendingException"
-			IL_0124: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0129: ldloc.0
-			IL_012a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_012f: dup
-			IL_0130: ldc.i4.0
-			IL_0131: ldloc.1
-			IL_0132: stelem.ref
-			IL_0133: dup
-			IL_0134: ldc.i4.1
-			IL_0135: ldloc.2
-			IL_0136: box [System.Runtime]System.Boolean
+			IL_00f6: ldloc.1
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_00fc: stloc.s 9
+			IL_00fe: ldloc.0
+			IL_00ff: ldc.i4.3
+			IL_0100: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0105: ldloc.0
+			IL_0106: ldloc.s 9
+			IL_0108: ldarg.0
+			IL_0109: ldc.i4.1
+			IL_010a: ldloc.0
+			IL_010b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0110: ldc.i4.1
+			IL_0111: ldstr "_pendingException"
+			IL_0116: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_011b: ldloc.0
+			IL_011c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0121: dup
+			IL_0122: ldc.i4.0
+			IL_0123: ldloc.1
+			IL_0124: stelem.ref
+			IL_0125: dup
+			IL_0126: ldc.i4.1
+			IL_0127: ldloc.2
+			IL_0128: box [System.Runtime]System.Boolean
+			IL_012d: stelem.ref
+			IL_012e: dup
+			IL_012f: ldc.i4.2
+			IL_0130: ldloc.3
+			IL_0131: box [System.Runtime]System.Boolean
+			IL_0136: stelem.ref
+			IL_0137: dup
+			IL_0138: ldc.i4.3
+			IL_0139: ldloc.s 4
 			IL_013b: stelem.ref
 			IL_013c: dup
-			IL_013d: ldc.i4.2
-			IL_013e: ldloc.3
-			IL_013f: box [System.Runtime]System.Boolean
-			IL_0144: stelem.ref
-			IL_0145: dup
-			IL_0146: ldc.i4.3
-			IL_0147: ldloc.s 4
-			IL_0149: stelem.ref
-			IL_014a: dup
-			IL_014b: ldc.i4.4
-			IL_014c: ldloc.s 5
-			IL_014e: stelem.ref
-			IL_014f: dup
-			IL_0150: ldc.i4.5
-			IL_0151: ldloc.s 6
-			IL_0153: stelem.ref
-			IL_0154: dup
-			IL_0155: ldc.i4.6
-			IL_0156: ldloc.s 7
-			IL_0158: box [System.Runtime]System.Boolean
-			IL_015d: stelem.ref
-			IL_015e: dup
-			IL_015f: ldc.i4.7
-			IL_0160: ldloc.s 8
-			IL_0162: box [System.Runtime]System.Boolean
-			IL_0167: stelem.ref
-			IL_0168: pop
-			IL_0169: ldloc.0
-			IL_016a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_016f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0174: ret
+			IL_013d: ldc.i4.4
+			IL_013e: ldloc.s 5
+			IL_0140: stelem.ref
+			IL_0141: dup
+			IL_0142: ldc.i4.5
+			IL_0143: ldloc.s 6
+			IL_0145: stelem.ref
+			IL_0146: dup
+			IL_0147: ldc.i4.6
+			IL_0148: ldloc.s 7
+			IL_014a: box [System.Runtime]System.Boolean
+			IL_014f: stelem.ref
+			IL_0150: dup
+			IL_0151: ldc.i4.7
+			IL_0152: ldloc.s 8
+			IL_0154: box [System.Runtime]System.Boolean
+			IL_0159: stelem.ref
+			IL_015a: pop
+			IL_015b: ldloc.0
+			IL_015c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0161: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0166: ret
 
-			IL_0175: ldloc.0
-			IL_0176: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope::_awaited1
-			IL_017b: stloc.s 9
-			IL_017d: ldloc.s 9
-			IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0184: stloc.s 10
-			IL_0186: ldloc.s 10
-			IL_0188: brtrue IL_01e7
+			IL_0167: ldloc.0
+			IL_0168: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope::_awaited1
+			IL_016d: stloc.s 9
+			IL_016f: ldloc.s 9
+			IL_0171: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0176: stloc.s 10
+			IL_0178: ldloc.s 10
+			IL_017a: brtrue IL_01d9
 
-			IL_018d: ldloc.s 9
-			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0194: stloc.s 9
-			IL_0196: ldloc.s 9
-			IL_0198: stloc.s 4
-			IL_019a: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope_ForOf_L18C15/Block_L18C36::.ctor()
-			IL_019f: stloc.s 5
-			IL_01a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01a6: ldstr "x:"
-			IL_01ab: ldloc.s 4
-			IL_01ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01b2: pop
-			IL_01b3: ldloc.s 4
-			IL_01b5: ldc.r8 1
-			IL_01be: box [System.Runtime]System.Double
-			IL_01c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01c8: stloc.s 10
-			IL_01ca: ldloc.s 10
-			IL_01cc: brfalse IL_01dd
+			IL_017f: ldloc.s 9
+			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_0186: stloc.s 9
+			IL_0188: ldloc.s 9
+			IL_018a: stloc.s 4
+			IL_018c: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope_ForOf_L18C15/Block_L18C36::.ctor()
+			IL_0191: stloc.s 5
+			IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0198: ldstr "x:"
+			IL_019d: ldloc.s 4
+			IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01a4: pop
+			IL_01a5: ldloc.s 4
+			IL_01a7: ldc.r8 1
+			IL_01b0: box [System.Runtime]System.Double
+			IL_01b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01ba: stloc.s 10
+			IL_01bc: ldloc.s 10
+			IL_01be: brfalse IL_01cf
 
-			IL_01d1: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope_ForOf_L18C15/Block_L18C36/Block_L20C21::.ctor()
-			IL_01d6: stloc.s 6
-			IL_01d8: br IL_01e2
+			IL_01c3: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope_ForOf_L18C15/Block_L18C36/Block_L20C21::.ctor()
+			IL_01c8: stloc.s 6
+			IL_01ca: br IL_01d4
 
-			IL_01dd: br IL_0104
+			IL_01cf: br IL_00f6
 
-			IL_01e2: br IL_0201
+			IL_01d4: br IL_01f3
 
-			IL_01e7: ldc.i4.1
-			IL_01e8: stloc.2
-			IL_01e9: br IL_0201
+			IL_01d9: ldc.i4.1
+			IL_01da: stloc.2
+			IL_01db: br IL_01f3
 
-			IL_01ee: ldloc.0
-			IL_01ef: ldc.i4.1
-			IL_01f0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01f5: ldloc.0
-			IL_01f6: ldc.i4.0
-			IL_01f7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_01fc: br IL_0201
+			IL_01e0: ldloc.0
+			IL_01e1: ldc.i4.1
+			IL_01e2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01e7: ldloc.0
+			IL_01e8: ldc.i4.0
+			IL_01e9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_01ee: br IL_01f3
 
-			IL_0201: ldloc.2
-			IL_0202: brtrue IL_0287
+			IL_01f3: ldloc.2
+			IL_01f4: brtrue IL_0279
 
-			IL_0207: ldloc.3
-			IL_0208: brtrue IL_0287
+			IL_01f9: ldloc.3
+			IL_01fa: brtrue IL_0279
 
-			IL_020d: ldc.i4.1
-			IL_020e: stloc.3
-			IL_020f: ldloc.1
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_0215: stloc.s 9
-			IL_0217: ldloc.0
-			IL_0218: ldc.i4.4
-			IL_0219: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_021e: ldloc.0
-			IL_021f: ldloc.s 9
-			IL_0221: ldarg.0
-			IL_0222: ldc.i4.2
-			IL_0223: ldloc.0
-			IL_0224: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0229: ldc.i4.2
-			IL_022a: ldstr "_pendingException"
-			IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0234: ldloc.0
-			IL_0235: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_023a: dup
-			IL_023b: ldc.i4.0
-			IL_023c: ldloc.1
-			IL_023d: stelem.ref
-			IL_023e: dup
-			IL_023f: ldc.i4.1
-			IL_0240: ldloc.2
-			IL_0241: box [System.Runtime]System.Boolean
+			IL_01ff: ldc.i4.1
+			IL_0200: stloc.3
+			IL_0201: ldloc.1
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_0207: stloc.s 9
+			IL_0209: ldloc.0
+			IL_020a: ldc.i4.4
+			IL_020b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0210: ldloc.0
+			IL_0211: ldloc.s 9
+			IL_0213: ldarg.0
+			IL_0214: ldc.i4.2
+			IL_0215: ldloc.0
+			IL_0216: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_021b: ldc.i4.2
+			IL_021c: ldstr "_pendingException"
+			IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0226: ldloc.0
+			IL_0227: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_022c: dup
+			IL_022d: ldc.i4.0
+			IL_022e: ldloc.1
+			IL_022f: stelem.ref
+			IL_0230: dup
+			IL_0231: ldc.i4.1
+			IL_0232: ldloc.2
+			IL_0233: box [System.Runtime]System.Boolean
+			IL_0238: stelem.ref
+			IL_0239: dup
+			IL_023a: ldc.i4.2
+			IL_023b: ldloc.3
+			IL_023c: box [System.Runtime]System.Boolean
+			IL_0241: stelem.ref
+			IL_0242: dup
+			IL_0243: ldc.i4.3
+			IL_0244: ldloc.s 4
 			IL_0246: stelem.ref
 			IL_0247: dup
-			IL_0248: ldc.i4.2
-			IL_0249: ldloc.3
-			IL_024a: box [System.Runtime]System.Boolean
-			IL_024f: stelem.ref
-			IL_0250: dup
-			IL_0251: ldc.i4.3
-			IL_0252: ldloc.s 4
-			IL_0254: stelem.ref
-			IL_0255: dup
-			IL_0256: ldc.i4.4
-			IL_0257: ldloc.s 5
-			IL_0259: stelem.ref
-			IL_025a: dup
-			IL_025b: ldc.i4.5
-			IL_025c: ldloc.s 6
-			IL_025e: stelem.ref
-			IL_025f: dup
-			IL_0260: ldc.i4.6
-			IL_0261: ldloc.s 7
-			IL_0263: box [System.Runtime]System.Boolean
-			IL_0268: stelem.ref
-			IL_0269: dup
-			IL_026a: ldc.i4.7
-			IL_026b: ldloc.s 8
-			IL_026d: box [System.Runtime]System.Boolean
-			IL_0272: stelem.ref
-			IL_0273: pop
-			IL_0274: ldloc.0
-			IL_0275: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_027a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_027f: ret
+			IL_0248: ldc.i4.4
+			IL_0249: ldloc.s 5
+			IL_024b: stelem.ref
+			IL_024c: dup
+			IL_024d: ldc.i4.5
+			IL_024e: ldloc.s 6
+			IL_0250: stelem.ref
+			IL_0251: dup
+			IL_0252: ldc.i4.6
+			IL_0253: ldloc.s 7
+			IL_0255: box [System.Runtime]System.Boolean
+			IL_025a: stelem.ref
+			IL_025b: dup
+			IL_025c: ldc.i4.7
+			IL_025d: ldloc.s 8
+			IL_025f: box [System.Runtime]System.Boolean
+			IL_0264: stelem.ref
+			IL_0265: pop
+			IL_0266: ldloc.0
+			IL_0267: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_026c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0271: ret
 
-			IL_0280: ldloc.0
-			IL_0281: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope::_awaited2
-			IL_0286: pop
+			IL_0272: ldloc.0
+			IL_0273: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope::_awaited2
+			IL_0278: pop
 
-			IL_0287: br IL_029f
+			IL_0279: br IL_0291
 
-			IL_028c: ldloc.0
-			IL_028d: ldc.i4.1
-			IL_028e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0293: ldloc.0
-			IL_0294: ldc.i4.0
-			IL_0295: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_029a: br IL_029f
+			IL_027e: ldloc.0
+			IL_027f: ldc.i4.1
+			IL_0280: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0285: ldloc.0
+			IL_0286: ldc.i4.0
+			IL_0287: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_028c: br IL_0291
 
-			IL_029f: ldloc.0
-			IL_02a0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02a5: stloc.s 7
-			IL_02a7: ldloc.s 7
-			IL_02a9: brfalse IL_02e6
+			IL_0291: ldloc.0
+			IL_0292: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0297: stloc.s 7
+			IL_0299: ldloc.s 7
+			IL_029b: brfalse IL_02d8
 
-			IL_02ae: ldloc.0
-			IL_02af: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_02b4: stloc.s 9
-			IL_02b6: ldloc.0
-			IL_02b7: ldc.i4.m1
-			IL_02b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02bd: ldloc.0
-			IL_02be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_02c8: ldarg.0
-			IL_02c9: ldc.i4.1
-			IL_02ca: newarr [System.Runtime]System.Object
-			IL_02cf: dup
-			IL_02d0: ldc.i4.0
-			IL_02d1: ldloc.s 9
-			IL_02d3: stelem.ref
-			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02d9: pop
-			IL_02da: ldloc.0
-			IL_02db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02e5: ret
+			IL_02a0: ldloc.0
+			IL_02a1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_02a6: stloc.s 9
+			IL_02a8: ldloc.0
+			IL_02a9: ldc.i4.m1
+			IL_02aa: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02af: ldloc.0
+			IL_02b0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_02ba: ldarg.0
+			IL_02bb: ldc.i4.1
+			IL_02bc: newarr [System.Runtime]System.Object
+			IL_02c1: dup
+			IL_02c2: ldc.i4.0
+			IL_02c3: ldloc.s 9
+			IL_02c5: stelem.ref
+			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02cb: pop
+			IL_02cc: ldloc.0
+			IL_02cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02d2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d7: ret
 
-			IL_02e6: ldloc.0
-			IL_02e7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02ec: stloc.s 8
-			IL_02ee: ldloc.s 8
-			IL_02f0: brfalse IL_032d
+			IL_02d8: ldloc.0
+			IL_02d9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02de: stloc.s 8
+			IL_02e0: ldloc.s 8
+			IL_02e2: brfalse IL_031f
 
-			IL_02f5: ldloc.0
-			IL_02f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_02fb: stloc.s 9
-			IL_02fd: ldloc.0
-			IL_02fe: ldc.i4.m1
-			IL_02ff: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0304: ldloc.0
-			IL_0305: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_030f: ldarg.0
-			IL_0310: ldc.i4.1
-			IL_0311: newarr [System.Runtime]System.Object
-			IL_0316: dup
-			IL_0317: ldc.i4.0
-			IL_0318: ldloc.s 9
-			IL_031a: stelem.ref
-			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0320: pop
-			IL_0321: ldloc.0
-			IL_0322: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0327: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_032c: ret
+			IL_02e7: ldloc.0
+			IL_02e8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_02ed: stloc.s 9
+			IL_02ef: ldloc.0
+			IL_02f0: ldc.i4.m1
+			IL_02f1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02f6: ldloc.0
+			IL_02f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0301: ldarg.0
+			IL_0302: ldc.i4.1
+			IL_0303: newarr [System.Runtime]System.Object
+			IL_0308: dup
+			IL_0309: ldc.i4.0
+			IL_030a: ldloc.s 9
+			IL_030c: stelem.ref
+			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0312: pop
+			IL_0313: ldloc.0
+			IL_0314: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0319: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_031e: ret
 
-			IL_032d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0332: ldstr "after"
-			IL_0337: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_033c: pop
-			IL_033d: ldloc.0
-			IL_033e: ldc.i4.m1
-			IL_033f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0344: ldloc.0
-			IL_0345: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_034a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_034f: ldarg.0
-			IL_0350: ldc.i4.1
-			IL_0351: newarr [System.Runtime]System.Object
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_035b: pop
-			IL_035c: ldloc.0
-			IL_035d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0362: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0367: ret
+			IL_031f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0324: ldstr "after"
+			IL_0329: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_032e: pop
+			IL_032f: ldloc.0
+			IL_0330: ldc.i4.m1
+			IL_0331: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0336: ldloc.0
+			IL_0337: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_033c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0341: ldarg.0
+			IL_0342: ldc.i4.1
+			IL_0343: newarr [System.Runtime]System.Object
+			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_034d: pop
+			IL_034e: ldloc.0
+			IL_034f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0354: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0359: ret
 		} // end of method test::__js_call__
 
 	} // end of class test
@@ -797,7 +793,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2670
+				// Method begins at RVA 0x2659
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -820,7 +816,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x253c
+			// Method begins at RVA 0x252e
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -851,18 +847,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x261d
+			// Method begins at RVA 0x2611
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::iterable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -978,7 +971,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2679
+		// Method begins at RVA 0x2662
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
+++ b/tests/Js2IL.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x260f
+					// Method begins at RVA 0x25f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2550
+				// Method begins at RVA 0x2544
 				// Header size: 12
 				// Code size: 115 (0x73)
 				.maxstack 8
@@ -109,7 +109,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2618
+					// Method begins at RVA 0x2601
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -133,7 +133,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25cf
+				// Method begins at RVA 0x25c3
 				// Header size: 1
 				// Code size: 34 (0x22)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2606
+				// Method begins at RVA 0x25ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -285,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2621
+				// Method begins at RVA 0x260a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -313,7 +313,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x263c
+						// Method begins at RVA 0x2625
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -331,7 +331,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2633
+					// Method begins at RVA 0x261c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -349,7 +349,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262a
+				// Method begins at RVA 0x2613
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -375,7 +375,7 @@
 			)
 			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 872 (0x368)
+			// Code size: 858 (0x35a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope,
@@ -473,302 +473,298 @@
 
 			IL_00a4: ldloc.0
 			IL_00a5: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00aa: switch (IL_00c3, IL_01ee, IL_028c, IL_0175, IL_0280)
+			IL_00aa: switch (IL_00c3, IL_01e0, IL_027e, IL_0167, IL_0272)
 
 			IL_00c3: ldarg.0
 			IL_00c4: ldc.i4.1
 			IL_00c5: ldelem.ref
 			IL_00c6: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope
 			IL_00cb: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::iterable
-			IL_00d0: ldstr "Cannot access 'iterable' before initialization"
-			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00da: stloc.s 9
-			IL_00dc: ldloc.s 9
-			IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_00e3: stloc.1
-			IL_00e4: ldc.i4.0
-			IL_00e5: stloc.2
-			IL_00e6: ldc.i4.0
-			IL_00e7: stloc.3
+			IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_00d5: stloc.1
+			IL_00d6: ldc.i4.0
+			IL_00d7: stloc.2
+			IL_00d8: ldc.i4.0
+			IL_00d9: stloc.3
+			IL_00da: ldloc.0
+			IL_00db: ldc.i4.0
+			IL_00dc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00e1: ldloc.0
+			IL_00e2: ldc.i4.0
+			IL_00e3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
 			IL_00e8: ldloc.0
 			IL_00e9: ldc.i4.0
-			IL_00ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00ea: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
 			IL_00ef: ldloc.0
 			IL_00f0: ldc.i4.0
-			IL_00f1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_00f6: ldloc.0
-			IL_00f7: ldc.i4.0
-			IL_00f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_00fd: ldloc.0
-			IL_00fe: ldc.i4.0
-			IL_00ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_0104: ldloc.1
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_010a: stloc.s 9
-			IL_010c: ldloc.0
-			IL_010d: ldc.i4.3
-			IL_010e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0113: ldloc.0
-			IL_0114: ldloc.s 9
-			IL_0116: ldarg.0
-			IL_0117: ldc.i4.1
-			IL_0118: ldloc.0
-			IL_0119: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_011e: ldc.i4.1
-			IL_011f: ldstr "_pendingException"
-			IL_0124: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0129: ldloc.0
-			IL_012a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_012f: dup
-			IL_0130: ldc.i4.0
-			IL_0131: ldloc.1
-			IL_0132: stelem.ref
-			IL_0133: dup
-			IL_0134: ldc.i4.1
-			IL_0135: ldloc.2
-			IL_0136: box [System.Runtime]System.Boolean
+			IL_00f6: ldloc.1
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_00fc: stloc.s 9
+			IL_00fe: ldloc.0
+			IL_00ff: ldc.i4.3
+			IL_0100: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0105: ldloc.0
+			IL_0106: ldloc.s 9
+			IL_0108: ldarg.0
+			IL_0109: ldc.i4.1
+			IL_010a: ldloc.0
+			IL_010b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0110: ldc.i4.1
+			IL_0111: ldstr "_pendingException"
+			IL_0116: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_011b: ldloc.0
+			IL_011c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0121: dup
+			IL_0122: ldc.i4.0
+			IL_0123: ldloc.1
+			IL_0124: stelem.ref
+			IL_0125: dup
+			IL_0126: ldc.i4.1
+			IL_0127: ldloc.2
+			IL_0128: box [System.Runtime]System.Boolean
+			IL_012d: stelem.ref
+			IL_012e: dup
+			IL_012f: ldc.i4.2
+			IL_0130: ldloc.3
+			IL_0131: box [System.Runtime]System.Boolean
+			IL_0136: stelem.ref
+			IL_0137: dup
+			IL_0138: ldc.i4.3
+			IL_0139: ldloc.s 4
 			IL_013b: stelem.ref
 			IL_013c: dup
-			IL_013d: ldc.i4.2
-			IL_013e: ldloc.3
-			IL_013f: box [System.Runtime]System.Boolean
-			IL_0144: stelem.ref
-			IL_0145: dup
-			IL_0146: ldc.i4.3
-			IL_0147: ldloc.s 4
-			IL_0149: stelem.ref
-			IL_014a: dup
-			IL_014b: ldc.i4.4
-			IL_014c: ldloc.s 5
-			IL_014e: stelem.ref
-			IL_014f: dup
-			IL_0150: ldc.i4.5
-			IL_0151: ldloc.s 6
-			IL_0153: stelem.ref
-			IL_0154: dup
-			IL_0155: ldc.i4.6
-			IL_0156: ldloc.s 7
-			IL_0158: box [System.Runtime]System.Boolean
-			IL_015d: stelem.ref
-			IL_015e: dup
-			IL_015f: ldc.i4.7
-			IL_0160: ldloc.s 8
-			IL_0162: box [System.Runtime]System.Boolean
-			IL_0167: stelem.ref
-			IL_0168: pop
-			IL_0169: ldloc.0
-			IL_016a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_016f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0174: ret
+			IL_013d: ldc.i4.4
+			IL_013e: ldloc.s 5
+			IL_0140: stelem.ref
+			IL_0141: dup
+			IL_0142: ldc.i4.5
+			IL_0143: ldloc.s 6
+			IL_0145: stelem.ref
+			IL_0146: dup
+			IL_0147: ldc.i4.6
+			IL_0148: ldloc.s 7
+			IL_014a: box [System.Runtime]System.Boolean
+			IL_014f: stelem.ref
+			IL_0150: dup
+			IL_0151: ldc.i4.7
+			IL_0152: ldloc.s 8
+			IL_0154: box [System.Runtime]System.Boolean
+			IL_0159: stelem.ref
+			IL_015a: pop
+			IL_015b: ldloc.0
+			IL_015c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0161: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0166: ret
 
-			IL_0175: ldloc.0
-			IL_0176: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope::_awaited1
-			IL_017b: stloc.s 9
-			IL_017d: ldloc.s 9
-			IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0184: stloc.s 10
-			IL_0186: ldloc.s 10
-			IL_0188: brtrue IL_01e7
+			IL_0167: ldloc.0
+			IL_0168: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope::_awaited1
+			IL_016d: stloc.s 9
+			IL_016f: ldloc.s 9
+			IL_0171: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0176: stloc.s 10
+			IL_0178: ldloc.s 10
+			IL_017a: brtrue IL_01d9
 
-			IL_018d: ldloc.s 9
-			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0194: stloc.s 9
-			IL_0196: ldloc.s 9
-			IL_0198: stloc.s 4
-			IL_019a: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope_ForOf_L19C15/Block_L19C36::.ctor()
-			IL_019f: stloc.s 5
-			IL_01a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01a6: ldstr "x:"
-			IL_01ab: ldloc.s 4
-			IL_01ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01b2: pop
-			IL_01b3: ldloc.s 4
-			IL_01b5: ldc.r8 1
-			IL_01be: box [System.Runtime]System.Double
-			IL_01c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01c8: stloc.s 10
-			IL_01ca: ldloc.s 10
-			IL_01cc: brfalse IL_01dd
+			IL_017f: ldloc.s 9
+			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_0186: stloc.s 9
+			IL_0188: ldloc.s 9
+			IL_018a: stloc.s 4
+			IL_018c: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope_ForOf_L19C15/Block_L19C36::.ctor()
+			IL_0191: stloc.s 5
+			IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0198: ldstr "x:"
+			IL_019d: ldloc.s 4
+			IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01a4: pop
+			IL_01a5: ldloc.s 4
+			IL_01a7: ldc.r8 1
+			IL_01b0: box [System.Runtime]System.Double
+			IL_01b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01ba: stloc.s 10
+			IL_01bc: ldloc.s 10
+			IL_01be: brfalse IL_01cf
 
-			IL_01d1: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope_ForOf_L19C15/Block_L19C36/Block_L21C21::.ctor()
-			IL_01d6: stloc.s 6
-			IL_01d8: br IL_01e2
+			IL_01c3: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope_ForOf_L19C15/Block_L19C36/Block_L21C21::.ctor()
+			IL_01c8: stloc.s 6
+			IL_01ca: br IL_01d4
 
-			IL_01dd: br IL_0104
+			IL_01cf: br IL_00f6
 
-			IL_01e2: br IL_0201
+			IL_01d4: br IL_01f3
 
-			IL_01e7: ldc.i4.1
-			IL_01e8: stloc.2
-			IL_01e9: br IL_0201
+			IL_01d9: ldc.i4.1
+			IL_01da: stloc.2
+			IL_01db: br IL_01f3
 
-			IL_01ee: ldloc.0
-			IL_01ef: ldc.i4.1
-			IL_01f0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01f5: ldloc.0
-			IL_01f6: ldc.i4.0
-			IL_01f7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_01fc: br IL_0201
+			IL_01e0: ldloc.0
+			IL_01e1: ldc.i4.1
+			IL_01e2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01e7: ldloc.0
+			IL_01e8: ldc.i4.0
+			IL_01e9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_01ee: br IL_01f3
 
-			IL_0201: ldloc.2
-			IL_0202: brtrue IL_0287
+			IL_01f3: ldloc.2
+			IL_01f4: brtrue IL_0279
 
-			IL_0207: ldloc.3
-			IL_0208: brtrue IL_0287
+			IL_01f9: ldloc.3
+			IL_01fa: brtrue IL_0279
 
-			IL_020d: ldc.i4.1
-			IL_020e: stloc.3
-			IL_020f: ldloc.1
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_0215: stloc.s 9
-			IL_0217: ldloc.0
-			IL_0218: ldc.i4.4
-			IL_0219: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_021e: ldloc.0
-			IL_021f: ldloc.s 9
-			IL_0221: ldarg.0
-			IL_0222: ldc.i4.2
-			IL_0223: ldloc.0
-			IL_0224: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0229: ldc.i4.2
-			IL_022a: ldstr "_pendingException"
-			IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0234: ldloc.0
-			IL_0235: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_023a: dup
-			IL_023b: ldc.i4.0
-			IL_023c: ldloc.1
-			IL_023d: stelem.ref
-			IL_023e: dup
-			IL_023f: ldc.i4.1
-			IL_0240: ldloc.2
-			IL_0241: box [System.Runtime]System.Boolean
+			IL_01ff: ldc.i4.1
+			IL_0200: stloc.3
+			IL_0201: ldloc.1
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_0207: stloc.s 9
+			IL_0209: ldloc.0
+			IL_020a: ldc.i4.4
+			IL_020b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0210: ldloc.0
+			IL_0211: ldloc.s 9
+			IL_0213: ldarg.0
+			IL_0214: ldc.i4.2
+			IL_0215: ldloc.0
+			IL_0216: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_021b: ldc.i4.2
+			IL_021c: ldstr "_pendingException"
+			IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0226: ldloc.0
+			IL_0227: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_022c: dup
+			IL_022d: ldc.i4.0
+			IL_022e: ldloc.1
+			IL_022f: stelem.ref
+			IL_0230: dup
+			IL_0231: ldc.i4.1
+			IL_0232: ldloc.2
+			IL_0233: box [System.Runtime]System.Boolean
+			IL_0238: stelem.ref
+			IL_0239: dup
+			IL_023a: ldc.i4.2
+			IL_023b: ldloc.3
+			IL_023c: box [System.Runtime]System.Boolean
+			IL_0241: stelem.ref
+			IL_0242: dup
+			IL_0243: ldc.i4.3
+			IL_0244: ldloc.s 4
 			IL_0246: stelem.ref
 			IL_0247: dup
-			IL_0248: ldc.i4.2
-			IL_0249: ldloc.3
-			IL_024a: box [System.Runtime]System.Boolean
-			IL_024f: stelem.ref
-			IL_0250: dup
-			IL_0251: ldc.i4.3
-			IL_0252: ldloc.s 4
-			IL_0254: stelem.ref
-			IL_0255: dup
-			IL_0256: ldc.i4.4
-			IL_0257: ldloc.s 5
-			IL_0259: stelem.ref
-			IL_025a: dup
-			IL_025b: ldc.i4.5
-			IL_025c: ldloc.s 6
-			IL_025e: stelem.ref
-			IL_025f: dup
-			IL_0260: ldc.i4.6
-			IL_0261: ldloc.s 7
-			IL_0263: box [System.Runtime]System.Boolean
-			IL_0268: stelem.ref
-			IL_0269: dup
-			IL_026a: ldc.i4.7
-			IL_026b: ldloc.s 8
-			IL_026d: box [System.Runtime]System.Boolean
-			IL_0272: stelem.ref
-			IL_0273: pop
-			IL_0274: ldloc.0
-			IL_0275: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_027a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_027f: ret
+			IL_0248: ldc.i4.4
+			IL_0249: ldloc.s 5
+			IL_024b: stelem.ref
+			IL_024c: dup
+			IL_024d: ldc.i4.5
+			IL_024e: ldloc.s 6
+			IL_0250: stelem.ref
+			IL_0251: dup
+			IL_0252: ldc.i4.6
+			IL_0253: ldloc.s 7
+			IL_0255: box [System.Runtime]System.Boolean
+			IL_025a: stelem.ref
+			IL_025b: dup
+			IL_025c: ldc.i4.7
+			IL_025d: ldloc.s 8
+			IL_025f: box [System.Runtime]System.Boolean
+			IL_0264: stelem.ref
+			IL_0265: pop
+			IL_0266: ldloc.0
+			IL_0267: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_026c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0271: ret
 
-			IL_0280: ldloc.0
-			IL_0281: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope::_awaited2
-			IL_0286: pop
+			IL_0272: ldloc.0
+			IL_0273: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope::_awaited2
+			IL_0278: pop
 
-			IL_0287: br IL_029f
+			IL_0279: br IL_0291
 
-			IL_028c: ldloc.0
-			IL_028d: ldc.i4.1
-			IL_028e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0293: ldloc.0
-			IL_0294: ldc.i4.0
-			IL_0295: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_029a: br IL_029f
+			IL_027e: ldloc.0
+			IL_027f: ldc.i4.1
+			IL_0280: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0285: ldloc.0
+			IL_0286: ldc.i4.0
+			IL_0287: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_028c: br IL_0291
 
-			IL_029f: ldloc.0
-			IL_02a0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02a5: stloc.s 7
-			IL_02a7: ldloc.s 7
-			IL_02a9: brfalse IL_02e6
+			IL_0291: ldloc.0
+			IL_0292: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0297: stloc.s 7
+			IL_0299: ldloc.s 7
+			IL_029b: brfalse IL_02d8
 
-			IL_02ae: ldloc.0
-			IL_02af: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_02b4: stloc.s 9
-			IL_02b6: ldloc.0
-			IL_02b7: ldc.i4.m1
-			IL_02b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02bd: ldloc.0
-			IL_02be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_02c8: ldarg.0
-			IL_02c9: ldc.i4.1
-			IL_02ca: newarr [System.Runtime]System.Object
-			IL_02cf: dup
-			IL_02d0: ldc.i4.0
-			IL_02d1: ldloc.s 9
-			IL_02d3: stelem.ref
-			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02d9: pop
-			IL_02da: ldloc.0
-			IL_02db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02e5: ret
+			IL_02a0: ldloc.0
+			IL_02a1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_02a6: stloc.s 9
+			IL_02a8: ldloc.0
+			IL_02a9: ldc.i4.m1
+			IL_02aa: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02af: ldloc.0
+			IL_02b0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_02ba: ldarg.0
+			IL_02bb: ldc.i4.1
+			IL_02bc: newarr [System.Runtime]System.Object
+			IL_02c1: dup
+			IL_02c2: ldc.i4.0
+			IL_02c3: ldloc.s 9
+			IL_02c5: stelem.ref
+			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02cb: pop
+			IL_02cc: ldloc.0
+			IL_02cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02d2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d7: ret
 
-			IL_02e6: ldloc.0
-			IL_02e7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02ec: stloc.s 8
-			IL_02ee: ldloc.s 8
-			IL_02f0: brfalse IL_032d
+			IL_02d8: ldloc.0
+			IL_02d9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02de: stloc.s 8
+			IL_02e0: ldloc.s 8
+			IL_02e2: brfalse IL_031f
 
-			IL_02f5: ldloc.0
-			IL_02f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_02fb: stloc.s 9
-			IL_02fd: ldloc.0
-			IL_02fe: ldc.i4.m1
-			IL_02ff: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0304: ldloc.0
-			IL_0305: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_030f: ldarg.0
-			IL_0310: ldc.i4.1
-			IL_0311: newarr [System.Runtime]System.Object
-			IL_0316: dup
-			IL_0317: ldc.i4.0
-			IL_0318: ldloc.s 9
-			IL_031a: stelem.ref
-			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0320: pop
-			IL_0321: ldloc.0
-			IL_0322: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0327: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_032c: ret
+			IL_02e7: ldloc.0
+			IL_02e8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_02ed: stloc.s 9
+			IL_02ef: ldloc.0
+			IL_02f0: ldc.i4.m1
+			IL_02f1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02f6: ldloc.0
+			IL_02f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0301: ldarg.0
+			IL_0302: ldc.i4.1
+			IL_0303: newarr [System.Runtime]System.Object
+			IL_0308: dup
+			IL_0309: ldc.i4.0
+			IL_030a: ldloc.s 9
+			IL_030c: stelem.ref
+			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0312: pop
+			IL_0313: ldloc.0
+			IL_0314: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0319: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_031e: ret
 
-			IL_032d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0332: ldstr "after"
-			IL_0337: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_033c: pop
-			IL_033d: ldloc.0
-			IL_033e: ldc.i4.m1
-			IL_033f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0344: ldloc.0
-			IL_0345: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_034a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_034f: ldarg.0
-			IL_0350: ldc.i4.1
-			IL_0351: newarr [System.Runtime]System.Object
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_035b: pop
-			IL_035c: ldloc.0
-			IL_035d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0362: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0367: ret
+			IL_031f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0324: ldstr "after"
+			IL_0329: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_032e: pop
+			IL_032f: ldloc.0
+			IL_0330: ldc.i4.m1
+			IL_0331: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0336: ldloc.0
+			IL_0337: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_033c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0341: ldarg.0
+			IL_0342: ldc.i4.1
+			IL_0343: newarr [System.Runtime]System.Object
+			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_034d: pop
+			IL_034e: ldloc.0
+			IL_034f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0354: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0359: ret
 		} // end of method test::__js_call__
 
 	} // end of class test
@@ -784,7 +780,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2645
+				// Method begins at RVA 0x262e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -807,7 +803,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x253c
+			// Method begins at RVA 0x252e
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -838,18 +834,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25f2
+			// Method begins at RVA 0x25e6
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::iterable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -965,7 +958,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x264e
+		// Method begins at RVA 0x2637
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -22,30 +22,23 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21d4
 			// Header size: 12
-			// Code size: 47 (0x2f)
+			// Code size: 33 (0x21)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-			IL_0006: ldstr "Cannot access 'fieldKey' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.r8 1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldloc.1
-			IL_002e: ret
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldarg.0
+			IL_0006: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0010: ldc.r8 1
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: ret
 		} // end of method methodKey::__js_call__
 
 	} // end of class methodKey
@@ -61,7 +54,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229e
+				// Method begins at RVA 0x224e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -81,7 +74,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a7
+				// Method begins at RVA 0x2257
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,9 +101,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2234
+			// Method begins at RVA 0x2204
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 53 (0x35)
 			.maxstack 8
 			.locals init (
 				[0] object[],
@@ -128,18 +121,16 @@
 			IL_0010: ldc.i4.0
 			IL_0011: ldelem.ref
 			IL_0012: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
-			IL_0017: ldfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-			IL_001c: ldstr "Cannot access 'fieldKey' before initialization"
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0026: stloc.1
-			IL_0027: ldarg.0
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 41
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: ldc.i4.1
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_003d: pop
-			IL_003e: ret
+			IL_0017: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
+			IL_001c: stloc.1
+			IL_001d: ldarg.0
+			IL_001e: ldloc.1
+			IL_001f: ldc.r8 41
+			IL_0028: box [System.Runtime]System.Double
+			IL_002d: ldc.i4.1
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0033: pop
+			IL_0034: ret
 		} // end of method Example::.ctor
 
 	} // end of class Example
@@ -154,28 +145,22 @@
 			65 79 7d 00 00
 		)
 		// Fields
-		.field public object fieldKey
-		.field public object methodKey
+		.field public string fieldKey
+		.field public string methodKey
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227f
+			// Method begins at RVA 0x2245
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -193,7 +178,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 411 (0x19b)
+		// Code size: 373 (0x175)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope,
@@ -213,133 +198,123 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldstr "value"
-		IL_000c: stfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
+		IL_000c: stfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
 		IL_0011: ldloc.0
 		IL_0012: ldstr "bump"
-		IL_0017: stfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
+		IL_0017: stfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
 		IL_001c: ldloc.0
-		IL_001d: ldfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
-		IL_0022: ldstr "Cannot access 'methodKey' before initialization"
-		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_002c: stloc.3
+		IL_001d: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
+		IL_0022: stloc.3
+		IL_0023: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_0028: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_002d: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0032: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0037: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_003c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0041: stloc.s 4
-		IL_0043: ldloc.s 4
-		IL_0045: ldstr "prototype"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004f: stloc.s 5
-		IL_0051: ldc.i4.1
-		IL_0052: newarr [System.Runtime]System.Object
-		IL_0057: dup
-		IL_0058: ldc.i4.0
-		IL_0059: ldloc.0
-		IL_005a: stelem.ref
-		IL_005b: ldc.i4.0
-		IL_005c: ldelem.ref
-		IL_005d: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
-		IL_0062: ldftn object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
-		IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_006d: ldc.i4.0
-		IL_006e: conv.r8
-		IL_006f: ldstr ""
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0079: stloc.s 6
-		IL_007b: ldloc.s 5
-		IL_007d: ldloc.3
-		IL_007e: ldloc.s 6
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0085: pop
-		IL_0086: ldc.i4.1
-		IL_0087: newarr [System.Runtime]System.Object
-		IL_008c: dup
-		IL_008d: ldc.i4.0
-		IL_008e: ldloc.0
-		IL_008f: stelem.ref
-		IL_0090: stloc.s 7
+		IL_0032: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0037: stloc.s 4
+		IL_0039: ldloc.s 4
+		IL_003b: ldstr "prototype"
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0045: stloc.s 5
+		IL_0047: ldc.i4.1
+		IL_0048: newarr [System.Runtime]System.Object
+		IL_004d: dup
+		IL_004e: ldc.i4.0
+		IL_004f: ldloc.0
+		IL_0050: stelem.ref
+		IL_0051: ldc.i4.0
+		IL_0052: ldelem.ref
+		IL_0053: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
+		IL_0058: ldftn object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
+		IL_005e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0063: ldc.i4.0
+		IL_0064: conv.r8
+		IL_0065: ldstr ""
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_006f: stloc.s 6
+		IL_0071: ldloc.s 5
+		IL_0073: ldloc.3
+		IL_0074: ldloc.s 6
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_007b: pop
+		IL_007c: ldc.i4.1
+		IL_007d: newarr [System.Runtime]System.Object
+		IL_0082: dup
+		IL_0083: ldc.i4.0
+		IL_0084: ldloc.0
+		IL_0085: stelem.ref
+		IL_0086: stloc.s 7
+		IL_0088: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_008d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0092: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0097: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_009c: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_00a1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00a6: stloc.s 4
-		IL_00a8: ldloc.s 4
-		IL_00aa: ldloc.s 7
-		IL_00ac: ldc.r8 0.0
-		IL_00b5: box [System.Runtime]System.Double
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00bf: stloc.s 6
-		IL_00c1: ldloc.s 6
-		IL_00c3: stloc.1
-		IL_00c4: ldc.i4.1
+		IL_0097: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_009c: stloc.s 4
+		IL_009e: ldloc.s 4
+		IL_00a0: ldloc.s 7
+		IL_00a2: ldc.r8 0.0
+		IL_00ab: box [System.Runtime]System.Double
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_00b5: stloc.s 6
+		IL_00b7: ldloc.s 6
+		IL_00b9: stloc.1
+		IL_00ba: ldc.i4.1
+		IL_00bb: newarr [System.Runtime]System.Object
+		IL_00c0: dup
+		IL_00c1: ldc.i4.0
+		IL_00c2: ldloc.0
+		IL_00c3: stelem.ref
+		IL_00c4: ldc.i4.0
 		IL_00c5: newarr [System.Runtime]System.Object
-		IL_00ca: dup
-		IL_00cb: ldc.i4.0
-		IL_00cc: ldloc.0
-		IL_00cd: stelem.ref
-		IL_00ce: ldc.i4.0
-		IL_00cf: newarr [System.Runtime]System.Object
-		IL_00d4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00d9: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
-		IL_00de: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00e3: stloc.s 8
-		IL_00e5: ldloc.s 8
-		IL_00e7: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_00ec: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00f1: ldstr "prototype"
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00fb: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0100: ldloc.s 8
-		IL_0102: stloc.2
-		IL_0103: ldloc.0
-		IL_0104: ldfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-		IL_0109: ldstr "Cannot access 'fieldKey' before initialization"
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0113: stloc.s 6
-		IL_0115: ldloc.2
-		IL_0116: ldloc.s 6
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_011d: stloc.s 6
-		IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0124: ldloc.s 6
-		IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012b: pop
-		IL_012c: ldloc.0
-		IL_012d: ldfld object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
-		IL_0132: ldstr "Cannot access 'methodKey' before initialization"
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_013c: stloc.s 6
-		IL_013e: ldloc.2
-		IL_013f: ldloc.s 6
-		IL_0141: ldc.i4.0
-		IL_0142: newarr [System.Runtime]System.Object
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
-		IL_014c: stloc.s 6
-		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0153: ldloc.s 6
-		IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015a: pop
-		IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0160: ldloc.2
-		IL_0161: ldstr "value"
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0170: pop
-		IL_0171: ldloc.2
-		IL_0172: ldstr "fieldKey"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017c: ldnull
-		IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0182: stloc.s 9
-		IL_0184: ldloc.s 9
-		IL_0186: box [System.Runtime]System.Boolean
-		IL_018b: stloc.s 10
-		IL_018d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0192: ldloc.s 10
-		IL_0194: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0199: pop
-		IL_019a: ret
+		IL_00ca: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00cf: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
+		IL_00d4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00d9: stloc.s 8
+		IL_00db: ldloc.s 8
+		IL_00dd: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_00e2: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00e7: ldstr "prototype"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_00f1: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00f6: ldloc.s 8
+		IL_00f8: stloc.2
+		IL_00f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fe: ldloc.2
+		IL_00ff: ldloc.0
+		IL_0100: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010f: pop
+		IL_0110: ldloc.0
+		IL_0111: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
+		IL_0116: stloc.s 6
+		IL_0118: ldloc.2
+		IL_0119: ldloc.s 6
+		IL_011b: ldc.i4.0
+		IL_011c: newarr [System.Runtime]System.Object
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
+		IL_0126: stloc.s 6
+		IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012d: ldloc.s 6
+		IL_012f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0134: pop
+		IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013a: ldloc.2
+		IL_013b: ldstr "value"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0145: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014a: pop
+		IL_014b: ldloc.2
+		IL_014c: ldstr "fieldKey"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0156: ldnull
+		IL_0157: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_015c: stloc.s 9
+		IL_015e: ldloc.s 9
+		IL_0160: box [System.Runtime]System.Boolean
+		IL_0165: stloc.s 10
+		IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016c: ldloc.s 10
+		IL_016e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0173: pop
+		IL_0174: ret
 	} // end of method Classes_ClassComputedFieldAndMethod_DynamicKey_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log
@@ -351,7 +326,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b0
+		// Method begins at RVA 0x2260
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c0
+					// Method begins at RVA 0x2192
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c9
+					// Method begins at RVA 0x219b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -71,11 +71,10 @@
 				)
 				// Method begins at RVA 0x2128
 				// Header size: 12
-				// Code size: 100 (0x64)
+				// Code size: 76 (0x4c)
 				.maxstack 8
 				.locals init (
-					[0] object[],
-					[1] object
+					[0] object[]
 				)
 
 				IL_0000: ldarg.0
@@ -85,35 +84,27 @@
 				IL_0008: ldarg.0
 				IL_0009: ldloc.0
 				IL_000a: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass::_scopes
-				IL_000f: ldarg.1
-				IL_0010: ldc.i4.0
-				IL_0011: ldelem.ref
-				IL_0012: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
-				IL_0017: ldfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-				IL_001c: ldstr "Cannot access 'GLOBAL_VALUE' before initialization"
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0026: stloc.1
+				IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0014: ldarg.1
+				IL_0015: ldc.i4.0
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
+				IL_001c: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
+				IL_0021: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0026: pop
 				IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_002c: ldloc.1
-				IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0032: pop
-				IL_0033: ldarg.1
-				IL_0034: ldc.i4.1
-				IL_0035: ldelem.ref
-				IL_0036: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope
-				IL_003b: ldfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0040: ldstr "Cannot access 'FUNCTION_VALUE' before initialization"
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_004a: stloc.1
-				IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0050: ldloc.1
-				IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0056: pop
-				IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_005c: ldarg.2
-				IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0062: pop
-				IL_0063: ret
+				IL_002c: ldarg.1
+				IL_002d: ldc.i4.1
+				IL_002e: ldelem.ref
+				IL_002f: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope
+				IL_0034: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_003e: pop
+				IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0044: ldarg.2
+				IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_004a: pop
+				IL_004b: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -127,24 +118,21 @@
 				4e 5f 56 41 4c 55 45 7d 00 00
 			)
 			// Fields
-			.field public object FUNCTION_VALUE
+			.field public string FUNCTION_VALUE
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ac
+				// Method begins at RVA 0x2189
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -176,7 +164,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
+			IL_000c: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
 			IL_0011: ldc.i4.2
 			IL_0012: newarr [System.Runtime]System.Object
 			IL_0017: dup
@@ -223,25 +211,22 @@
 			7d 00 00
 		)
 		// Fields
-		.field public object GLOBAL_VALUE
+		.field public string GLOBAL_VALUE
 		.field public object testFunction
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2198
+			// Method begins at RVA 0x2180
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -289,7 +274,7 @@
 		IL_0030: stloc.1
 		IL_0031: ldloc.0
 		IL_0032: ldstr "Hello from global"
-		IL_0037: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
+		IL_0037: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
 		IL_003c: ldc.i4.1
 		IL_003d: newarr [System.Runtime]System.Object
 		IL_0042: dup
@@ -316,7 +301,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d2
+		// Method begins at RVA 0x21a4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a8
+					// Method begins at RVA 0x217a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b1
+					// Method begins at RVA 0x2183
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -70,11 +70,10 @@
 				)
 				// Method begins at RVA 0x211c
 				// Header size: 12
-				// Code size: 88 (0x58)
+				// Code size: 64 (0x40)
 				.maxstack 8
 				.locals init (
-					[0] object[],
-					[1] object
+					[0] object[]
 				)
 
 				IL_0000: ldarg.0
@@ -84,31 +83,23 @@
 				IL_0008: ldarg.0
 				IL_0009: ldloc.0
 				IL_000a: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
-				IL_000f: ldarg.1
-				IL_0010: ldc.i4.0
-				IL_0011: ldelem.ref
-				IL_0012: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
-				IL_0017: ldfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-				IL_001c: ldstr "Cannot access 'GLOBAL_VALUE' before initialization"
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0026: stloc.1
+				IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0014: ldarg.1
+				IL_0015: ldc.i4.0
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
+				IL_001c: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+				IL_0021: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0026: pop
 				IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_002c: ldloc.1
-				IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0032: pop
-				IL_0033: ldarg.1
-				IL_0034: ldc.i4.1
-				IL_0035: ldelem.ref
-				IL_0036: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
-				IL_003b: ldfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0040: ldstr "Cannot access 'FUNCTION_VALUE' before initialization"
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_004a: stloc.1
-				IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0050: ldloc.1
-				IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0056: pop
-				IL_0057: ret
+				IL_002c: ldarg.1
+				IL_002d: ldc.i4.1
+				IL_002e: ldelem.ref
+				IL_002f: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
+				IL_0034: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_003e: pop
+				IL_003f: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -122,24 +113,21 @@
 				4e 5f 56 41 4c 55 45 7d 00 00
 			)
 			// Fields
-			.field public object FUNCTION_VALUE
+			.field public string FUNCTION_VALUE
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2194
+				// Method begins at RVA 0x2171
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -171,7 +159,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
+			IL_000c: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
 			IL_0011: ldc.i4.2
 			IL_0012: newarr [System.Runtime]System.Object
 			IL_0017: dup
@@ -213,25 +201,22 @@
 			7d 00 00
 		)
 		// Fields
-		.field public object GLOBAL_VALUE
+		.field public string GLOBAL_VALUE
 		.field public object testFunction
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x2168
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -279,7 +264,7 @@
 		IL_0030: stloc.1
 		IL_0031: ldloc.0
 		IL_0032: ldstr "Hello from global"
-		IL_0037: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+		IL_0037: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
 		IL_003c: ldc.i4.1
 		IL_003d: newarr [System.Runtime]System.Object
 		IL_0042: dup
@@ -306,7 +291,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ba
+		// Method begins at RVA 0x218c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2189
+					// Method begins at RVA 0x2172
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2192
+					// Method begins at RVA 0x217b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -71,11 +71,10 @@
 				)
 				// Method begins at RVA 0x2120
 				// Header size: 12
-				// Code size: 64 (0x40)
+				// Code size: 52 (0x34)
 				.maxstack 8
 				.locals init (
-					[0] object[],
-					[1] object
+					[0] object[]
 				)
 
 				IL_0000: ldarg.0
@@ -85,23 +84,19 @@
 				IL_0008: ldarg.0
 				IL_0009: ldloc.0
 				IL_000a: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass::_scopes
-				IL_000f: ldarg.1
-				IL_0010: ldc.i4.1
-				IL_0011: ldelem.ref
-				IL_0012: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope
-				IL_0017: ldfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_001c: ldstr "Cannot access 'FUNCTION_VALUE' before initialization"
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0026: stloc.1
+				IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0014: ldarg.1
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope
+				IL_001c: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_0021: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0026: pop
 				IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_002c: ldloc.1
+				IL_002c: ldarg.2
 				IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 				IL_0032: pop
-				IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0038: ldarg.2
-				IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_003e: pop
-				IL_003f: ret
+				IL_0033: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -115,24 +110,21 @@
 				4e 5f 56 41 4c 55 45 7d 00 00
 			)
 			// Fields
-			.field public object FUNCTION_VALUE
+			.field public string FUNCTION_VALUE
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2175
+				// Method begins at RVA 0x2169
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -164,7 +156,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
+			IL_000c: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
 			IL_0011: ldc.i4.2
 			IL_0012: newarr [System.Runtime]System.Object
 			IL_0017: dup
@@ -215,7 +207,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216c
+			// Method begins at RVA 0x2160
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -295,7 +287,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219b
+		// Method begins at RVA 0x2184
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2171
+					// Method begins at RVA 0x215a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217a
+					// Method begins at RVA 0x2163
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -70,11 +70,10 @@
 				)
 				// Method begins at RVA 0x2114
 				// Header size: 12
-				// Code size: 52 (0x34)
+				// Code size: 40 (0x28)
 				.maxstack 8
 				.locals init (
-					[0] object[],
-					[1] object
+					[0] object[]
 				)
 
 				IL_0000: ldarg.0
@@ -84,19 +83,15 @@
 				IL_0008: ldarg.0
 				IL_0009: ldloc.0
 				IL_000a: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass::_scopes
-				IL_000f: ldarg.1
-				IL_0010: ldc.i4.1
-				IL_0011: ldelem.ref
-				IL_0012: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope
-				IL_0017: ldfld object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_001c: ldstr "Cannot access 'FUNCTION_VALUE' before initialization"
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0026: stloc.1
-				IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_002c: ldloc.1
-				IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0032: pop
-				IL_0033: ret
+				IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0014: ldarg.1
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope
+				IL_001c: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_0021: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0026: pop
+				IL_0027: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -110,24 +105,21 @@
 				4e 5f 56 41 4c 55 45 7d 00 00
 			)
 			// Fields
-			.field public object FUNCTION_VALUE
+			.field public string FUNCTION_VALUE
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x215d
+				// Method begins at RVA 0x2151
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -159,7 +151,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
+			IL_000c: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
 			IL_0011: ldc.i4.2
 			IL_0012: newarr [System.Runtime]System.Object
 			IL_0017: dup
@@ -205,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2154
+			// Method begins at RVA 0x2148
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -285,7 +277,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2183
+		// Method begins at RVA 0x216c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2118
+				// Method begins at RVA 0x2101
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2121
+				// Method begins at RVA 0x210a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -67,11 +67,10 @@
 			)
 			// Method begins at RVA 0x20b8
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -81,23 +80,19 @@
 			IL_0008: ldarg.0
 			IL_0009: ldloc.0
 			IL_000a: stfld object[] Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass::_scopes
-			IL_000f: ldarg.1
-			IL_0010: ldc.i4.0
-			IL_0011: ldelem.ref
-			IL_0012: castclass Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope
-			IL_0017: ldfld object Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-			IL_001c: ldstr "Cannot access 'GLOBAL_VALUE' before initialization"
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0026: stloc.1
+			IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0014: ldarg.1
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: castclass Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope
+			IL_001c: ldfld string Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
+			IL_0021: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0026: pop
 			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_002c: ldloc.1
+			IL_002c: ldarg.2
 			IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0032: pop
-			IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0038: ldarg.2
-			IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003e: pop
-			IL_003f: ret
+			IL_0033: ret
 		} // end of method MyClass::.ctor
 
 	} // end of class MyClass
@@ -111,24 +106,21 @@
 			4c 55 45 7d 00 00
 		)
 		// Fields
-		.field public object GLOBAL_VALUE
+		.field public string GLOBAL_VALUE
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2104
+			// Method begins at RVA 0x20f8
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -158,7 +150,7 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldstr "Hello from global"
-		IL_000c: stfld object Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
+		IL_000c: stfld string Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
 		IL_0011: ldc.i4.1
 		IL_0012: newarr [System.Runtime]System.Object
 		IL_0017: dup
@@ -196,7 +188,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212a
+		// Method begins at RVA 0x2113
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2100
+				// Method begins at RVA 0x20e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2109
+				// Method begins at RVA 0x20f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,11 +66,10 @@
 			)
 			// Method begins at RVA 0x20ac
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -80,19 +79,15 @@
 			IL_0008: ldarg.0
 			IL_0009: ldloc.0
 			IL_000a: stfld object[] Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass::_scopes
-			IL_000f: ldarg.1
-			IL_0010: ldc.i4.0
-			IL_0011: ldelem.ref
-			IL_0012: castclass Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope
-			IL_0017: ldfld object Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_001c: ldstr "Cannot access 'GLOBAL_VALUE' before initialization"
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0026: stloc.1
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_002c: ldloc.1
-			IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0032: pop
-			IL_0033: ret
+			IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0014: ldarg.1
+			IL_0015: ldc.i4.0
+			IL_0016: ldelem.ref
+			IL_0017: castclass Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope
+			IL_001c: ldfld string Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
+			IL_0021: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0026: pop
+			IL_0027: ret
 		} // end of method MyClass::.ctor
 
 	} // end of class MyClass
@@ -106,24 +101,21 @@
 			4c 55 45 7d 00 00
 		)
 		// Fields
-		.field public object GLOBAL_VALUE
+		.field public string GLOBAL_VALUE
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ec
+			// Method begins at RVA 0x20e0
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -153,7 +145,7 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldstr "Hello from global"
-		IL_000c: stfld object Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
+		IL_000c: stfld string Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
 		IL_0011: ldc.i4.1
 		IL_0012: newarr [System.Runtime]System.Object
 		IL_0017: dup
@@ -186,7 +178,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2112
+		// Method begins at RVA 0x20fb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cf
+				// Method begins at RVA 0x21b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d8
+				// Method begins at RVA 0x21c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,13 +65,12 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x217c
 			// Header size: 12
-			// Code size: 47 (0x2f)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -81,18 +80,15 @@
 			IL_0008: ldarg.0
 			IL_0009: ldloc.0
 			IL_000a: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::_scopes
-			IL_000f: ldarg.1
-			IL_0010: ldc.i4.0
-			IL_0011: ldelem.ref
-			IL_0012: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope
-			IL_0017: ldfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
-			IL_001c: ldstr "Cannot access 'GLOBAL_VALUE' before initialization"
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0026: stloc.1
-			IL_0027: ldarg.0
-			IL_0028: ldloc.1
-			IL_0029: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::'value'
-			IL_002e: ret
+			IL_000f: ldarg.0
+			IL_0010: ldarg.1
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope
+			IL_0018: ldfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::'value'
+			IL_0027: ret
 		} // end of method Inner::.ctor
 
 	} // end of class Inner
@@ -108,7 +104,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e1
+				// Method begins at RVA 0x21cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -128,7 +124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ea
+				// Method begins at RVA 0x21d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -155,7 +151,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2154
+			// Method begins at RVA 0x2150
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -192,25 +188,22 @@
 			65 72 7d 00 00
 		)
 		// Fields
-		.field public object GLOBAL_VALUE
+		.field public float64 GLOBAL_VALUE
 		.field public object Inner
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21bb
+			// Method begins at RVA 0x21b0
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -228,7 +221,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 247 (0xf7)
+		// Code size: 242 (0xf2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope,
@@ -244,78 +237,77 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldc.r8 42
-		IL_0010: box [System.Runtime]System.Double
-		IL_0015: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
-		IL_001a: ldc.i4.1
-		IL_001b: newarr [System.Runtime]System.Object
-		IL_0020: dup
-		IL_0021: ldc.i4.0
-		IL_0022: ldloc.0
-		IL_0023: stelem.ref
-		IL_0024: stloc.3
-		IL_0025: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
-		IL_002a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_002f: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
-		IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0039: stloc.s 4
-		IL_003b: ldloc.s 4
-		IL_003d: ldloc.3
-		IL_003e: ldc.r8 0.0
-		IL_0047: box [System.Runtime]System.Double
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0051: stloc.s 5
-		IL_0053: ldloc.0
-		IL_0054: ldloc.s 5
-		IL_0056: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::Inner
-		IL_005b: ldc.i4.1
-		IL_005c: newarr [System.Runtime]System.Object
-		IL_0061: dup
-		IL_0062: ldc.i4.0
-		IL_0063: ldloc.0
-		IL_0064: stelem.ref
-		IL_0065: stloc.3
-		IL_0066: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_006b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0070: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_0075: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_007a: stloc.s 4
-		IL_007c: ldloc.s 4
-		IL_007e: ldloc.3
-		IL_007f: ldc.r8 0.0
-		IL_0088: box [System.Runtime]System.Double
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0092: stloc.s 5
-		IL_0094: ldloc.s 5
-		IL_0096: stloc.1
-		IL_0097: ldc.i4.1
-		IL_0098: newarr [System.Runtime]System.Object
-		IL_009d: dup
-		IL_009e: ldc.i4.0
-		IL_009f: ldloc.0
-		IL_00a0: stelem.ref
-		IL_00a1: ldc.i4.0
-		IL_00a2: newarr [System.Runtime]System.Object
-		IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00ac: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer::.ctor(object[])
-		IL_00b1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00b6: stloc.s 6
-		IL_00b8: ldloc.s 6
-		IL_00ba: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_00bf: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00c4: ldstr "prototype"
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_00ce: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00d3: ldloc.s 6
-		IL_00d5: stloc.2
-		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00db: ldloc.2
-		IL_00dc: ldstr "inner"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e6: ldstr "value"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f5: pop
-		IL_00f6: ret
+		IL_0010: stfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
+		IL_0015: ldc.i4.1
+		IL_0016: newarr [System.Runtime]System.Object
+		IL_001b: dup
+		IL_001c: ldc.i4.0
+		IL_001d: ldloc.0
+		IL_001e: stelem.ref
+		IL_001f: stloc.3
+		IL_0020: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
+		IL_0025: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_002a: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
+		IL_002f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0034: stloc.s 4
+		IL_0036: ldloc.s 4
+		IL_0038: ldloc.3
+		IL_0039: ldc.r8 0.0
+		IL_0042: box [System.Runtime]System.Double
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_004c: stloc.s 5
+		IL_004e: ldloc.0
+		IL_004f: ldloc.s 5
+		IL_0051: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::Inner
+		IL_0056: ldc.i4.1
+		IL_0057: newarr [System.Runtime]System.Object
+		IL_005c: dup
+		IL_005d: ldc.i4.0
+		IL_005e: ldloc.0
+		IL_005f: stelem.ref
+		IL_0060: stloc.3
+		IL_0061: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_0066: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_006b: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_0070: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0075: stloc.s 4
+		IL_0077: ldloc.s 4
+		IL_0079: ldloc.3
+		IL_007a: ldc.r8 0.0
+		IL_0083: box [System.Runtime]System.Double
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_008d: stloc.s 5
+		IL_008f: ldloc.s 5
+		IL_0091: stloc.1
+		IL_0092: ldc.i4.1
+		IL_0093: newarr [System.Runtime]System.Object
+		IL_0098: dup
+		IL_0099: ldc.i4.0
+		IL_009a: ldloc.0
+		IL_009b: stelem.ref
+		IL_009c: ldc.i4.0
+		IL_009d: newarr [System.Runtime]System.Object
+		IL_00a2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00a7: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer::.ctor(object[])
+		IL_00ac: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00b1: stloc.s 6
+		IL_00b3: ldloc.s 6
+		IL_00b5: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_00ba: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00bf: ldstr "prototype"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_00c9: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00ce: ldloc.s 6
+		IL_00d0: stloc.2
+		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d6: ldloc.2
+		IL_00d7: ldstr "inner"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e1: ldstr "value"
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f0: pop
+		IL_00f1: ret
 	} // end of method Classes_ClassConstructor_NewClassReferencingGlobal::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_NewClassReferencingGlobal
@@ -327,7 +319,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f3
+		// Method begins at RVA 0x21dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d8
+					// Method begins at RVA 0x219f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e1
+					// Method begins at RVA 0x21a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -93,41 +93,30 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Method begins at RVA 0x2150
-				// Header size: 12
-				// Code size: 84 (0x54)
+				// Header size: 1
+				// Code size: 60 (0x3c)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
-				IL_0006: ldc.i4.0
-				IL_0007: ldelem.ref
-				IL_0008: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
-				IL_000d: ldfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-				IL_0012: ldstr "Cannot access 'GLOBAL_VALUE' before initialization"
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001c: stloc.0
+				IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0005: ldarg.0
+				IL_0006: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
+				IL_000b: ldc.i4.0
+				IL_000c: ldelem.ref
+				IL_000d: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
+				IL_0012: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+				IL_0017: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_001c: pop
 				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0022: ldloc.0
-				IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0028: pop
-				IL_0029: ldarg.0
-				IL_002a: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
-				IL_002f: ldc.i4.1
-				IL_0030: ldelem.ref
-				IL_0031: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope
-				IL_0036: ldfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
-				IL_003b: ldstr "Cannot access 'FUNCTION_VALUE' before initialization"
-				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0045: stloc.0
-				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_004b: ldloc.0
-				IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0051: pop
-				IL_0052: ldnull
-				IL_0053: ret
+				IL_0022: ldarg.0
+				IL_0023: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
+				IL_0028: ldc.i4.1
+				IL_0029: ldelem.ref
+				IL_002a: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope
+				IL_002f: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
+				IL_0034: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0039: pop
+				IL_003a: ldnull
+				IL_003b: ret
 			} // end of method MyClass::logValues
 
 		} // end of class MyClass
@@ -141,24 +130,21 @@
 				4e 5f 56 41 4c 55 45 7d 00 00
 			)
 			// Fields
-			.field public object FUNCTION_VALUE
+			.field public string FUNCTION_VALUE
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c4
+				// Method begins at RVA 0x2196
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -190,7 +176,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
+			IL_000c: stfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
 			IL_0011: ldc.i4.2
 			IL_0012: newarr [System.Runtime]System.Object
 			IL_0017: dup
@@ -234,24 +220,21 @@
 			4c 55 45 7d 00 00
 		)
 		// Fields
-		.field public object GLOBAL_VALUE
+		.field public string GLOBAL_VALUE
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b0
+			// Method begins at RVA 0x218d
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -281,7 +264,7 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldstr "Hello from global"
-		IL_000c: stfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+		IL_000c: stfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
 		IL_0011: ldc.i4.1
 		IL_0012: newarr [System.Runtime]System.Object
 		IL_0017: dup
@@ -328,7 +311,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ea
+		// Method begins at RVA 0x21b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2198
+					// Method begins at RVA 0x2176
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a1
+					// Method begins at RVA 0x217f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -93,28 +93,21 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Method begins at RVA 0x2144
-				// Header size: 12
-				// Code size: 43 (0x2b)
+				// Header size: 1
+				// Code size: 31 (0x1f)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::_scopes
-				IL_0006: ldc.i4.1
-				IL_0007: ldelem.ref
-				IL_0008: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope
-				IL_000d: ldfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
-				IL_0012: ldstr "Cannot access 'FUNCTION_VALUE' before initialization"
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001c: stloc.0
-				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0022: ldloc.0
-				IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0028: pop
-				IL_0029: ldnull
-				IL_002a: ret
+				IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0005: ldarg.0
+				IL_0006: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::_scopes
+				IL_000b: ldc.i4.1
+				IL_000c: ldelem.ref
+				IL_000d: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope
+				IL_0012: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
+				IL_0017: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_001c: pop
+				IL_001d: ldnull
+				IL_001e: ret
 			} // end of method MyClass::logValue
 
 		} // end of class MyClass
@@ -128,24 +121,21 @@
 				4e 5f 56 41 4c 55 45 7d 00 00
 			)
 			// Fields
-			.field public object FUNCTION_VALUE
+			.field public string FUNCTION_VALUE
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2184
+				// Method begins at RVA 0x216d
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -177,7 +167,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
+			IL_000c: stfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
 			IL_0011: ldc.i4.2
 			IL_0012: newarr [System.Runtime]System.Object
 			IL_0017: dup
@@ -219,7 +209,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217b
+			// Method begins at RVA 0x2164
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -301,7 +291,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21aa
+		// Method begins at RVA 0x2188
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21cc
+					// Method begins at RVA 0x2193
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d5
+					// Method begins at RVA 0x219c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -93,41 +93,30 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Method begins at RVA 0x2144
-				// Header size: 12
-				// Code size: 84 (0x54)
+				// Header size: 1
+				// Code size: 60 (0x3c)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
-				IL_0006: ldc.i4.0
-				IL_0007: ldelem.ref
-				IL_0008: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
-				IL_000d: ldfld object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-				IL_0012: ldstr "Cannot access 'GLOBAL_VALUE' before initialization"
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001c: stloc.0
+				IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0005: ldarg.0
+				IL_0006: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
+				IL_000b: ldc.i4.0
+				IL_000c: ldelem.ref
+				IL_000d: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
+				IL_0012: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+				IL_0017: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_001c: pop
 				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0022: ldloc.0
-				IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0028: pop
-				IL_0029: ldarg.0
-				IL_002a: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
-				IL_002f: ldc.i4.1
-				IL_0030: ldelem.ref
-				IL_0031: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
-				IL_0036: ldfld object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_003b: ldstr "Cannot access 'FUNCTION_VALUE' before initialization"
-				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0045: stloc.0
-				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_004b: ldloc.0
-				IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0051: pop
-				IL_0052: ldnull
-				IL_0053: ret
+				IL_0022: ldarg.0
+				IL_0023: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
+				IL_0028: ldc.i4.1
+				IL_0029: ldelem.ref
+				IL_002a: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
+				IL_002f: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_0034: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0039: pop
+				IL_003a: ldnull
+				IL_003b: ret
 			} // end of method MyClass::logValues
 
 		} // end of class MyClass
@@ -141,24 +130,21 @@
 				4e 5f 56 41 4c 55 45 7d 00 00
 			)
 			// Fields
-			.field public object FUNCTION_VALUE
+			.field public string FUNCTION_VALUE
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b8
+				// Method begins at RVA 0x218a
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -190,7 +176,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
+			IL_000c: stfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
 			IL_0011: ldc.i4.2
 			IL_0012: newarr [System.Runtime]System.Object
 			IL_0017: dup
@@ -236,25 +222,22 @@
 			7d 00 00
 		)
 		// Fields
-		.field public object GLOBAL_VALUE
+		.field public string GLOBAL_VALUE
 		.field public object testFunction
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a4
+			// Method begins at RVA 0x2181
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -302,7 +285,7 @@
 		IL_0030: stloc.1
 		IL_0031: ldloc.0
 		IL_0032: ldstr "Hello from global"
-		IL_0037: stfld object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+		IL_0037: stfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
 		IL_003c: ldc.i4.1
 		IL_003d: newarr [System.Runtime]System.Object
 		IL_0042: dup
@@ -329,7 +312,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21de
+		// Method begins at RVA 0x21a5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2190
+					// Method begins at RVA 0x216e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2199
+					// Method begins at RVA 0x2177
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -93,28 +93,21 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Method begins at RVA 0x213c
-				// Header size: 12
-				// Code size: 43 (0x2b)
+				// Header size: 1
+				// Code size: 31 (0x1f)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::_scopes
-				IL_0006: ldc.i4.1
-				IL_0007: ldelem.ref
-				IL_0008: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope
-				IL_000d: ldfld object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0012: ldstr "Cannot access 'FUNCTION_VALUE' before initialization"
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001c: stloc.0
-				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0022: ldloc.0
-				IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0028: pop
-				IL_0029: ldnull
-				IL_002a: ret
+				IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0005: ldarg.0
+				IL_0006: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::_scopes
+				IL_000b: ldc.i4.1
+				IL_000c: ldelem.ref
+				IL_000d: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope
+				IL_0012: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_0017: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_001c: pop
+				IL_001d: ldnull
+				IL_001e: ret
 			} // end of method MyClass::logValue
 
 		} // end of class MyClass
@@ -128,24 +121,21 @@
 				4e 5f 56 41 4c 55 45 7d 00 00
 			)
 			// Fields
-			.field public object FUNCTION_VALUE
+			.field public string FUNCTION_VALUE
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217c
+				// Method begins at RVA 0x2165
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -177,7 +167,7 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
+			IL_000c: stfld string Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
 			IL_0011: ldc.i4.2
 			IL_0012: newarr [System.Runtime]System.Object
 			IL_0017: dup
@@ -227,7 +217,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2173
+			// Method begins at RVA 0x215c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -307,7 +297,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a2
+		// Method begins at RVA 0x2180
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211f
+				// Method begins at RVA 0x20fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2128
+				// Method begins at RVA 0x2106
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -89,28 +89,21 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Method begins at RVA 0x20d4
-			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Header size: 1
+			// Code size: 31 (0x1f)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::_scopes
-			IL_0006: ldc.i4.0
-			IL_0007: ldelem.ref
-			IL_0008: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope
-			IL_000d: ldfld object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_0012: ldstr "Cannot access 'GLOBAL_VALUE' before initialization"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001c: stloc.0
-			IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0022: ldloc.0
-			IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0028: pop
-			IL_0029: ldnull
-			IL_002a: ret
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: ldarg.0
+			IL_0006: ldfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::_scopes
+			IL_000b: ldc.i4.0
+			IL_000c: ldelem.ref
+			IL_000d: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope
+			IL_0012: ldfld string Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
+			IL_0017: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_001c: pop
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method MyClass::logGlobal
 
 	} // end of class MyClass
@@ -124,24 +117,21 @@
 			4c 55 45 7d 00 00
 		)
 		// Fields
-		.field public object GLOBAL_VALUE
+		.field public string GLOBAL_VALUE
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x210b
+			// Method begins at RVA 0x20f4
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -171,7 +161,7 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldstr "Hello from global"
-		IL_000c: stfld object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
+		IL_000c: stfld string Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
 		IL_0011: ldc.i4.1
 		IL_0012: newarr [System.Runtime]System.Object
 		IL_0017: dup
@@ -208,7 +198,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2131
+		// Method begins at RVA 0x210f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Js2IL.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x236c
+					// Method begins at RVA 0x233c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2375
+					// Method begins at RVA 0x2345
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22b8
+				// Method begins at RVA 0x22b0
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,30 +92,20 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2314
-				// Header size: 12
-				// Code size: 47 (0x2f)
+				// Method begins at RVA 0x230c
+				// Header size: 1
+				// Code size: 29 (0x1d)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] float64
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base::_scopes
 				IL_0006: ldc.i4.1
 				IL_0007: ldelem.ref
 				IL_0008: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope
-				IL_000d: ldfld object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
-				IL_0012: ldstr "Cannot access 'captured' before initialization"
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001c: stloc.0
-				IL_001d: ldloc.0
-				IL_001e: ldc.r8 2
-				IL_0027: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
-				IL_002c: stloc.1
-				IL_002d: ldloc.1
-				IL_002e: ret
+				IL_000d: ldfld float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
+				IL_0012: ldc.r8 2
+				IL_001b: add
+				IL_001c: ret
 			} // end of method Base::m
 
 		} // end of class Base
@@ -131,7 +121,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x237e
+					// Method begins at RVA 0x234e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -151,7 +141,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2387
+					// Method begins at RVA 0x2357
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -177,7 +167,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22d4
+				// Method begins at RVA 0x22cc
 				// Header size: 12
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -204,7 +194,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22f8
+				// Method begins at RVA 0x22f0
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -233,24 +223,21 @@
 				64 3d 7b 63 61 70 74 75 72 65 64 7d 00 00
 			)
 			// Fields
-			.field public object captured
+			.field public float64 captured
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2358
+				// Method begins at RVA 0x2333
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -270,7 +257,7 @@
 			)
 			// Method begins at RVA 0x20b4
 			// Header size: 12
-			// Code size: 501 (0x1f5)
+			// Code size: 496 (0x1f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope,
@@ -285,213 +272,212 @@
 			IL_0005: stloc.0
 			IL_0006: ldloc.0
 			IL_0007: ldc.r8 40
-			IL_0010: box [System.Runtime]System.Double
-			IL_0015: stfld object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
-			IL_001a: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-			IL_001f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0024: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-			IL_0029: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_002e: stloc.3
-			IL_002f: ldc.i4.2
-			IL_0030: newarr [System.Runtime]System.Object
-			IL_0035: dup
-			IL_0036: ldc.i4.0
-			IL_0037: ldarg.0
-			IL_0038: stelem.ref
-			IL_0039: dup
-			IL_003a: ldc.i4.1
-			IL_003b: ldloc.0
-			IL_003c: stelem.ref
-			IL_003d: stloc.s 4
-			IL_003f: ldc.i4.s 10
-			IL_0041: newarr [System.Runtime]System.Object
-			IL_0046: dup
-			IL_0047: ldc.i4.0
-			IL_0048: ldloc.3
-			IL_0049: stelem.ref
-			IL_004a: dup
-			IL_004b: ldc.i4.1
-			IL_004c: ldstr "m"
-			IL_0051: stelem.ref
-			IL_0052: dup
-			IL_0053: ldc.i4.2
-			IL_0054: ldstr "m"
-			IL_0059: stelem.ref
-			IL_005a: dup
-			IL_005b: ldc.i4.3
-			IL_005c: ldc.r8 0.0
-			IL_0065: box [System.Runtime]System.Double
-			IL_006a: stelem.ref
-			IL_006b: dup
-			IL_006c: ldc.i4.4
-			IL_006d: ldstr "m"
-			IL_0072: stelem.ref
-			IL_0073: dup
-			IL_0074: ldc.i4.5
-			IL_0075: ldc.i4.0
-			IL_0076: box [System.Runtime]System.Boolean
-			IL_007b: stelem.ref
-			IL_007c: dup
-			IL_007d: ldc.i4.6
-			IL_007e: ldc.i4.0
-			IL_007f: box [System.Runtime]System.Boolean
-			IL_0084: stelem.ref
-			IL_0085: dup
-			IL_0086: ldc.i4.7
-			IL_0087: ldc.i4.0
-			IL_0088: box [System.Runtime]System.Boolean
-			IL_008d: stelem.ref
-			IL_008e: dup
-			IL_008f: ldc.i4.8
-			IL_0090: ldc.i4.0
-			IL_0091: box [System.Runtime]System.Boolean
-			IL_0096: stelem.ref
-			IL_0097: dup
-			IL_0098: ldc.i4.s 9
-			IL_009a: ldloc.s 4
-			IL_009c: stelem.ref
-			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-			IL_00a2: pop
-			IL_00a3: ldc.i4.2
-			IL_00a4: newarr [System.Runtime]System.Object
-			IL_00a9: dup
-			IL_00aa: ldc.i4.0
-			IL_00ab: ldarg.0
-			IL_00ac: stelem.ref
-			IL_00ad: dup
-			IL_00ae: ldc.i4.1
-			IL_00af: ldloc.0
-			IL_00b0: stelem.ref
-			IL_00b1: stloc.s 4
-			IL_00b3: ldloc.3
-			IL_00b4: ldloc.s 4
-			IL_00b6: ldc.r8 0.0
-			IL_00bf: box [System.Runtime]System.Double
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_00c9: stloc.s 5
-			IL_00cb: ldloc.s 5
-			IL_00cd: stloc.1
-			IL_00ce: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00d3: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00d8: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00dd: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00e2: stloc.3
-			IL_00e3: ldc.i4.2
-			IL_00e4: newarr [System.Runtime]System.Object
-			IL_00e9: dup
-			IL_00ea: ldc.i4.0
-			IL_00eb: ldarg.0
-			IL_00ec: stelem.ref
-			IL_00ed: dup
-			IL_00ee: ldc.i4.1
-			IL_00ef: ldloc.0
-			IL_00f0: stelem.ref
-			IL_00f1: stloc.s 4
-			IL_00f3: ldc.i4.s 10
-			IL_00f5: newarr [System.Runtime]System.Object
-			IL_00fa: dup
-			IL_00fb: ldc.i4.0
-			IL_00fc: ldloc.3
-			IL_00fd: stelem.ref
-			IL_00fe: dup
-			IL_00ff: ldc.i4.1
-			IL_0100: ldstr "n"
-			IL_0105: stelem.ref
-			IL_0106: dup
-			IL_0107: ldc.i4.2
-			IL_0108: ldstr "n"
-			IL_010d: stelem.ref
-			IL_010e: dup
-			IL_010f: ldc.i4.3
-			IL_0110: ldc.r8 0.0
-			IL_0119: box [System.Runtime]System.Double
-			IL_011e: stelem.ref
-			IL_011f: dup
-			IL_0120: ldc.i4.4
-			IL_0121: ldstr "n"
-			IL_0126: stelem.ref
-			IL_0127: dup
-			IL_0128: ldc.i4.5
-			IL_0129: ldc.i4.0
-			IL_012a: box [System.Runtime]System.Boolean
-			IL_012f: stelem.ref
-			IL_0130: dup
-			IL_0131: ldc.i4.6
-			IL_0132: ldc.i4.0
-			IL_0133: box [System.Runtime]System.Boolean
-			IL_0138: stelem.ref
-			IL_0139: dup
-			IL_013a: ldc.i4.7
-			IL_013b: ldc.i4.0
-			IL_013c: box [System.Runtime]System.Boolean
-			IL_0141: stelem.ref
-			IL_0142: dup
-			IL_0143: ldc.i4.8
-			IL_0144: ldc.i4.0
-			IL_0145: box [System.Runtime]System.Boolean
-			IL_014a: stelem.ref
-			IL_014b: dup
-			IL_014c: ldc.i4.s 9
-			IL_014e: ldloc.s 4
-			IL_0150: stelem.ref
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-			IL_0156: pop
-			IL_0157: ldc.i4.2
-			IL_0158: newarr [System.Runtime]System.Object
-			IL_015d: dup
-			IL_015e: ldc.i4.0
-			IL_015f: ldarg.0
-			IL_0160: stelem.ref
-			IL_0161: dup
-			IL_0162: ldc.i4.1
-			IL_0163: ldloc.0
-			IL_0164: stelem.ref
-			IL_0165: stloc.s 4
-			IL_0167: ldloc.3
-			IL_0168: ldloc.s 4
-			IL_016a: ldc.r8 0.0
-			IL_0173: box [System.Runtime]System.Double
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_017d: stloc.s 5
-			IL_017f: ldloc.s 5
-			IL_0181: stloc.2
-			IL_0182: ldc.i4.2
-			IL_0183: newarr [System.Runtime]System.Object
-			IL_0188: dup
-			IL_0189: ldc.i4.0
-			IL_018a: ldarg.0
-			IL_018b: stelem.ref
-			IL_018c: dup
-			IL_018d: ldc.i4.1
-			IL_018e: ldloc.0
-			IL_018f: stelem.ref
-			IL_0190: ldc.i4.0
-			IL_0191: newarr [System.Runtime]System.Object
-			IL_0196: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_019b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_01a0: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
-			IL_01a5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_01aa: stloc.s 5
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_01b6: stloc.s 5
-			IL_01b8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_01bd: ldloc.s 5
-			IL_01bf: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_01c4: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_01c9: ldstr "prototype"
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-			IL_01d3: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_01d8: ldloc.s 5
-			IL_01da: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_01df: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
-			IL_01e4: stloc.s 5
-			IL_01e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01eb: ldloc.s 5
-			IL_01ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01f2: pop
-			IL_01f3: ldnull
-			IL_01f4: ret
+			IL_0010: stfld float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
+			IL_0015: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+			IL_001a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_001f: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+			IL_0024: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0029: stloc.3
+			IL_002a: ldc.i4.2
+			IL_002b: newarr [System.Runtime]System.Object
+			IL_0030: dup
+			IL_0031: ldc.i4.0
+			IL_0032: ldarg.0
+			IL_0033: stelem.ref
+			IL_0034: dup
+			IL_0035: ldc.i4.1
+			IL_0036: ldloc.0
+			IL_0037: stelem.ref
+			IL_0038: stloc.s 4
+			IL_003a: ldc.i4.s 10
+			IL_003c: newarr [System.Runtime]System.Object
+			IL_0041: dup
+			IL_0042: ldc.i4.0
+			IL_0043: ldloc.3
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.1
+			IL_0047: ldstr "m"
+			IL_004c: stelem.ref
+			IL_004d: dup
+			IL_004e: ldc.i4.2
+			IL_004f: ldstr "m"
+			IL_0054: stelem.ref
+			IL_0055: dup
+			IL_0056: ldc.i4.3
+			IL_0057: ldc.r8 0.0
+			IL_0060: box [System.Runtime]System.Double
+			IL_0065: stelem.ref
+			IL_0066: dup
+			IL_0067: ldc.i4.4
+			IL_0068: ldstr "m"
+			IL_006d: stelem.ref
+			IL_006e: dup
+			IL_006f: ldc.i4.5
+			IL_0070: ldc.i4.0
+			IL_0071: box [System.Runtime]System.Boolean
+			IL_0076: stelem.ref
+			IL_0077: dup
+			IL_0078: ldc.i4.6
+			IL_0079: ldc.i4.0
+			IL_007a: box [System.Runtime]System.Boolean
+			IL_007f: stelem.ref
+			IL_0080: dup
+			IL_0081: ldc.i4.7
+			IL_0082: ldc.i4.0
+			IL_0083: box [System.Runtime]System.Boolean
+			IL_0088: stelem.ref
+			IL_0089: dup
+			IL_008a: ldc.i4.8
+			IL_008b: ldc.i4.0
+			IL_008c: box [System.Runtime]System.Boolean
+			IL_0091: stelem.ref
+			IL_0092: dup
+			IL_0093: ldc.i4.s 9
+			IL_0095: ldloc.s 4
+			IL_0097: stelem.ref
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+			IL_009d: pop
+			IL_009e: ldc.i4.2
+			IL_009f: newarr [System.Runtime]System.Object
+			IL_00a4: dup
+			IL_00a5: ldc.i4.0
+			IL_00a6: ldarg.0
+			IL_00a7: stelem.ref
+			IL_00a8: dup
+			IL_00a9: ldc.i4.1
+			IL_00aa: ldloc.0
+			IL_00ab: stelem.ref
+			IL_00ac: stloc.s 4
+			IL_00ae: ldloc.3
+			IL_00af: ldloc.s 4
+			IL_00b1: ldc.r8 0.0
+			IL_00ba: box [System.Runtime]System.Double
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_00c4: stloc.s 5
+			IL_00c6: ldloc.s 5
+			IL_00c8: stloc.1
+			IL_00c9: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_00ce: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00d3: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_00d8: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00dd: stloc.3
+			IL_00de: ldc.i4.2
+			IL_00df: newarr [System.Runtime]System.Object
+			IL_00e4: dup
+			IL_00e5: ldc.i4.0
+			IL_00e6: ldarg.0
+			IL_00e7: stelem.ref
+			IL_00e8: dup
+			IL_00e9: ldc.i4.1
+			IL_00ea: ldloc.0
+			IL_00eb: stelem.ref
+			IL_00ec: stloc.s 4
+			IL_00ee: ldc.i4.s 10
+			IL_00f0: newarr [System.Runtime]System.Object
+			IL_00f5: dup
+			IL_00f6: ldc.i4.0
+			IL_00f7: ldloc.3
+			IL_00f8: stelem.ref
+			IL_00f9: dup
+			IL_00fa: ldc.i4.1
+			IL_00fb: ldstr "n"
+			IL_0100: stelem.ref
+			IL_0101: dup
+			IL_0102: ldc.i4.2
+			IL_0103: ldstr "n"
+			IL_0108: stelem.ref
+			IL_0109: dup
+			IL_010a: ldc.i4.3
+			IL_010b: ldc.r8 0.0
+			IL_0114: box [System.Runtime]System.Double
+			IL_0119: stelem.ref
+			IL_011a: dup
+			IL_011b: ldc.i4.4
+			IL_011c: ldstr "n"
+			IL_0121: stelem.ref
+			IL_0122: dup
+			IL_0123: ldc.i4.5
+			IL_0124: ldc.i4.0
+			IL_0125: box [System.Runtime]System.Boolean
+			IL_012a: stelem.ref
+			IL_012b: dup
+			IL_012c: ldc.i4.6
+			IL_012d: ldc.i4.0
+			IL_012e: box [System.Runtime]System.Boolean
+			IL_0133: stelem.ref
+			IL_0134: dup
+			IL_0135: ldc.i4.7
+			IL_0136: ldc.i4.0
+			IL_0137: box [System.Runtime]System.Boolean
+			IL_013c: stelem.ref
+			IL_013d: dup
+			IL_013e: ldc.i4.8
+			IL_013f: ldc.i4.0
+			IL_0140: box [System.Runtime]System.Boolean
+			IL_0145: stelem.ref
+			IL_0146: dup
+			IL_0147: ldc.i4.s 9
+			IL_0149: ldloc.s 4
+			IL_014b: stelem.ref
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+			IL_0151: pop
+			IL_0152: ldc.i4.2
+			IL_0153: newarr [System.Runtime]System.Object
+			IL_0158: dup
+			IL_0159: ldc.i4.0
+			IL_015a: ldarg.0
+			IL_015b: stelem.ref
+			IL_015c: dup
+			IL_015d: ldc.i4.1
+			IL_015e: ldloc.0
+			IL_015f: stelem.ref
+			IL_0160: stloc.s 4
+			IL_0162: ldloc.3
+			IL_0163: ldloc.s 4
+			IL_0165: ldc.r8 0.0
+			IL_016e: box [System.Runtime]System.Double
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0178: stloc.s 5
+			IL_017a: ldloc.s 5
+			IL_017c: stloc.2
+			IL_017d: ldc.i4.2
+			IL_017e: newarr [System.Runtime]System.Object
+			IL_0183: dup
+			IL_0184: ldc.i4.0
+			IL_0185: ldarg.0
+			IL_0186: stelem.ref
+			IL_0187: dup
+			IL_0188: ldc.i4.1
+			IL_0189: ldloc.0
+			IL_018a: stelem.ref
+			IL_018b: ldc.i4.0
+			IL_018c: newarr [System.Runtime]System.Object
+			IL_0191: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0196: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_019b: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
+			IL_01a0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_01a5: stloc.s 5
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_01b1: stloc.s 5
+			IL_01b3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_01b8: ldloc.s 5
+			IL_01ba: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_01bf: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_01c4: ldstr "prototype"
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+			IL_01ce: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_01d3: ldloc.s 5
+			IL_01d5: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_01da: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+			IL_01df: stloc.s 5
+			IL_01e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01e6: ldloc.s 5
+			IL_01e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01ed: pop
+			IL_01ee: ldnull
+			IL_01ef: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -510,7 +496,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x234f
+			// Method begins at RVA 0x232a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -590,7 +576,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2390
+		// Method begins at RVA 0x2360
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/tests/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227b
+			// Method begins at RVA 0x2263
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -114,7 +114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2298
+				// Method begins at RVA 0x2275
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -141,37 +141,23 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x21a8
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 21 (0x15)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] float64,
-				[3] object
+				[0] float64
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope::moduleFactor
-			IL_0006: ldstr "Cannot access 'moduleFactor' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldarg.2
-			IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0017: stloc.1
-			IL_0018: ldloc.0
-			IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001e: stloc.2
-			IL_001f: ldloc.1
-			IL_0020: ldloc.2
-			IL_0021: mul
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: box [System.Runtime]System.Double
-			IL_0029: stloc.3
-			IL_002a: ldloc.3
-			IL_002b: ret
+			IL_0001: ldfld float64 Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope::moduleFactor
+			IL_0006: stloc.0
+			IL_0007: ldarg.2
+			IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000d: ldloc.0
+			IL_000e: mul
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: ret
 		} // end of method multiplyModuleFactor::__js_call__
 
 	} // end of class multiplyModuleFactor
@@ -191,7 +177,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22aa
+					// Method begins at RVA 0x2287
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -216,7 +202,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x224c
+				// Method begins at RVA 0x2234
 				// Header size: 12
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -260,7 +246,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a1
+				// Method begins at RVA 0x227e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -287,7 +273,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x21e4
+			// Method begins at RVA 0x21cc
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -353,7 +339,7 @@
 			6c 61 74 6f 72 7d 00 00
 		)
 		// Fields
-		.field public object moduleFactor
+		.field public float64 moduleFactor
 		.field public object multiplyModuleFactor
 		.field public object createCalculator
 
@@ -361,18 +347,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x226c
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope::moduleFactor
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -390,7 +373,7 @@
 	{
 		// Method begins at RVA 0x2100
 		// Header size: 12
-		// Code size: 159 (0x9f)
+		// Code size: 154 (0x9a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope,
@@ -440,25 +423,24 @@
 		IL_005b: stloc.2
 		IL_005c: ldloc.0
 		IL_005d: ldc.r8 7
-		IL_0066: box [System.Runtime]System.Double
-		IL_006b: stfld object Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope::moduleFactor
-		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0075: dup
-		IL_0076: ldstr "multiplyModuleFactor"
-		IL_007b: ldloc.1
-		IL_007c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0081: dup
-		IL_0082: ldstr "createCalculator"
-		IL_0087: ldloc.2
-		IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_008d: stloc.s 4
-		IL_008f: ldarg.2
-		IL_0090: ldstr "exports"
-		IL_0095: ldloc.s 4
-		IL_0097: ldc.i4.1
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_009d: pop
-		IL_009e: ret
+		IL_0066: stfld float64 Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope::moduleFactor
+		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0070: dup
+		IL_0071: ldstr "multiplyModuleFactor"
+		IL_0076: ldloc.1
+		IL_0077: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_007c: dup
+		IL_007d: ldstr "createCalculator"
+		IL_0082: ldloc.2
+		IL_0083: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0088: stloc.s 4
+		IL_008a: ldarg.2
+		IL_008b: ldstr "exports"
+		IL_0090: ldloc.s 4
+		IL_0092: ldc.i4.1
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0098: pop
+		IL_0099: ret
 	} // end of method CommonJS_Export_ObjectWithClosure_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ObjectWithClosure_Lib
@@ -470,7 +452,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b3
+		// Method begins at RVA 0x2290
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/tests/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241a
+				// Method begins at RVA 0x23df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2435
+				// Method begins at RVA 0x23fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,35 +98,30 @@
 			)
 			// Method begins at RVA 0x2284
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] string
+				[0] string
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.CommonJS_Require_Basic/Scope::moduleName
-			IL_0006: ldstr "Cannot access 'moduleName' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
+			IL_0001: ldfld string Modules.CommonJS_Require_Basic/Scope::moduleName
+			IL_0006: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_000b: stloc.0
+			IL_000c: ldstr "Function from "
 			IL_0011: ldloc.0
-			IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0017: stloc.1
-			IL_0018: ldstr "Function from "
-			IL_001d: ldloc.1
+			IL_0012: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0017: stloc.0
+			IL_0018: ldloc.0
+			IL_0019: ldstr " has been called"
 			IL_001e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0023: stloc.1
-			IL_0024: ldloc.1
-			IL_0025: ldstr " has been called"
-			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.1
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldloc.1
-			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003b: pop
-			IL_003c: ldnull
-			IL_003d: ret
+			IL_0023: stloc.0
+			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0029: ldloc.0
+			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_002f: pop
+			IL_0030: ldnull
+			IL_0031: ret
 		} // end of method commonFunctionName::__js_call__
 
 	} // end of class commonFunctionName
@@ -142,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2423
+				// Method begins at RVA 0x23e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x23f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -188,7 +183,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22c4
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -212,13 +207,12 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22ec
+			// Method begins at RVA 0x22e0
 			// Header size: 12
-			// Code size: 74 (0x4a)
+			// Code size: 62 (0x3e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] string
+				[0] string
 			)
 
 			IL_0000: ldarg.0
@@ -226,27 +220,23 @@
 			IL_0006: ldc.i4.0
 			IL_0007: ldelem.ref
 			IL_0008: castclass Modules.CommonJS_Require_Basic/Scope
-			IL_000d: ldfld object Modules.CommonJS_Require_Basic/Scope::moduleName
-			IL_0012: ldstr "Cannot access 'moduleName' before initialization"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001c: stloc.0
+			IL_000d: ldfld string Modules.CommonJS_Require_Basic/Scope::moduleName
+			IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0017: stloc.0
+			IL_0018: ldstr "class from "
 			IL_001d: ldloc.0
-			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0023: stloc.1
-			IL_0024: ldstr "class from "
-			IL_0029: ldloc.1
+			IL_001e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ldstr " has been loaded"
 			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
-			IL_0031: ldstr " has been loaded"
-			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.1
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0041: ldloc.1
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0047: pop
-			IL_0048: ldnull
-			IL_0049: ret
+			IL_002f: stloc.0
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0035: ldloc.0
+			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_003b: pop
+			IL_003c: ldnull
+			IL_003d: ret
 		} // end of method CommonClassName::Log
 
 	} // end of class CommonClassName
@@ -262,25 +252,22 @@
 			74 69 6f 6e 4e 61 6d 65 7d 00 00
 		)
 		// Fields
-		.field public object moduleName
+		.field public string moduleName
 		.field public object commonFunctionName
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2406
+			// Method begins at RVA 0x23d6
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.CommonJS_Require_Basic/Scope::moduleName
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -367,7 +354,7 @@
 		IL_00a3: pop
 		IL_00a4: ldloc.0
 		IL_00a5: ldstr "CommonJS_Require_Basic"
-		IL_00aa: stfld object Modules.CommonJS_Require_Basic/Scope::moduleName
+		IL_00aa: stfld string Modules.CommonJS_Require_Basic/Scope::moduleName
 		IL_00af: ldc.i4.1
 		IL_00b0: newarr [System.Runtime]System.Object
 		IL_00b5: dup
@@ -430,7 +417,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2452
+				// Method begins at RVA 0x240c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -454,7 +441,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2342
+			// Method begins at RVA 0x232a
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -476,7 +463,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246d
+				// Method begins at RVA 0x2427
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -502,37 +489,32 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2348
+			// Method begins at RVA 0x2330
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] string
+				[0] string
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.CommonJS_Require_Dependency/Scope::moduleName
-			IL_0006: ldstr "Cannot access 'moduleName' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
+			IL_0001: ldfld string Modules.CommonJS_Require_Dependency/Scope::moduleName
+			IL_0006: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_000b: stloc.0
+			IL_000c: ldstr "Function from "
 			IL_0011: ldloc.0
-			IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0017: stloc.1
-			IL_0018: ldstr "Function from "
-			IL_001d: ldloc.1
+			IL_0012: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0017: stloc.0
+			IL_0018: ldloc.0
+			IL_0019: ldstr " has been called"
 			IL_001e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0023: stloc.1
-			IL_0024: ldloc.1
-			IL_0025: ldstr " has been called"
-			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.1
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldloc.1
-			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003b: pop
-			IL_003c: ldnull
-			IL_003d: ret
+			IL_0023: stloc.0
+			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0029: ldloc.0
+			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_002f: pop
+			IL_0030: ldnull
+			IL_0031: ret
 		} // end of method commonFunctionName::__js_call__
 
 	} // end of class commonFunctionName
@@ -548,7 +530,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245b
+				// Method begins at RVA 0x2415
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -568,7 +550,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2464
+				// Method begins at RVA 0x241e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -594,7 +576,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2394
+			// Method begins at RVA 0x2370
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -618,13 +600,12 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23b0
+			// Method begins at RVA 0x238c
 			// Header size: 12
-			// Code size: 74 (0x4a)
+			// Code size: 62 (0x3e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] string
+				[0] string
 			)
 
 			IL_0000: ldarg.0
@@ -632,27 +613,23 @@
 			IL_0006: ldc.i4.0
 			IL_0007: ldelem.ref
 			IL_0008: castclass Modules.CommonJS_Require_Dependency/Scope
-			IL_000d: ldfld object Modules.CommonJS_Require_Dependency/Scope::moduleName
-			IL_0012: ldstr "Cannot access 'moduleName' before initialization"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001c: stloc.0
+			IL_000d: ldfld string Modules.CommonJS_Require_Dependency/Scope::moduleName
+			IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0017: stloc.0
+			IL_0018: ldstr "class from "
 			IL_001d: ldloc.0
-			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0023: stloc.1
-			IL_0024: ldstr "class from "
-			IL_0029: ldloc.1
+			IL_001e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ldstr " has been loaded"
 			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
-			IL_0031: ldstr " has been loaded"
-			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.1
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0041: ldloc.1
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0047: pop
-			IL_0048: ldnull
-			IL_0049: ret
+			IL_002f: stloc.0
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0035: ldloc.0
+			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_003b: pop
+			IL_003c: ldnull
+			IL_003d: ret
 		} // end of method CommonClassName::Log
 
 	} // end of class CommonClassName
@@ -668,25 +645,22 @@
 			74 69 6f 6e 4e 61 6d 65 7d 00 00
 		)
 		// Fields
-		.field public object moduleName
+		.field public string moduleName
 		.field public object commonFunctionName
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x243e
+			// Method begins at RVA 0x2403
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.CommonJS_Require_Dependency/Scope::moduleName
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -765,7 +739,7 @@
 		IL_0087: pop
 		IL_0088: ldloc.0
 		IL_0089: ldstr "CommonJS_Require_Dependency"
-		IL_008e: stfld object Modules.CommonJS_Require_Dependency/Scope::moduleName
+		IL_008e: stfld string Modules.CommonJS_Require_Dependency/Scope::moduleName
 		IL_0093: ldc.i4.1
 		IL_0094: newarr [System.Runtime]System.Object
 		IL_0099: dup
@@ -814,7 +788,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2476
+		// Method begins at RVA 0x2430
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/tests/Js2IL.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2426
+			// Method begins at RVA 0x23f6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -86,7 +86,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2443
+				// Method begins at RVA 0x2408
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245e
+				// Method begins at RVA 0x2423
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -160,35 +160,30 @@
 			)
 			// Method begins at RVA 0x22a4
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] string
+				[0] string
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.b/Scope::moduleName
-			IL_0006: ldstr "Cannot access 'moduleName' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
+			IL_0001: ldfld string Modules.b/Scope::moduleName
+			IL_0006: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_000b: stloc.0
+			IL_000c: ldstr "Function from "
 			IL_0011: ldloc.0
-			IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0017: stloc.1
-			IL_0018: ldstr "Function from "
-			IL_001d: ldloc.1
+			IL_0012: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0017: stloc.0
+			IL_0018: ldloc.0
+			IL_0019: ldstr " has been called"
 			IL_001e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0023: stloc.1
-			IL_0024: ldloc.1
-			IL_0025: ldstr " has been called"
-			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.1
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldloc.1
-			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003b: pop
-			IL_003c: ldnull
-			IL_003d: ret
+			IL_0023: stloc.0
+			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0029: ldloc.0
+			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_002f: pop
+			IL_0030: ldnull
+			IL_0031: ret
 		} // end of method commonFunctionName::__js_call__
 
 	} // end of class commonFunctionName
@@ -204,7 +199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x2411
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,7 +219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2455
+				// Method begins at RVA 0x241a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +245,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f0
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -274,13 +269,12 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x230c
+			// Method begins at RVA 0x2300
 			// Header size: 12
-			// Code size: 74 (0x4a)
+			// Code size: 62 (0x3e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] string
+				[0] string
 			)
 
 			IL_0000: ldarg.0
@@ -288,27 +282,23 @@
 			IL_0006: ldc.i4.0
 			IL_0007: ldelem.ref
 			IL_0008: castclass Modules.b/Scope
-			IL_000d: ldfld object Modules.b/Scope::moduleName
-			IL_0012: ldstr "Cannot access 'moduleName' before initialization"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001c: stloc.0
+			IL_000d: ldfld string Modules.b/Scope::moduleName
+			IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0017: stloc.0
+			IL_0018: ldstr "class from "
 			IL_001d: ldloc.0
-			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0023: stloc.1
-			IL_0024: ldstr "class from "
-			IL_0029: ldloc.1
+			IL_001e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ldstr " has been loaded"
 			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
-			IL_0031: ldstr " has been loaded"
-			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.1
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0041: ldloc.1
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0047: pop
-			IL_0048: ldnull
-			IL_0049: ret
+			IL_002f: stloc.0
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0035: ldloc.0
+			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_003b: pop
+			IL_003c: ldnull
+			IL_003d: ret
 		} // end of method CommonClassName::Log
 
 	} // end of class CommonClassName
@@ -324,25 +314,22 @@
 			74 69 6f 6e 4e 61 6d 65 7d 00 00
 		)
 		// Fields
-		.field public object moduleName
+		.field public string moduleName
 		.field public object commonFunctionName
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x242f
+			// Method begins at RVA 0x23ff
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.b/Scope::moduleName
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -421,7 +408,7 @@
 		IL_0087: pop
 		IL_0088: ldloc.0
 		IL_0089: ldstr "CommonJS_Require_NestedNameConflict/b"
-		IL_008e: stfld object Modules.b/Scope::moduleName
+		IL_008e: stfld string Modules.b/Scope::moduleName
 		IL_0093: ldc.i4.1
 		IL_0094: newarr [System.Runtime]System.Object
 		IL_0099: dup
@@ -484,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247b
+				// Method begins at RVA 0x2435
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -508,7 +495,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2362
+			// Method begins at RVA 0x234a
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -530,7 +517,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2496
+				// Method begins at RVA 0x2450
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -556,37 +543,32 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2368
+			// Method begins at RVA 0x2350
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] string
+				[0] string
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.helpers_b/Scope::moduleName
-			IL_0006: ldstr "Cannot access 'moduleName' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
+			IL_0001: ldfld string Modules.helpers_b/Scope::moduleName
+			IL_0006: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_000b: stloc.0
+			IL_000c: ldstr "Function from "
 			IL_0011: ldloc.0
-			IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0017: stloc.1
-			IL_0018: ldstr "Function from "
-			IL_001d: ldloc.1
+			IL_0012: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0017: stloc.0
+			IL_0018: ldloc.0
+			IL_0019: ldstr " has been called"
 			IL_001e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0023: stloc.1
-			IL_0024: ldloc.1
-			IL_0025: ldstr " has been called"
-			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.1
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldloc.1
-			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003b: pop
-			IL_003c: ldnull
-			IL_003d: ret
+			IL_0023: stloc.0
+			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0029: ldloc.0
+			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_002f: pop
+			IL_0030: ldnull
+			IL_0031: ret
 		} // end of method commonFunctionName::__js_call__
 
 	} // end of class commonFunctionName
@@ -602,7 +584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2484
+				// Method begins at RVA 0x243e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -622,7 +604,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248d
+				// Method begins at RVA 0x2447
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -648,7 +630,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23b4
+			// Method begins at RVA 0x2390
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -672,13 +654,12 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23d0
+			// Method begins at RVA 0x23ac
 			// Header size: 12
-			// Code size: 74 (0x4a)
+			// Code size: 62 (0x3e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] string
+				[0] string
 			)
 
 			IL_0000: ldarg.0
@@ -686,27 +667,23 @@
 			IL_0006: ldc.i4.0
 			IL_0007: ldelem.ref
 			IL_0008: castclass Modules.helpers_b/Scope
-			IL_000d: ldfld object Modules.helpers_b/Scope::moduleName
-			IL_0012: ldstr "Cannot access 'moduleName' before initialization"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001c: stloc.0
+			IL_000d: ldfld string Modules.helpers_b/Scope::moduleName
+			IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0017: stloc.0
+			IL_0018: ldstr "class from "
 			IL_001d: ldloc.0
-			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0023: stloc.1
-			IL_0024: ldstr "class from "
-			IL_0029: ldloc.1
+			IL_001e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ldstr " has been loaded"
 			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
-			IL_0031: ldstr " has been loaded"
-			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.1
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0041: ldloc.1
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0047: pop
-			IL_0048: ldnull
-			IL_0049: ret
+			IL_002f: stloc.0
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0035: ldloc.0
+			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_003b: pop
+			IL_003c: ldnull
+			IL_003d: ret
 		} // end of method CommonClassName::Log
 
 	} // end of class CommonClassName
@@ -722,25 +699,22 @@
 			74 69 6f 6e 4e 61 6d 65 7d 00 00
 		)
 		// Fields
-		.field public object moduleName
+		.field public string moduleName
 		.field public object commonFunctionName
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2467
+			// Method begins at RVA 0x242c
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.helpers_b/Scope::moduleName
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -819,7 +793,7 @@
 		IL_0087: pop
 		IL_0088: ldloc.0
 		IL_0089: ldstr "CommonJS_Require_NestedNameConflict/helpers/b"
-		IL_008e: stfld object Modules.helpers_b/Scope::moduleName
+		IL_008e: stfld string Modules.helpers_b/Scope::moduleName
 		IL_0093: ldc.i4.1
 		IL_0094: newarr [System.Runtime]System.Object
 		IL_0099: dup
@@ -868,7 +842,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x249f
+		// Method begins at RVA 0x2459
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
+++ b/tests/Js2IL.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2431
+				// Method begins at RVA 0x23c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,31 +52,28 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22e8
+			// Method begins at RVA 0x22cc
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 29 (0x1d)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldstr "cleanup:"
-			IL_0016: ldarg.2
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001c: stloc.1
-			IL_001d: ldloc.0
-			IL_001e: ldstr "push"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0029: pop
-			IL_002a: ldnull
-			IL_002b: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
+			IL_0006: stloc.0
+			IL_0007: ldstr "cleanup:"
+			IL_000c: ldarg.2
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0012: stloc.1
+			IL_0013: ldloc.0
+			IL_0014: ldloc.1
+			IL_0015: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_001a: pop
+			IL_001b: ldnull
+			IL_001c: ret
 		} // end of method ArrowFunction_L4C43::__js_call__
 
 	} // end of class ArrowFunction_L4C43
@@ -92,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x23e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,13 +115,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2320
+			// Method begins at RVA 0x22f8
 			// Header size: 12
-			// Code size: 59 (0x3b)
+			// Code size: 47 (0x2f)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -135,17 +131,13 @@
 			IL_0015: stloc.0
 			IL_0016: ldarg.0
 			IL_0017: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
-			IL_001c: ldstr "Cannot access 'registry' before initialization"
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0026: stloc.1
-			IL_0027: ldloc.1
-			IL_0028: ldstr "register"
-			IL_002d: ldloc.0
-			IL_002e: ldstr "held"
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0038: pop
-			IL_0039: ldnull
-			IL_003a: ret
+			IL_001c: ldstr "register"
+			IL_0021: ldloc.0
+			IL_0022: ldstr "held"
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_002c: pop
+			IL_002d: ldnull
+			IL_002e: ret
 		} // end of method FunctionExpression_L19C1::__js_call__
 
 	} // end of class FunctionExpression_L19C1
@@ -168,7 +160,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2455
+				// Method begins at RVA 0x23ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -192,7 +184,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2368
+			// Method begins at RVA 0x2334
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -221,7 +213,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245e
+				// Method begins at RVA 0x23f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -247,26 +239,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2384
+			// Method begins at RVA 0x2350
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
+			IL_0006: ldstr "promise"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "promise"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L24C42::__js_call__
 
 	} // end of class ArrowFunction_L24C42
@@ -282,7 +273,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2467
+				// Method begins at RVA 0x23fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -308,40 +299,35 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23b4
+			// Method begins at RVA 0x2378
 			// Header size: 12
-			// Code size: 82 (0x52)
+			// Code size: 57 (0x39)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] string
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "immediate"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::order
-			IL_0028: ldstr "Cannot access 'order' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.0
-			IL_0033: ldloc.0
-			IL_0034: ldstr "join"
-			IL_0039: ldstr ","
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0043: stloc.0
-			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0049: ldloc.0
-			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_004f: pop
-			IL_0050: ldnull
-			IL_0051: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
+			IL_0006: ldstr "immediate"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldarg.0
+			IL_0012: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
+			IL_0017: ldc.i4.1
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: dup
+			IL_001e: ldc.i4.0
+			IL_001f: ldstr ","
+			IL_0024: stelem.ref
+			IL_0025: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_002a: stloc.0
+			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0030: ldloc.0
+			IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0036: pop
+			IL_0037: ldnull
+			IL_0038: ret
 		} // end of method ArrowFunction_L27C14::__js_call__
 
 	} // end of class ArrowFunction_L27C14
@@ -362,7 +348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243a
+				// Method begins at RVA 0x23cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -382,7 +368,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2443
+				// Method begins at RVA 0x23d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -397,28 +383,22 @@
 
 
 		// Fields
-		.field public object order
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array order
 		.field public object registry
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2412
+			// Method begins at RVA 0x23bd
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::order
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -436,7 +416,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 636 (0x27c)
+		// Code size: 608 (0x260)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Cleanup_Order/Scope,
@@ -457,7 +437,7 @@
 		IL_0006: ldloc.0
 		IL_0007: ldc.i4.0
 		IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_000d: stfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::order
+		IL_000d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
 		IL_0012: ldc.i4.1
 		IL_0013: newarr [System.Runtime]System.Object
 		IL_0018: dup
@@ -488,202 +468,194 @@
 		IL_0059: ldloc.0
 		IL_005a: ldloc.s 8
 		IL_005c: stfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
-		IL_0061: ldloc.0
-		IL_0062: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
-		IL_0067: ldstr "Cannot access 'registry' before initialization"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0071: stloc.s 7
-		IL_0073: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_0078: ldstr "prototype"
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0082: ldstr "toString"
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008c: ldstr "call"
+		IL_0061: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0066: ldstr "prototype"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0070: ldstr "toString"
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007a: ldstr "call"
+		IL_007f: ldloc.0
+		IL_0080: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008a: stloc.s 7
+		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0091: ldloc.s 7
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0098: stloc.s 7
-		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009f: ldloc.s 7
-		IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a6: pop
+		IL_0093: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0098: pop
 		.try
 		{
-			IL_00a7: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/Scope/Block_L10C4::.ctor()
-			IL_00ac: stloc.1
-			IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00b2: stloc.2
-			IL_00b3: ldloc.0
-			IL_00b4: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
-			IL_00b9: ldstr "Cannot access 'registry' before initialization"
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c3: stloc.s 7
-			IL_00c5: ldloc.s 7
-			IL_00c7: ldstr "register"
-			IL_00cc: ldloc.2
-			IL_00cd: ldloc.2
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00d3: pop
-			IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00d9: ldstr "same target threw:"
-			IL_00de: ldc.i4.0
-			IL_00df: box [System.Runtime]System.Boolean
-			IL_00e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00e9: pop
-			IL_00ea: leave IL_0164
+			IL_0099: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/Scope/Block_L10C4::.ctor()
+			IL_009e: stloc.1
+			IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00a4: stloc.2
+			IL_00a5: ldloc.0
+			IL_00a6: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
+			IL_00ab: ldstr "register"
+			IL_00b0: ldloc.2
+			IL_00b1: ldloc.2
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00b7: pop
+			IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00bd: ldstr "same target threw:"
+			IL_00c2: ldc.i4.0
+			IL_00c3: box [System.Runtime]System.Boolean
+			IL_00c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00cd: pop
+			IL_00ce: leave IL_0148
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00ef: stloc.3
-			IL_00f0: ldloc.3
-			IL_00f1: dup
-			IL_00f2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00f7: dup
-			IL_00f8: brtrue IL_010e
+			IL_00d3: stloc.3
+			IL_00d4: ldloc.3
+			IL_00d5: dup
+			IL_00d6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00db: dup
+			IL_00dc: brtrue IL_00f2
 
-			IL_00fd: pop
-			IL_00fe: dup
-			IL_00ff: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0104: dup
-			IL_0105: brtrue IL_011b
+			IL_00e1: pop
+			IL_00e2: dup
+			IL_00e3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00e8: dup
+			IL_00e9: brtrue IL_00ff
 
-			IL_010a: pop
-			IL_010b: pop
-			IL_010c: rethrow
+			IL_00ee: pop
+			IL_00ef: pop
+			IL_00f0: rethrow
 
-			IL_010e: pop
-			IL_010f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0114: stloc.s 4
-			IL_0116: br IL_011e
+			IL_00f2: pop
+			IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00f8: stloc.s 4
+			IL_00fa: br IL_0102
 
-			IL_011b: pop
-			IL_011c: stloc.s 4
+			IL_00ff: pop
+			IL_0100: stloc.s 4
 
-			IL_011e: ldloc.s 4
-			IL_0120: stloc.s 7
-			IL_0122: ldloc.s 7
-			IL_0124: stloc.s 5
-			IL_0126: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/Scope/Block_L14C16::.ctor()
-			IL_012b: stloc.s 6
-			IL_012d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0132: ldstr "same target threw:"
-			IL_0137: ldc.i4.1
-			IL_0138: box [System.Runtime]System.Boolean
+			IL_0102: ldloc.s 4
+			IL_0104: stloc.s 7
+			IL_0106: ldloc.s 7
+			IL_0108: stloc.s 5
+			IL_010a: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/Scope/Block_L14C16::.ctor()
+			IL_010f: stloc.s 6
+			IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0116: ldstr "same target threw:"
+			IL_011b: ldc.i4.1
+			IL_011c: box [System.Runtime]System.Boolean
+			IL_0121: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0126: pop
+			IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012c: ldstr "same target name:"
+			IL_0131: ldloc.s 5
+			IL_0133: ldstr "name"
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_0142: pop
-			IL_0143: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0148: ldstr "same target name:"
-			IL_014d: ldloc.s 5
-			IL_014f: ldstr "name"
-			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_015e: pop
-			IL_015f: leave IL_0164
+			IL_0143: leave IL_0148
 		} // end handler
 
-		IL_0164: ldc.i4.1
-		IL_0165: newarr [System.Runtime]System.Object
-		IL_016a: dup
-		IL_016b: ldc.i4.0
-		IL_016c: ldloc.0
-		IL_016d: stelem.ref
-		IL_016e: ldc.i4.0
-		IL_016f: ldelem.ref
-		IL_0170: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_0175: ldftn object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_017b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0180: ldc.i4.0
-		IL_0181: conv.r8
-		IL_0182: ldstr ""
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_018c: stloc.s 7
-		IL_018e: ldc.i4.0
-		IL_018f: newarr [System.Runtime]System.Object
-		IL_0194: stloc.s 9
-		IL_0196: ldloc.s 7
-		IL_0198: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_019d: ldloc.s 9
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_01a4: pop
-		IL_01a5: ldnull
-		IL_01a6: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13::__js_call__(object, object)
-		IL_01ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01b1: ldc.i4.1
-		IL_01b2: newarr [System.Runtime]System.Object
-		IL_01b7: dup
-		IL_01b8: ldc.i4.0
-		IL_01b9: ldloc.0
-		IL_01ba: stelem.ref
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01c5: ldc.i4.1
-		IL_01c6: conv.r8
-		IL_01c7: ldstr ""
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01d1: stloc.s 7
-		IL_01d3: ldloc.s 7
-		IL_01d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
-		IL_01da: stloc.s 10
+		IL_0148: ldc.i4.1
+		IL_0149: newarr [System.Runtime]System.Object
+		IL_014e: dup
+		IL_014f: ldc.i4.0
+		IL_0150: ldloc.0
+		IL_0151: stelem.ref
+		IL_0152: ldc.i4.0
+		IL_0153: ldelem.ref
+		IL_0154: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_0159: ldftn object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_015f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0164: ldc.i4.0
+		IL_0165: conv.r8
+		IL_0166: ldstr ""
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0170: stloc.s 7
+		IL_0172: ldc.i4.0
+		IL_0173: newarr [System.Runtime]System.Object
+		IL_0178: stloc.s 9
+		IL_017a: ldloc.s 7
+		IL_017c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0181: ldloc.s 9
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0188: pop
+		IL_0189: ldnull
+		IL_018a: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13::__js_call__(object, object)
+		IL_0190: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0195: ldc.i4.1
+		IL_0196: newarr [System.Runtime]System.Object
+		IL_019b: dup
+		IL_019c: ldc.i4.0
+		IL_019d: ldloc.0
+		IL_019e: stelem.ref
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01a9: ldc.i4.1
+		IL_01aa: conv.r8
+		IL_01ab: ldstr ""
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01b5: stloc.s 7
+		IL_01b7: ldloc.s 7
+		IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+		IL_01be: stloc.s 10
+		IL_01c0: ldc.i4.1
+		IL_01c1: newarr [System.Runtime]System.Object
+		IL_01c6: dup
+		IL_01c7: ldc.i4.0
+		IL_01c8: ldloc.0
+		IL_01c9: stelem.ref
+		IL_01ca: ldc.i4.0
+		IL_01cb: ldelem.ref
+		IL_01cc: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_01d1: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_01d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_01dc: ldc.i4.1
 		IL_01dd: newarr [System.Runtime]System.Object
 		IL_01e2: dup
 		IL_01e3: ldc.i4.0
 		IL_01e4: ldloc.0
 		IL_01e5: stelem.ref
-		IL_01e6: ldc.i4.0
-		IL_01e7: ldelem.ref
-		IL_01e8: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_01ed: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_01f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01f8: ldc.i4.1
-		IL_01f9: newarr [System.Runtime]System.Object
-		IL_01fe: dup
-		IL_01ff: ldc.i4.0
-		IL_0200: ldloc.0
-		IL_0201: stelem.ref
-		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_020c: ldc.i4.0
-		IL_020d: conv.r8
-		IL_020e: ldstr ""
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0218: stloc.s 7
-		IL_021a: ldloc.s 10
-		IL_021c: ldstr "then"
-		IL_0221: ldloc.s 7
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0228: pop
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_022e: pop
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01f0: ldc.i4.0
+		IL_01f1: conv.r8
+		IL_01f2: ldstr ""
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01fc: stloc.s 7
+		IL_01fe: ldloc.s 10
+		IL_0200: ldstr "then"
+		IL_0205: ldloc.s 7
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_020c: pop
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_0212: pop
+		IL_0213: ldc.i4.1
+		IL_0214: newarr [System.Runtime]System.Object
+		IL_0219: dup
+		IL_021a: ldc.i4.0
+		IL_021b: ldloc.0
+		IL_021c: stelem.ref
+		IL_021d: ldc.i4.0
+		IL_021e: ldelem.ref
+		IL_021f: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_0224: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_022f: ldc.i4.1
 		IL_0230: newarr [System.Runtime]System.Object
 		IL_0235: dup
 		IL_0236: ldc.i4.0
 		IL_0237: ldloc.0
 		IL_0238: stelem.ref
-		IL_0239: ldc.i4.0
-		IL_023a: ldelem.ref
-		IL_023b: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_0240: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_0246: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_024b: ldc.i4.1
-		IL_024c: newarr [System.Runtime]System.Object
-		IL_0251: dup
-		IL_0252: ldc.i4.0
-		IL_0253: ldloc.0
-		IL_0254: stelem.ref
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_025f: ldc.i4.0
-		IL_0260: conv.r8
-		IL_0261: ldstr ""
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_026b: stloc.s 7
-		IL_026d: ldloc.s 7
-		IL_026f: ldc.i4.0
-		IL_0270: newarr [System.Runtime]System.Object
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_027a: pop
-		IL_027b: ret
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0243: ldc.i4.0
+		IL_0244: conv.r8
+		IL_0245: ldstr ""
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_024f: stloc.s 7
+		IL_0251: ldloc.s 7
+		IL_0253: ldc.i4.0
+		IL_0254: newarr [System.Runtime]System.Object
+		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_025e: pop
+		IL_025f: ret
 	} // end of method FinalizationRegistry_Cleanup_Order::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Cleanup_Order
@@ -695,7 +667,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2470
+		// Method begins at RVA 0x2405
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
+++ b/tests/Js2IL.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2361
+				// Method begins at RVA 0x22c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,26 +52,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2270
-			// Header size: 12
-			// Code size: 32 (0x20)
+			// Method begins at RVA 0x2248
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
-			IL_0006: ldstr "Cannot access 'hits' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldarg.2
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001d: pop
-			IL_001e: ldnull
-			IL_001f: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method ArrowFunction_L4C43::__js_call__
 
 	} // end of class ArrowFunction_L4C43
@@ -87,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236a
+				// Method begins at RVA 0x22ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,14 +105,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x229c
+			// Method begins at RVA 0x2258
 			// Header size: 12
-			// Code size: 77 (0x4d)
+			// Code size: 53 (0x35)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[1] object,
-				[2] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -131,23 +121,15 @@
 			IL_0015: stloc.0
 			IL_0016: ldarg.0
 			IL_0017: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
-			IL_001c: ldstr "Cannot access 'registry' before initialization"
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0026: stloc.1
+			IL_001c: ldstr "register"
+			IL_0021: ldloc.0
+			IL_0022: ldstr "held"
 			IL_0027: ldarg.0
 			IL_0028: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
-			IL_002d: ldstr "Cannot access 'token' before initialization"
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0037: stloc.2
-			IL_0038: ldloc.1
-			IL_0039: ldstr "register"
-			IL_003e: ldloc.0
-			IL_003f: ldstr "held"
-			IL_0044: ldloc.2
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_004a: pop
-			IL_004b: ldnull
-			IL_004c: ret
+			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0032: pop
+			IL_0033: ldnull
+			IL_0034: ret
 		} // end of method FunctionExpression_L9C1::__js_call__
 
 	} // end of class FunctionExpression_L9C1
@@ -163,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2385
+				// Method begins at RVA 0x22e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -189,35 +171,21 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22f8
-			// Header size: 12
-			// Code size: 51 (0x33)
+			// Method begins at RVA 0x2299
+			// Header size: 1
+			// Code size: 30 (0x1e)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object
-			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
-			IL_0006: ldstr "Cannot access 'hits' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0017: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_001c: conv.r8
-			IL_001d: stloc.1
-			IL_001e: ldloc.1
-			IL_001f: box [System.Runtime]System.Double
-			IL_0024: stloc.2
-			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_002a: ldloc.2
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0030: pop
-			IL_0031: ldnull
-			IL_0032: ret
+			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0005: ldarg.0
+			IL_0006: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
+			IL_000b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0010: conv.r8
+			IL_0011: box [System.Runtime]System.Double
+			IL_0016: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_001b: pop
+			IL_001c: ldnull
+			IL_001d: ret
 		} // end of method ArrowFunction_L26C14::__js_call__
 
 	} // end of class ArrowFunction_L26C14
@@ -239,7 +207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2373
+				// Method begins at RVA 0x22d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -259,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x237c
+				// Method begins at RVA 0x22dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +242,7 @@
 
 
 		// Fields
-		.field public object hits
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array hits
 		.field public object registry
 		.field public object token
 
@@ -282,24 +250,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2337
+			// Method begins at RVA 0x22b8
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -317,7 +276,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 513 (0x201)
+		// Code size: 475 (0x1db)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Unregister_Basic/Scope,
@@ -328,8 +287,7 @@
 			[5] class Modules.FinalizationRegistry_Unregister_Basic/Scope/Block_L19C16,
 			[6] object,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
-			[8] object[],
-			[9] object
+			[8] object[]
 		)
 
 		IL_0000: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/Scope::.ctor()
@@ -337,7 +295,7 @@
 		IL_0006: ldloc.0
 		IL_0007: ldc.i4.0
 		IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_000d: stfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
+		IL_000d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
 		IL_0012: ldc.i4.1
 		IL_0013: newarr [System.Runtime]System.Object
 		IL_0018: dup
@@ -397,127 +355,117 @@
 		IL_00ac: pop
 		IL_00ad: ldloc.0
 		IL_00ae: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
-		IL_00b3: ldstr "Cannot access 'registry' before initialization"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00bd: stloc.s 6
-		IL_00bf: ldloc.0
-		IL_00c0: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
-		IL_00c5: ldstr "Cannot access 'token' before initialization"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00cf: stloc.s 9
-		IL_00d1: ldloc.s 6
-		IL_00d3: ldstr "unregister"
-		IL_00d8: ldloc.s 9
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00df: stloc.s 9
-		IL_00e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e6: ldloc.s 9
-		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ed: pop
+		IL_00b3: ldstr "unregister"
+		IL_00b8: ldloc.0
+		IL_00b9: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c3: stloc.s 6
+		IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ca: ldloc.s 6
+		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d1: pop
 		.try
 		{
-			IL_00ee: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/Scope/Block_L16C4::.ctor()
-			IL_00f3: stloc.1
-			IL_00f4: ldloc.0
-			IL_00f5: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
-			IL_00fa: ldstr "Cannot access 'registry' before initialization"
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0104: stloc.s 9
-			IL_0106: ldloc.s 9
-			IL_0108: ldstr "unregister"
-			IL_010d: ldc.r8 123
-			IL_0116: box [System.Runtime]System.Double
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0120: pop
-			IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0126: ldstr "bad token threw:"
-			IL_012b: ldc.i4.0
-			IL_012c: box [System.Runtime]System.Boolean
-			IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0136: pop
-			IL_0137: leave IL_01ae
+			IL_00d2: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/Scope/Block_L16C4::.ctor()
+			IL_00d7: stloc.1
+			IL_00d8: ldloc.0
+			IL_00d9: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
+			IL_00de: stloc.s 6
+			IL_00e0: ldloc.s 6
+			IL_00e2: ldstr "unregister"
+			IL_00e7: ldc.r8 123
+			IL_00f0: box [System.Runtime]System.Double
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00fa: pop
+			IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0100: ldstr "bad token threw:"
+			IL_0105: ldc.i4.0
+			IL_0106: box [System.Runtime]System.Boolean
+			IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0110: pop
+			IL_0111: leave IL_0188
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_013c: stloc.2
-			IL_013d: ldloc.2
-			IL_013e: dup
-			IL_013f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0144: dup
-			IL_0145: brtrue IL_015b
+			IL_0116: stloc.2
+			IL_0117: ldloc.2
+			IL_0118: dup
+			IL_0119: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_011e: dup
+			IL_011f: brtrue IL_0135
 
-			IL_014a: pop
-			IL_014b: dup
-			IL_014c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0151: dup
-			IL_0152: brtrue IL_0167
+			IL_0124: pop
+			IL_0125: dup
+			IL_0126: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_012b: dup
+			IL_012c: brtrue IL_0141
 
-			IL_0157: pop
-			IL_0158: pop
-			IL_0159: rethrow
+			IL_0131: pop
+			IL_0132: pop
+			IL_0133: rethrow
 
-			IL_015b: pop
-			IL_015c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0161: stloc.3
-			IL_0162: br IL_0169
+			IL_0135: pop
+			IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_013b: stloc.3
+			IL_013c: br IL_0143
 
-			IL_0167: pop
-			IL_0168: stloc.3
+			IL_0141: pop
+			IL_0142: stloc.3
 
-			IL_0169: ldloc.3
-			IL_016a: stloc.s 9
-			IL_016c: ldloc.s 9
-			IL_016e: stloc.s 4
-			IL_0170: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/Scope/Block_L19C16::.ctor()
-			IL_0175: stloc.s 5
-			IL_0177: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_017c: ldstr "bad token threw:"
-			IL_0181: ldc.i4.1
-			IL_0182: box [System.Runtime]System.Boolean
-			IL_0187: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_018c: pop
-			IL_018d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0192: ldstr "bad token name:"
-			IL_0197: ldloc.s 4
-			IL_0199: ldstr "name"
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01a8: pop
-			IL_01a9: leave IL_01ae
+			IL_0143: ldloc.3
+			IL_0144: stloc.s 6
+			IL_0146: ldloc.s 6
+			IL_0148: stloc.s 4
+			IL_014a: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/Scope/Block_L19C16::.ctor()
+			IL_014f: stloc.s 5
+			IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0156: ldstr "bad token threw:"
+			IL_015b: ldc.i4.1
+			IL_015c: box [System.Runtime]System.Boolean
+			IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0166: pop
+			IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_016c: ldstr "bad token name:"
+			IL_0171: ldloc.s 4
+			IL_0173: ldstr "name"
+			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0182: pop
+			IL_0183: leave IL_0188
 		} // end handler
 
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_01b3: pop
-		IL_01b4: ldc.i4.1
-		IL_01b5: newarr [System.Runtime]System.Object
-		IL_01ba: dup
-		IL_01bb: ldc.i4.0
-		IL_01bc: ldloc.0
-		IL_01bd: stelem.ref
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_018d: pop
+		IL_018e: ldc.i4.1
+		IL_018f: newarr [System.Runtime]System.Object
+		IL_0194: dup
+		IL_0195: ldc.i4.0
+		IL_0196: ldloc.0
+		IL_0197: stelem.ref
+		IL_0198: ldc.i4.0
+		IL_0199: ldelem.ref
+		IL_019a: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
+		IL_019f: ldftn object Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
+		IL_01a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01aa: ldc.i4.1
+		IL_01ab: newarr [System.Runtime]System.Object
+		IL_01b0: dup
+		IL_01b1: ldc.i4.0
+		IL_01b2: ldloc.0
+		IL_01b3: stelem.ref
+		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_01be: ldc.i4.0
-		IL_01bf: ldelem.ref
-		IL_01c0: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
-		IL_01c5: ldftn object Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
-		IL_01cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01d0: ldc.i4.1
-		IL_01d1: newarr [System.Runtime]System.Object
-		IL_01d6: dup
-		IL_01d7: ldc.i4.0
-		IL_01d8: ldloc.0
-		IL_01d9: stelem.ref
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01e4: ldc.i4.0
-		IL_01e5: conv.r8
-		IL_01e6: ldstr ""
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01f0: stloc.s 9
-		IL_01f2: ldloc.s 9
-		IL_01f4: ldc.i4.0
-		IL_01f5: newarr [System.Runtime]System.Object
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_01ff: pop
-		IL_0200: ret
+		IL_01bf: conv.r8
+		IL_01c0: ldstr ""
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01ca: stloc.s 6
+		IL_01cc: ldloc.s 6
+		IL_01ce: ldc.i4.0
+		IL_01cf: newarr [System.Runtime]System.Object
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_01d9: pop
+		IL_01da: ret
 	} // end of method FinalizationRegistry_Unregister_Basic::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Unregister_Basic
@@ -529,7 +477,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x238e
+		// Method begins at RVA 0x22ee
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Construct_NewTargetAndPrototype.verified.txt
+++ b/tests/Js2IL.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Construct_NewTargetAndPrototype.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229a
+				// Method begins at RVA 0x2277
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,9 +46,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x220c
+			// Method begins at RVA 0x2200
 			// Header size: 12
-			// Code size: 110 (0x6e)
+			// Code size: 98 (0x62)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -71,34 +71,30 @@
 			IL_001b: ldloc.2
 			IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0021: pop
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::boundThis
-			IL_0028: ldstr "Cannot access 'boundThis' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.0
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0038: ldloc.0
-			IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_003e: stloc.1
-			IL_003f: ldloc.1
-			IL_0040: box [System.Runtime]System.Boolean
-			IL_0045: stloc.2
-			IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_004b: ldloc.2
-			IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0051: pop
-			IL_0052: ldarg.2
-			IL_0053: ldarg.3
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0059: stloc.3
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_005f: ldstr "sum"
-			IL_0064: ldloc.3
-			IL_0065: ldc.i4.1
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_006b: pop
-			IL_006c: ldnull
-			IL_006d: ret
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0027: ldarg.0
+			IL_0028: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::boundThis
+			IL_002d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0032: stloc.1
+			IL_0033: ldloc.1
+			IL_0034: box [System.Runtime]System.Boolean
+			IL_0039: stloc.2
+			IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_003f: ldloc.2
+			IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0045: pop
+			IL_0046: ldarg.2
+			IL_0047: ldarg.3
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004d: stloc.3
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0053: ldstr "sum"
+			IL_0058: ldloc.3
+			IL_0059: ldc.i4.1
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_005f: pop
+			IL_0060: ldnull
+			IL_0061: ret
 		} // end of method C::__js_call__
 
 	} // end of class C
@@ -119,18 +115,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2286
+			// Method begins at RVA 0x226e
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::boundThis
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -148,7 +141,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 430 (0x1ae)
+		// Code size: 420 (0x1a4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope,
@@ -203,96 +196,94 @@
 		IL_007d: stloc.3
 		IL_007e: ldloc.0
 		IL_007f: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::boundThis
-		IL_0084: ldstr "Cannot access 'boundThis' before initialization"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_008e: stloc.s 4
-		IL_0090: ldloc.3
-		IL_0091: ldstr "bind"
-		IL_0096: ldloc.s 4
-		IL_0098: ldc.r8 5
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00ab: stloc.s 4
-		IL_00ad: ldloc.s 4
-		IL_00af: stloc.1
-		IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b5: ldloc.1
-		IL_00b6: ldstr "length"
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c5: pop
-		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cb: ldloc.1
-		IL_00cc: ldstr "name"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00db: pop
-		IL_00dc: ldloc.1
-		IL_00dd: ldstr "prototype"
-		IL_00e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_00e7: stloc.s 5
-		IL_00e9: ldloc.s 5
-		IL_00eb: box [System.Runtime]System.Boolean
-		IL_00f0: stloc.s 6
-		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f7: ldloc.s 6
-		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fe: pop
-		IL_00ff: ldloc.1
-		IL_0100: ldstr "prototype"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010a: ldnull
-		IL_010b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0110: stloc.s 5
-		IL_0112: ldloc.s 5
-		IL_0114: box [System.Runtime]System.Boolean
-		IL_0119: stloc.s 6
-		IL_011b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0120: ldloc.s 6
-		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0127: pop
-		IL_0128: ldloc.1
-		IL_0129: ldc.i4.1
-		IL_012a: newarr [System.Runtime]System.Object
-		IL_012f: dup
-		IL_0130: ldc.i4.0
-		IL_0131: ldc.r8 7
-		IL_013a: box [System.Runtime]System.Double
-		IL_013f: stelem.ref
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0145: stloc.s 4
-		IL_0147: ldloc.s 4
-		IL_0149: stloc.2
-		IL_014a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014f: ldloc.2
-		IL_0150: ldstr "sum"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015f: pop
-		IL_0160: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0165: ldloc.2
-		IL_0166: ldstr "kind"
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0175: pop
-		IL_0176: ldloc.2
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_017c: stloc.s 4
-		IL_017e: ldloc.s 4
-		IL_0180: ldloc.0
-		IL_0181: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::C
-		IL_0186: ldstr "prototype"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0195: stloc.s 5
-		IL_0197: ldloc.s 5
-		IL_0199: box [System.Runtime]System.Boolean
-		IL_019e: stloc.s 6
-		IL_01a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a5: ldloc.s 6
-		IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ac: pop
-		IL_01ad: ret
+		IL_0084: stloc.s 4
+		IL_0086: ldloc.3
+		IL_0087: ldstr "bind"
+		IL_008c: ldloc.s 4
+		IL_008e: ldc.r8 5
+		IL_0097: box [System.Runtime]System.Double
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00a1: stloc.s 4
+		IL_00a3: ldloc.s 4
+		IL_00a5: stloc.1
+		IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ab: ldloc.1
+		IL_00ac: ldstr "length"
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00bb: pop
+		IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c1: ldloc.1
+		IL_00c2: ldstr "name"
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d1: pop
+		IL_00d2: ldloc.1
+		IL_00d3: ldstr "prototype"
+		IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_00dd: stloc.s 5
+		IL_00df: ldloc.s 5
+		IL_00e1: box [System.Runtime]System.Boolean
+		IL_00e6: stloc.s 6
+		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ed: ldloc.s 6
+		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f4: pop
+		IL_00f5: ldloc.1
+		IL_00f6: ldstr "prototype"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0100: ldnull
+		IL_0101: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0106: stloc.s 5
+		IL_0108: ldloc.s 5
+		IL_010a: box [System.Runtime]System.Boolean
+		IL_010f: stloc.s 6
+		IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0116: ldloc.s 6
+		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011d: pop
+		IL_011e: ldloc.1
+		IL_011f: ldc.i4.1
+		IL_0120: newarr [System.Runtime]System.Object
+		IL_0125: dup
+		IL_0126: ldc.i4.0
+		IL_0127: ldc.r8 7
+		IL_0130: box [System.Runtime]System.Double
+		IL_0135: stelem.ref
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_013b: stloc.s 4
+		IL_013d: ldloc.s 4
+		IL_013f: stloc.2
+		IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0145: ldloc.2
+		IL_0146: ldstr "sum"
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0150: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0155: pop
+		IL_0156: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015b: ldloc.2
+		IL_015c: ldstr "kind"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016b: pop
+		IL_016c: ldloc.2
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0172: stloc.s 4
+		IL_0174: ldloc.s 4
+		IL_0176: ldloc.0
+		IL_0177: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::C
+		IL_017c: ldstr "prototype"
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0186: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_018b: stloc.s 5
+		IL_018d: ldloc.s 5
+		IL_018f: box [System.Runtime]System.Boolean
+		IL_0194: stloc.s 6
+		IL_0196: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019b: ldloc.s 6
+		IL_019d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a2: pop
+		IL_01a3: ret
 	} // end of method Function_Bind_Construct_NewTargetAndPrototype::__js_module_init__
 
 } // end of class Modules.Function_Bind_Construct_NewTargetAndPrototype
@@ -304,7 +295,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22a3
+		// Method begins at RVA 0x2280
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27de
+				// Method begins at RVA 0x270e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2382
+			// Method begins at RVA 0x237d
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27e7
+				// Method begins at RVA 0x2717
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2385
+			// Method begins at RVA 0x2380
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27f9
+					// Method begins at RVA 0x2729
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f0
+				// Method begins at RVA 0x2720
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2388
+			// Method begins at RVA 0x2384
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x280b
+					// Method begins at RVA 0x273b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2802
+				// Method begins at RVA 0x2732
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23b4
+			// Method begins at RVA 0x23b0
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2814
+				// Method begins at RVA 0x2744
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -299,7 +299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2826
+					// Method begins at RVA 0x2756
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -317,7 +317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x281d
+				// Method begins at RVA 0x274d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -343,62 +343,49 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x23e0
+			// Method begins at RVA 0x23dc
 			// Header size: 12
-			// Code size: 126 (0x7e)
+			// Code size: 90 (0x5a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/Scope_For_L16C9/Block_L16C37,
-				[2] object,
-				[3] float64
+				[2] float64
 			)
 
 			IL_0000: ldc.r8 0.0
 			IL_0009: stloc.0
 			// loop start (head: IL_000a)
-				IL_000a: ldarg.0
-				IL_000b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0010: ldstr "Cannot access 'i' before initialization"
-				IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001a: stloc.2
-				IL_001b: ldloc.2
-				IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0021: stloc.3
-				IL_0022: ldloc.3
-				IL_0023: ldc.r8 15
-				IL_002c: mul
-				IL_002d: stloc.3
-				IL_002e: ldloc.0
-				IL_002f: ldloc.3
-				IL_0030: clt
-				IL_0032: brfalse IL_007c
+				IL_000a: ldloc.0
+				IL_000b: ldarg.0
+				IL_000c: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0011: ldc.r8 15
+				IL_001a: mul
+				IL_001b: clt
+				IL_001d: brfalse IL_0058
 
-				IL_0037: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/Scope_For_L16C9/Block_L16C37::.ctor()
-				IL_003c: stloc.1
-				IL_003d: ldarg.0
-				IL_003e: ldc.i4.0
-				IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0049: ldarg.0
-				IL_004a: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_004f: ldstr "Cannot access 'i' before initialization"
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0059: stloc.2
-				IL_005a: ldarg.0
-				IL_005b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0060: ldloc.2
-				IL_0061: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::set_length(float64)
-				IL_006b: ldloc.0
-				IL_006c: ldc.r8 1
-				IL_0075: add
-				IL_0076: stloc.0
-				IL_0077: br IL_000a
+				IL_0022: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/Scope_For_L16C9/Block_L16C37::.ctor()
+				IL_0027: stloc.1
+				IL_0028: ldarg.0
+				IL_0029: ldc.i4.0
+				IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0034: ldarg.0
+				IL_0035: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_003a: stloc.2
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0041: ldloc.2
+				IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::set_length(float64)
+				IL_0047: ldloc.0
+				IL_0048: ldc.r8 1
+				IL_0051: add
+				IL_0052: stloc.0
+				IL_0053: br IL_000a
 			// end loop
 
-			IL_007c: ldnull
-			IL_007d: ret
+			IL_0058: ldnull
+			IL_0059: ret
 		} // end of method ArrowFunction_L15C32::__js_call__
 
 	} // end of class ArrowFunction_L15C32
@@ -414,7 +401,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x282f
+				// Method begins at RVA 0x275f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -434,7 +421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2838
+				// Method begins at RVA 0x2768
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -460,62 +447,49 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x246c
+			// Method begins at RVA 0x2444
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 91 (0x5b)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] object,
-				[2] float64
+				[1] object
 			)
 
 			IL_0000: ldc.r8 0.0
 			IL_0009: stloc.0
 			// loop start (head: IL_000a)
-				IL_000a: ldarg.0
-				IL_000b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0010: ldstr "Cannot access 'i' before initialization"
-				IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001a: stloc.1
-				IL_001b: ldloc.1
-				IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0021: stloc.2
-				IL_0022: ldloc.2
-				IL_0023: ldc.r8 10
-				IL_002c: mul
-				IL_002d: stloc.2
-				IL_002e: ldloc.0
-				IL_002f: ldloc.2
-				IL_0030: clt
-				IL_0032: brfalse IL_0075
+				IL_000a: ldloc.0
+				IL_000b: ldarg.0
+				IL_000c: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0011: ldc.r8 10
+				IL_001a: mul
+				IL_001b: clt
+				IL_001d: brfalse IL_0059
 
-				IL_0037: ldarg.0
-				IL_0038: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_003d: ldstr "Cannot access 'i' before initialization"
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0047: stloc.1
-				IL_0048: ldc.i4.1
-				IL_0049: newarr [System.Runtime]System.Object
-				IL_004e: dup
-				IL_004f: ldc.i4.0
-				IL_0050: ldloc.1
-				IL_0051: stelem.ref
-				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
-				IL_0057: stloc.1
-				IL_0058: ldarg.0
-				IL_0059: ldloc.1
-				IL_005a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_005f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0064: ldloc.0
-				IL_0065: ldc.r8 1
-				IL_006e: add
-				IL_006f: stloc.0
-				IL_0070: br IL_000a
+				IL_0022: ldc.i4.1
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0030: box [System.Runtime]System.Double
+				IL_0035: stelem.ref
+				IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
+				IL_003b: stloc.1
+				IL_003c: ldarg.0
+				IL_003d: ldloc.1
+				IL_003e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0043: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0048: ldloc.0
+				IL_0049: ldc.r8 1
+				IL_0052: add
+				IL_0053: stloc.0
+				IL_0054: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0059: ldnull
+			IL_005a: ret
 		} // end of method ArrowFunction_L22C41::__js_call__
 
 	} // end of class ArrowFunction_L22C41
@@ -531,7 +505,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2841
+				// Method begins at RVA 0x2771
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -551,7 +525,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x284a
+				// Method begins at RVA 0x277a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -577,16 +551,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x24f0
+			// Method begins at RVA 0x24ac
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] object,
-				[2] float64,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[4] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
@@ -596,38 +568,31 @@
 			IL_000c: ldc.r8 0.0
 			IL_0015: stloc.0
 			// loop start (head: IL_0016)
-				IL_0016: ldarg.0
-				IL_0017: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001c: ldstr "Cannot access 'i' before initialization"
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0026: stloc.1
-				IL_0027: ldloc.1
-				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_002d: stloc.2
-				IL_002e: ldloc.0
-				IL_002f: ldloc.2
-				IL_0030: clt
-				IL_0032: brfalse IL_0060
+				IL_0016: ldloc.0
+				IL_0017: ldarg.0
+				IL_0018: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001d: clt
+				IL_001f: brfalse IL_004b
 
-				IL_0037: ldarg.0
-				IL_0038: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_003d: stloc.3
-				IL_003e: ldloc.0
-				IL_003f: box [System.Runtime]System.Double
-				IL_0044: stloc.s 4
-				IL_0046: ldloc.3
-				IL_0047: ldloc.s 4
-				IL_0049: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
-				IL_004e: pop
-				IL_004f: ldloc.0
-				IL_0050: ldc.r8 1
-				IL_0059: add
-				IL_005a: stloc.0
-				IL_005b: br IL_0016
+				IL_0024: ldarg.0
+				IL_0025: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_002a: stloc.1
+				IL_002b: ldloc.0
+				IL_002c: box [System.Runtime]System.Double
+				IL_0031: stloc.2
+				IL_0032: ldloc.1
+				IL_0033: ldloc.2
+				IL_0034: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
+				IL_0039: pop
+				IL_003a: ldloc.0
+				IL_003b: ldc.r8 1
+				IL_0044: add
+				IL_0045: stloc.0
+				IL_0046: br IL_0016
 			// end loop
 
-			IL_0060: ldnull
-			IL_0061: ret
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method ArrowFunction_L27C37::__js_call__
 
 	} // end of class ArrowFunction_L27C37
@@ -643,7 +608,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2853
+				// Method begins at RVA 0x2783
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -663,7 +628,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x285c
+				// Method begins at RVA 0x278c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -689,16 +654,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2560
+			// Method begins at RVA 0x2508
 			// Header size: 12
-			// Code size: 126 (0x7e)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] object,
-				[2] float64,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[4] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
@@ -708,42 +671,35 @@
 			IL_000c: ldc.r8 0.0
 			IL_0015: stloc.0
 			// loop start (head: IL_0016)
-				IL_0016: ldarg.0
-				IL_0017: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001c: ldstr "Cannot access 'i' before initialization"
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0026: stloc.1
-				IL_0027: ldloc.1
-				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_002d: stloc.2
-				IL_002e: ldloc.0
-				IL_002f: ldloc.2
-				IL_0030: clt
-				IL_0032: brfalse IL_007c
+				IL_0016: ldloc.0
+				IL_0017: ldarg.0
+				IL_0018: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001d: clt
+				IL_001f: brfalse IL_0067
 
-				IL_0037: ldarg.0
-				IL_0038: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_003d: stloc.3
-				IL_003e: ldloc.0
-				IL_003f: box [System.Runtime]System.Double
-				IL_0044: stloc.s 4
-				IL_0046: ldloc.3
-				IL_0047: ldc.r8 0.0
-				IL_0050: box [System.Runtime]System.Double
-				IL_0055: ldc.r8 0.0
-				IL_005e: box [System.Runtime]System.Double
-				IL_0063: ldloc.s 4
-				IL_0065: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
-				IL_006a: pop
-				IL_006b: ldloc.0
-				IL_006c: ldc.r8 1
-				IL_0075: add
-				IL_0076: stloc.0
-				IL_0077: br IL_0016
+				IL_0024: ldarg.0
+				IL_0025: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_002a: stloc.1
+				IL_002b: ldloc.0
+				IL_002c: box [System.Runtime]System.Double
+				IL_0031: stloc.2
+				IL_0032: ldloc.1
+				IL_0033: ldc.r8 0.0
+				IL_003c: box [System.Runtime]System.Double
+				IL_0041: ldc.r8 0.0
+				IL_004a: box [System.Runtime]System.Double
+				IL_004f: ldloc.2
+				IL_0050: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
+				IL_0055: pop
+				IL_0056: ldloc.0
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.0
+				IL_0062: br IL_0016
 			// end loop
 
-			IL_007c: ldnull
-			IL_007d: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method ArrowFunction_L33C36::__js_call__
 
 	} // end of class ArrowFunction_L33C36
@@ -759,7 +715,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2865
+				// Method begins at RVA 0x2795
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -779,7 +735,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x286e
+				// Method begins at RVA 0x279e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -805,16 +761,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x25ec
+			// Method begins at RVA 0x2580
 			// Header size: 12
-			// Code size: 92 (0x5c)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[3] object,
-				[4] float64
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -826,34 +781,27 @@
 			IL_000e: ldc.r8 0.0
 			IL_0017: stloc.1
 			// loop start (head: IL_0018)
-				IL_0018: ldarg.0
-				IL_0019: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001e: ldstr "Cannot access 'i' before initialization"
-				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0028: stloc.3
-				IL_0029: ldloc.3
-				IL_002a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_002f: stloc.s 4
-				IL_0031: ldloc.1
-				IL_0032: ldloc.s 4
-				IL_0034: clt
-				IL_0036: brfalse IL_005a
+				IL_0018: ldloc.1
+				IL_0019: ldarg.0
+				IL_001a: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001f: clt
+				IL_0021: brfalse IL_0045
 
-				IL_003b: ldloc.0
-				IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::shift()
-				IL_0041: stloc.3
-				IL_0042: ldarg.0
-				IL_0043: ldloc.3
-				IL_0044: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0049: ldloc.1
-				IL_004a: ldc.r8 1
-				IL_0053: add
-				IL_0054: stloc.1
-				IL_0055: br IL_0018
+				IL_0026: ldloc.0
+				IL_0027: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::shift()
+				IL_002c: stloc.3
+				IL_002d: ldarg.0
+				IL_002e: ldloc.3
+				IL_002f: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_0034: ldloc.1
+				IL_0035: ldc.r8 1
+				IL_003e: add
+				IL_003f: stloc.1
+				IL_0040: br IL_0018
 			// end loop
 
-			IL_005a: ldnull
-			IL_005b: ret
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method ArrowFunction_L39C37::__js_call__
 
 	} // end of class ArrowFunction_L39C37
@@ -869,7 +817,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2877
+				// Method begins at RVA 0x27a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -889,7 +837,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2880
+				// Method begins at RVA 0x27b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -915,16 +863,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2654
+			// Method begins at RVA 0x25d4
 			// Header size: 12
-			// Code size: 120 (0x78)
+			// Code size: 99 (0x63)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[3] object,
-				[4] float64
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -936,38 +882,31 @@
 			IL_000e: ldc.r8 0.0
 			IL_0017: stloc.1
 			// loop start (head: IL_0018)
-				IL_0018: ldarg.0
-				IL_0019: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001e: ldstr "Cannot access 'i' before initialization"
-				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0028: stloc.3
-				IL_0029: ldloc.3
-				IL_002a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_002f: stloc.s 4
-				IL_0031: ldloc.1
-				IL_0032: ldloc.s 4
-				IL_0034: clt
-				IL_0036: brfalse IL_0076
+				IL_0018: ldloc.1
+				IL_0019: ldarg.0
+				IL_001a: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001f: clt
+				IL_0021: brfalse IL_0061
 
-				IL_003b: ldloc.0
-				IL_003c: ldc.r8 0.0
-				IL_0045: box [System.Runtime]System.Double
-				IL_004a: ldc.r8 1
-				IL_0053: box [System.Runtime]System.Double
-				IL_0058: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
-				IL_005d: stloc.2
-				IL_005e: ldarg.0
-				IL_005f: ldloc.2
-				IL_0060: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0065: ldloc.1
-				IL_0066: ldc.r8 1
-				IL_006f: add
-				IL_0070: stloc.1
-				IL_0071: br IL_0018
+				IL_0026: ldloc.0
+				IL_0027: ldc.r8 0.0
+				IL_0030: box [System.Runtime]System.Double
+				IL_0035: ldc.r8 1
+				IL_003e: box [System.Runtime]System.Double
+				IL_0043: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
+				IL_0048: stloc.2
+				IL_0049: ldarg.0
+				IL_004a: ldloc.2
+				IL_004b: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_0050: ldloc.1
+				IL_0051: ldc.r8 1
+				IL_005a: add
+				IL_005b: stloc.1
+				IL_005c: br IL_0018
 			// end loop
 
-			IL_0076: ldnull
-			IL_0077: ret
+			IL_0061: ldnull
+			IL_0062: ret
 		} // end of method ArrowFunction_L45C38::__js_call__
 
 	} // end of class ArrowFunction_L45C38
@@ -983,7 +922,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2889
+				// Method begins at RVA 0x27b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1003,7 +942,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2892
+				// Method begins at RVA 0x27c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1029,16 +968,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x26d8
+			// Method begins at RVA 0x2644
 			// Header size: 12
-			// Code size: 110 (0x6e)
+			// Code size: 87 (0x57)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] object,
-				[2] float64,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[4] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
@@ -1048,42 +985,33 @@
 			IL_000c: ldc.r8 0.0
 			IL_0015: stloc.0
 			// loop start (head: IL_0016)
-				IL_0016: ldarg.0
-				IL_0017: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001c: ldstr "Cannot access 'i' before initialization"
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0026: stloc.1
-				IL_0027: ldloc.1
-				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_002d: stloc.2
-				IL_002e: ldloc.2
-				IL_002f: ldc.r8 25
-				IL_0038: mul
-				IL_0039: stloc.2
-				IL_003a: ldloc.0
-				IL_003b: ldloc.2
-				IL_003c: clt
-				IL_003e: brfalse IL_006c
+				IL_0016: ldloc.0
+				IL_0017: ldarg.0
+				IL_0018: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001d: ldc.r8 25
+				IL_0026: mul
+				IL_0027: clt
+				IL_0029: brfalse IL_0055
 
-				IL_0043: ldarg.0
-				IL_0044: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0049: stloc.3
-				IL_004a: ldloc.0
-				IL_004b: box [System.Runtime]System.Double
-				IL_0050: stloc.s 4
-				IL_0052: ldloc.3
-				IL_0053: ldloc.s 4
-				IL_0055: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_005a: pop
-				IL_005b: ldloc.0
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.0
-				IL_0067: br IL_0016
+				IL_002e: ldarg.0
+				IL_002f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0034: stloc.1
+				IL_0035: ldloc.0
+				IL_0036: box [System.Runtime]System.Double
+				IL_003b: stloc.2
+				IL_003c: ldloc.1
+				IL_003d: ldloc.2
+				IL_003e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0043: pop
+				IL_0044: ldloc.0
+				IL_0045: ldc.r8 1
+				IL_004e: add
+				IL_004f: stloc.0
+				IL_0050: br IL_0016
 			// end loop
 
-			IL_006c: ldnull
-			IL_006d: ret
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method ArrowFunction_L51C34::__js_call__
 
 	} // end of class ArrowFunction_L51C34
@@ -1099,7 +1027,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x289b
+				// Method begins at RVA 0x27cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1119,7 +1047,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28a4
+				// Method begins at RVA 0x27d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1145,16 +1073,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2754
+			// Method begins at RVA 0x26a8
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[3] object,
-				[4] float64
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -1166,38 +1093,29 @@
 			IL_000e: ldc.r8 0.0
 			IL_0017: stloc.1
 			// loop start (head: IL_0018)
-				IL_0018: ldarg.0
-				IL_0019: ldfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001e: ldstr "Cannot access 'i' before initialization"
-				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0028: stloc.3
-				IL_0029: ldloc.3
-				IL_002a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_002f: stloc.s 4
-				IL_0031: ldloc.s 4
-				IL_0033: ldc.r8 25
-				IL_003c: mul
-				IL_003d: stloc.s 4
-				IL_003f: ldloc.1
-				IL_0040: ldloc.s 4
-				IL_0042: clt
-				IL_0044: brfalse IL_0068
+				IL_0018: ldloc.1
+				IL_0019: ldarg.0
+				IL_001a: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001f: ldc.r8 25
+				IL_0028: mul
+				IL_0029: clt
+				IL_002b: brfalse IL_004f
 
-				IL_0049: ldloc.0
-				IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
-				IL_004f: stloc.3
-				IL_0050: ldarg.0
-				IL_0051: ldloc.3
-				IL_0052: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0057: ldloc.1
-				IL_0058: ldc.r8 1
-				IL_0061: add
-				IL_0062: stloc.1
-				IL_0063: br IL_0018
+				IL_0030: ldloc.0
+				IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
+				IL_0036: stloc.3
+				IL_0037: ldarg.0
+				IL_0038: ldloc.3
+				IL_0039: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_003e: ldloc.1
+				IL_003f: ldc.r8 1
+				IL_0048: add
+				IL_0049: stloc.1
+				IL_004a: br IL_0018
 			// end loop
 
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_004f: ldnull
+			IL_0050: ret
 		} // end of method ArrowFunction_L57C35::__js_call__
 
 	} // end of class ArrowFunction_L57C35
@@ -1221,24 +1139,21 @@
 		.field public object test
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array 'ret'
 		.field public object tmp
-		.field public object i
+		.field public float64 i
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27ca
+			// Method begins at RVA 0x2705
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1256,7 +1171,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 806 (0x326)
+		// Code size: 801 (0x321)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope,
@@ -1326,244 +1241,243 @@
 		IL_00a8: stloc.s 5
 		IL_00aa: ldloc.0
 		IL_00ab: ldc.r8 1024
-		IL_00b4: box [System.Runtime]System.Double
-		IL_00b9: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-		IL_00be: ldc.i4.1
-		IL_00bf: newarr [System.Runtime]System.Object
-		IL_00c4: dup
-		IL_00c5: ldc.i4.0
-		IL_00c6: ldloc.0
-		IL_00c7: stelem.ref
-		IL_00c8: ldc.i4.0
-		IL_00c9: ldelem.ref
-		IL_00ca: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_00cf: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00da: ldc.i4.1
-		IL_00db: newarr [System.Runtime]System.Object
-		IL_00e0: dup
-		IL_00e1: ldc.i4.0
-		IL_00e2: ldloc.0
-		IL_00e3: stelem.ref
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00ee: ldc.i4.0
-		IL_00ef: conv.r8
-		IL_00f0: ldstr ""
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00fa: stloc.s 6
-		IL_00fc: ldnull
-		IL_00fd: ldstr "Array Construction, []"
-		IL_0102: ldloc.s 6
-		IL_0104: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_0109: pop
-		IL_010a: ldc.i4.1
-		IL_010b: newarr [System.Runtime]System.Object
-		IL_0110: dup
-		IL_0111: ldc.i4.0
-		IL_0112: ldloc.0
-		IL_0113: stelem.ref
-		IL_0114: ldc.i4.0
-		IL_0115: ldelem.ref
-		IL_0116: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_011b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0126: ldc.i4.1
-		IL_0127: newarr [System.Runtime]System.Object
-		IL_012c: dup
-		IL_012d: ldc.i4.0
-		IL_012e: ldloc.0
-		IL_012f: stelem.ref
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_013a: ldc.i4.0
-		IL_013b: conv.r8
-		IL_013c: ldstr ""
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0146: stloc.s 6
-		IL_0148: ldnull
-		IL_0149: ldstr "Array Construction, new Array()"
-		IL_014e: ldloc.s 6
-		IL_0150: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_0155: pop
-		IL_0156: ldc.i4.1
-		IL_0157: newarr [System.Runtime]System.Object
-		IL_015c: dup
-		IL_015d: ldc.i4.0
-		IL_015e: ldloc.0
-		IL_015f: stelem.ref
-		IL_0160: ldc.i4.0
-		IL_0161: ldelem.ref
-		IL_0162: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0167: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_016d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0172: ldc.i4.1
-		IL_0173: newarr [System.Runtime]System.Object
-		IL_0178: dup
-		IL_0179: ldc.i4.0
-		IL_017a: ldloc.0
-		IL_017b: stelem.ref
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0186: ldc.i4.0
-		IL_0187: conv.r8
-		IL_0188: ldstr ""
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0192: stloc.s 6
-		IL_0194: ldnull
-		IL_0195: ldstr "Array Construction, unshift"
-		IL_019a: ldloc.s 6
-		IL_019c: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_01a1: pop
-		IL_01a2: ldc.i4.1
-		IL_01a3: newarr [System.Runtime]System.Object
-		IL_01a8: dup
-		IL_01a9: ldc.i4.0
-		IL_01aa: ldloc.0
-		IL_01ab: stelem.ref
-		IL_01ac: ldc.i4.0
-		IL_01ad: ldelem.ref
-		IL_01ae: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_01b3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01be: ldc.i4.1
-		IL_01bf: newarr [System.Runtime]System.Object
-		IL_01c4: dup
-		IL_01c5: ldc.i4.0
-		IL_01c6: ldloc.0
-		IL_01c7: stelem.ref
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01d2: ldc.i4.0
-		IL_01d3: conv.r8
-		IL_01d4: ldstr ""
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01de: stloc.s 6
-		IL_01e0: ldnull
-		IL_01e1: ldstr "Array Construction, splice"
-		IL_01e6: ldloc.s 6
-		IL_01e8: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_01ed: pop
-		IL_01ee: ldc.i4.1
-		IL_01ef: newarr [System.Runtime]System.Object
-		IL_01f4: dup
-		IL_01f5: ldc.i4.0
-		IL_01f6: ldloc.0
-		IL_01f7: stelem.ref
-		IL_01f8: ldc.i4.0
-		IL_01f9: ldelem.ref
-		IL_01fa: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_01ff: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0205: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_020a: ldc.i4.1
-		IL_020b: newarr [System.Runtime]System.Object
-		IL_0210: dup
-		IL_0211: ldc.i4.0
-		IL_0212: ldloc.0
-		IL_0213: stelem.ref
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_021e: ldc.i4.0
-		IL_021f: conv.r8
-		IL_0220: ldstr ""
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_022a: stloc.s 6
-		IL_022c: ldnull
-		IL_022d: ldstr "Array Deconstruction, shift"
-		IL_0232: ldloc.s 6
-		IL_0234: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_0239: pop
-		IL_023a: ldc.i4.1
-		IL_023b: newarr [System.Runtime]System.Object
-		IL_0240: dup
-		IL_0241: ldc.i4.0
-		IL_0242: ldloc.0
-		IL_0243: stelem.ref
-		IL_0244: ldc.i4.0
-		IL_0245: ldelem.ref
-		IL_0246: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_024b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0251: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0256: ldc.i4.1
-		IL_0257: newarr [System.Runtime]System.Object
-		IL_025c: dup
-		IL_025d: ldc.i4.0
-		IL_025e: ldloc.0
-		IL_025f: stelem.ref
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_026a: ldc.i4.0
-		IL_026b: conv.r8
-		IL_026c: ldstr ""
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0276: stloc.s 6
-		IL_0278: ldnull
-		IL_0279: ldstr "Array Deconstruction, splice"
-		IL_027e: ldloc.s 6
-		IL_0280: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_0285: pop
-		IL_0286: ldc.i4.1
-		IL_0287: newarr [System.Runtime]System.Object
-		IL_028c: dup
-		IL_028d: ldc.i4.0
-		IL_028e: ldloc.0
-		IL_028f: stelem.ref
-		IL_0290: ldc.i4.0
-		IL_0291: ldelem.ref
-		IL_0292: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0297: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_029d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02a2: ldc.i4.1
-		IL_02a3: newarr [System.Runtime]System.Object
-		IL_02a8: dup
-		IL_02a9: ldc.i4.0
-		IL_02aa: ldloc.0
-		IL_02ab: stelem.ref
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02b6: ldc.i4.0
-		IL_02b7: conv.r8
-		IL_02b8: ldstr ""
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02c2: stloc.s 6
-		IL_02c4: ldnull
-		IL_02c5: ldstr "Array Construction, push"
-		IL_02ca: ldloc.s 6
-		IL_02cc: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_02d1: pop
-		IL_02d2: ldc.i4.1
-		IL_02d3: newarr [System.Runtime]System.Object
-		IL_02d8: dup
-		IL_02d9: ldc.i4.0
-		IL_02da: ldloc.0
-		IL_02db: stelem.ref
-		IL_02dc: ldc.i4.0
-		IL_02dd: ldelem.ref
-		IL_02de: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_02e3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_02e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02ee: ldc.i4.1
-		IL_02ef: newarr [System.Runtime]System.Object
-		IL_02f4: dup
-		IL_02f5: ldc.i4.0
-		IL_02f6: ldloc.0
-		IL_02f7: stelem.ref
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0302: ldc.i4.0
-		IL_0303: conv.r8
-		IL_0304: ldstr ""
-		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_030e: stloc.s 6
-		IL_0310: ldnull
-		IL_0311: ldstr "Array Deconstruction, pop"
-		IL_0316: ldloc.s 6
-		IL_0318: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_031d: pop
-		IL_031e: ldnull
-		IL_031f: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
-		IL_0324: pop
-		IL_0325: ret
+		IL_00b4: stfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+		IL_00b9: ldc.i4.1
+		IL_00ba: newarr [System.Runtime]System.Object
+		IL_00bf: dup
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldloc.0
+		IL_00c2: stelem.ref
+		IL_00c3: ldc.i4.0
+		IL_00c4: ldelem.ref
+		IL_00c5: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_00ca: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00d5: ldc.i4.1
+		IL_00d6: newarr [System.Runtime]System.Object
+		IL_00db: dup
+		IL_00dc: ldc.i4.0
+		IL_00dd: ldloc.0
+		IL_00de: stelem.ref
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00e9: ldc.i4.0
+		IL_00ea: conv.r8
+		IL_00eb: ldstr ""
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00f5: stloc.s 6
+		IL_00f7: ldnull
+		IL_00f8: ldstr "Array Construction, []"
+		IL_00fd: ldloc.s 6
+		IL_00ff: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
+		IL_0104: pop
+		IL_0105: ldc.i4.1
+		IL_0106: newarr [System.Runtime]System.Object
+		IL_010b: dup
+		IL_010c: ldc.i4.0
+		IL_010d: ldloc.0
+		IL_010e: stelem.ref
+		IL_010f: ldc.i4.0
+		IL_0110: ldelem.ref
+		IL_0111: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0116: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0121: ldc.i4.1
+		IL_0122: newarr [System.Runtime]System.Object
+		IL_0127: dup
+		IL_0128: ldc.i4.0
+		IL_0129: ldloc.0
+		IL_012a: stelem.ref
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0135: ldc.i4.0
+		IL_0136: conv.r8
+		IL_0137: ldstr ""
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0141: stloc.s 6
+		IL_0143: ldnull
+		IL_0144: ldstr "Array Construction, new Array()"
+		IL_0149: ldloc.s 6
+		IL_014b: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
+		IL_0150: pop
+		IL_0151: ldc.i4.1
+		IL_0152: newarr [System.Runtime]System.Object
+		IL_0157: dup
+		IL_0158: ldc.i4.0
+		IL_0159: ldloc.0
+		IL_015a: stelem.ref
+		IL_015b: ldc.i4.0
+		IL_015c: ldelem.ref
+		IL_015d: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0162: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0168: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_016d: ldc.i4.1
+		IL_016e: newarr [System.Runtime]System.Object
+		IL_0173: dup
+		IL_0174: ldc.i4.0
+		IL_0175: ldloc.0
+		IL_0176: stelem.ref
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0181: ldc.i4.0
+		IL_0182: conv.r8
+		IL_0183: ldstr ""
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_018d: stloc.s 6
+		IL_018f: ldnull
+		IL_0190: ldstr "Array Construction, unshift"
+		IL_0195: ldloc.s 6
+		IL_0197: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
+		IL_019c: pop
+		IL_019d: ldc.i4.1
+		IL_019e: newarr [System.Runtime]System.Object
+		IL_01a3: dup
+		IL_01a4: ldc.i4.0
+		IL_01a5: ldloc.0
+		IL_01a6: stelem.ref
+		IL_01a7: ldc.i4.0
+		IL_01a8: ldelem.ref
+		IL_01a9: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_01ae: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_01b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01b9: ldc.i4.1
+		IL_01ba: newarr [System.Runtime]System.Object
+		IL_01bf: dup
+		IL_01c0: ldc.i4.0
+		IL_01c1: ldloc.0
+		IL_01c2: stelem.ref
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01cd: ldc.i4.0
+		IL_01ce: conv.r8
+		IL_01cf: ldstr ""
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01d9: stloc.s 6
+		IL_01db: ldnull
+		IL_01dc: ldstr "Array Construction, splice"
+		IL_01e1: ldloc.s 6
+		IL_01e3: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
+		IL_01e8: pop
+		IL_01e9: ldc.i4.1
+		IL_01ea: newarr [System.Runtime]System.Object
+		IL_01ef: dup
+		IL_01f0: ldc.i4.0
+		IL_01f1: ldloc.0
+		IL_01f2: stelem.ref
+		IL_01f3: ldc.i4.0
+		IL_01f4: ldelem.ref
+		IL_01f5: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_01fa: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0200: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0205: ldc.i4.1
+		IL_0206: newarr [System.Runtime]System.Object
+		IL_020b: dup
+		IL_020c: ldc.i4.0
+		IL_020d: ldloc.0
+		IL_020e: stelem.ref
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0219: ldc.i4.0
+		IL_021a: conv.r8
+		IL_021b: ldstr ""
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0225: stloc.s 6
+		IL_0227: ldnull
+		IL_0228: ldstr "Array Deconstruction, shift"
+		IL_022d: ldloc.s 6
+		IL_022f: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
+		IL_0234: pop
+		IL_0235: ldc.i4.1
+		IL_0236: newarr [System.Runtime]System.Object
+		IL_023b: dup
+		IL_023c: ldc.i4.0
+		IL_023d: ldloc.0
+		IL_023e: stelem.ref
+		IL_023f: ldc.i4.0
+		IL_0240: ldelem.ref
+		IL_0241: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0246: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_024c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0251: ldc.i4.1
+		IL_0252: newarr [System.Runtime]System.Object
+		IL_0257: dup
+		IL_0258: ldc.i4.0
+		IL_0259: ldloc.0
+		IL_025a: stelem.ref
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0265: ldc.i4.0
+		IL_0266: conv.r8
+		IL_0267: ldstr ""
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0271: stloc.s 6
+		IL_0273: ldnull
+		IL_0274: ldstr "Array Deconstruction, splice"
+		IL_0279: ldloc.s 6
+		IL_027b: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
+		IL_0280: pop
+		IL_0281: ldc.i4.1
+		IL_0282: newarr [System.Runtime]System.Object
+		IL_0287: dup
+		IL_0288: ldc.i4.0
+		IL_0289: ldloc.0
+		IL_028a: stelem.ref
+		IL_028b: ldc.i4.0
+		IL_028c: ldelem.ref
+		IL_028d: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0292: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0298: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_029d: ldc.i4.1
+		IL_029e: newarr [System.Runtime]System.Object
+		IL_02a3: dup
+		IL_02a4: ldc.i4.0
+		IL_02a5: ldloc.0
+		IL_02a6: stelem.ref
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02b1: ldc.i4.0
+		IL_02b2: conv.r8
+		IL_02b3: ldstr ""
+		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_02bd: stloc.s 6
+		IL_02bf: ldnull
+		IL_02c0: ldstr "Array Construction, push"
+		IL_02c5: ldloc.s 6
+		IL_02c7: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
+		IL_02cc: pop
+		IL_02cd: ldc.i4.1
+		IL_02ce: newarr [System.Runtime]System.Object
+		IL_02d3: dup
+		IL_02d4: ldc.i4.0
+		IL_02d5: ldloc.0
+		IL_02d6: stelem.ref
+		IL_02d7: ldc.i4.0
+		IL_02d8: ldelem.ref
+		IL_02d9: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_02de: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_02e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02e9: ldc.i4.1
+		IL_02ea: newarr [System.Runtime]System.Object
+		IL_02ef: dup
+		IL_02f0: ldc.i4.0
+		IL_02f1: ldloc.0
+		IL_02f2: stelem.ref
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02fd: ldc.i4.0
+		IL_02fe: conv.r8
+		IL_02ff: ldstr ""
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0309: stloc.s 6
+		IL_030b: ldnull
+		IL_030c: ldstr "Array Deconstruction, pop"
+		IL_0311: ldloc.s 6
+		IL_0313: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
+		IL_0318: pop
+		IL_0319: ldnull
+		IL_031a: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
+		IL_031f: pop
+		IL_0320: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Array_Modern::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Array_Modern
@@ -1575,7 +1489,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x28ad
+		// Method begins at RVA 0x27dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x321d
+					// Method begins at RVA 0x30d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3214
+				// Method begins at RVA 0x30d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,9 +79,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2450
+			// Method begins at RVA 0x2444
 			// Header size: 12
-			// Code size: 302 (0x12e)
+			// Code size: 247 (0xf7)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -91,10 +91,10 @@
 				[4] object,
 				[5] object,
 				[6] float64,
-				[7] float64,
-				[8] object,
-				[9] object[],
-				[10] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
+				[7] object,
+				[8] object[],
+				[9] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
+				[10] float64,
 				[11] object
 			)
 
@@ -109,102 +109,85 @@
 			IL_001f: stloc.0
 			IL_0020: ldarg.0
 			IL_0021: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_0026: ldstr "Cannot access 'performance' before initialization"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0026: ldstr "now"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0030: stloc.s 5
 			IL_0032: ldloc.s 5
-			IL_0034: ldstr "now"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_003e: stloc.s 5
-			IL_0040: ldloc.s 5
-			IL_0042: stloc.1
-			IL_0043: ldarg.0
-			IL_0044: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_0049: ldstr "Cannot access 'NOW_UNITS_PER_SECOND' before initialization"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0053: stloc.s 5
-			IL_0055: ldarg.3
-			IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 5
-			IL_005f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0064: stloc.s 7
-			IL_0066: ldloc.s 6
-			IL_0068: ldloc.s 7
-			IL_006a: mul
-			IL_006b: stloc.s 7
-			IL_006d: ldloc.1
-			IL_006e: ldloc.s 7
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0075: stloc.s 8
-			IL_0077: ldloc.s 8
-			IL_0079: stloc.2
-			// loop start (head: IL_007a)
-				IL_007a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L218C1::.ctor()
-				IL_007f: stloc.3
-				IL_0080: ldc.i4.1
-				IL_0081: newarr [System.Runtime]System.Object
-				IL_0086: dup
-				IL_0087: ldc.i4.0
-				IL_0088: ldarg.0
-				IL_0089: stelem.ref
-				IL_008a: stloc.s 9
-				IL_008c: ldloc.s 9
-				IL_008e: ldc.i4.1
-				IL_008f: newarr [System.Runtime]System.Object
-				IL_0094: dup
-				IL_0095: ldc.i4.0
-				IL_0096: ldarg.2
-				IL_0097: stelem.ref
-				IL_0098: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-				IL_009d: ldarg.2
-				IL_009e: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], object)
-				IL_00a3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-				IL_00a8: stloc.s 10
-				IL_00aa: ldloc.s 10
-				IL_00ac: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_00b1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_00b6: ldstr "prototype"
-				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-				IL_00c0: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-				IL_00c5: ldloc.s 10
-				IL_00c7: stloc.s 4
-				IL_00c9: ldloc.s 4
-				IL_00cb: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_00d0: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
-				IL_00d5: pop
-				IL_00d6: ldloc.0
-				IL_00d7: ldc.r8 1
-				IL_00e0: add
-				IL_00e1: stloc.0
-				IL_00e2: ldarg.0
-				IL_00e3: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-				IL_00e8: ldstr "Cannot access 'performance' before initialization"
-				IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00f2: stloc.s 5
-				IL_00f4: ldloc.s 5
-				IL_00f6: ldstr "now"
-				IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0100: stloc.s 5
-				IL_0102: ldloc.s 5
-				IL_0104: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0109: stloc.s 7
-				IL_010b: ldloc.2
-				IL_010c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0111: stloc.s 6
-				IL_0113: ldloc.s 7
-				IL_0115: ldloc.s 6
-				IL_0117: clt
-				IL_0119: brfalse IL_0123
+			IL_0034: stloc.1
+			IL_0035: ldarg.0
+			IL_0036: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
+			IL_003b: stloc.s 6
+			IL_003d: ldloc.1
+			IL_003e: ldarg.3
+			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0044: ldloc.s 6
+			IL_0046: mul
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_004c: stloc.s 7
+			IL_004e: ldloc.s 7
+			IL_0050: stloc.2
+			// loop start (head: IL_0051)
+				IL_0051: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L218C1::.ctor()
+				IL_0056: stloc.3
+				IL_0057: ldc.i4.1
+				IL_0058: newarr [System.Runtime]System.Object
+				IL_005d: dup
+				IL_005e: ldc.i4.0
+				IL_005f: ldarg.0
+				IL_0060: stelem.ref
+				IL_0061: stloc.s 8
+				IL_0063: ldloc.s 8
+				IL_0065: ldc.i4.1
+				IL_0066: newarr [System.Runtime]System.Object
+				IL_006b: dup
+				IL_006c: ldc.i4.0
+				IL_006d: ldarg.2
+				IL_006e: stelem.ref
+				IL_006f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+				IL_0074: ldarg.2
+				IL_0075: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], object)
+				IL_007a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+				IL_007f: stloc.s 9
+				IL_0081: ldloc.s 9
+				IL_0083: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_0088: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+				IL_008d: ldstr "prototype"
+				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+				IL_0097: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+				IL_009c: ldloc.s 9
+				IL_009e: stloc.s 4
+				IL_00a0: ldloc.s 4
+				IL_00a2: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_00a7: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
+				IL_00ac: pop
+				IL_00ad: ldloc.0
+				IL_00ae: ldc.r8 1
+				IL_00b7: add
+				IL_00b8: stloc.0
+				IL_00b9: ldarg.0
+				IL_00ba: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+				IL_00bf: ldstr "now"
+				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00c9: stloc.s 5
+				IL_00cb: ldloc.s 5
+				IL_00cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d2: stloc.s 6
+				IL_00d4: ldloc.2
+				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00da: stloc.s 10
+				IL_00dc: ldloc.s 6
+				IL_00de: ldloc.s 10
+				IL_00e0: clt
+				IL_00e2: brfalse IL_00ec
 
-				IL_011e: br IL_007a
+				IL_00e7: br IL_0051
 			// end loop
 
-			IL_0123: ldloc.0
-			IL_0124: box [System.Runtime]System.Double
-			IL_0129: stloc.s 11
-			IL_012b: ldloc.s 11
-			IL_012d: ret
+			IL_00ec: ldloc.0
+			IL_00ed: box [System.Runtime]System.Double
+			IL_00f2: stloc.s 11
+			IL_00f4: ldloc.s 11
+			IL_00f6: ret
 		} // end of method ArrowFunction_L210C23::__js_call__
 
 	} // end of class ArrowFunction_L210C23
@@ -235,7 +218,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3226
+				// Method begins at RVA 0x30e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -262,9 +245,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x258c
+			// Method begins at RVA 0x2548
 			// Header size: 12
-			// Code size: 498 (0x1f2)
+			// Code size: 433 (0x1b1)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -359,108 +342,89 @@
 
 			IL_00c4: ldarg.0
 			IL_00c5: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_00ca: ldstr "Cannot access 'performance' before initialization"
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00ca: ldstr "now"
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_00d4: stloc.s 12
 			IL_00d6: ldloc.s 12
-			IL_00d8: ldstr "now"
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e2: stloc.s 12
-			IL_00e4: ldloc.s 12
-			IL_00e6: stloc.s 5
+			IL_00d8: stloc.s 5
+			IL_00da: ldarg.0
+			IL_00db: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+			IL_00e0: ldc.i4.1
+			IL_00e1: newarr [System.Runtime]System.Object
+			IL_00e6: dup
+			IL_00e7: ldc.i4.0
 			IL_00e8: ldarg.0
-			IL_00e9: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-			IL_00ee: ldstr "Cannot access 'runSieveBatch' before initialization"
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00f8: stloc.s 12
-			IL_00fa: ldloc.s 12
-			IL_00fc: ldc.i4.1
-			IL_00fd: newarr [System.Runtime]System.Object
-			IL_0102: dup
-			IL_0103: ldc.i4.0
-			IL_0104: ldarg.0
-			IL_0105: stelem.ref
-			IL_0106: ldloc.0
-			IL_0107: ldloc.1
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs2(object, object[], object, object)
-			IL_010d: stloc.s 12
-			IL_010f: ldloc.s 12
-			IL_0111: stloc.s 6
-			IL_0113: ldarg.0
-			IL_0114: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_0119: ldstr "Cannot access 'performance' before initialization"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0123: stloc.s 12
-			IL_0125: ldloc.s 12
-			IL_0127: ldstr "now"
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0131: stloc.s 12
-			IL_0133: ldloc.s 12
-			IL_0135: stloc.s 7
-			IL_0137: ldloc.s 7
-			IL_0139: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_013e: stloc.s 13
-			IL_0140: ldloc.s 5
-			IL_0142: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0147: stloc.s 14
-			IL_0149: ldloc.s 13
-			IL_014b: ldloc.s 14
-			IL_014d: sub
-			IL_014e: stloc.s 14
-			IL_0150: ldarg.0
-			IL_0151: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_0156: ldstr "Cannot access 'NOW_UNITS_PER_SECOND' before initialization"
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0160: stloc.s 12
-			IL_0162: ldloc.s 12
-			IL_0164: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0169: stloc.s 13
-			IL_016b: ldloc.s 14
-			IL_016d: ldloc.s 13
-			IL_016f: div
-			IL_0170: stloc.s 13
-			IL_0172: ldloc.s 13
-			IL_0174: stloc.s 8
-			IL_0176: ldloc.3
-			IL_0177: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_017c: stloc.s 15
-			IL_017e: ldstr "\nrogiervandam-"
-			IL_0183: ldloc.s 15
-			IL_0185: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018a: stloc.s 15
-			IL_018c: ldloc.s 15
-			IL_018e: ldstr ";"
-			IL_0193: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0198: stloc.s 15
-			IL_019a: ldloc.s 6
-			IL_019c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a1: stloc.s 16
-			IL_01a3: ldloc.s 15
-			IL_01a5: ldloc.s 16
-			IL_01a7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ac: stloc.s 16
-			IL_01ae: ldloc.s 16
-			IL_01b0: ldstr ";"
-			IL_01b5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ba: stloc.s 16
-			IL_01bc: ldloc.s 8
-			IL_01be: box [System.Runtime]System.Double
-			IL_01c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c8: stloc.s 15
-			IL_01ca: ldloc.s 16
-			IL_01cc: ldloc.s 15
-			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d3: stloc.s 15
-			IL_01d5: ldloc.s 15
-			IL_01d7: ldstr ";1;algorithm=base,faithful=yes,bits=1"
-			IL_01dc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e1: stloc.s 15
-			IL_01e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01e8: ldloc.s 15
-			IL_01ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01ef: pop
-			IL_01f0: ldnull
-			IL_01f1: ret
+			IL_00e9: stelem.ref
+			IL_00ea: ldloc.0
+			IL_00eb: ldloc.1
+			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs2(object, object[], object, object)
+			IL_00f1: stloc.s 12
+			IL_00f3: ldloc.s 12
+			IL_00f5: stloc.s 6
+			IL_00f7: ldarg.0
+			IL_00f8: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+			IL_00fd: ldstr "now"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0107: stloc.s 12
+			IL_0109: ldloc.s 12
+			IL_010b: stloc.s 7
+			IL_010d: ldloc.s 7
+			IL_010f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0114: stloc.s 13
+			IL_0116: ldloc.s 5
+			IL_0118: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_011d: stloc.s 14
+			IL_011f: ldloc.s 13
+			IL_0121: ldloc.s 14
+			IL_0123: sub
+			IL_0124: stloc.s 14
+			IL_0126: ldloc.s 14
+			IL_0128: ldarg.0
+			IL_0129: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
+			IL_012e: div
+			IL_012f: stloc.s 14
+			IL_0131: ldloc.s 14
+			IL_0133: stloc.s 8
+			IL_0135: ldloc.3
+			IL_0136: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_013b: stloc.s 15
+			IL_013d: ldstr "\nrogiervandam-"
+			IL_0142: ldloc.s 15
+			IL_0144: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0149: stloc.s 15
+			IL_014b: ldloc.s 15
+			IL_014d: ldstr ";"
+			IL_0152: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0157: stloc.s 15
+			IL_0159: ldloc.s 6
+			IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0160: stloc.s 16
+			IL_0162: ldloc.s 15
+			IL_0164: ldloc.s 16
+			IL_0166: call string [System.Runtime]System.String::Concat(string, string)
+			IL_016b: stloc.s 16
+			IL_016d: ldloc.s 16
+			IL_016f: ldstr ";"
+			IL_0174: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0179: stloc.s 16
+			IL_017b: ldloc.s 8
+			IL_017d: box [System.Runtime]System.Double
+			IL_0182: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0187: stloc.s 15
+			IL_0189: ldloc.s 16
+			IL_018b: ldloc.s 15
+			IL_018d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0192: stloc.s 15
+			IL_0194: ldloc.s 15
+			IL_0196: ldstr ";1;algorithm=base,faithful=yes,bits=1"
+			IL_019b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a0: stloc.s 15
+			IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01a7: ldloc.s 15
+			IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01ae: pop
+			IL_01af: ldnull
+			IL_01b0: ret
 		} // end of method ArrowFunction_L229C14::__js_call__
 
 	} // end of class ArrowFunction_L229C14
@@ -476,7 +440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x310f
+				// Method begins at RVA 0x2fcb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -496,7 +460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3118
+				// Method begins at RVA 0x2fd4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -516,7 +480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3121
+				// Method begins at RVA 0x2fdd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -544,7 +508,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x313c
+						// Method begins at RVA 0x2ff8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -568,7 +532,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x314e
+							// Method begins at RVA 0x300a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -586,7 +550,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3145
+						// Method begins at RVA 0x3001
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -604,7 +568,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3133
+					// Method begins at RVA 0x2fef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -632,7 +596,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3169
+							// Method begins at RVA 0x3025
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -650,7 +614,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3160
+						// Method begins at RVA 0x301c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -668,7 +632,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3157
+					// Method begins at RVA 0x3013
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -692,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x317b
+						// Method begins at RVA 0x3037
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -710,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3172
+					// Method begins at RVA 0x302e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -728,7 +692,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x312a
+				// Method begins at RVA 0x2fe6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -748,7 +712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3184
+				// Method begins at RVA 0x3040
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -772,7 +736,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3196
+					// Method begins at RVA 0x3052
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -790,7 +754,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x318d
+				// Method begins at RVA 0x3049
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -818,7 +782,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27f4
+			// Method begins at RVA 0x2770
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -867,7 +831,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b58
+			// Method begins at RVA 0x2a40
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -937,9 +901,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2890
+			// Method begins at RVA 0x280c
 			// Header size: 12
-			// Code size: 697 (0x2b9)
+			// Code size: 552 (0x228)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26,
@@ -954,321 +918,275 @@
 				[9] float64,
 				[10] float64,
 				[11] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75/Block_L70C7,
-				[12] object,
-				[13] object,
+				[12] float64,
+				[13] float64,
 				[14] float64,
 				[15] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29,
 				[16] float64,
 				[17] float64,
 				[18] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36,
 				[19] object,
-				[20] float64,
-				[21] object,
-				[22] object,
-				[23] bool
+				[20] float64
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray::_scopes
-			IL_0006: ldc.i4.0
-			IL_0007: ldelem.ref
-			IL_0008: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-			IL_000d: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
-			IL_0012: ldstr "Cannot access 'WORD_SIZE' before initialization"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001c: stloc.s 19
-			IL_001e: ldloc.s 19
-			IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0025: stloc.s 20
-			IL_0027: ldloc.s 20
-			IL_0029: ldc.r8 2
-			IL_0032: div
-			IL_0033: stloc.s 20
-			IL_0035: ldarg.2
-			IL_0036: ldloc.s 20
-			IL_0038: cgt
-			IL_003a: brfalse IL_015d
+			IL_0000: ldarg.2
+			IL_0001: ldarg.0
+			IL_0002: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray::_scopes
+			IL_0007: ldc.i4.0
+			IL_0008: ldelem.ref
+			IL_0009: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+			IL_000e: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
+			IL_0013: ldc.r8 2
+			IL_001c: div
+			IL_001d: cgt
+			IL_001f: brfalse IL_0142
 
-			IL_003f: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26::.ctor()
-			IL_0044: stloc.0
-			IL_0045: ldarg.1
-			IL_0046: ldc.r8 32
-			IL_004f: ldarg.2
-			IL_0050: mul
-			IL_0051: add
-			IL_0052: stloc.1
-			IL_0053: ldloc.1
-			IL_0054: ldarg.3
-			IL_0055: cgt
-			IL_0057: brfalse IL_0093
+			IL_0024: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26::.ctor()
+			IL_0029: stloc.0
+			IL_002a: ldarg.1
+			IL_002b: ldc.r8 32
+			IL_0034: ldarg.2
+			IL_0035: mul
+			IL_0036: add
+			IL_0037: stloc.1
+			IL_0038: ldloc.1
+			IL_0039: ldarg.3
+			IL_003a: cgt
+			IL_003c: brfalse IL_0078
 
-			IL_005c: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Block_L57C39::.ctor()
-			IL_0061: stloc.2
-			IL_0062: ldarg.1
-			IL_0063: stloc.3
-			// loop start (head: IL_0064)
-				IL_0064: ldloc.3
-				IL_0065: ldarg.3
-				IL_0066: clt
-				IL_0068: brfalse IL_0091
+			IL_0041: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Block_L57C39::.ctor()
+			IL_0046: stloc.2
+			IL_0047: ldarg.1
+			IL_0048: stloc.3
+			// loop start (head: IL_0049)
+				IL_0049: ldloc.3
+				IL_004a: ldarg.3
+				IL_004b: clt
+				IL_004d: brfalse IL_0076
 
-				IL_006d: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Scope_For_L59C9/Block_L59C69::.ctor()
-				IL_0072: stloc.s 4
-				IL_0074: ldloc.3
-				IL_0075: box [System.Runtime]System.Double
-				IL_007a: stloc.s 21
-				IL_007c: ldarg.0
-				IL_007d: ldloc.3
-				IL_007e: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
-				IL_0083: pop
-				IL_0084: ldloc.3
-				IL_0085: ldarg.2
-				IL_0086: add
-				IL_0087: stloc.s 20
-				IL_0089: ldloc.s 20
-				IL_008b: stloc.3
-				IL_008c: br IL_0064
+				IL_0052: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Scope_For_L59C9/Block_L59C69::.ctor()
+				IL_0057: stloc.s 4
+				IL_0059: ldloc.3
+				IL_005a: box [System.Runtime]System.Double
+				IL_005f: stloc.s 19
+				IL_0061: ldarg.0
+				IL_0062: ldloc.3
+				IL_0063: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
+				IL_0068: pop
+				IL_0069: ldloc.3
+				IL_006a: ldarg.2
+				IL_006b: add
+				IL_006c: stloc.s 20
+				IL_006e: ldloc.s 20
+				IL_0070: stloc.3
+				IL_0071: br IL_0049
 			// end loop
 
-			IL_0091: ldnull
-			IL_0092: ret
+			IL_0076: ldnull
+			IL_0077: ret
 
-			IL_0093: ldarg.3
-			IL_0094: conv.i4
-			IL_0095: conv.u4
-			IL_0096: ldc.r8 5
-			IL_009f: conv.i4
-			IL_00a0: shr.un
-			IL_00a1: conv.r.un
-			IL_00a2: stloc.s 20
-			IL_00a4: ldloc.s 20
-			IL_00a6: stloc.s 5
-			IL_00a8: ldarg.1
-			IL_00a9: stloc.s 6
-			// loop start (head: IL_00ab)
-				IL_00ab: ldloc.s 6
-				IL_00ad: ldloc.1
-				IL_00ae: clt
-				IL_00b0: brfalse IL_015b
+			IL_0078: ldarg.3
+			IL_0079: conv.i4
+			IL_007a: conv.u4
+			IL_007b: ldc.r8 5
+			IL_0084: conv.i4
+			IL_0085: shr.un
+			IL_0086: conv.r.un
+			IL_0087: stloc.s 20
+			IL_0089: ldloc.s 20
+			IL_008b: stloc.s 5
+			IL_008d: ldarg.1
+			IL_008e: stloc.s 6
+			// loop start (head: IL_0090)
+				IL_0090: ldloc.s 6
+				IL_0092: ldloc.1
+				IL_0093: clt
+				IL_0095: brfalse IL_0140
 
-				IL_00b5: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75::.ctor()
-				IL_00ba: stloc.s 7
-				IL_00bc: ldloc.s 6
-				IL_00be: conv.i4
-				IL_00bf: conv.u4
-				IL_00c0: ldc.r8 5
-				IL_00c9: conv.i4
-				IL_00ca: shr.un
-				IL_00cb: conv.r.un
-				IL_00cc: stloc.s 20
-				IL_00ce: ldloc.s 20
-				IL_00d0: stloc.s 8
-				IL_00d2: ldloc.s 6
-				IL_00d4: conv.i4
-				IL_00d5: ldc.r8 31
-				IL_00de: conv.i4
-				IL_00df: and
-				IL_00e0: conv.r8
-				IL_00e1: stloc.s 20
-				IL_00e3: ldloc.s 20
-				IL_00e5: stloc.s 9
-				IL_00e7: ldc.r8 1
-				IL_00f0: conv.i4
-				IL_00f1: ldloc.s 9
-				IL_00f3: conv.i4
-				IL_00f4: shl
-				IL_00f5: conv.r8
-				IL_00f6: stloc.s 20
-				IL_00f8: ldloc.s 20
-				IL_00fa: stloc.s 10
-				// loop start (head: IL_00fc)
-					IL_00fc: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75/Block_L70C7::.ctor()
-					IL_0101: stloc.s 11
-					IL_0103: ldarg.0
-					IL_0104: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_0109: ldloc.s 8
-					IL_010b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_0110: stloc.s 20
-					IL_0112: ldloc.s 20
-					IL_0114: stloc.s 20
-					IL_0116: ldloc.s 20
-					IL_0118: conv.i4
-					IL_0119: ldloc.s 10
-					IL_011b: conv.i4
-					IL_011c: or
-					IL_011d: conv.r8
-					IL_011e: stloc.s 20
-					IL_0120: ldarg.0
-					IL_0121: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_0126: ldloc.s 8
-					IL_0128: ldloc.s 20
-					IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_012f: ldloc.s 8
-					IL_0131: ldarg.2
-					IL_0132: add
-					IL_0133: stloc.s 20
-					IL_0135: ldloc.s 20
-					IL_0137: stloc.s 8
-					IL_0139: ldloc.s 8
-					IL_013b: ldloc.s 5
-					IL_013d: cgt
-					IL_013f: ldc.i4.0
-					IL_0140: ceq
-					IL_0142: brfalse IL_014c
+				IL_009a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75::.ctor()
+				IL_009f: stloc.s 7
+				IL_00a1: ldloc.s 6
+				IL_00a3: conv.i4
+				IL_00a4: conv.u4
+				IL_00a5: ldc.r8 5
+				IL_00ae: conv.i4
+				IL_00af: shr.un
+				IL_00b0: conv.r.un
+				IL_00b1: stloc.s 20
+				IL_00b3: ldloc.s 20
+				IL_00b5: stloc.s 8
+				IL_00b7: ldloc.s 6
+				IL_00b9: conv.i4
+				IL_00ba: ldc.r8 31
+				IL_00c3: conv.i4
+				IL_00c4: and
+				IL_00c5: conv.r8
+				IL_00c6: stloc.s 20
+				IL_00c8: ldloc.s 20
+				IL_00ca: stloc.s 9
+				IL_00cc: ldc.r8 1
+				IL_00d5: conv.i4
+				IL_00d6: ldloc.s 9
+				IL_00d8: conv.i4
+				IL_00d9: shl
+				IL_00da: conv.r8
+				IL_00db: stloc.s 20
+				IL_00dd: ldloc.s 20
+				IL_00df: stloc.s 10
+				// loop start (head: IL_00e1)
+					IL_00e1: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75/Block_L70C7::.ctor()
+					IL_00e6: stloc.s 11
+					IL_00e8: ldarg.0
+					IL_00e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_00ee: ldloc.s 8
+					IL_00f0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00f5: stloc.s 20
+					IL_00f7: ldloc.s 20
+					IL_00f9: stloc.s 20
+					IL_00fb: ldloc.s 20
+					IL_00fd: conv.i4
+					IL_00fe: ldloc.s 10
+					IL_0100: conv.i4
+					IL_0101: or
+					IL_0102: conv.r8
+					IL_0103: stloc.s 20
+					IL_0105: ldarg.0
+					IL_0106: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_010b: ldloc.s 8
+					IL_010d: ldloc.s 20
+					IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_0114: ldloc.s 8
+					IL_0116: ldarg.2
+					IL_0117: add
+					IL_0118: stloc.s 20
+					IL_011a: ldloc.s 20
+					IL_011c: stloc.s 8
+					IL_011e: ldloc.s 8
+					IL_0120: ldloc.s 5
+					IL_0122: cgt
+					IL_0124: ldc.i4.0
+					IL_0125: ceq
+					IL_0127: brfalse IL_0131
 
-					IL_0147: br IL_00fc
+					IL_012c: br IL_00e1
 				// end loop
 
-				IL_014c: ldloc.s 6
-				IL_014e: ldarg.2
-				IL_014f: add
-				IL_0150: stloc.s 20
-				IL_0152: ldloc.s 20
-				IL_0154: stloc.s 6
-				IL_0156: br IL_00ab
+				IL_0131: ldloc.s 6
+				IL_0133: ldarg.2
+				IL_0134: add
+				IL_0135: stloc.s 20
+				IL_0137: ldloc.s 20
+				IL_0139: stloc.s 6
+				IL_013b: br IL_0090
 			// end loop
 
-			IL_015b: ldnull
-			IL_015c: ret
+			IL_0140: ldnull
+			IL_0141: ret
 
-			IL_015d: ldarg.1
-			IL_015e: box [System.Runtime]System.Double
-			IL_0163: stloc.s 12
-			IL_0165: ldloc.s 12
-			IL_0167: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_016c: stloc.s 20
-			IL_016e: ldloc.s 20
-			IL_0170: conv.i4
-			IL_0171: conv.u4
-			IL_0172: ldc.r8 5
-			IL_017b: conv.i4
-			IL_017c: shr.un
-			IL_017d: conv.r.un
-			IL_017e: stloc.s 20
-			IL_0180: ldloc.s 20
-			IL_0182: box [System.Runtime]System.Double
-			IL_0187: stloc.s 21
-			IL_0189: ldloc.s 21
-			IL_018b: stloc.s 13
-			IL_018d: ldarg.0
-			IL_018e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_0193: ldloc.s 13
-			IL_0195: unbox.any [System.Runtime]System.Double
-			IL_019a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_019f: stloc.s 20
-			IL_01a1: ldloc.s 20
-			IL_01a3: stloc.s 20
-			IL_01a5: ldloc.s 20
-			IL_01a7: stloc.s 14
-			// loop start (head: IL_01a9)
-				IL_01a9: ldloc.s 12
-				IL_01ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01b0: stloc.s 20
-				IL_01b2: ldloc.s 20
-				IL_01b4: ldarg.3
-				IL_01b5: clt
-				IL_01b7: brfalse IL_029a
+			IL_0142: ldarg.1
+			IL_0143: stloc.s 12
+			IL_0145: ldloc.s 12
+			IL_0147: conv.i4
+			IL_0148: conv.u4
+			IL_0149: ldc.r8 5
+			IL_0152: conv.i4
+			IL_0153: shr.un
+			IL_0154: conv.r.un
+			IL_0155: stloc.s 20
+			IL_0157: ldloc.s 20
+			IL_0159: stloc.s 13
+			IL_015b: ldarg.0
+			IL_015c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0161: ldloc.s 13
+			IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0168: stloc.s 20
+			IL_016a: ldloc.s 20
+			IL_016c: stloc.s 14
+			// loop start (head: IL_016e)
+				IL_016e: ldloc.s 12
+				IL_0170: ldarg.3
+				IL_0171: clt
+				IL_0173: brfalse IL_0217
 
-				IL_01bc: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
-				IL_01c1: stloc.s 15
-				IL_01c3: ldloc.s 12
-				IL_01c5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01ca: stloc.s 20
-				IL_01cc: ldloc.s 20
-				IL_01ce: conv.i4
-				IL_01cf: ldc.r8 31
-				IL_01d8: conv.i4
-				IL_01d9: and
-				IL_01da: conv.r8
-				IL_01db: stloc.s 20
-				IL_01dd: ldloc.s 20
-				IL_01df: stloc.s 16
-				IL_01e1: ldc.r8 1
-				IL_01ea: conv.i4
-				IL_01eb: ldloc.s 16
-				IL_01ed: conv.i4
-				IL_01ee: shl
-				IL_01ef: conv.r8
-				IL_01f0: stloc.s 20
-				IL_01f2: ldloc.s 14
-				IL_01f4: conv.i4
-				IL_01f5: ldloc.s 20
-				IL_01f7: conv.i4
-				IL_01f8: or
-				IL_01f9: conv.r8
-				IL_01fa: stloc.s 20
-				IL_01fc: ldloc.s 20
-				IL_01fe: stloc.s 14
-				IL_0200: ldloc.s 12
-				IL_0202: ldarg.2
-				IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0208: stloc.s 22
-				IL_020a: ldloc.s 22
-				IL_020c: stloc.s 12
-				IL_020e: ldloc.s 12
-				IL_0210: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0215: stloc.s 20
-				IL_0217: ldloc.s 20
-				IL_0219: conv.i4
-				IL_021a: conv.u4
-				IL_021b: ldc.r8 5
-				IL_0224: conv.i4
-				IL_0225: shr.un
-				IL_0226: conv.r.un
-				IL_0227: stloc.s 20
-				IL_0229: ldloc.s 20
-				IL_022b: stloc.s 17
-				IL_022d: ldloc.s 17
-				IL_022f: box [System.Runtime]System.Double
-				IL_0234: stloc.s 21
-				IL_0236: ldloc.s 21
-				IL_0238: ldloc.s 13
-				IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-				IL_023f: stloc.s 23
-				IL_0241: ldloc.s 23
-				IL_0243: brfalse IL_0295
+				IL_0178: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
+				IL_017d: stloc.s 15
+				IL_017f: ldloc.s 12
+				IL_0181: conv.i4
+				IL_0182: ldc.r8 31
+				IL_018b: conv.i4
+				IL_018c: and
+				IL_018d: conv.r8
+				IL_018e: stloc.s 20
+				IL_0190: ldloc.s 20
+				IL_0192: stloc.s 16
+				IL_0194: ldc.r8 1
+				IL_019d: conv.i4
+				IL_019e: ldloc.s 16
+				IL_01a0: conv.i4
+				IL_01a1: shl
+				IL_01a2: conv.r8
+				IL_01a3: stloc.s 20
+				IL_01a5: ldloc.s 14
+				IL_01a7: conv.i4
+				IL_01a8: ldloc.s 20
+				IL_01aa: conv.i4
+				IL_01ab: or
+				IL_01ac: conv.r8
+				IL_01ad: stloc.s 20
+				IL_01af: ldloc.s 20
+				IL_01b1: stloc.s 14
+				IL_01b3: ldloc.s 12
+				IL_01b5: ldarg.2
+				IL_01b6: add
+				IL_01b7: stloc.s 20
+				IL_01b9: ldloc.s 20
+				IL_01bb: stloc.s 12
+				IL_01bd: ldloc.s 12
+				IL_01bf: conv.i4
+				IL_01c0: conv.u4
+				IL_01c1: ldc.r8 5
+				IL_01ca: conv.i4
+				IL_01cb: shr.un
+				IL_01cc: conv.r.un
+				IL_01cd: stloc.s 20
+				IL_01cf: ldloc.s 20
+				IL_01d1: stloc.s 17
+				IL_01d3: ldloc.s 17
+				IL_01d5: ldloc.s 13
+				IL_01d7: ceq
+				IL_01d9: ldc.i4.0
+				IL_01da: ceq
+				IL_01dc: brfalse IL_0212
 
-				IL_0248: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36::.ctor()
-				IL_024d: stloc.s 18
-				IL_024f: ldloc.s 14
-				IL_0251: box [System.Runtime]System.Double
-				IL_0256: stloc.s 21
-				IL_0258: ldarg.0
-				IL_0259: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_025e: ldloc.s 13
-				IL_0260: unbox.any [System.Runtime]System.Double
-				IL_0265: ldloc.s 14
-				IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_026c: ldloc.s 17
-				IL_026e: box [System.Runtime]System.Double
-				IL_0273: stloc.s 21
-				IL_0275: ldloc.s 21
-				IL_0277: stloc.s 13
-				IL_0279: ldarg.0
-				IL_027a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_027f: ldloc.s 13
-				IL_0281: unbox.any [System.Runtime]System.Double
-				IL_0286: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_028b: stloc.s 20
-				IL_028d: ldloc.s 20
-				IL_028f: stloc.s 20
-				IL_0291: ldloc.s 20
-				IL_0293: stloc.s 14
+				IL_01e1: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36::.ctor()
+				IL_01e6: stloc.s 18
+				IL_01e8: ldarg.0
+				IL_01e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_01ee: ldloc.s 13
+				IL_01f0: ldloc.s 14
+				IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_01f7: ldloc.s 17
+				IL_01f9: stloc.s 20
+				IL_01fb: ldloc.s 20
+				IL_01fd: stloc.s 13
+				IL_01ff: ldarg.0
+				IL_0200: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_0205: ldloc.s 13
+				IL_0207: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_020c: stloc.s 20
+				IL_020e: ldloc.s 20
+				IL_0210: stloc.s 14
 
-				IL_0295: br IL_01a9
+				IL_0212: br IL_016e
 			// end loop
 
-			IL_029a: ldloc.s 14
-			IL_029c: box [System.Runtime]System.Double
-			IL_02a1: stloc.s 21
-			IL_02a3: ldarg.0
-			IL_02a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_02a9: ldloc.s 13
-			IL_02ab: unbox.any [System.Runtime]System.Double
-			IL_02b0: ldloc.s 14
-			IL_02b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_02b7: ldnull
-			IL_02b8: ret
+			IL_0217: ldarg.0
+			IL_0218: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_021d: ldloc.s 13
+			IL_021f: ldloc.s 14
+			IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_0226: ldnull
+			IL_0227: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1279,7 +1197,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bbc
+			// Method begins at RVA 0x2aa4
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1343,7 +1261,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2844
+			// Method begins at RVA 0x27c0
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -1393,7 +1311,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x319f
+				// Method begins at RVA 0x305b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1413,7 +1331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31a8
+				// Method begins at RVA 0x3064
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1437,7 +1355,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31ba
+					// Method begins at RVA 0x3076
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1455,7 +1373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b1
+				// Method begins at RVA 0x306d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1475,7 +1393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31c3
+				// Method begins at RVA 0x307f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1503,7 +1421,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31de
+						// Method begins at RVA 0x309a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1521,7 +1439,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31d5
+					// Method begins at RVA 0x3091
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1539,7 +1457,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31cc
+				// Method begins at RVA 0x3088
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1559,7 +1477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e7
+				// Method begins at RVA 0x30a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1583,7 +1501,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31f9
+					// Method begins at RVA 0x30b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1601,7 +1519,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f0
+				// Method begins at RVA 0x30ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1625,7 +1543,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x320b
+					// Method begins at RVA 0x30c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1643,7 +1561,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3202
+				// Method begins at RVA 0x30be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1673,7 +1591,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x278c
+			// Method begins at RVA 0x2708
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1730,7 +1648,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c18
+			// Method begins at RVA 0x2b00
 			// Header size: 12
 			// Code size: 200 (0xc8)
 			.maxstack 8
@@ -1827,7 +1745,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f74
+			// Method begins at RVA 0x2e5c
 			// Header size: 12
 			// Code size: 120 (0x78)
 			.maxstack 8
@@ -1894,7 +1812,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ff8
+			// Method begins at RVA 0x2ee0
 			// Header size: 12
 			// Code size: 214 (0xd6)
 			.maxstack 8
@@ -1993,7 +1911,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cec
+			// Method begins at RVA 0x2bd4
 			// Header size: 12
 			// Code size: 633 (0x279)
 			.maxstack 8
@@ -2229,8 +2147,8 @@
 			74 63 68 7d 00 00
 		)
 		// Fields
-		.field public object NOW_UNITS_PER_SECOND
-		.field public object WORD_SIZE
+		.field public float64 NOW_UNITS_PER_SECOND
+		.field public float64 WORD_SIZE
 		.field public object performance
 		.field public object BitArray
 		.field public object PrimeSieve
@@ -2240,27 +2158,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x30da
+			// Method begins at RVA 0x2fc2
 			// Header size: 1
-			// Code size: 52 (0x34)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-			IL_0032: nop
-			IL_0033: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -2278,7 +2184,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1010 (0x3f2)
+		// Code size: 1000 (0x3e8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -2295,387 +2201,385 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldc.r8 1000
-		IL_0010: box [System.Runtime]System.Double
-		IL_0015: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-		IL_001a: ldloc.0
-		IL_001b: ldc.r8 32
-		IL_0024: box [System.Runtime]System.Double
-		IL_0029: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
-		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0033: dup
-		IL_0034: ldstr "sieveSize"
-		IL_0039: ldc.r8 1000000
-		IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0047: dup
-		IL_0048: ldstr "timeLimitSeconds"
-		IL_004d: ldc.r8 5
-		IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_005b: dup
-		IL_005c: ldstr "verbose"
-		IL_0061: ldc.i4.0
-		IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0067: dup
-		IL_0068: ldstr "runtime"
-		IL_006d: ldstr ""
-		IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0077: stloc.1
-		IL_0078: ldarg.1
-		IL_0079: ldstr "perf_hooks"
-		IL_007e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0083: stloc.s 4
-		IL_0085: ldloc.s 4
-		IL_0087: brfalse IL_0098
+		IL_0010: stfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
+		IL_0015: ldloc.0
+		IL_0016: ldc.r8 32
+		IL_001f: stfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
+		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0029: dup
+		IL_002a: ldstr "sieveSize"
+		IL_002f: ldc.r8 1000000
+		IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_003d: dup
+		IL_003e: ldstr "timeLimitSeconds"
+		IL_0043: ldc.r8 5
+		IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0051: dup
+		IL_0052: ldstr "verbose"
+		IL_0057: ldc.i4.0
+		IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_005d: dup
+		IL_005e: ldstr "runtime"
+		IL_0063: ldstr ""
+		IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_006d: stloc.1
+		IL_006e: ldarg.1
+		IL_006f: ldstr "perf_hooks"
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0079: stloc.s 4
+		IL_007b: ldloc.s 4
+		IL_007d: brfalse IL_008e
 
-		IL_008c: ldloc.s 4
-		IL_008e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0093: brfalse IL_00a9
+		IL_0082: ldloc.s 4
+		IL_0084: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0089: brfalse IL_009f
 
-		IL_0098: ldloc.s 4
-		IL_009a: ldstr ""
-		IL_009f: ldstr "performance"
-		IL_00a4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_008e: ldloc.s 4
+		IL_0090: ldstr ""
+		IL_0095: ldstr "performance"
+		IL_009a: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_00a9: ldloc.s 4
-		IL_00ab: ldstr "performance"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b5: stloc.s 4
-		IL_00b7: ldloc.0
-		IL_00b8: ldloc.s 4
-		IL_00ba: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-		IL_00bf: ldstr "[\\\\/]"
-		IL_00c4: ldstr ""
-		IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00ce: stloc.s 5
-		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_00d5: ldstr "argv"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00df: ldc.r8 0.0
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00ed: ldstr "split"
-		IL_00f2: ldloc.s 5
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f9: stloc.s 4
-		IL_00fb: ldloc.s 4
-		IL_00fd: stloc.2
-		IL_00fe: ldloc.2
-		IL_00ff: ldloc.2
-		IL_0100: ldstr "length"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_010f: ldc.r8 1
-		IL_0118: sub
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_011e: stloc.s 4
-		IL_0120: ldloc.1
-		IL_0121: ldstr "runtime"
-		IL_0126: ldloc.s 4
-		IL_0128: ldc.i4.1
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_012e: pop
-		IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_0134: ldstr "argv"
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013e: ldstr "includes"
-		IL_0143: ldstr "verbose"
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014d: stloc.s 4
-		IL_014f: ldloc.1
-		IL_0150: ldstr "verbose"
-		IL_0155: ldloc.s 4
-		IL_0157: ldc.i4.1
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_015d: pop
+		IL_009f: ldloc.s 4
+		IL_00a1: ldstr "performance"
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ab: stloc.s 4
+		IL_00ad: ldloc.0
+		IL_00ae: ldloc.s 4
+		IL_00b0: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+		IL_00b5: ldstr "[\\\\/]"
+		IL_00ba: ldstr ""
+		IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00c4: stloc.s 5
+		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_00cb: ldstr "argv"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d5: ldc.r8 0.0
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00e3: ldstr "split"
+		IL_00e8: ldloc.s 5
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ef: stloc.s 4
+		IL_00f1: ldloc.s 4
+		IL_00f3: stloc.2
+		IL_00f4: ldloc.2
+		IL_00f5: ldloc.2
+		IL_00f6: ldstr "length"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0105: ldc.r8 1
+		IL_010e: sub
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0114: stloc.s 4
+		IL_0116: ldloc.1
+		IL_0117: ldstr "runtime"
+		IL_011c: ldloc.s 4
+		IL_011e: ldc.i4.1
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0124: pop
+		IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_012a: ldstr "argv"
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0134: ldstr "includes"
+		IL_0139: ldstr "verbose"
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0143: stloc.s 4
+		IL_0145: ldloc.1
+		IL_0146: ldstr "verbose"
+		IL_014b: ldloc.s 4
+		IL_014d: ldc.i4.1
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0153: pop
+		IL_0154: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_0159: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_015e: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0163: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0168: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_016d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0172: stloc.s 6
-		IL_0174: ldc.i4.1
-		IL_0175: newarr [System.Runtime]System.Object
-		IL_017a: dup
-		IL_017b: ldc.i4.0
-		IL_017c: ldloc.0
-		IL_017d: stelem.ref
-		IL_017e: stloc.s 7
-		IL_0180: ldc.i4.s 10
-		IL_0182: newarr [System.Runtime]System.Object
-		IL_0187: dup
-		IL_0188: ldc.i4.0
-		IL_0189: ldloc.s 6
-		IL_018b: stelem.ref
-		IL_018c: dup
-		IL_018d: ldc.i4.1
-		IL_018e: ldstr "setBitTrue"
-		IL_0193: stelem.ref
-		IL_0194: dup
-		IL_0195: ldc.i4.2
-		IL_0196: ldstr "setBitTrue"
-		IL_019b: stelem.ref
-		IL_019c: dup
-		IL_019d: ldc.i4.3
-		IL_019e: ldc.r8 1
-		IL_01a7: box [System.Runtime]System.Double
-		IL_01ac: stelem.ref
-		IL_01ad: dup
-		IL_01ae: ldc.i4.4
-		IL_01af: ldstr "setBitTrue"
-		IL_01b4: stelem.ref
-		IL_01b5: dup
-		IL_01b6: ldc.i4.5
-		IL_01b7: ldc.i4.0
-		IL_01b8: box [System.Runtime]System.Boolean
-		IL_01bd: stelem.ref
-		IL_01be: dup
-		IL_01bf: ldc.i4.6
-		IL_01c0: ldc.i4.0
-		IL_01c1: box [System.Runtime]System.Boolean
-		IL_01c6: stelem.ref
-		IL_01c7: dup
-		IL_01c8: ldc.i4.7
-		IL_01c9: ldc.i4.0
-		IL_01ca: box [System.Runtime]System.Boolean
-		IL_01cf: stelem.ref
-		IL_01d0: dup
-		IL_01d1: ldc.i4.8
-		IL_01d2: ldc.i4.0
-		IL_01d3: box [System.Runtime]System.Boolean
-		IL_01d8: stelem.ref
-		IL_01d9: dup
-		IL_01da: ldc.i4.s 9
-		IL_01dc: ldloc.s 7
-		IL_01de: stelem.ref
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_01e4: pop
-		IL_01e5: ldc.i4.s 10
-		IL_01e7: newarr [System.Runtime]System.Object
-		IL_01ec: dup
-		IL_01ed: ldc.i4.0
-		IL_01ee: ldloc.s 6
-		IL_01f0: stelem.ref
-		IL_01f1: dup
-		IL_01f2: ldc.i4.1
-		IL_01f3: ldstr "setBitsTrue"
-		IL_01f8: stelem.ref
-		IL_01f9: dup
-		IL_01fa: ldc.i4.2
-		IL_01fb: ldstr "setBitsTrue"
-		IL_0200: stelem.ref
-		IL_0201: dup
-		IL_0202: ldc.i4.3
-		IL_0203: ldc.r8 3
-		IL_020c: box [System.Runtime]System.Double
-		IL_0211: stelem.ref
-		IL_0212: dup
-		IL_0213: ldc.i4.4
-		IL_0214: ldstr "setBitsTrue"
-		IL_0219: stelem.ref
-		IL_021a: dup
-		IL_021b: ldc.i4.5
-		IL_021c: ldc.i4.0
-		IL_021d: box [System.Runtime]System.Boolean
-		IL_0222: stelem.ref
-		IL_0223: dup
-		IL_0224: ldc.i4.6
-		IL_0225: ldc.i4.0
-		IL_0226: box [System.Runtime]System.Boolean
-		IL_022b: stelem.ref
-		IL_022c: dup
-		IL_022d: ldc.i4.7
-		IL_022e: ldc.i4.0
-		IL_022f: box [System.Runtime]System.Boolean
-		IL_0234: stelem.ref
-		IL_0235: dup
-		IL_0236: ldc.i4.8
-		IL_0237: ldc.i4.0
-		IL_0238: box [System.Runtime]System.Boolean
-		IL_023d: stelem.ref
-		IL_023e: dup
-		IL_023f: ldc.i4.s 9
-		IL_0241: ldloc.s 7
-		IL_0243: stelem.ref
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0249: pop
-		IL_024a: ldc.i4.s 10
-		IL_024c: newarr [System.Runtime]System.Object
-		IL_0251: dup
-		IL_0252: ldc.i4.0
-		IL_0253: ldloc.s 6
-		IL_0255: stelem.ref
-		IL_0256: dup
-		IL_0257: ldc.i4.1
-		IL_0258: ldstr "testBitTrue"
-		IL_025d: stelem.ref
-		IL_025e: dup
-		IL_025f: ldc.i4.2
-		IL_0260: ldstr "testBitTrue"
-		IL_0265: stelem.ref
-		IL_0266: dup
-		IL_0267: ldc.i4.3
-		IL_0268: ldc.r8 1
-		IL_0271: box [System.Runtime]System.Double
-		IL_0276: stelem.ref
-		IL_0277: dup
-		IL_0278: ldc.i4.4
-		IL_0279: ldstr "testBitTrue"
-		IL_027e: stelem.ref
-		IL_027f: dup
-		IL_0280: ldc.i4.5
-		IL_0281: ldc.i4.0
-		IL_0282: box [System.Runtime]System.Boolean
-		IL_0287: stelem.ref
-		IL_0288: dup
-		IL_0289: ldc.i4.6
-		IL_028a: ldc.i4.0
-		IL_028b: box [System.Runtime]System.Boolean
-		IL_0290: stelem.ref
-		IL_0291: dup
-		IL_0292: ldc.i4.7
-		IL_0293: ldc.i4.0
-		IL_0294: box [System.Runtime]System.Boolean
-		IL_0299: stelem.ref
-		IL_029a: dup
-		IL_029b: ldc.i4.8
-		IL_029c: ldc.i4.0
-		IL_029d: box [System.Runtime]System.Boolean
-		IL_02a2: stelem.ref
-		IL_02a3: dup
-		IL_02a4: ldc.i4.s 9
-		IL_02a6: ldloc.s 7
-		IL_02a8: stelem.ref
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_02ae: pop
-		IL_02af: ldc.i4.s 10
-		IL_02b1: newarr [System.Runtime]System.Object
-		IL_02b6: dup
-		IL_02b7: ldc.i4.0
-		IL_02b8: ldloc.s 6
-		IL_02ba: stelem.ref
-		IL_02bb: dup
-		IL_02bc: ldc.i4.1
-		IL_02bd: ldstr "searchBitFalse"
-		IL_02c2: stelem.ref
-		IL_02c3: dup
-		IL_02c4: ldc.i4.2
-		IL_02c5: ldstr "searchBitFalse"
-		IL_02ca: stelem.ref
-		IL_02cb: dup
-		IL_02cc: ldc.i4.3
-		IL_02cd: ldc.r8 1
-		IL_02d6: box [System.Runtime]System.Double
-		IL_02db: stelem.ref
-		IL_02dc: dup
-		IL_02dd: ldc.i4.4
-		IL_02de: ldstr "searchBitFalse"
-		IL_02e3: stelem.ref
-		IL_02e4: dup
-		IL_02e5: ldc.i4.5
-		IL_02e6: ldc.i4.0
-		IL_02e7: box [System.Runtime]System.Boolean
-		IL_02ec: stelem.ref
-		IL_02ed: dup
-		IL_02ee: ldc.i4.6
-		IL_02ef: ldc.i4.0
-		IL_02f0: box [System.Runtime]System.Boolean
-		IL_02f5: stelem.ref
-		IL_02f6: dup
-		IL_02f7: ldc.i4.7
-		IL_02f8: ldc.i4.0
-		IL_02f9: box [System.Runtime]System.Boolean
-		IL_02fe: stelem.ref
-		IL_02ff: dup
-		IL_0300: ldc.i4.8
-		IL_0301: ldc.i4.0
-		IL_0302: box [System.Runtime]System.Boolean
-		IL_0307: stelem.ref
-		IL_0308: dup
-		IL_0309: ldc.i4.s 9
-		IL_030b: ldloc.s 7
-		IL_030d: stelem.ref
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0313: pop
-		IL_0314: ldc.i4.1
-		IL_0315: newarr [System.Runtime]System.Object
-		IL_031a: dup
-		IL_031b: ldc.i4.0
-		IL_031c: ldloc.0
-		IL_031d: stelem.ref
-		IL_031e: stloc.s 7
-		IL_0320: ldloc.s 6
-		IL_0322: ldloc.s 7
-		IL_0324: ldc.r8 1
-		IL_032d: box [System.Runtime]System.Double
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0337: stloc.s 4
-		IL_0339: ldloc.0
-		IL_033a: ldloc.s 4
-		IL_033c: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_0341: ldc.i4.1
-		IL_0342: newarr [System.Runtime]System.Object
-		IL_0347: dup
-		IL_0348: ldc.i4.0
-		IL_0349: ldloc.0
-		IL_034a: stelem.ref
-		IL_034b: ldc.i4.0
-		IL_034c: ldelem.ref
-		IL_034d: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0352: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object, object)
-		IL_0358: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_035d: ldc.i4.1
-		IL_035e: newarr [System.Runtime]System.Object
-		IL_0363: dup
-		IL_0364: ldc.i4.0
-		IL_0365: ldloc.0
-		IL_0366: stelem.ref
-		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0371: ldc.i4.1
-		IL_0372: conv.r8
-		IL_0373: ldstr ""
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_037d: stloc.s 4
-		IL_037f: ldloc.s 4
-		IL_0381: ldstr "runSieveBatch"
-		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_038b: stloc.s 4
-		IL_038d: ldloc.0
-		IL_038e: ldloc.s 4
-		IL_0390: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_0395: ldc.i4.1
-		IL_0396: newarr [System.Runtime]System.Object
-		IL_039b: dup
-		IL_039c: ldc.i4.0
-		IL_039d: ldloc.0
-		IL_039e: stelem.ref
-		IL_039f: ldc.i4.0
-		IL_03a0: ldelem.ref
-		IL_03a1: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_03a6: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_03ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_03b1: ldc.i4.1
-		IL_03b2: newarr [System.Runtime]System.Object
-		IL_03b7: dup
-		IL_03b8: ldc.i4.0
-		IL_03b9: ldloc.0
-		IL_03ba: stelem.ref
-		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_03c5: ldc.i4.1
-		IL_03c6: conv.r8
-		IL_03c7: ldstr ""
-		IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_03d1: stloc.s 4
-		IL_03d3: ldloc.s 4
-		IL_03d5: ldstr "main"
-		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_03df: stloc.s 4
-		IL_03e1: ldloc.s 4
-		IL_03e3: stloc.3
-		IL_03e4: ldloc.3
-		IL_03e5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03ea: ldloc.1
-		IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_03f0: pop
-		IL_03f1: ret
+		IL_0163: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0168: stloc.s 6
+		IL_016a: ldc.i4.1
+		IL_016b: newarr [System.Runtime]System.Object
+		IL_0170: dup
+		IL_0171: ldc.i4.0
+		IL_0172: ldloc.0
+		IL_0173: stelem.ref
+		IL_0174: stloc.s 7
+		IL_0176: ldc.i4.s 10
+		IL_0178: newarr [System.Runtime]System.Object
+		IL_017d: dup
+		IL_017e: ldc.i4.0
+		IL_017f: ldloc.s 6
+		IL_0181: stelem.ref
+		IL_0182: dup
+		IL_0183: ldc.i4.1
+		IL_0184: ldstr "setBitTrue"
+		IL_0189: stelem.ref
+		IL_018a: dup
+		IL_018b: ldc.i4.2
+		IL_018c: ldstr "setBitTrue"
+		IL_0191: stelem.ref
+		IL_0192: dup
+		IL_0193: ldc.i4.3
+		IL_0194: ldc.r8 1
+		IL_019d: box [System.Runtime]System.Double
+		IL_01a2: stelem.ref
+		IL_01a3: dup
+		IL_01a4: ldc.i4.4
+		IL_01a5: ldstr "setBitTrue"
+		IL_01aa: stelem.ref
+		IL_01ab: dup
+		IL_01ac: ldc.i4.5
+		IL_01ad: ldc.i4.0
+		IL_01ae: box [System.Runtime]System.Boolean
+		IL_01b3: stelem.ref
+		IL_01b4: dup
+		IL_01b5: ldc.i4.6
+		IL_01b6: ldc.i4.0
+		IL_01b7: box [System.Runtime]System.Boolean
+		IL_01bc: stelem.ref
+		IL_01bd: dup
+		IL_01be: ldc.i4.7
+		IL_01bf: ldc.i4.0
+		IL_01c0: box [System.Runtime]System.Boolean
+		IL_01c5: stelem.ref
+		IL_01c6: dup
+		IL_01c7: ldc.i4.8
+		IL_01c8: ldc.i4.0
+		IL_01c9: box [System.Runtime]System.Boolean
+		IL_01ce: stelem.ref
+		IL_01cf: dup
+		IL_01d0: ldc.i4.s 9
+		IL_01d2: ldloc.s 7
+		IL_01d4: stelem.ref
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_01da: pop
+		IL_01db: ldc.i4.s 10
+		IL_01dd: newarr [System.Runtime]System.Object
+		IL_01e2: dup
+		IL_01e3: ldc.i4.0
+		IL_01e4: ldloc.s 6
+		IL_01e6: stelem.ref
+		IL_01e7: dup
+		IL_01e8: ldc.i4.1
+		IL_01e9: ldstr "setBitsTrue"
+		IL_01ee: stelem.ref
+		IL_01ef: dup
+		IL_01f0: ldc.i4.2
+		IL_01f1: ldstr "setBitsTrue"
+		IL_01f6: stelem.ref
+		IL_01f7: dup
+		IL_01f8: ldc.i4.3
+		IL_01f9: ldc.r8 3
+		IL_0202: box [System.Runtime]System.Double
+		IL_0207: stelem.ref
+		IL_0208: dup
+		IL_0209: ldc.i4.4
+		IL_020a: ldstr "setBitsTrue"
+		IL_020f: stelem.ref
+		IL_0210: dup
+		IL_0211: ldc.i4.5
+		IL_0212: ldc.i4.0
+		IL_0213: box [System.Runtime]System.Boolean
+		IL_0218: stelem.ref
+		IL_0219: dup
+		IL_021a: ldc.i4.6
+		IL_021b: ldc.i4.0
+		IL_021c: box [System.Runtime]System.Boolean
+		IL_0221: stelem.ref
+		IL_0222: dup
+		IL_0223: ldc.i4.7
+		IL_0224: ldc.i4.0
+		IL_0225: box [System.Runtime]System.Boolean
+		IL_022a: stelem.ref
+		IL_022b: dup
+		IL_022c: ldc.i4.8
+		IL_022d: ldc.i4.0
+		IL_022e: box [System.Runtime]System.Boolean
+		IL_0233: stelem.ref
+		IL_0234: dup
+		IL_0235: ldc.i4.s 9
+		IL_0237: ldloc.s 7
+		IL_0239: stelem.ref
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_023f: pop
+		IL_0240: ldc.i4.s 10
+		IL_0242: newarr [System.Runtime]System.Object
+		IL_0247: dup
+		IL_0248: ldc.i4.0
+		IL_0249: ldloc.s 6
+		IL_024b: stelem.ref
+		IL_024c: dup
+		IL_024d: ldc.i4.1
+		IL_024e: ldstr "testBitTrue"
+		IL_0253: stelem.ref
+		IL_0254: dup
+		IL_0255: ldc.i4.2
+		IL_0256: ldstr "testBitTrue"
+		IL_025b: stelem.ref
+		IL_025c: dup
+		IL_025d: ldc.i4.3
+		IL_025e: ldc.r8 1
+		IL_0267: box [System.Runtime]System.Double
+		IL_026c: stelem.ref
+		IL_026d: dup
+		IL_026e: ldc.i4.4
+		IL_026f: ldstr "testBitTrue"
+		IL_0274: stelem.ref
+		IL_0275: dup
+		IL_0276: ldc.i4.5
+		IL_0277: ldc.i4.0
+		IL_0278: box [System.Runtime]System.Boolean
+		IL_027d: stelem.ref
+		IL_027e: dup
+		IL_027f: ldc.i4.6
+		IL_0280: ldc.i4.0
+		IL_0281: box [System.Runtime]System.Boolean
+		IL_0286: stelem.ref
+		IL_0287: dup
+		IL_0288: ldc.i4.7
+		IL_0289: ldc.i4.0
+		IL_028a: box [System.Runtime]System.Boolean
+		IL_028f: stelem.ref
+		IL_0290: dup
+		IL_0291: ldc.i4.8
+		IL_0292: ldc.i4.0
+		IL_0293: box [System.Runtime]System.Boolean
+		IL_0298: stelem.ref
+		IL_0299: dup
+		IL_029a: ldc.i4.s 9
+		IL_029c: ldloc.s 7
+		IL_029e: stelem.ref
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_02a4: pop
+		IL_02a5: ldc.i4.s 10
+		IL_02a7: newarr [System.Runtime]System.Object
+		IL_02ac: dup
+		IL_02ad: ldc.i4.0
+		IL_02ae: ldloc.s 6
+		IL_02b0: stelem.ref
+		IL_02b1: dup
+		IL_02b2: ldc.i4.1
+		IL_02b3: ldstr "searchBitFalse"
+		IL_02b8: stelem.ref
+		IL_02b9: dup
+		IL_02ba: ldc.i4.2
+		IL_02bb: ldstr "searchBitFalse"
+		IL_02c0: stelem.ref
+		IL_02c1: dup
+		IL_02c2: ldc.i4.3
+		IL_02c3: ldc.r8 1
+		IL_02cc: box [System.Runtime]System.Double
+		IL_02d1: stelem.ref
+		IL_02d2: dup
+		IL_02d3: ldc.i4.4
+		IL_02d4: ldstr "searchBitFalse"
+		IL_02d9: stelem.ref
+		IL_02da: dup
+		IL_02db: ldc.i4.5
+		IL_02dc: ldc.i4.0
+		IL_02dd: box [System.Runtime]System.Boolean
+		IL_02e2: stelem.ref
+		IL_02e3: dup
+		IL_02e4: ldc.i4.6
+		IL_02e5: ldc.i4.0
+		IL_02e6: box [System.Runtime]System.Boolean
+		IL_02eb: stelem.ref
+		IL_02ec: dup
+		IL_02ed: ldc.i4.7
+		IL_02ee: ldc.i4.0
+		IL_02ef: box [System.Runtime]System.Boolean
+		IL_02f4: stelem.ref
+		IL_02f5: dup
+		IL_02f6: ldc.i4.8
+		IL_02f7: ldc.i4.0
+		IL_02f8: box [System.Runtime]System.Boolean
+		IL_02fd: stelem.ref
+		IL_02fe: dup
+		IL_02ff: ldc.i4.s 9
+		IL_0301: ldloc.s 7
+		IL_0303: stelem.ref
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0309: pop
+		IL_030a: ldc.i4.1
+		IL_030b: newarr [System.Runtime]System.Object
+		IL_0310: dup
+		IL_0311: ldc.i4.0
+		IL_0312: ldloc.0
+		IL_0313: stelem.ref
+		IL_0314: stloc.s 7
+		IL_0316: ldloc.s 6
+		IL_0318: ldloc.s 7
+		IL_031a: ldc.r8 1
+		IL_0323: box [System.Runtime]System.Double
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_032d: stloc.s 4
+		IL_032f: ldloc.0
+		IL_0330: ldloc.s 4
+		IL_0332: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_0337: ldc.i4.1
+		IL_0338: newarr [System.Runtime]System.Object
+		IL_033d: dup
+		IL_033e: ldc.i4.0
+		IL_033f: ldloc.0
+		IL_0340: stelem.ref
+		IL_0341: ldc.i4.0
+		IL_0342: ldelem.ref
+		IL_0343: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0348: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object, object)
+		IL_034e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0353: ldc.i4.1
+		IL_0354: newarr [System.Runtime]System.Object
+		IL_0359: dup
+		IL_035a: ldc.i4.0
+		IL_035b: ldloc.0
+		IL_035c: stelem.ref
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0367: ldc.i4.1
+		IL_0368: conv.r8
+		IL_0369: ldstr ""
+		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0373: stloc.s 4
+		IL_0375: ldloc.s 4
+		IL_0377: ldstr "runSieveBatch"
+		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0381: stloc.s 4
+		IL_0383: ldloc.0
+		IL_0384: ldloc.s 4
+		IL_0386: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_038b: ldc.i4.1
+		IL_038c: newarr [System.Runtime]System.Object
+		IL_0391: dup
+		IL_0392: ldc.i4.0
+		IL_0393: ldloc.0
+		IL_0394: stelem.ref
+		IL_0395: ldc.i4.0
+		IL_0396: ldelem.ref
+		IL_0397: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_039c: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_03a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_03a7: ldc.i4.1
+		IL_03a8: newarr [System.Runtime]System.Object
+		IL_03ad: dup
+		IL_03ae: ldc.i4.0
+		IL_03af: ldloc.0
+		IL_03b0: stelem.ref
+		IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_03bb: ldc.i4.1
+		IL_03bc: conv.r8
+		IL_03bd: ldstr ""
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_03c7: stloc.s 4
+		IL_03c9: ldloc.s 4
+		IL_03cb: ldstr "main"
+		IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03d5: stloc.s 4
+		IL_03d7: ldloc.s 4
+		IL_03d9: stloc.3
+		IL_03da: ldloc.3
+		IL_03db: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03e0: ldloc.1
+		IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_03e6: pop
+		IL_03e7: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -2687,7 +2591,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x322f
+		// Method begins at RVA 0x30eb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37b9
+				// Method begins at RVA 0x368d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 			)
 			// Method begins at RVA 0x246c
 			// Header size: 12
-			// Code size: 37 (0x25)
+			// Code size: 25 (0x19)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -55,17 +55,13 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
-			IL_0006: ldstr "Cannot access 'fs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "readFileSync"
-			IL_0017: ldarg.2
-			IL_0018: ldstr "utf8"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0022: stloc.0
-			IL_0023: ldloc.0
-			IL_0024: ret
+			IL_0006: ldstr "readFileSync"
+			IL_000b: ldarg.2
+			IL_000c: ldstr "utf8"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0016: stloc.0
+			IL_0017: ldloc.0
+			IL_0018: ret
 		} // end of method readFile::__js_call__
 
 	} // end of class readFile
@@ -81,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37c2
+				// Method begins at RVA 0x3696
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -109,28 +105,21 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24a0
-			// Header size: 12
-			// Code size: 38 (0x26)
+			// Method begins at RVA 0x2491
+			// Header size: 1
+			// Code size: 26 (0x1a)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
-			IL_0006: ldstr "Cannot access 'fs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "writeFileSync"
-			IL_0017: ldarg.2
-			IL_0018: ldarg.3
-			IL_0019: ldstr "utf8"
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0023: pop
-			IL_0024: ldnull
-			IL_0025: ret
+			IL_0006: ldstr "writeFileSync"
+			IL_000b: ldarg.2
+			IL_000c: ldarg.3
+			IL_000d: ldstr "utf8"
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0017: pop
+			IL_0018: ldnull
+			IL_0019: ret
 		} // end of method writeFile::__js_call__
 
 	} // end of class writeFile
@@ -146,7 +135,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37cb
+				// Method begins at RVA 0x369f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -170,7 +159,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24d4
+			// Method begins at RVA 0x24ac
 			// Header size: 12
 			// Code size: 111 (0x6f)
 			.maxstack 8
@@ -248,7 +237,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37dd
+					// Method begins at RVA 0x36b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -272,7 +261,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3640
+				// Method begins at RVA 0x356c
 				// Header size: 12
 				// Code size: 30 (0x1e)
 				.maxstack 8
@@ -312,7 +301,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37e6
+					// Method begins at RVA 0x36ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -336,7 +325,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x366c
+				// Method begins at RVA 0x3598
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -368,7 +357,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37ef
+					// Method begins at RVA 0x36c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -386,7 +375,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37d4
+				// Method begins at RVA 0x36a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -414,7 +403,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2550
+			// Method begins at RVA 0x2528
 			// Header size: 12
 			// Code size: 758 (0x2f6)
 			.maxstack 8
@@ -709,7 +698,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37f8
+				// Method begins at RVA 0x36cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -737,7 +726,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2854
+			// Method begins at RVA 0x282c
 			// Header size: 12
 			// Code size: 206 (0xce)
 			.maxstack 8
@@ -855,7 +844,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x380a
+					// Method begins at RVA 0x36de
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -873,7 +862,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3801
+				// Method begins at RVA 0x36d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -898,7 +887,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2930
+			// Method begins at RVA 0x2908
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -989,7 +978,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x381c
+					// Method begins at RVA 0x36f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1007,7 +996,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3813
+				// Method begins at RVA 0x36e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1032,7 +1021,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29ec
+			// Method begins at RVA 0x29c4
 			// Header size: 12
 			// Code size: 139 (0x8b)
 			.maxstack 8
@@ -1118,7 +1107,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x382e
+					// Method begins at RVA 0x3702
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1136,7 +1125,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3825
+				// Method begins at RVA 0x36f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1163,7 +1152,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2a84
+			// Method begins at RVA 0x2a5c
 			// Header size: 12
 			// Code size: 478 (0x1de)
 			.maxstack 8
@@ -1354,7 +1343,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3837
+				// Method begins at RVA 0x370b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1378,7 +1367,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c70
+			// Method begins at RVA 0x2c48
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1426,7 +1415,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3849
+					// Method begins at RVA 0x371d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1451,7 +1440,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3688
+				// Method begins at RVA 0x35b4
 				// Header size: 12
 				// Code size: 105 (0x69)
 				.maxstack 8
@@ -1521,7 +1510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3840
+				// Method begins at RVA 0x3714
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1549,7 +1538,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2ca4
+			// Method begins at RVA 0x2c7c
 			// Header size: 12
 			// Code size: 329 (0x149)
 			.maxstack 8
@@ -1700,7 +1689,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3864
+					// Method begins at RVA 0x3738
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1725,7 +1714,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3700
+				// Method begins at RVA 0x362c
 				// Header size: 12
 				// Code size: 76 (0x4c)
 				.maxstack 8
@@ -1788,7 +1777,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x385b
+					// Method begins at RVA 0x372f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1808,7 +1797,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x386d
+					// Method begins at RVA 0x3741
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1826,7 +1815,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3852
+				// Method begins at RVA 0x3726
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1852,9 +1841,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2dfc
+			// Method begins at RVA 0x2dd4
 			// Header size: 12
-			// Code size: 2101 (0x835)
+			// Code size: 1931 (0x78b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -1920,96 +1909,106 @@
 			IL_0046: stloc.2
 			IL_0047: ldarg.0
 			IL_0048: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_004d: ldstr "Cannot access 'CSPROJ_PATH' before initialization"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0057: stloc.s 32
-			IL_0059: ldc.i4.1
-			IL_005a: newarr [System.Runtime]System.Object
-			IL_005f: dup
-			IL_0060: ldc.i4.0
-			IL_0061: ldarg.0
-			IL_0062: stelem.ref
-			IL_0063: ldc.i4.0
-			IL_0064: ldelem.ref
-			IL_0065: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_006a: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_0070: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0075: ldnull
-			IL_0076: ldloc.s 32
-			IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_007d: stloc.s 32
-			IL_007f: ldloc.s 32
-			IL_0081: stloc.3
-			IL_0082: ldarg.0
-			IL_0083: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0088: ldstr "Cannot access 'CORE_CSPROJ_PATH' before initialization"
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0092: stloc.s 32
-			IL_0094: ldc.i4.1
-			IL_0095: newarr [System.Runtime]System.Object
-			IL_009a: dup
-			IL_009b: ldc.i4.0
-			IL_009c: ldarg.0
-			IL_009d: stelem.ref
-			IL_009e: ldc.i4.0
-			IL_009f: ldelem.ref
-			IL_00a0: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_00a5: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00b0: ldnull
-			IL_00b1: ldloc.s 32
-			IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00b8: stloc.s 32
-			IL_00ba: ldloc.s 32
-			IL_00bc: stloc.s 4
-			IL_00be: ldarg.0
-			IL_00bf: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_00c4: ldstr "Cannot access 'SDK_CSPROJ_PATH' before initialization"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00ce: stloc.s 32
-			IL_00d0: ldc.i4.1
-			IL_00d1: newarr [System.Runtime]System.Object
-			IL_00d6: dup
-			IL_00d7: ldc.i4.0
-			IL_00d8: ldarg.0
-			IL_00d9: stelem.ref
-			IL_00da: ldc.i4.0
-			IL_00db: ldelem.ref
-			IL_00dc: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_00e1: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ec: ldnull
-			IL_00ed: ldloc.s 32
-			IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00f4: stloc.s 32
-			IL_00f6: ldloc.s 32
-			IL_00f8: stloc.s 5
-			IL_00fa: ldarg.0
-			IL_00fb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0100: ldstr "Cannot access 'RUNTIME_CSPROJ_PATH' before initialization"
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_010a: stloc.s 32
-			IL_010c: ldc.i4.1
-			IL_010d: newarr [System.Runtime]System.Object
-			IL_0112: dup
-			IL_0113: ldc.i4.0
-			IL_0114: ldarg.0
-			IL_0115: stelem.ref
-			IL_0116: ldc.i4.0
-			IL_0117: ldelem.ref
-			IL_0118: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_011d: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_0123: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0128: ldnull
-			IL_0129: ldloc.s 32
-			IL_012b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0130: stloc.s 32
-			IL_0132: ldloc.s 32
-			IL_0134: stloc.s 6
-			IL_0136: ldarg.0
-			IL_0137: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_013c: ldstr "Cannot access 'SAMPLES_PROPS_PATH' before initialization"
-			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_004d: stloc.s 32
+			IL_004f: ldc.i4.1
+			IL_0050: newarr [System.Runtime]System.Object
+			IL_0055: dup
+			IL_0056: ldc.i4.0
+			IL_0057: ldarg.0
+			IL_0058: stelem.ref
+			IL_0059: ldc.i4.0
+			IL_005a: ldelem.ref
+			IL_005b: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0060: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0066: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_006b: ldnull
+			IL_006c: ldloc.s 32
+			IL_006e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0073: stloc.s 32
+			IL_0075: ldloc.s 32
+			IL_0077: stloc.3
+			IL_0078: ldarg.0
+			IL_0079: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_007e: stloc.s 32
+			IL_0080: ldc.i4.1
+			IL_0081: newarr [System.Runtime]System.Object
+			IL_0086: dup
+			IL_0087: ldc.i4.0
+			IL_0088: ldarg.0
+			IL_0089: stelem.ref
+			IL_008a: ldc.i4.0
+			IL_008b: ldelem.ref
+			IL_008c: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0091: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_009c: ldnull
+			IL_009d: ldloc.s 32
+			IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_00a4: stloc.s 32
+			IL_00a6: ldloc.s 32
+			IL_00a8: stloc.s 4
+			IL_00aa: ldarg.0
+			IL_00ab: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_00b0: stloc.s 32
+			IL_00b2: ldc.i4.1
+			IL_00b3: newarr [System.Runtime]System.Object
+			IL_00b8: dup
+			IL_00b9: ldc.i4.0
+			IL_00ba: ldarg.0
+			IL_00bb: stelem.ref
+			IL_00bc: ldc.i4.0
+			IL_00bd: ldelem.ref
+			IL_00be: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_00c3: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00ce: ldnull
+			IL_00cf: ldloc.s 32
+			IL_00d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_00d6: stloc.s 32
+			IL_00d8: ldloc.s 32
+			IL_00da: stloc.s 5
+			IL_00dc: ldarg.0
+			IL_00dd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_00e2: stloc.s 32
+			IL_00e4: ldc.i4.1
+			IL_00e5: newarr [System.Runtime]System.Object
+			IL_00ea: dup
+			IL_00eb: ldc.i4.0
+			IL_00ec: ldarg.0
+			IL_00ed: stelem.ref
+			IL_00ee: ldc.i4.0
+			IL_00ef: ldelem.ref
+			IL_00f0: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_00f5: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_00fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0100: ldnull
+			IL_0101: ldloc.s 32
+			IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0108: stloc.s 32
+			IL_010a: ldloc.s 32
+			IL_010c: stloc.s 6
+			IL_010e: ldarg.0
+			IL_010f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_0114: stloc.s 32
+			IL_0116: ldc.i4.1
+			IL_0117: newarr [System.Runtime]System.Object
+			IL_011c: dup
+			IL_011d: ldc.i4.0
+			IL_011e: ldarg.0
+			IL_011f: stelem.ref
+			IL_0120: ldc.i4.0
+			IL_0121: ldelem.ref
+			IL_0122: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0127: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0132: ldnull
+			IL_0133: ldloc.s 32
+			IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_013a: stloc.s 32
+			IL_013c: ldloc.s 32
+			IL_013e: stloc.s 7
+			IL_0140: ldarg.0
+			IL_0141: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
 			IL_0146: stloc.s 32
 			IL_0148: ldc.i4.1
 			IL_0149: newarr [System.Runtime]System.Object
@@ -2027,629 +2026,585 @@
 			IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
 			IL_016c: stloc.s 32
 			IL_016e: ldloc.s 32
-			IL_0170: stloc.s 7
-			IL_0172: ldarg.0
-			IL_0173: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_0178: ldstr "Cannot access 'CHANGELOG_PATH' before initialization"
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0182: stloc.s 32
-			IL_0184: ldc.i4.1
-			IL_0185: newarr [System.Runtime]System.Object
-			IL_018a: dup
-			IL_018b: ldc.i4.0
-			IL_018c: ldarg.0
-			IL_018d: stelem.ref
-			IL_018e: ldc.i4.0
-			IL_018f: ldelem.ref
-			IL_0190: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0195: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_019b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_01a0: ldnull
-			IL_01a1: ldloc.s 32
-			IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_01a8: stloc.s 32
-			IL_01aa: ldloc.s 32
-			IL_01ac: stloc.s 8
-			IL_01ae: ldnull
-			IL_01af: ldloc.3
-			IL_01b0: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
-			IL_01b5: stloc.s 32
-			IL_01b7: ldloc.s 32
-			IL_01b9: stloc.s 9
-			IL_01bb: ldc.i4.1
-			IL_01bc: newarr [System.Runtime]System.Object
-			IL_01c1: dup
-			IL_01c2: ldc.i4.0
-			IL_01c3: ldarg.0
-			IL_01c4: stelem.ref
-			IL_01c5: ldc.i4.0
-			IL_01c6: ldelem.ref
-			IL_01c7: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_01cc: ldftn object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_01d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_01d7: ldnull
-			IL_01d8: ldloc.1
-			IL_01d9: ldloc.s 9
-			IL_01db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_01e0: stloc.s 32
-			IL_01e2: ldloc.s 32
-			IL_01e4: stloc.s 10
-			IL_01e6: ldloc.s 9
-			IL_01e8: ldloc.s 10
-			IL_01ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01ef: stloc.s 33
-			IL_01f1: ldloc.s 33
-			IL_01f3: brfalse IL_0253
+			IL_0170: stloc.s 8
+			IL_0172: ldnull
+			IL_0173: ldloc.3
+			IL_0174: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
+			IL_0179: stloc.s 32
+			IL_017b: ldloc.s 32
+			IL_017d: stloc.s 9
+			IL_017f: ldc.i4.1
+			IL_0180: newarr [System.Runtime]System.Object
+			IL_0185: dup
+			IL_0186: ldc.i4.0
+			IL_0187: ldarg.0
+			IL_0188: stelem.ref
+			IL_0189: ldc.i4.0
+			IL_018a: ldelem.ref
+			IL_018b: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0190: ldftn object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0196: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_019b: ldnull
+			IL_019c: ldloc.1
+			IL_019d: ldloc.s 9
+			IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_01a4: stloc.s 32
+			IL_01a6: ldloc.s 32
+			IL_01a8: stloc.s 10
+			IL_01aa: ldloc.s 9
+			IL_01ac: ldloc.s 10
+			IL_01ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01b3: stloc.s 33
+			IL_01b5: ldloc.s 33
+			IL_01b7: brfalse IL_0217
 
-			IL_01f8: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L130C36::.ctor()
-			IL_01fd: stloc.s 11
-			IL_01ff: ldloc.s 9
-			IL_0201: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0206: stloc.s 34
-			IL_0208: ldstr "Version unchanged ("
-			IL_020d: ldloc.s 34
-			IL_020f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0214: stloc.s 34
-			IL_0216: ldloc.s 34
-			IL_0218: ldstr "); aborting."
-			IL_021d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0222: stloc.s 34
-			IL_0224: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0229: ldloc.s 34
-			IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0230: pop
-			IL_0231: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0236: stloc.s 35
-			IL_0238: ldloc.s 35
-			IL_023a: ldstr "exit"
-			IL_023f: ldc.r8 1
-			IL_0248: box [System.Runtime]System.Double
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0252: pop
+			IL_01bc: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L130C36::.ctor()
+			IL_01c1: stloc.s 11
+			IL_01c3: ldloc.s 9
+			IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ca: stloc.s 34
+			IL_01cc: ldstr "Version unchanged ("
+			IL_01d1: ldloc.s 34
+			IL_01d3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d8: stloc.s 34
+			IL_01da: ldloc.s 34
+			IL_01dc: ldstr "); aborting."
+			IL_01e1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e6: stloc.s 34
+			IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01ed: ldloc.s 34
+			IL_01ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_01f4: pop
+			IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_01fa: stloc.s 35
+			IL_01fc: ldloc.s 35
+			IL_01fe: ldstr "exit"
+			IL_0203: ldc.r8 1
+			IL_020c: box [System.Runtime]System.Double
+			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0216: pop
 
-			IL_0253: ldc.i4.1
-			IL_0254: newarr [System.Runtime]System.Object
-			IL_0259: dup
-			IL_025a: ldc.i4.0
-			IL_025b: ldarg.0
-			IL_025c: stelem.ref
-			IL_025d: ldc.i4.0
-			IL_025e: ldelem.ref
-			IL_025f: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0264: ldftn object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_026a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_026f: ldnull
-			IL_0270: ldloc.s 8
-			IL_0272: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0277: stloc.s 32
-			IL_0279: ldloc.s 32
-			IL_027b: brfalse IL_028c
+			IL_0217: ldc.i4.1
+			IL_0218: newarr [System.Runtime]System.Object
+			IL_021d: dup
+			IL_021e: ldc.i4.0
+			IL_021f: ldarg.0
+			IL_0220: stelem.ref
+			IL_0221: ldc.i4.0
+			IL_0222: ldelem.ref
+			IL_0223: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0228: ldftn object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_022e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0233: ldnull
+			IL_0234: ldloc.s 8
+			IL_0236: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_023b: stloc.s 32
+			IL_023d: ldloc.s 32
+			IL_023f: brfalse IL_0250
 
-			IL_0280: ldloc.s 32
-			IL_0282: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0287: brfalse IL_029d
+			IL_0244: ldloc.s 32
+			IL_0246: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_024b: brfalse IL_0261
 
-			IL_028c: ldloc.s 32
-			IL_028e: ldstr ""
-			IL_0293: ldstr "body"
-			IL_0298: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0250: ldloc.s 32
+			IL_0252: ldstr ""
+			IL_0257: ldstr "body"
+			IL_025c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_029d: ldloc.s 32
-			IL_029f: ldstr "body"
-			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a9: stloc.s 12
-			IL_02ab: ldloc.s 32
-			IL_02ad: ldstr "start"
-			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b7: stloc.s 13
-			IL_02b9: ldloc.s 32
-			IL_02bb: ldstr "end"
-			IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c5: stloc.s 14
-			IL_02c7: ldstr "\\r?\\n"
-			IL_02cc: ldstr ""
-			IL_02d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02d6: stloc.s 36
-			IL_02d8: ldloc.s 12
-			IL_02da: ldstr "split"
-			IL_02df: ldloc.s 36
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02e6: stloc.s 32
-			IL_02e8: ldnull
-			IL_02e9: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
-			IL_02ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_02f4: ldc.i4.2
-			IL_02f5: newarr [System.Runtime]System.Object
-			IL_02fa: dup
-			IL_02fb: ldc.i4.0
-			IL_02fc: ldarg.0
-			IL_02fd: stelem.ref
-			IL_02fe: dup
-			IL_02ff: ldc.i4.1
-			IL_0300: ldloc.0
-			IL_0301: stelem.ref
-			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_030c: ldc.i4.1
-			IL_030d: conv.r8
-			IL_030e: ldstr ""
-			IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0318: stloc.s 37
-			IL_031a: ldloc.s 32
-			IL_031c: ldstr "some"
-			IL_0321: ldloc.s 37
-			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0328: stloc.s 37
-			IL_032a: ldloc.s 37
-			IL_032c: stloc.s 15
-			IL_032e: ldloc.s 15
-			IL_0330: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0335: ldc.i4.0
-			IL_0336: ceq
-			IL_0338: stloc.s 33
-			IL_033a: ldloc.s 33
-			IL_033c: box [System.Runtime]System.Boolean
-			IL_0341: stloc.s 38
-			IL_0343: ldloc.s 38
-			IL_0345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_034a: stloc.s 33
-			IL_034c: ldloc.s 33
-			IL_034e: brfalse IL_035b
+			IL_0261: ldloc.s 32
+			IL_0263: ldstr "body"
+			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026d: stloc.s 12
+			IL_026f: ldloc.s 32
+			IL_0271: ldstr "start"
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027b: stloc.s 13
+			IL_027d: ldloc.s 32
+			IL_027f: ldstr "end"
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0289: stloc.s 14
+			IL_028b: ldstr "\\r?\\n"
+			IL_0290: ldstr ""
+			IL_0295: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_029a: stloc.s 36
+			IL_029c: ldloc.s 12
+			IL_029e: ldstr "split"
+			IL_02a3: ldloc.s 36
+			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02aa: stloc.s 32
+			IL_02ac: ldnull
+			IL_02ad: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
+			IL_02b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_02b8: ldc.i4.2
+			IL_02b9: newarr [System.Runtime]System.Object
+			IL_02be: dup
+			IL_02bf: ldc.i4.0
+			IL_02c0: ldarg.0
+			IL_02c1: stelem.ref
+			IL_02c2: dup
+			IL_02c3: ldc.i4.1
+			IL_02c4: ldloc.0
+			IL_02c5: stelem.ref
+			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_02d0: ldc.i4.1
+			IL_02d1: conv.r8
+			IL_02d2: ldstr ""
+			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_02dc: stloc.s 37
+			IL_02de: ldloc.s 32
+			IL_02e0: ldstr "some"
+			IL_02e5: ldloc.s 37
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02ec: stloc.s 37
+			IL_02ee: ldloc.s 37
+			IL_02f0: stloc.s 15
+			IL_02f2: ldloc.s 15
+			IL_02f4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02f9: ldc.i4.0
+			IL_02fa: ceq
+			IL_02fc: stloc.s 33
+			IL_02fe: ldloc.s 33
+			IL_0300: box [System.Runtime]System.Boolean
+			IL_0305: stloc.s 38
+			IL_0307: ldloc.s 38
+			IL_0309: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_030e: stloc.s 33
+			IL_0310: ldloc.s 33
+			IL_0312: brfalse IL_031f
 
-			IL_0353: ldloc.2
-			IL_0354: stloc.s 40
-			IL_0356: br IL_035f
+			IL_0317: ldloc.2
+			IL_0318: stloc.s 40
+			IL_031a: br IL_0323
 
-			IL_035b: ldloc.s 38
-			IL_035d: stloc.s 40
+			IL_031f: ldloc.s 38
+			IL_0321: stloc.s 40
 
-			IL_035f: ldloc.s 40
-			IL_0361: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0366: stloc.s 33
-			IL_0368: ldloc.s 33
-			IL_036a: brfalse IL_04f4
+			IL_0323: ldloc.s 40
+			IL_0325: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_032a: stloc.s 33
+			IL_032c: ldloc.s 33
+			IL_032e: brfalse IL_0486
 
-			IL_036f: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
-			IL_0374: stloc.s 16
-			IL_0376: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_037b: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_0380: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0385: pop
-			IL_0386: ldnull
-			IL_0387: ldloc.3
-			IL_0388: ldloc.s 10
-			IL_038a: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_038f: stloc.s 37
-			IL_0391: ldloc.s 37
-			IL_0393: stloc.s 17
-			IL_0395: ldnull
-			IL_0396: ldloc.s 4
-			IL_0398: ldloc.s 10
-			IL_039a: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0333: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
+			IL_0338: stloc.s 16
+			IL_033a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_033f: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_0344: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0349: pop
+			IL_034a: ldnull
+			IL_034b: ldloc.3
+			IL_034c: ldloc.s 10
+			IL_034e: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0353: stloc.s 37
+			IL_0355: ldloc.s 37
+			IL_0357: stloc.s 17
+			IL_0359: ldnull
+			IL_035a: ldloc.s 4
+			IL_035c: ldloc.s 10
+			IL_035e: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0363: stloc.s 37
+			IL_0365: ldloc.s 37
+			IL_0367: stloc.s 18
+			IL_0369: ldnull
+			IL_036a: ldloc.s 5
+			IL_036c: ldloc.s 10
+			IL_036e: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0373: stloc.s 37
+			IL_0375: ldloc.s 37
+			IL_0377: stloc.s 19
+			IL_0379: ldnull
+			IL_037a: ldloc.s 6
+			IL_037c: ldloc.s 10
+			IL_037e: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0383: stloc.s 37
+			IL_0385: ldloc.s 37
+			IL_0387: stloc.s 20
+			IL_0389: ldnull
+			IL_038a: ldloc.s 7
+			IL_038c: ldloc.s 10
+			IL_038e: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
+			IL_0393: stloc.s 37
+			IL_0395: ldloc.s 37
+			IL_0397: stloc.s 21
+			IL_0399: ldarg.0
+			IL_039a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
 			IL_039f: stloc.s 37
-			IL_03a1: ldloc.s 37
-			IL_03a3: stloc.s 18
-			IL_03a5: ldnull
-			IL_03a6: ldloc.s 5
-			IL_03a8: ldloc.s 10
-			IL_03aa: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_03af: stloc.s 37
-			IL_03b1: ldloc.s 37
-			IL_03b3: stloc.s 19
-			IL_03b5: ldnull
-			IL_03b6: ldloc.s 6
-			IL_03b8: ldloc.s 10
-			IL_03ba: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_03bf: stloc.s 37
-			IL_03c1: ldloc.s 37
-			IL_03c3: stloc.s 20
-			IL_03c5: ldnull
-			IL_03c6: ldloc.s 7
-			IL_03c8: ldloc.s 10
-			IL_03ca: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
-			IL_03cf: stloc.s 37
-			IL_03d1: ldloc.s 37
-			IL_03d3: stloc.s 21
-			IL_03d5: ldarg.0
-			IL_03d6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_03db: ldstr "Cannot access 'CSPROJ_PATH' before initialization"
-			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_03e5: stloc.s 37
-			IL_03e7: ldc.i4.1
-			IL_03e8: newarr [System.Runtime]System.Object
-			IL_03ed: dup
-			IL_03ee: ldc.i4.0
-			IL_03ef: ldarg.0
-			IL_03f0: stelem.ref
-			IL_03f1: ldc.i4.0
-			IL_03f2: ldelem.ref
-			IL_03f3: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_03f8: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_03fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0403: ldnull
-			IL_0404: ldloc.s 37
-			IL_0406: ldloc.s 17
-			IL_0408: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_040d: pop
-			IL_040e: ldarg.0
-			IL_040f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0414: ldstr "Cannot access 'CORE_CSPROJ_PATH' before initialization"
-			IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_041e: stloc.s 37
-			IL_0420: ldc.i4.1
-			IL_0421: newarr [System.Runtime]System.Object
-			IL_0426: dup
-			IL_0427: ldc.i4.0
-			IL_0428: ldarg.0
-			IL_0429: stelem.ref
-			IL_042a: ldc.i4.0
-			IL_042b: ldelem.ref
-			IL_042c: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0431: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0437: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_043c: ldnull
-			IL_043d: ldloc.s 37
-			IL_043f: ldloc.s 18
-			IL_0441: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0446: pop
-			IL_0447: ldarg.0
-			IL_0448: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_044d: ldstr "Cannot access 'SDK_CSPROJ_PATH' before initialization"
-			IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0457: stloc.s 37
-			IL_0459: ldc.i4.1
-			IL_045a: newarr [System.Runtime]System.Object
-			IL_045f: dup
-			IL_0460: ldc.i4.0
-			IL_0461: ldarg.0
-			IL_0462: stelem.ref
-			IL_0463: ldc.i4.0
-			IL_0464: ldelem.ref
-			IL_0465: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_046a: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0470: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0475: ldnull
-			IL_0476: ldloc.s 37
-			IL_0478: ldloc.s 19
-			IL_047a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_047f: pop
-			IL_0480: ldarg.0
-			IL_0481: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0486: ldstr "Cannot access 'RUNTIME_CSPROJ_PATH' before initialization"
-			IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0490: stloc.s 37
-			IL_0492: ldc.i4.1
-			IL_0493: newarr [System.Runtime]System.Object
-			IL_0498: dup
-			IL_0499: ldc.i4.0
-			IL_049a: ldarg.0
-			IL_049b: stelem.ref
-			IL_049c: ldc.i4.0
-			IL_049d: ldelem.ref
-			IL_049e: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_04a3: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_04a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_04ae: ldnull
-			IL_04af: ldloc.s 37
-			IL_04b1: ldloc.s 20
-			IL_04b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_04b8: pop
-			IL_04b9: ldarg.0
-			IL_04ba: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_04bf: ldstr "Cannot access 'SAMPLES_PROPS_PATH' before initialization"
-			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_04c9: stloc.s 37
-			IL_04cb: ldc.i4.1
-			IL_04cc: newarr [System.Runtime]System.Object
-			IL_04d1: dup
-			IL_04d2: ldc.i4.0
-			IL_04d3: ldarg.0
-			IL_04d4: stelem.ref
-			IL_04d5: ldc.i4.0
-			IL_04d6: ldelem.ref
-			IL_04d7: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_04dc: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_04e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_04e7: ldnull
-			IL_04e8: ldloc.s 37
-			IL_04ea: ldloc.s 21
-			IL_04ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_04f1: pop
-			IL_04f2: ldnull
-			IL_04f3: ret
+			IL_03a1: ldc.i4.1
+			IL_03a2: newarr [System.Runtime]System.Object
+			IL_03a7: dup
+			IL_03a8: ldc.i4.0
+			IL_03a9: ldarg.0
+			IL_03aa: stelem.ref
+			IL_03ab: ldc.i4.0
+			IL_03ac: ldelem.ref
+			IL_03ad: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_03b2: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_03b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_03bd: ldnull
+			IL_03be: ldloc.s 37
+			IL_03c0: ldloc.s 17
+			IL_03c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_03c7: pop
+			IL_03c8: ldarg.0
+			IL_03c9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_03ce: stloc.s 37
+			IL_03d0: ldc.i4.1
+			IL_03d1: newarr [System.Runtime]System.Object
+			IL_03d6: dup
+			IL_03d7: ldc.i4.0
+			IL_03d8: ldarg.0
+			IL_03d9: stelem.ref
+			IL_03da: ldc.i4.0
+			IL_03db: ldelem.ref
+			IL_03dc: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_03e1: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_03e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_03ec: ldnull
+			IL_03ed: ldloc.s 37
+			IL_03ef: ldloc.s 18
+			IL_03f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_03f6: pop
+			IL_03f7: ldarg.0
+			IL_03f8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_03fd: stloc.s 37
+			IL_03ff: ldc.i4.1
+			IL_0400: newarr [System.Runtime]System.Object
+			IL_0405: dup
+			IL_0406: ldc.i4.0
+			IL_0407: ldarg.0
+			IL_0408: stelem.ref
+			IL_0409: ldc.i4.0
+			IL_040a: ldelem.ref
+			IL_040b: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0410: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0416: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_041b: ldnull
+			IL_041c: ldloc.s 37
+			IL_041e: ldloc.s 19
+			IL_0420: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0425: pop
+			IL_0426: ldarg.0
+			IL_0427: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_042c: stloc.s 37
+			IL_042e: ldc.i4.1
+			IL_042f: newarr [System.Runtime]System.Object
+			IL_0434: dup
+			IL_0435: ldc.i4.0
+			IL_0436: ldarg.0
+			IL_0437: stelem.ref
+			IL_0438: ldc.i4.0
+			IL_0439: ldelem.ref
+			IL_043a: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_043f: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0445: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_044a: ldnull
+			IL_044b: ldloc.s 37
+			IL_044d: ldloc.s 20
+			IL_044f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0454: pop
+			IL_0455: ldarg.0
+			IL_0456: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_045b: stloc.s 37
+			IL_045d: ldc.i4.1
+			IL_045e: newarr [System.Runtime]System.Object
+			IL_0463: dup
+			IL_0464: ldc.i4.0
+			IL_0465: ldarg.0
+			IL_0466: stelem.ref
+			IL_0467: ldc.i4.0
+			IL_0468: ldelem.ref
+			IL_0469: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_046e: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0474: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0479: ldnull
+			IL_047a: ldloc.s 37
+			IL_047c: ldloc.s 21
+			IL_047e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0483: pop
+			IL_0484: ldnull
+			IL_0485: ret
 
-			IL_04f4: ldc.i4.1
-			IL_04f5: newarr [System.Runtime]System.Object
-			IL_04fa: dup
-			IL_04fb: ldc.i4.0
-			IL_04fc: ldarg.0
-			IL_04fd: stelem.ref
-			IL_04fe: ldc.i4.0
-			IL_04ff: ldelem.ref
-			IL_0500: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0505: ldftn object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_050b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0510: ldnull
-			IL_0511: ldloc.s 10
-			IL_0513: ldloc.s 12
-			IL_0515: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_051a: stloc.s 37
-			IL_051c: ldloc.s 37
-			IL_051e: stloc.s 22
-			IL_0520: ldloc.s 8
-			IL_0522: ldstr "slice"
-			IL_0527: ldc.r8 0.0
-			IL_0530: box [System.Runtime]System.Double
-			IL_0535: ldloc.s 13
-			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_053c: stloc.s 37
-			IL_053e: ldloc.s 37
-			IL_0540: stloc.s 23
-			IL_0542: ldloc.s 8
-			IL_0544: ldstr "slice"
-			IL_0549: ldloc.s 14
-			IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0550: stloc.s 37
-			IL_0552: ldloc.s 37
-			IL_0554: stloc.s 24
-			IL_0556: ldstr "\n_Nothing yet._\n\n"
-			IL_055b: stloc.s 25
-			IL_055d: ldloc.s 23
-			IL_055f: ldloc.s 25
-			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0566: stloc.s 40
-			IL_0568: ldloc.s 40
-			IL_056a: ldloc.s 22
-			IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0571: stloc.s 40
-			IL_0573: ldloc.s 40
-			IL_0575: ldloc.s 24
-			IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_057c: stloc.s 40
-			IL_057e: ldloc.s 40
-			IL_0580: stloc.s 26
-			IL_0582: ldnull
-			IL_0583: ldloc.3
-			IL_0584: ldloc.s 10
-			IL_0586: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_058b: stloc.s 37
-			IL_058d: ldloc.s 37
-			IL_058f: stloc.s 27
-			IL_0591: ldnull
-			IL_0592: ldloc.s 4
-			IL_0594: ldloc.s 10
-			IL_0596: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_059b: stloc.s 37
-			IL_059d: ldloc.s 37
-			IL_059f: stloc.s 28
-			IL_05a1: ldnull
-			IL_05a2: ldloc.s 5
-			IL_05a4: ldloc.s 10
-			IL_05a6: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_05ab: stloc.s 37
-			IL_05ad: ldloc.s 37
-			IL_05af: stloc.s 29
-			IL_05b1: ldnull
-			IL_05b2: ldloc.s 6
-			IL_05b4: ldloc.s 10
-			IL_05b6: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_05bb: stloc.s 37
-			IL_05bd: ldloc.s 37
-			IL_05bf: stloc.s 30
-			IL_05c1: ldnull
-			IL_05c2: ldloc.s 7
-			IL_05c4: ldloc.s 10
-			IL_05c6: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
-			IL_05cb: stloc.s 37
-			IL_05cd: ldloc.s 37
-			IL_05cf: stloc.s 31
+			IL_0486: ldc.i4.1
+			IL_0487: newarr [System.Runtime]System.Object
+			IL_048c: dup
+			IL_048d: ldc.i4.0
+			IL_048e: ldarg.0
+			IL_048f: stelem.ref
+			IL_0490: ldc.i4.0
+			IL_0491: ldelem.ref
+			IL_0492: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0497: ldftn object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_049d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_04a2: ldnull
+			IL_04a3: ldloc.s 10
+			IL_04a5: ldloc.s 12
+			IL_04a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_04ac: stloc.s 37
+			IL_04ae: ldloc.s 37
+			IL_04b0: stloc.s 22
+			IL_04b2: ldloc.s 8
+			IL_04b4: ldstr "slice"
+			IL_04b9: ldc.r8 0.0
+			IL_04c2: box [System.Runtime]System.Double
+			IL_04c7: ldloc.s 13
+			IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04ce: stloc.s 37
+			IL_04d0: ldloc.s 37
+			IL_04d2: stloc.s 23
+			IL_04d4: ldloc.s 8
+			IL_04d6: ldstr "slice"
+			IL_04db: ldloc.s 14
+			IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04e2: stloc.s 37
+			IL_04e4: ldloc.s 37
+			IL_04e6: stloc.s 24
+			IL_04e8: ldstr "\n_Nothing yet._\n\n"
+			IL_04ed: stloc.s 25
+			IL_04ef: ldloc.s 23
+			IL_04f1: ldloc.s 25
+			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04f8: stloc.s 40
+			IL_04fa: ldloc.s 40
+			IL_04fc: ldloc.s 22
+			IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0503: stloc.s 40
+			IL_0505: ldloc.s 40
+			IL_0507: ldloc.s 24
+			IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_050e: stloc.s 40
+			IL_0510: ldloc.s 40
+			IL_0512: stloc.s 26
+			IL_0514: ldnull
+			IL_0515: ldloc.3
+			IL_0516: ldloc.s 10
+			IL_0518: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_051d: stloc.s 37
+			IL_051f: ldloc.s 37
+			IL_0521: stloc.s 27
+			IL_0523: ldnull
+			IL_0524: ldloc.s 4
+			IL_0526: ldloc.s 10
+			IL_0528: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_052d: stloc.s 37
+			IL_052f: ldloc.s 37
+			IL_0531: stloc.s 28
+			IL_0533: ldnull
+			IL_0534: ldloc.s 5
+			IL_0536: ldloc.s 10
+			IL_0538: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_053d: stloc.s 37
+			IL_053f: ldloc.s 37
+			IL_0541: stloc.s 29
+			IL_0543: ldnull
+			IL_0544: ldloc.s 6
+			IL_0546: ldloc.s 10
+			IL_0548: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_054d: stloc.s 37
+			IL_054f: ldloc.s 37
+			IL_0551: stloc.s 30
+			IL_0553: ldnull
+			IL_0554: ldloc.s 7
+			IL_0556: ldloc.s 10
+			IL_0558: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
+			IL_055d: stloc.s 37
+			IL_055f: ldloc.s 37
+			IL_0561: stloc.s 31
+			IL_0563: ldarg.0
+			IL_0564: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_0569: stloc.s 37
+			IL_056b: ldc.i4.1
+			IL_056c: newarr [System.Runtime]System.Object
+			IL_0571: dup
+			IL_0572: ldc.i4.0
+			IL_0573: ldarg.0
+			IL_0574: stelem.ref
+			IL_0575: ldc.i4.0
+			IL_0576: ldelem.ref
+			IL_0577: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_057c: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0582: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0587: ldnull
+			IL_0588: ldloc.s 37
+			IL_058a: ldloc.s 26
+			IL_058c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0591: pop
+			IL_0592: ldarg.0
+			IL_0593: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0598: stloc.s 37
+			IL_059a: ldc.i4.1
+			IL_059b: newarr [System.Runtime]System.Object
+			IL_05a0: dup
+			IL_05a1: ldc.i4.0
+			IL_05a2: ldarg.0
+			IL_05a3: stelem.ref
+			IL_05a4: ldc.i4.0
+			IL_05a5: ldelem.ref
+			IL_05a6: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_05ab: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_05b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_05b6: ldnull
+			IL_05b7: ldloc.s 37
+			IL_05b9: ldloc.s 27
+			IL_05bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_05c0: pop
+			IL_05c1: ldarg.0
+			IL_05c2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_05c7: stloc.s 37
+			IL_05c9: ldc.i4.1
+			IL_05ca: newarr [System.Runtime]System.Object
+			IL_05cf: dup
+			IL_05d0: ldc.i4.0
 			IL_05d1: ldarg.0
-			IL_05d2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_05d7: ldstr "Cannot access 'CHANGELOG_PATH' before initialization"
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_05e1: stloc.s 37
-			IL_05e3: ldc.i4.1
-			IL_05e4: newarr [System.Runtime]System.Object
-			IL_05e9: dup
-			IL_05ea: ldc.i4.0
-			IL_05eb: ldarg.0
-			IL_05ec: stelem.ref
-			IL_05ed: ldc.i4.0
-			IL_05ee: ldelem.ref
-			IL_05ef: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_05f4: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_05fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_05ff: ldnull
-			IL_0600: ldloc.s 37
-			IL_0602: ldloc.s 26
-			IL_0604: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0609: pop
-			IL_060a: ldarg.0
-			IL_060b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_0610: ldstr "Cannot access 'CSPROJ_PATH' before initialization"
-			IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_061a: stloc.s 37
-			IL_061c: ldc.i4.1
-			IL_061d: newarr [System.Runtime]System.Object
-			IL_0622: dup
-			IL_0623: ldc.i4.0
-			IL_0624: ldarg.0
-			IL_0625: stelem.ref
-			IL_0626: ldc.i4.0
-			IL_0627: ldelem.ref
-			IL_0628: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_062d: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0633: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0638: ldnull
-			IL_0639: ldloc.s 37
-			IL_063b: ldloc.s 27
-			IL_063d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0642: pop
-			IL_0643: ldarg.0
-			IL_0644: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0649: ldstr "Cannot access 'CORE_CSPROJ_PATH' before initialization"
-			IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0653: stloc.s 37
-			IL_0655: ldc.i4.1
-			IL_0656: newarr [System.Runtime]System.Object
-			IL_065b: dup
-			IL_065c: ldc.i4.0
-			IL_065d: ldarg.0
-			IL_065e: stelem.ref
-			IL_065f: ldc.i4.0
-			IL_0660: ldelem.ref
-			IL_0661: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0666: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_066c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0671: ldnull
-			IL_0672: ldloc.s 37
-			IL_0674: ldloc.s 28
-			IL_0676: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_067b: pop
-			IL_067c: ldarg.0
-			IL_067d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0682: ldstr "Cannot access 'SDK_CSPROJ_PATH' before initialization"
-			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_068c: stloc.s 37
-			IL_068e: ldc.i4.1
-			IL_068f: newarr [System.Runtime]System.Object
-			IL_0694: dup
-			IL_0695: ldc.i4.0
-			IL_0696: ldarg.0
-			IL_0697: stelem.ref
-			IL_0698: ldc.i4.0
-			IL_0699: ldelem.ref
-			IL_069a: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_069f: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_06a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_06aa: ldnull
-			IL_06ab: ldloc.s 37
-			IL_06ad: ldloc.s 29
-			IL_06af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_06b4: pop
-			IL_06b5: ldarg.0
-			IL_06b6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_06bb: ldstr "Cannot access 'RUNTIME_CSPROJ_PATH' before initialization"
-			IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_06c5: stloc.s 37
-			IL_06c7: ldc.i4.1
-			IL_06c8: newarr [System.Runtime]System.Object
-			IL_06cd: dup
-			IL_06ce: ldc.i4.0
-			IL_06cf: ldarg.0
-			IL_06d0: stelem.ref
-			IL_06d1: ldc.i4.0
-			IL_06d2: ldelem.ref
-			IL_06d3: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_06d8: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_06de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_06e3: ldnull
-			IL_06e4: ldloc.s 37
-			IL_06e6: ldloc.s 30
-			IL_06e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_06ed: pop
-			IL_06ee: ldarg.0
-			IL_06ef: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_06f4: ldstr "Cannot access 'SAMPLES_PROPS_PATH' before initialization"
-			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_06fe: stloc.s 37
-			IL_0700: ldc.i4.1
-			IL_0701: newarr [System.Runtime]System.Object
-			IL_0706: dup
-			IL_0707: ldc.i4.0
-			IL_0708: ldarg.0
-			IL_0709: stelem.ref
-			IL_070a: ldc.i4.0
-			IL_070b: ldelem.ref
-			IL_070c: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0711: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0717: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_071c: ldnull
-			IL_071d: ldloc.s 37
-			IL_071f: ldloc.s 31
-			IL_0721: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0726: pop
-			IL_0727: ldloc.s 9
-			IL_0729: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_072e: stloc.s 34
-			IL_0730: ldstr "Bumped version: "
-			IL_0735: ldloc.s 34
-			IL_0737: call string [System.Runtime]System.String::Concat(string, string)
-			IL_073c: stloc.s 34
-			IL_073e: ldloc.s 34
-			IL_0740: ldstr " -> "
-			IL_0745: call string [System.Runtime]System.String::Concat(string, string)
-			IL_074a: stloc.s 34
-			IL_074c: ldloc.s 10
-			IL_074e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0753: stloc.s 41
+			IL_05d2: stelem.ref
+			IL_05d3: ldc.i4.0
+			IL_05d4: ldelem.ref
+			IL_05d5: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_05da: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_05e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_05e5: ldnull
+			IL_05e6: ldloc.s 37
+			IL_05e8: ldloc.s 28
+			IL_05ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_05ef: pop
+			IL_05f0: ldarg.0
+			IL_05f1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_05f6: stloc.s 37
+			IL_05f8: ldc.i4.1
+			IL_05f9: newarr [System.Runtime]System.Object
+			IL_05fe: dup
+			IL_05ff: ldc.i4.0
+			IL_0600: ldarg.0
+			IL_0601: stelem.ref
+			IL_0602: ldc.i4.0
+			IL_0603: ldelem.ref
+			IL_0604: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0609: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_060f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0614: ldnull
+			IL_0615: ldloc.s 37
+			IL_0617: ldloc.s 29
+			IL_0619: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_061e: pop
+			IL_061f: ldarg.0
+			IL_0620: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0625: stloc.s 37
+			IL_0627: ldc.i4.1
+			IL_0628: newarr [System.Runtime]System.Object
+			IL_062d: dup
+			IL_062e: ldc.i4.0
+			IL_062f: ldarg.0
+			IL_0630: stelem.ref
+			IL_0631: ldc.i4.0
+			IL_0632: ldelem.ref
+			IL_0633: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0638: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_063e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0643: ldnull
+			IL_0644: ldloc.s 37
+			IL_0646: ldloc.s 30
+			IL_0648: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_064d: pop
+			IL_064e: ldarg.0
+			IL_064f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_0654: stloc.s 37
+			IL_0656: ldc.i4.1
+			IL_0657: newarr [System.Runtime]System.Object
+			IL_065c: dup
+			IL_065d: ldc.i4.0
+			IL_065e: ldarg.0
+			IL_065f: stelem.ref
+			IL_0660: ldc.i4.0
+			IL_0661: ldelem.ref
+			IL_0662: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0667: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_066d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0672: ldnull
+			IL_0673: ldloc.s 37
+			IL_0675: ldloc.s 31
+			IL_0677: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_067c: pop
+			IL_067d: ldloc.s 9
+			IL_067f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0684: stloc.s 34
+			IL_0686: ldstr "Bumped version: "
+			IL_068b: ldloc.s 34
+			IL_068d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0692: stloc.s 34
+			IL_0694: ldloc.s 34
+			IL_0696: ldstr " -> "
+			IL_069b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06a0: stloc.s 34
+			IL_06a2: ldloc.s 10
+			IL_06a4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06a9: stloc.s 41
+			IL_06ab: ldloc.s 34
+			IL_06ad: ldloc.s 41
+			IL_06af: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06b4: stloc.s 41
+			IL_06b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06bb: ldloc.s 41
+			IL_06bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06c2: pop
+			IL_06c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06c8: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Js2IL.csproj, src/Js2IL.Core/Js2IL.Core.csproj, src/Js2IL.SDK/Js2IL.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_06cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06d2: pop
+			IL_06d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06d8: ldstr "\nNext steps:"
+			IL_06dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06e2: pop
+			IL_06e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06e8: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Js2IL.csproj src/Js2IL.Core/Js2IL.Core.csproj src/Js2IL.SDK/Js2IL.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_06ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06f2: pop
+			IL_06f3: ldloc.s 10
+			IL_06f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06fa: stloc.s 41
+			IL_06fc: ldstr "  git commit -m \"chore(release): cut "
+			IL_0701: ldloc.s 41
+			IL_0703: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0708: stloc.s 41
+			IL_070a: ldloc.s 41
+			IL_070c: ldstr "\""
+			IL_0711: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0716: stloc.s 41
+			IL_0718: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_071d: ldloc.s 41
+			IL_071f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0724: pop
+			IL_0725: ldloc.s 10
+			IL_0727: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_072c: stloc.s 41
+			IL_072e: ldstr "  git tag -a v"
+			IL_0733: ldloc.s 41
+			IL_0735: call string [System.Runtime]System.String::Concat(string, string)
+			IL_073a: stloc.s 41
+			IL_073c: ldloc.s 41
+			IL_073e: ldstr " -m \"Release "
+			IL_0743: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0748: stloc.s 41
+			IL_074a: ldloc.s 10
+			IL_074c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0751: stloc.s 34
+			IL_0753: ldloc.s 41
 			IL_0755: ldloc.s 34
-			IL_0757: ldloc.s 41
-			IL_0759: call string [System.Runtime]System.String::Concat(string, string)
-			IL_075e: stloc.s 41
-			IL_0760: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0765: ldloc.s 41
-			IL_0767: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_076c: pop
-			IL_076d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0772: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Js2IL.csproj, src/Js2IL.Core/Js2IL.Core.csproj, src/Js2IL.SDK/Js2IL.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0777: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_077c: pop
-			IL_077d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0782: ldstr "\nNext steps:"
-			IL_0787: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_078c: pop
-			IL_078d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0792: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Js2IL.csproj src/Js2IL.Core/Js2IL.Core.csproj src/Js2IL.SDK/Js2IL.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0797: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_079c: pop
-			IL_079d: ldloc.s 10
-			IL_079f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07a4: stloc.s 41
-			IL_07a6: ldstr "  git commit -m \"chore(release): cut "
-			IL_07ab: ldloc.s 41
-			IL_07ad: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07b2: stloc.s 41
-			IL_07b4: ldloc.s 41
-			IL_07b6: ldstr "\""
-			IL_07bb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07c0: stloc.s 41
-			IL_07c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07c7: ldloc.s 41
-			IL_07c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07ce: pop
-			IL_07cf: ldloc.s 10
-			IL_07d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07d6: stloc.s 41
-			IL_07d8: ldstr "  git tag -a v"
-			IL_07dd: ldloc.s 41
-			IL_07df: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07e4: stloc.s 41
-			IL_07e6: ldloc.s 41
-			IL_07e8: ldstr " -m \"Release "
-			IL_07ed: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07f2: stloc.s 41
-			IL_07f4: ldloc.s 10
-			IL_07f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07fb: stloc.s 34
-			IL_07fd: ldloc.s 41
-			IL_07ff: ldloc.s 34
-			IL_0801: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0806: stloc.s 34
-			IL_0808: ldloc.s 34
-			IL_080a: ldstr "\""
-			IL_080f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0814: stloc.s 34
-			IL_0816: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_081b: ldloc.s 34
-			IL_081d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0822: pop
-			IL_0823: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0828: ldstr "  git push && git push --tags"
-			IL_082d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0832: pop
-			IL_0833: ldnull
-			IL_0834: ret
+			IL_0757: call string [System.Runtime]System.String::Concat(string, string)
+			IL_075c: stloc.s 34
+			IL_075e: ldloc.s 34
+			IL_0760: ldstr "\""
+			IL_0765: call string [System.Runtime]System.String::Concat(string, string)
+			IL_076a: stloc.s 34
+			IL_076c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0771: ldloc.s 34
+			IL_0773: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0778: pop
+			IL_0779: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_077e: ldstr "  git push && git push --tags"
+			IL_0783: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0788: pop
+			IL_0789: ldnull
+			IL_078a: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform
@@ -2684,7 +2639,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3876
+				// Method begins at RVA 0x374a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2704,7 +2659,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x387f
+				// Method begins at RVA 0x3753
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2742,36 +2697,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3758
-			// Header size: 12
-			// Code size: 85 (0x55)
+			// Method begins at RVA 0x3684
+			// Header size: 1
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0032: ldarg.0
-			IL_0033: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0038: stfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_003d: ldarg.0
-			IL_003e: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0043: stfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0048: ldarg.0
-			IL_0049: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_004e: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_0053: nop
-			IL_0054: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -3215,7 +3149,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3888
+		// Method begins at RVA 0x375c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3045
+				// Method begins at RVA 0x2fd4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3060
+						// Method begins at RVA 0x2fef
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3069
+						// Method begins at RVA 0x2ff8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3072
+						// Method begins at RVA 0x3001
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x307b
+						// Method begins at RVA 0x300a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3057
+					// Method begins at RVA 0x2fe6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x304e
+				// Method begins at RVA 0x2fdd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -437,7 +437,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x308d
+					// Method begins at RVA 0x301c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -462,7 +462,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a70
+				// Method begins at RVA 0x2a20
 				// Header size: 12
 				// Code size: 409 (0x199)
 				.maxstack 8
@@ -639,7 +639,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3096
+					// Method begins at RVA 0x3025
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -663,7 +663,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c18
+				// Method begins at RVA 0x2bc8
 				// Header size: 12
 				// Code size: 148 (0x94)
 				.maxstack 8
@@ -748,7 +748,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x309f
+					// Method begins at RVA 0x302e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -772,7 +772,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cb8
+				// Method begins at RVA 0x2c68
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -818,7 +818,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30b1
+						// Method begins at RVA 0x3040
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -842,7 +842,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f08
+					// Method begins at RVA 0x2eb8
 					// Header size: 12
 					// Code size: 209 (0xd1)
 					.maxstack 8
@@ -961,7 +961,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30ba
+						// Method begins at RVA 0x3049
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -979,7 +979,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30a8
+					// Method begins at RVA 0x3037
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1005,7 +1005,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ce4
+				// Method begins at RVA 0x2c94
 				// Header size: 12
 				// Code size: 536 (0x218)
 				.maxstack 8
@@ -1249,7 +1249,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3084
+				// Method begins at RVA 0x3013
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1278,7 +1278,7 @@
 			)
 			// Method begins at RVA 0x257c
 			// Header size: 12
-			// Code size: 536 (0x218)
+			// Code size: 526 (0x20e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/Scope,
@@ -1295,172 +1295,170 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::TurndownService
-			IL_000c: ldstr "Cannot access 'TurndownService' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0016: stloc.3
-			IL_0017: ldloc.3
-			IL_0018: ldc.i4.1
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: dup
-			IL_001f: ldc.i4.0
-			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0025: dup
-			IL_0026: ldstr "codeBlockStyle"
-			IL_002b: ldstr "fenced"
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0035: dup
-			IL_0036: ldstr "emDelimiter"
-			IL_003b: ldstr "_"
-			IL_0040: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0045: dup
-			IL_0046: ldstr "strongDelimiter"
-			IL_004b: ldstr "**"
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: dup
-			IL_0056: ldstr "bulletListMarker"
-			IL_005b: ldstr "-"
-			IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0065: stelem.ref
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_006b: stloc.3
-			IL_006c: ldloc.3
-			IL_006d: stloc.1
-			IL_006e: ldnull
-			IL_006f: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
-			IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_007a: ldc.i4.2
-			IL_007b: conv.r8
-			IL_007c: ldstr ""
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0086: stloc.3
-			IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_008c: dup
-			IL_008d: ldstr "filter"
-			IL_0092: ldc.i4.3
-			IL_0093: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0098: dup
-			IL_0099: ldstr "h1"
-			IL_009e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00a3: dup
-			IL_00a4: ldstr "h2"
-			IL_00a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00ae: dup
-			IL_00af: ldstr "h3"
-			IL_00b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00be: dup
-			IL_00bf: ldstr "replacement"
-			IL_00c4: ldloc.3
-			IL_00c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00ca: stloc.s 4
-			IL_00cc: ldloc.1
-			IL_00cd: ldstr "addRule"
-			IL_00d2: ldstr "ecmaHeadings"
-			IL_00d7: ldloc.s 4
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00de: pop
-			IL_00df: ldnull
-			IL_00e0: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
-			IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00eb: ldc.i4.1
-			IL_00ec: conv.r8
-			IL_00ed: ldstr ""
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00f7: stloc.3
-			IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00fd: dup
-			IL_00fe: ldstr "filter"
-			IL_0103: ldc.i4.3
-			IL_0104: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0109: dup
-			IL_010a: ldstr "emu-val"
-			IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0114: dup
-			IL_0115: ldstr "emu-const"
-			IL_011a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_011f: dup
-			IL_0120: ldstr "var"
-			IL_0125: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_012f: dup
-			IL_0130: ldstr "replacement"
-			IL_0135: ldloc.3
-			IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_013b: stloc.s 4
-			IL_013d: ldloc.1
-			IL_013e: ldstr "addRule"
-			IL_0143: ldstr "ecmarkupInlineCode"
-			IL_0148: ldloc.s 4
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_014f: pop
-			IL_0150: ldnull
-			IL_0151: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
-			IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_015c: ldc.i4.1
-			IL_015d: conv.r8
-			IL_015e: ldstr ""
-			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0168: stloc.3
-			IL_0169: ldc.i4.2
-			IL_016a: newarr [System.Runtime]System.Object
-			IL_016f: dup
-			IL_0170: ldc.i4.0
-			IL_0171: ldarg.0
-			IL_0172: stelem.ref
-			IL_0173: dup
-			IL_0174: ldc.i4.1
-			IL_0175: ldloc.0
-			IL_0176: stelem.ref
-			IL_0177: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
-			IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0182: ldc.i4.2
-			IL_0183: conv.r8
-			IL_0184: ldstr ""
-			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_018e: stloc.s 5
-			IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0195: dup
-			IL_0196: ldstr "filter"
-			IL_019b: ldloc.3
-			IL_019c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01a1: dup
-			IL_01a2: ldstr "replacement"
-			IL_01a7: ldloc.s 5
-			IL_01a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01ae: stloc.s 4
-			IL_01b0: ldloc.1
-			IL_01b1: ldstr "addRule"
-			IL_01b6: ldstr "fencedCodeWithLanguage"
-			IL_01bb: ldloc.s 4
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c2: pop
-			IL_01c3: ldloc.1
-			IL_01c4: ldstr "turndown"
-			IL_01c9: ldarg.2
-			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01cf: stloc.s 5
-			IL_01d1: ldloc.s 5
-			IL_01d3: stloc.2
-			IL_01d4: ldstr "\\n{4,}"
-			IL_01d9: ldstr "g"
-			IL_01de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_01e3: stloc.s 6
-			IL_01e5: ldloc.2
-			IL_01e6: ldstr "replace"
-			IL_01eb: ldloc.s 6
-			IL_01ed: ldstr "\n\n\n"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01f7: stloc.s 5
-			IL_01f9: ldloc.s 5
-			IL_01fb: ldstr "trim"
-			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0205: stloc.s 5
-			IL_0207: ldloc.s 5
-			IL_0209: ldstr "\n"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0213: stloc.s 7
-			IL_0215: ldloc.s 7
-			IL_0217: ret
+			IL_000c: stloc.3
+			IL_000d: ldloc.3
+			IL_000e: ldc.i4.1
+			IL_000f: newarr [System.Runtime]System.Object
+			IL_0014: dup
+			IL_0015: ldc.i4.0
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "codeBlockStyle"
+			IL_0021: ldstr "fenced"
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_002b: dup
+			IL_002c: ldstr "emDelimiter"
+			IL_0031: ldstr "_"
+			IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003b: dup
+			IL_003c: ldstr "strongDelimiter"
+			IL_0041: ldstr "**"
+			IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004b: dup
+			IL_004c: ldstr "bulletListMarker"
+			IL_0051: ldstr "-"
+			IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005b: stelem.ref
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0061: stloc.3
+			IL_0062: ldloc.3
+			IL_0063: stloc.1
+			IL_0064: ldnull
+			IL_0065: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
+			IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0070: ldc.i4.2
+			IL_0071: conv.r8
+			IL_0072: ldstr ""
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_007c: stloc.3
+			IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0082: dup
+			IL_0083: ldstr "filter"
+			IL_0088: ldc.i4.3
+			IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_008e: dup
+			IL_008f: ldstr "h1"
+			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0099: dup
+			IL_009a: ldstr "h2"
+			IL_009f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00a4: dup
+			IL_00a5: ldstr "h3"
+			IL_00aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00b4: dup
+			IL_00b5: ldstr "replacement"
+			IL_00ba: ldloc.3
+			IL_00bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00c0: stloc.s 4
+			IL_00c2: ldloc.1
+			IL_00c3: ldstr "addRule"
+			IL_00c8: ldstr "ecmaHeadings"
+			IL_00cd: ldloc.s 4
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d4: pop
+			IL_00d5: ldnull
+			IL_00d6: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
+			IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00e1: ldc.i4.1
+			IL_00e2: conv.r8
+			IL_00e3: ldstr ""
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00ed: stloc.3
+			IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00f3: dup
+			IL_00f4: ldstr "filter"
+			IL_00f9: ldc.i4.3
+			IL_00fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00ff: dup
+			IL_0100: ldstr "emu-val"
+			IL_0105: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_010a: dup
+			IL_010b: ldstr "emu-const"
+			IL_0110: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0115: dup
+			IL_0116: ldstr "var"
+			IL_011b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0120: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0125: dup
+			IL_0126: ldstr "replacement"
+			IL_012b: ldloc.3
+			IL_012c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0131: stloc.s 4
+			IL_0133: ldloc.1
+			IL_0134: ldstr "addRule"
+			IL_0139: ldstr "ecmarkupInlineCode"
+			IL_013e: ldloc.s 4
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0145: pop
+			IL_0146: ldnull
+			IL_0147: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
+			IL_014d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0152: ldc.i4.1
+			IL_0153: conv.r8
+			IL_0154: ldstr ""
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_015e: stloc.3
+			IL_015f: ldc.i4.2
+			IL_0160: newarr [System.Runtime]System.Object
+			IL_0165: dup
+			IL_0166: ldc.i4.0
+			IL_0167: ldarg.0
+			IL_0168: stelem.ref
+			IL_0169: dup
+			IL_016a: ldc.i4.1
+			IL_016b: ldloc.0
+			IL_016c: stelem.ref
+			IL_016d: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
+			IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0178: ldc.i4.2
+			IL_0179: conv.r8
+			IL_017a: ldstr ""
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0184: stloc.s 5
+			IL_0186: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_018b: dup
+			IL_018c: ldstr "filter"
+			IL_0191: ldloc.3
+			IL_0192: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0197: dup
+			IL_0198: ldstr "replacement"
+			IL_019d: ldloc.s 5
+			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01a4: stloc.s 4
+			IL_01a6: ldloc.1
+			IL_01a7: ldstr "addRule"
+			IL_01ac: ldstr "fencedCodeWithLanguage"
+			IL_01b1: ldloc.s 4
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01b8: pop
+			IL_01b9: ldloc.1
+			IL_01ba: ldstr "turndown"
+			IL_01bf: ldarg.2
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01c5: stloc.s 5
+			IL_01c7: ldloc.s 5
+			IL_01c9: stloc.2
+			IL_01ca: ldstr "\\n{4,}"
+			IL_01cf: ldstr "g"
+			IL_01d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01d9: stloc.s 6
+			IL_01db: ldloc.2
+			IL_01dc: ldstr "replace"
+			IL_01e1: ldloc.s 6
+			IL_01e3: ldstr "\n\n\n"
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01ed: stloc.s 5
+			IL_01ef: ldloc.s 5
+			IL_01f1: ldstr "trim"
+			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01fb: stloc.s 5
+			IL_01fd: ldloc.s 5
+			IL_01ff: ldstr "\n"
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0209: stloc.s 7
+			IL_020b: ldloc.s 7
+			IL_020d: ret
 		} // end of method convertHtmlToMarkdown::__js_call__
 
 	} // end of class convertHtmlToMarkdown
@@ -1476,7 +1474,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c3
+				// Method begins at RVA 0x3052
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1502,9 +1500,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x27a0
+			// Method begins at RVA 0x2798
 			// Header size: 12
-			// Code size: 705 (0x2c1)
+			// Code size: 633 (0x279)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1593,165 +1591,147 @@
 
 			IL_00ba: ldarg.0
 			IL_00bb: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_00c0: ldstr "Cannot access 'path' before initialization"
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00ca: stloc.s 5
-			IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_00d1: ldstr "cwd"
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00db: stloc.s 7
-			IL_00dd: ldloc.s 5
-			IL_00df: ldstr "resolve"
-			IL_00e4: ldloc.s 7
-			IL_00e6: ldloc.0
-			IL_00e7: ldstr "inFile"
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f6: stloc.s 7
-			IL_00f8: ldloc.s 7
-			IL_00fa: stloc.1
-			IL_00fb: ldarg.0
-			IL_00fc: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_0101: ldstr "Cannot access 'path' before initialization"
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_010b: stloc.s 7
-			IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0112: ldstr "cwd"
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_011c: stloc.s 5
-			IL_011e: ldloc.s 7
-			IL_0120: ldstr "resolve"
+			IL_00c0: stloc.s 5
+			IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00c7: ldstr "cwd"
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00d1: stloc.s 7
+			IL_00d3: ldloc.s 5
+			IL_00d5: ldstr "resolve"
+			IL_00da: ldloc.s 7
+			IL_00dc: ldloc.0
+			IL_00dd: ldstr "inFile"
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ec: stloc.s 7
+			IL_00ee: ldloc.s 7
+			IL_00f0: stloc.1
+			IL_00f1: ldarg.0
+			IL_00f2: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_00f7: stloc.s 7
+			IL_00f9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00fe: ldstr "cwd"
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0108: stloc.s 5
+			IL_010a: ldloc.s 7
+			IL_010c: ldstr "resolve"
+			IL_0111: ldloc.s 5
+			IL_0113: ldloc.0
+			IL_0114: ldstr "outFile"
+			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0123: stloc.s 5
 			IL_0125: ldloc.s 5
-			IL_0127: ldloc.0
-			IL_0128: ldstr "outFile"
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0137: stloc.s 5
-			IL_0139: ldloc.s 5
-			IL_013b: stloc.2
-			IL_013c: ldarg.0
-			IL_013d: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_0142: ldstr "Cannot access 'fs' before initialization"
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_014c: stloc.s 5
-			IL_014e: ldloc.s 5
-			IL_0150: ldstr "readFileSync"
-			IL_0155: ldloc.1
-			IL_0156: ldstr "utf8"
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0160: stloc.s 5
-			IL_0162: ldloc.s 5
-			IL_0164: stloc.3
-			IL_0165: ldc.i4.1
-			IL_0166: newarr [System.Runtime]System.Object
-			IL_016b: dup
-			IL_016c: ldc.i4.0
-			IL_016d: ldarg.0
-			IL_016e: stelem.ref
-			IL_016f: ldc.i4.0
-			IL_0170: ldelem.ref
-			IL_0171: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-			IL_0176: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-			IL_017c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0181: ldnull
-			IL_0182: ldloc.3
-			IL_0183: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0188: stloc.s 5
-			IL_018a: ldloc.s 5
-			IL_018c: stloc.s 4
-			IL_018e: ldarg.0
-			IL_018f: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_0194: ldstr "Cannot access 'fs' before initialization"
-			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_019e: stloc.s 5
-			IL_01a0: ldarg.0
-			IL_01a1: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_01a6: ldstr "Cannot access 'path' before initialization"
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01b0: stloc.s 7
-			IL_01b2: ldloc.s 7
-			IL_01b4: ldstr "dirname"
-			IL_01b9: ldloc.2
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01bf: stloc.s 7
-			IL_01c1: ldloc.s 5
-			IL_01c3: ldstr "mkdirSync"
-			IL_01c8: ldloc.s 7
-			IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01cf: dup
-			IL_01d0: ldstr "recursive"
-			IL_01d5: ldc.i4.1
-			IL_01d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01e0: pop
-			IL_01e1: ldarg.0
-			IL_01e2: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_01e7: ldstr "Cannot access 'fs' before initialization"
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01f1: stloc.s 7
-			IL_01f3: ldloc.s 7
-			IL_01f5: ldstr "writeFileSync"
-			IL_01fa: ldloc.2
-			IL_01fb: ldloc.s 4
-			IL_01fd: ldstr "utf8"
-			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0207: pop
-			IL_0208: ldloc.0
-			IL_0209: ldstr "inFile"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0213: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0218: stloc.s 8
-			IL_021a: ldstr "Converted "
-			IL_021f: ldloc.s 8
-			IL_0221: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0226: stloc.s 8
-			IL_0228: ldloc.s 8
-			IL_022a: ldstr " -> "
-			IL_022f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0234: stloc.s 8
-			IL_0236: ldloc.0
-			IL_0237: ldstr "outFile"
-			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0241: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0246: stloc.s 9
-			IL_0248: ldloc.s 8
-			IL_024a: ldloc.s 9
-			IL_024c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0251: stloc.s 9
-			IL_0253: ldloc.s 9
-			IL_0255: ldstr " ("
-			IL_025a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_025f: stloc.s 9
-			IL_0261: ldstr "\\n"
-			IL_0266: ldstr ""
-			IL_026b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0270: stloc.s 10
-			IL_0272: ldloc.s 4
-			IL_0274: ldstr "split"
-			IL_0279: ldloc.s 10
-			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0280: stloc.s 7
-			IL_0282: ldloc.s 7
-			IL_0284: ldstr "length"
-			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028e: stloc.s 7
-			IL_0290: ldloc.s 7
-			IL_0292: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0297: stloc.s 8
-			IL_0299: ldloc.s 9
-			IL_029b: ldloc.s 8
-			IL_029d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02a2: stloc.s 8
-			IL_02a4: ldloc.s 8
-			IL_02a6: ldstr " lines)"
-			IL_02ab: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02b0: stloc.s 8
-			IL_02b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02b7: ldloc.s 8
-			IL_02b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02be: pop
-			IL_02bf: ldnull
-			IL_02c0: ret
+			IL_0127: stloc.2
+			IL_0128: ldarg.0
+			IL_0129: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_012e: ldstr "readFileSync"
+			IL_0133: ldloc.1
+			IL_0134: ldstr "utf8"
+			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_013e: stloc.s 5
+			IL_0140: ldloc.s 5
+			IL_0142: stloc.3
+			IL_0143: ldc.i4.1
+			IL_0144: newarr [System.Runtime]System.Object
+			IL_0149: dup
+			IL_014a: ldc.i4.0
+			IL_014b: ldarg.0
+			IL_014c: stelem.ref
+			IL_014d: ldc.i4.0
+			IL_014e: ldelem.ref
+			IL_014f: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
+			IL_0154: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+			IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_015f: ldnull
+			IL_0160: ldloc.3
+			IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0166: stloc.s 5
+			IL_0168: ldloc.s 5
+			IL_016a: stloc.s 4
+			IL_016c: ldarg.0
+			IL_016d: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_0172: stloc.s 5
+			IL_0174: ldarg.0
+			IL_0175: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_017a: ldstr "dirname"
+			IL_017f: ldloc.2
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0185: stloc.s 7
+			IL_0187: ldloc.s 5
+			IL_0189: ldstr "mkdirSync"
+			IL_018e: ldloc.s 7
+			IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0195: dup
+			IL_0196: ldstr "recursive"
+			IL_019b: ldc.i4.1
+			IL_019c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01a6: pop
+			IL_01a7: ldarg.0
+			IL_01a8: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_01ad: ldstr "writeFileSync"
+			IL_01b2: ldloc.2
+			IL_01b3: ldloc.s 4
+			IL_01b5: ldstr "utf8"
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01bf: pop
+			IL_01c0: ldloc.0
+			IL_01c1: ldstr "inFile"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d0: stloc.s 8
+			IL_01d2: ldstr "Converted "
+			IL_01d7: ldloc.s 8
+			IL_01d9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01de: stloc.s 8
+			IL_01e0: ldloc.s 8
+			IL_01e2: ldstr " -> "
+			IL_01e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ec: stloc.s 8
+			IL_01ee: ldloc.0
+			IL_01ef: ldstr "outFile"
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01fe: stloc.s 9
+			IL_0200: ldloc.s 8
+			IL_0202: ldloc.s 9
+			IL_0204: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0209: stloc.s 9
+			IL_020b: ldloc.s 9
+			IL_020d: ldstr " ("
+			IL_0212: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0217: stloc.s 9
+			IL_0219: ldstr "\\n"
+			IL_021e: ldstr ""
+			IL_0223: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0228: stloc.s 10
+			IL_022a: ldloc.s 4
+			IL_022c: ldstr "split"
+			IL_0231: ldloc.s 10
+			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0238: stloc.s 7
+			IL_023a: ldloc.s 7
+			IL_023c: ldstr "length"
+			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0246: stloc.s 7
+			IL_0248: ldloc.s 7
+			IL_024a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_024f: stloc.s 8
+			IL_0251: ldloc.s 9
+			IL_0253: ldloc.s 8
+			IL_0255: call string [System.Runtime]System.String::Concat(string, string)
+			IL_025a: stloc.s 8
+			IL_025c: ldloc.s 8
+			IL_025e: ldstr " lines)"
+			IL_0263: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0268: stloc.s 8
+			IL_026a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_026f: ldloc.s 8
+			IL_0271: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0276: pop
+			IL_0277: ldnull
+			IL_0278: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1783,7 +1763,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30d5
+					// Method begins at RVA 0x3064
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1803,7 +1783,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30de
+					// Method begins at RVA 0x306d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1821,7 +1801,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30cc
+				// Method begins at RVA 0x305b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1847,24 +1827,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x301b
+			// Method begins at RVA 0x2fcb
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::TurndownService
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -2109,7 +2080,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30f0
+				// Method begins at RVA 0x307f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2132,7 +2103,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fe5
+			// Method begins at RVA 0x2f95
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2161,7 +2132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30f9
+				// Method begins at RVA 0x3088
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2186,7 +2157,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fe8
+			// Method begins at RVA 0x2f98
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2215,7 +2186,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3102
+				// Method begins at RVA 0x3091
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2239,7 +2210,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fec
+			// Method begins at RVA 0x2f9c
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -2287,7 +2258,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x30e7
+			// Method begins at RVA 0x3076
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2383,7 +2354,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x310b
+		// Method begins at RVA 0x309a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c8
+				// Method begins at RVA 0x2f6f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -123,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30d1
+				// Method begins at RVA 0x2f78
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -152,7 +152,7 @@
 			)
 			// Method begins at RVA 0x22e4
 			// Header size: 12
-			// Code size: 190 (0xbe)
+			// Code size: 158 (0x9e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -164,72 +164,64 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
-			IL_0006: ldstr "Cannot access 'os' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0006: ldstr "tmpdir"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0010: stloc.1
 			IL_0011: ldloc.1
-			IL_0012: ldstr "tmpdir"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_001c: stloc.1
-			IL_001d: ldloc.1
-			IL_001e: stloc.0
-			IL_001f: ldarg.0
-			IL_0020: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0025: ldstr "Cannot access 'path' before initialization"
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_002f: stloc.1
-			IL_0030: ldarg.2
-			IL_0031: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0036: stloc.2
-			IL_0037: ldstr ""
-			IL_003c: ldloc.2
-			IL_003d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0042: stloc.2
-			IL_0043: ldloc.2
-			IL_0044: ldstr ".GeneratorTests"
-			IL_0049: call string [System.Runtime]System.String::Concat(string, string)
-			IL_004e: stloc.2
-			IL_004f: ldloc.1
-			IL_0050: ldstr "join"
-			IL_0055: ldloc.0
-			IL_0056: ldstr "Js2IL.Tests"
-			IL_005b: ldloc.2
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0061: stloc.1
-			IL_0062: ldarg.0
-			IL_0063: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0068: ldstr "Cannot access 'path' before initialization"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0072: stloc.3
-			IL_0073: ldarg.2
-			IL_0074: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0079: stloc.2
-			IL_007a: ldstr ""
-			IL_007f: ldloc.2
-			IL_0080: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0085: stloc.2
-			IL_0086: ldloc.2
-			IL_0087: ldstr ".ExecutionTests"
-			IL_008c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0091: stloc.2
-			IL_0092: ldloc.3
-			IL_0093: ldstr "join"
-			IL_0098: ldloc.0
-			IL_0099: ldstr "Js2IL.Tests"
-			IL_009e: ldloc.2
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_00a4: stloc.3
-			IL_00a5: ldc.i4.2
-			IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00ab: dup
-			IL_00ac: ldloc.1
-			IL_00ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b2: dup
-			IL_00b3: ldloc.3
-			IL_00b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b9: stloc.s 4
-			IL_00bb: ldloc.s 4
-			IL_00bd: ret
+			IL_0012: stloc.0
+			IL_0013: ldarg.0
+			IL_0014: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_0019: stloc.1
+			IL_001a: ldarg.2
+			IL_001b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0020: stloc.2
+			IL_0021: ldstr ""
+			IL_0026: ldloc.2
+			IL_0027: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002c: stloc.2
+			IL_002d: ldloc.2
+			IL_002e: ldstr ".GeneratorTests"
+			IL_0033: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0038: stloc.2
+			IL_0039: ldloc.1
+			IL_003a: ldstr "join"
+			IL_003f: ldloc.0
+			IL_0040: ldstr "Js2IL.Tests"
+			IL_0045: ldloc.2
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_004b: stloc.1
+			IL_004c: ldarg.0
+			IL_004d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_0052: stloc.3
+			IL_0053: ldarg.2
+			IL_0054: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0059: stloc.2
+			IL_005a: ldstr ""
+			IL_005f: ldloc.2
+			IL_0060: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0065: stloc.2
+			IL_0066: ldloc.2
+			IL_0067: ldstr ".ExecutionTests"
+			IL_006c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0071: stloc.2
+			IL_0072: ldloc.3
+			IL_0073: ldstr "join"
+			IL_0078: ldloc.0
+			IL_0079: ldstr "Js2IL.Tests"
+			IL_007e: ldloc.2
+			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0084: stloc.3
+			IL_0085: ldc.i4.2
+			IL_0086: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_008b: dup
+			IL_008c: ldloc.1
+			IL_008d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0092: dup
+			IL_0093: ldloc.3
+			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0099: stloc.s 4
+			IL_009b: ldloc.s 4
+			IL_009d: ret
 		} // end of method getCandidateCategoryRoots::__js_call__
 
 	} // end of class getCandidateCategoryRoots
@@ -255,7 +247,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30ec
+					// Method begins at RVA 0x2f93
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -279,7 +271,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3020
+				// Method begins at RVA 0x2f08
 				// Header size: 12
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30f5
+					// Method begins at RVA 0x2f9c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -339,9 +331,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x303c
+				// Method begins at RVA 0x2f24
 				// Header size: 12
-				// Code size: 64 (0x40)
+				// Code size: 54 (0x36)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -353,25 +345,23 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
 				IL_0008: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_000d: ldstr "Cannot access 'path' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.1
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope
-				IL_0020: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-				IL_0025: stloc.1
-				IL_0026: ldloc.0
-				IL_0027: ldstr "join"
-				IL_002c: ldloc.1
-				IL_002d: ldarg.2
-				IL_002e: ldstr "name"
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_003d: stloc.1
-				IL_003e: ldloc.1
-				IL_003f: ret
+				IL_000d: stloc.0
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope
+				IL_0016: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+				IL_001b: stloc.1
+				IL_001c: ldloc.0
+				IL_001d: ldstr "join"
+				IL_0022: ldloc.1
+				IL_0023: ldarg.2
+				IL_0024: ldstr "name"
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0033: stloc.1
+				IL_0034: ldloc.1
+				IL_0035: ret
 			} // end of method ArrowFunction_L48C10::__js_call__
 
 		} // end of class ArrowFunction_L48C10
@@ -392,7 +382,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30e3
+					// Method begins at RVA 0x2f8a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -413,7 +403,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30da
+				// Method begins at RVA 0x2f81
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -441,7 +431,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3110
+						// Method begins at RVA 0x2fb7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -459,7 +449,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3107
+					// Method begins at RVA 0x2fae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -477,7 +467,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30fe
+				// Method begins at RVA 0x2fa5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -505,9 +495,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x23b0
+			// Method begins at RVA 0x2390
 			// Header size: 12
-			// Code size: 609 (0x261)
+			// Code size: 543 (0x21f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope,
@@ -537,226 +527,208 @@
 			IL_0008: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
 			IL_000d: ldarg.0
 			IL_000e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_0013: ldstr "Cannot access 'fs' before initialization"
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001d: stloc.s 13
-			IL_001f: ldloc.s 13
-			IL_0021: ldstr "existsSync"
-			IL_0026: ldloc.0
-			IL_0027: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0031: stloc.s 13
-			IL_0033: ldloc.s 13
-			IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_003a: ldc.i4.0
-			IL_003b: ceq
-			IL_003d: stloc.s 14
-			IL_003f: ldloc.s 14
-			IL_0041: brfalse IL_0053
+			IL_0013: ldstr "existsSync"
+			IL_0018: ldloc.0
+			IL_0019: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0023: stloc.s 13
+			IL_0025: ldloc.s 13
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_002c: ldc.i4.0
+			IL_002d: ceq
+			IL_002f: stloc.s 14
+			IL_0031: ldloc.s 14
+			IL_0033: brfalse IL_0045
 
-			IL_0046: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope/Block_L41C36::.ctor()
-			IL_004b: stloc.1
-			IL_004c: ldc.i4.0
-			IL_004d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0052: ret
+			IL_0038: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope/Block_L41C36::.ctor()
+			IL_003d: stloc.1
+			IL_003e: ldc.i4.0
+			IL_003f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0044: ret
 
-			IL_0053: ldarg.0
-			IL_0054: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_0059: ldstr "Cannot access 'fs' before initialization"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0063: stloc.s 13
-			IL_0065: ldloc.0
-			IL_0066: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-			IL_006b: stloc.s 15
-			IL_006d: ldloc.s 13
-			IL_006f: ldstr "readdirSync"
-			IL_0074: ldloc.s 15
-			IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_007b: dup
-			IL_007c: ldstr "withFileTypes"
-			IL_0081: ldc.i4.1
-			IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_008c: stloc.s 15
-			IL_008e: ldnull
-			IL_008f: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L47C13::__js_call__(object, object)
-			IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_009a: ldc.i4.1
-			IL_009b: newarr [System.Runtime]System.Object
-			IL_00a0: dup
-			IL_00a1: ldc.i4.0
-			IL_00a2: ldarg.0
-			IL_00a3: stelem.ref
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00ae: ldc.i4.1
-			IL_00af: conv.r8
-			IL_00b0: ldstr ""
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00ba: stloc.s 13
-			IL_00bc: ldloc.s 15
-			IL_00be: ldstr "filter"
-			IL_00c3: ldloc.s 13
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ca: stloc.s 13
-			IL_00cc: ldnull
-			IL_00cd: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L48C10::__js_call__(object[], object, object)
-			IL_00d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00d8: ldc.i4.2
-			IL_00d9: newarr [System.Runtime]System.Object
-			IL_00de: dup
-			IL_00df: ldc.i4.0
-			IL_00e0: ldarg.0
-			IL_00e1: stelem.ref
-			IL_00e2: dup
-			IL_00e3: ldc.i4.1
-			IL_00e4: ldloc.0
-			IL_00e5: stelem.ref
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00f0: ldc.i4.1
-			IL_00f1: conv.r8
-			IL_00f2: ldstr ""
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00fc: stloc.s 15
-			IL_00fe: ldloc.s 13
-			IL_0100: ldstr "map"
-			IL_0105: ldloc.s 15
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_010c: stloc.s 15
-			IL_010e: ldloc.s 15
-			IL_0110: stloc.2
-			IL_0111: ldc.i4.0
-			IL_0112: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0117: stloc.3
-			IL_0118: ldc.r8 1
-			IL_0121: neg
-			IL_0122: box [System.Runtime]System.Double
-			IL_0127: stloc.s 4
-			IL_0129: ldloc.2
-			IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_012f: stloc.s 5
-			IL_0131: ldc.i4.0
-			IL_0132: stloc.s 6
-			IL_0134: ldc.i4.0
-			IL_0135: stloc.s 7
+			IL_0045: ldarg.0
+			IL_0046: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_004b: stloc.s 13
+			IL_004d: ldloc.0
+			IL_004e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+			IL_0053: stloc.s 15
+			IL_0055: ldloc.s 13
+			IL_0057: ldstr "readdirSync"
+			IL_005c: ldloc.s 15
+			IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0063: dup
+			IL_0064: ldstr "withFileTypes"
+			IL_0069: ldc.i4.1
+			IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0074: stloc.s 15
+			IL_0076: ldnull
+			IL_0077: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L47C13::__js_call__(object, object)
+			IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0082: ldc.i4.1
+			IL_0083: newarr [System.Runtime]System.Object
+			IL_0088: dup
+			IL_0089: ldc.i4.0
+			IL_008a: ldarg.0
+			IL_008b: stelem.ref
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0096: ldc.i4.1
+			IL_0097: conv.r8
+			IL_0098: ldstr ""
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00a2: stloc.s 13
+			IL_00a4: ldloc.s 15
+			IL_00a6: ldstr "filter"
+			IL_00ab: ldloc.s 13
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b2: stloc.s 13
+			IL_00b4: ldnull
+			IL_00b5: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L48C10::__js_call__(object[], object, object)
+			IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00c0: ldc.i4.2
+			IL_00c1: newarr [System.Runtime]System.Object
+			IL_00c6: dup
+			IL_00c7: ldc.i4.0
+			IL_00c8: ldarg.0
+			IL_00c9: stelem.ref
+			IL_00ca: dup
+			IL_00cb: ldc.i4.1
+			IL_00cc: ldloc.0
+			IL_00cd: stelem.ref
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00d8: ldc.i4.1
+			IL_00d9: conv.r8
+			IL_00da: ldstr ""
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00e4: stloc.s 15
+			IL_00e6: ldloc.s 13
+			IL_00e8: ldstr "map"
+			IL_00ed: ldloc.s 15
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f4: stloc.s 15
+			IL_00f6: ldloc.s 15
+			IL_00f8: stloc.2
+			IL_00f9: ldc.i4.0
+			IL_00fa: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00ff: stloc.3
+			IL_0100: ldc.r8 1
+			IL_0109: neg
+			IL_010a: box [System.Runtime]System.Double
+			IL_010f: stloc.s 4
+			IL_0111: ldloc.2
+			IL_0112: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0117: stloc.s 5
+			IL_0119: ldc.i4.0
+			IL_011a: stloc.s 6
+			IL_011c: ldc.i4.0
+			IL_011d: stloc.s 7
 			.try
 			{
-				// loop start (head: IL_0137)
-					IL_0137: ldloc.s 5
-					IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_013e: stloc.s 15
-					IL_0140: ldloc.s 15
-					IL_0142: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0147: stloc.s 14
-					IL_0149: ldloc.s 14
-					IL_014b: brtrue IL_0241
+				// loop start (head: IL_011f)
+					IL_011f: ldloc.s 5
+					IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_0126: stloc.s 15
+					IL_0128: ldloc.s 15
+					IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_012f: stloc.s 14
+					IL_0131: ldloc.s 14
+					IL_0133: brtrue IL_01ff
 
-					IL_0150: ldloc.s 15
-					IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0157: stloc.s 15
-					IL_0159: ldloc.s 15
-					IL_015b: stloc.s 8
-					IL_015d: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32::.ctor()
-					IL_0162: stloc.s 9
-					IL_0164: ldarg.0
-					IL_0165: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-					IL_016a: ldstr "Cannot access 'path' before initialization"
-					IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0174: stloc.s 15
-					IL_0176: ldloc.s 15
-					IL_0178: ldstr "join"
-					IL_017d: ldloc.s 8
-					IL_017f: ldarg.3
-					IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0185: stloc.s 15
-					IL_0187: ldloc.s 15
-					IL_0189: stloc.s 10
-					IL_018b: ldarg.0
-					IL_018c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_0191: ldstr "Cannot access 'fs' before initialization"
-					IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_019b: stloc.s 15
-					IL_019d: ldloc.s 15
-					IL_019f: ldstr "existsSync"
-					IL_01a4: ldloc.s 10
-					IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_01ab: stloc.s 15
-					IL_01ad: ldloc.s 15
-					IL_01af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_01b4: ldc.i4.0
-					IL_01b5: ceq
-					IL_01b7: stloc.s 14
-					IL_01b9: ldloc.s 14
-					IL_01bb: brfalse IL_01c5
+					IL_0138: ldloc.s 15
+					IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_013f: stloc.s 15
+					IL_0141: ldloc.s 15
+					IL_0143: stloc.s 8
+					IL_0145: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32::.ctor()
+					IL_014a: stloc.s 9
+					IL_014c: ldarg.0
+					IL_014d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+					IL_0152: ldstr "join"
+					IL_0157: ldloc.s 8
+					IL_0159: ldarg.3
+					IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_015f: stloc.s 15
+					IL_0161: ldloc.s 15
+					IL_0163: stloc.s 10
+					IL_0165: ldarg.0
+					IL_0166: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_016b: ldstr "existsSync"
+					IL_0170: ldloc.s 10
+					IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0177: stloc.s 15
+					IL_0179: ldloc.s 15
+					IL_017b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0180: ldc.i4.0
+					IL_0181: ceq
+					IL_0183: stloc.s 14
+					IL_0185: ldloc.s 14
+					IL_0187: brfalse IL_0191
 
-					IL_01c0: br IL_022d
+					IL_018c: br IL_01eb
 
-					IL_01c5: ldarg.0
-					IL_01c6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_01cb: ldstr "Cannot access 'fs' before initialization"
-					IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_01d5: stloc.s 15
-					IL_01d7: ldloc.s 15
-					IL_01d9: ldstr "statSync"
-					IL_01de: ldloc.s 10
-					IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_01e5: stloc.s 15
-					IL_01e7: ldloc.s 15
-					IL_01e9: stloc.s 11
-					IL_01eb: ldloc.s 11
-					IL_01ed: ldstr "mtimeMs"
-					IL_01f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-					IL_01f7: stloc.s 16
-					IL_01f9: ldloc.s 4
-					IL_01fb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0200: stloc.s 17
-					IL_0202: ldloc.s 16
-					IL_0204: ldloc.s 17
-					IL_0206: cgt
-					IL_0208: brfalse IL_022d
+					IL_0191: ldarg.0
+					IL_0192: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_0197: ldstr "statSync"
+					IL_019c: ldloc.s 10
+					IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_01a3: stloc.s 15
+					IL_01a5: ldloc.s 15
+					IL_01a7: stloc.s 11
+					IL_01a9: ldloc.s 11
+					IL_01ab: ldstr "mtimeMs"
+					IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+					IL_01b5: stloc.s 16
+					IL_01b7: ldloc.s 4
+					IL_01b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01be: stloc.s 17
+					IL_01c0: ldloc.s 16
+					IL_01c2: ldloc.s 17
+					IL_01c4: cgt
+					IL_01c6: brfalse IL_01eb
 
-					IL_020d: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32/Block_L57C34::.ctor()
-					IL_0212: stloc.s 12
-					IL_0214: ldloc.s 11
-					IL_0216: ldstr "mtimeMs"
-					IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0220: stloc.s 15
-					IL_0222: ldloc.s 15
-					IL_0224: stloc.s 4
-					IL_0226: ldloc.s 10
-					IL_0228: stloc.s 15
-					IL_022a: ldloc.s 15
-					IL_022c: stloc.3
+					IL_01cb: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32/Block_L57C34::.ctor()
+					IL_01d0: stloc.s 12
+					IL_01d2: ldloc.s 11
+					IL_01d4: ldstr "mtimeMs"
+					IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01de: stloc.s 15
+					IL_01e0: ldloc.s 15
+					IL_01e2: stloc.s 4
+					IL_01e4: ldloc.s 10
+					IL_01e6: stloc.s 15
+					IL_01e8: ldloc.s 15
+					IL_01ea: stloc.3
 
-					IL_022d: br IL_0137
+					IL_01eb: br IL_011f
 				// end loop
-				IL_0232: ldloc.s 5
-				IL_0234: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0239: ldc.i4.1
-				IL_023a: stloc.s 7
-				IL_023c: leave IL_025f
+				IL_01f0: ldloc.s 5
+				IL_01f2: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_01f7: ldc.i4.1
+				IL_01f8: stloc.s 7
+				IL_01fa: leave IL_021d
 
-				IL_0241: ldc.i4.1
-				IL_0242: stloc.s 6
-				IL_0244: leave IL_025f
+				IL_01ff: ldc.i4.1
+				IL_0200: stloc.s 6
+				IL_0202: leave IL_021d
 			} // end .try
 			finally
 			{
-				IL_0249: ldloc.s 6
-				IL_024b: brtrue IL_025e
+				IL_0207: ldloc.s 6
+				IL_0209: brtrue IL_021c
 
-				IL_0250: ldloc.s 7
-				IL_0252: brtrue IL_025e
+				IL_020e: ldloc.s 7
+				IL_0210: brtrue IL_021c
 
-				IL_0257: ldloc.s 5
-				IL_0259: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0215: ldloc.s 5
+				IL_0217: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
 
-				IL_025e: endfinally
+				IL_021c: endfinally
 			} // end handler
 
-			IL_025f: ldloc.3
-			IL_0260: ret
+			IL_021d: ldloc.3
+			IL_021e: ret
 		} // end of method tryFindLatestGeneratedAssemblyInRoot::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssemblyInRoot
@@ -776,7 +748,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3122
+					// Method begins at RVA 0x2fc9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -794,7 +766,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3119
+				// Method begins at RVA 0x2fc0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -822,7 +794,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x263c
+			// Method begins at RVA 0x25cc
 			// Header size: 12
 			// Code size: 252 (0xfc)
 			.maxstack 8
@@ -955,7 +927,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x313d
+						// Method begins at RVA 0x2fe4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -973,7 +945,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3134
+					// Method begins at RVA 0x2fdb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -991,7 +963,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x312b
+				// Method begins at RVA 0x2fd2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1018,9 +990,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2744
+			// Method begins at RVA 0x26d4
 			// Header size: 12
-			// Code size: 417 (0x1a1)
+			// Code size: 347 (0x15b)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1044,160 +1016,140 @@
 			IL_0001: stloc.0
 			// loop start (head: IL_0002)
 				IL_0002: ldc.i4.1
-				IL_0003: brfalse IL_0168
+				IL_0003: brfalse IL_0122
 
 				IL_0008: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/Scope/Block_L80C15::.ctor()
 				IL_000d: stloc.1
 				IL_000e: ldarg.0
 				IL_000f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_0014: ldstr "Cannot access 'path' before initialization"
-				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001e: stloc.s 6
-				IL_0020: ldloc.s 6
-				IL_0022: ldstr "join"
-				IL_0027: ldloc.0
-				IL_0028: ldstr "js2il.sln"
-				IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0032: stloc.s 6
-				IL_0034: ldloc.s 6
-				IL_0036: stloc.2
-				IL_0037: ldarg.0
-				IL_0038: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_003d: ldstr "Cannot access 'path' before initialization"
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0047: stloc.s 6
-				IL_0049: ldloc.s 6
-				IL_004b: ldstr "join"
-				IL_0050: ldloc.0
-				IL_0051: ldstr "tests"
-				IL_0056: ldstr "Js2IL.Tests"
-				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_0060: stloc.s 6
-				IL_0062: ldloc.s 6
-				IL_0064: stloc.3
-				IL_0065: ldarg.0
-				IL_0066: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-				IL_006b: ldstr "Cannot access 'fs' before initialization"
-				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0075: stloc.s 6
-				IL_0077: ldloc.s 6
-				IL_0079: ldstr "existsSync"
-				IL_007e: ldloc.2
-				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0084: stloc.s 6
-				IL_0086: ldloc.s 6
-				IL_0088: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_008d: stloc.s 7
-				IL_008f: ldloc.s 7
-				IL_0091: brfalse IL_00c0
+				IL_0014: ldstr "join"
+				IL_0019: ldloc.0
+				IL_001a: ldstr "js2il.sln"
+				IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0024: stloc.s 6
+				IL_0026: ldloc.s 6
+				IL_0028: stloc.2
+				IL_0029: ldarg.0
+				IL_002a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_002f: ldstr "join"
+				IL_0034: ldloc.0
+				IL_0035: ldstr "tests"
+				IL_003a: ldstr "Js2IL.Tests"
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0044: stloc.s 6
+				IL_0046: ldloc.s 6
+				IL_0048: stloc.3
+				IL_0049: ldarg.0
+				IL_004a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+				IL_004f: ldstr "existsSync"
+				IL_0054: ldloc.2
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005a: stloc.s 6
+				IL_005c: ldloc.s 6
+				IL_005e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0063: stloc.s 7
+				IL_0065: ldloc.s 7
+				IL_0067: brfalse IL_0088
 
-				IL_0096: ldarg.0
-				IL_0097: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-				IL_009c: ldstr "Cannot access 'fs' before initialization"
-				IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00a6: stloc.s 8
-				IL_00a8: ldloc.s 8
-				IL_00aa: ldstr "existsSync"
-				IL_00af: ldloc.3
-				IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00b5: stloc.s 8
-				IL_00b7: ldloc.s 8
-				IL_00b9: stloc.s 10
-				IL_00bb: br IL_00c4
+				IL_006c: ldarg.0
+				IL_006d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+				IL_0072: ldstr "existsSync"
+				IL_0077: ldloc.3
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_007d: stloc.s 8
+				IL_007f: ldloc.s 8
+				IL_0081: stloc.s 10
+				IL_0083: br IL_008c
 
-				IL_00c0: ldloc.s 6
-				IL_00c2: stloc.s 10
+				IL_0088: ldloc.s 6
+				IL_008a: stloc.s 10
 
-				IL_00c4: ldloc.s 10
-				IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00cb: stloc.s 7
-				IL_00cd: ldloc.s 7
-				IL_00cf: brfalse IL_00dd
+				IL_008c: ldloc.s 10
+				IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0093: stloc.s 7
+				IL_0095: ldloc.s 7
+				IL_0097: brfalse IL_00a5
 
-				IL_00d4: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/Scope/Block_L80C15/Block_L83C55::.ctor()
-				IL_00d9: stloc.s 4
-				IL_00db: ldloc.0
-				IL_00dc: ret
+				IL_009c: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/Scope/Block_L80C15/Block_L83C55::.ctor()
+				IL_00a1: stloc.s 4
+				IL_00a3: ldloc.0
+				IL_00a4: ret
 
-				IL_00dd: ldarg.0
-				IL_00de: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_00e3: ldstr "Cannot access 'path' before initialization"
-				IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00ed: stloc.s 6
-				IL_00ef: ldloc.s 6
-				IL_00f1: ldstr "dirname"
-				IL_00f6: ldloc.0
-				IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00fc: stloc.s 6
-				IL_00fe: ldloc.s 6
-				IL_0100: stloc.s 5
-				IL_0102: ldloc.s 5
-				IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0109: ldc.i4.0
-				IL_010a: ceq
-				IL_010c: stloc.s 7
-				IL_010e: ldloc.s 7
-				IL_0110: box [System.Runtime]System.Boolean
-				IL_0115: stloc.s 11
-				IL_0117: ldloc.s 11
-				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_011e: stloc.s 7
-				IL_0120: ldloc.s 7
-				IL_0122: brtrue IL_0143
+				IL_00a5: ldarg.0
+				IL_00a6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_00ab: ldstr "dirname"
+				IL_00b0: ldloc.0
+				IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00b6: stloc.s 6
+				IL_00b8: ldloc.s 6
+				IL_00ba: stloc.s 5
+				IL_00bc: ldloc.s 5
+				IL_00be: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00c3: ldc.i4.0
+				IL_00c4: ceq
+				IL_00c6: stloc.s 7
+				IL_00c8: ldloc.s 7
+				IL_00ca: box [System.Runtime]System.Boolean
+				IL_00cf: stloc.s 11
+				IL_00d1: ldloc.s 11
+				IL_00d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00d8: stloc.s 7
+				IL_00da: ldloc.s 7
+				IL_00dc: brtrue IL_00fd
 
-				IL_0127: ldloc.s 5
-				IL_0129: ldloc.0
-				IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_012f: stloc.s 7
-				IL_0131: ldloc.s 7
-				IL_0133: box [System.Runtime]System.Boolean
-				IL_0138: stloc.s 12
-				IL_013a: ldloc.s 12
-				IL_013c: stloc.s 13
-				IL_013e: br IL_0147
+				IL_00e1: ldloc.s 5
+				IL_00e3: ldloc.0
+				IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00e9: stloc.s 7
+				IL_00eb: ldloc.s 7
+				IL_00ed: box [System.Runtime]System.Boolean
+				IL_00f2: stloc.s 12
+				IL_00f4: ldloc.s 12
+				IL_00f6: stloc.s 13
+				IL_00f8: br IL_0101
 
-				IL_0143: ldloc.s 11
-				IL_0145: stloc.s 13
+				IL_00fd: ldloc.s 11
+				IL_00ff: stloc.s 13
 
-				IL_0147: ldloc.s 13
-				IL_0149: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_014e: stloc.s 7
-				IL_0150: ldloc.s 7
-				IL_0152: brfalse IL_015c
+				IL_0101: ldloc.s 13
+				IL_0103: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0108: stloc.s 7
+				IL_010a: ldloc.s 7
+				IL_010c: brfalse IL_0116
 
-				IL_0157: br IL_0168
+				IL_0111: br IL_0122
 
-				IL_015c: ldloc.s 5
-				IL_015e: stloc.s 6
-				IL_0160: ldloc.s 6
-				IL_0162: stloc.0
-				IL_0163: br IL_0002
+				IL_0116: ldloc.s 5
+				IL_0118: stloc.s 6
+				IL_011a: ldloc.s 6
+				IL_011c: stloc.0
+				IL_011d: br IL_0002
 			// end loop
 
-			IL_0168: ldarg.2
-			IL_0169: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_016e: stloc.s 14
-			IL_0170: ldstr "Could not locate js2il repo root starting from: "
-			IL_0175: ldloc.s 14
-			IL_0177: call string [System.Runtime]System.String::Concat(string, string)
-			IL_017c: stloc.s 14
-			IL_017e: ldloc.s 14
-			IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0185: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_018a: dup
-			IL_018b: isinst [System.Runtime]System.Exception
-			IL_0190: dup
-			IL_0191: brtrue IL_019d
+			IL_0122: ldarg.2
+			IL_0123: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0128: stloc.s 14
+			IL_012a: ldstr "Could not locate js2il repo root starting from: "
+			IL_012f: ldloc.s 14
+			IL_0131: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0136: stloc.s 14
+			IL_0138: ldloc.s 14
+			IL_013a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0144: dup
+			IL_0145: isinst [System.Runtime]System.Exception
+			IL_014a: dup
+			IL_014b: brtrue IL_0157
 
-			IL_0196: pop
-			IL_0197: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_019c: throw
+			IL_0150: pop
+			IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0156: throw
 
-			IL_019d: pop
-			IL_019e: throw
+			IL_0157: pop
+			IL_0158: throw
 
-			IL_019f: ldnull
-			IL_01a0: ret
+			IL_0159: ldnull
+			IL_015a: ret
 		} // end of method findProjectRoot::__js_call__
 
 	} // end of class findProjectRoot
@@ -1213,7 +1165,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3146
+				// Method begins at RVA 0x2fed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1240,9 +1192,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x28f4
+			// Method begins at RVA 0x283c
 			// Header size: 12
-			// Code size: 142 (0x8e)
+			// Code size: 132 (0x84)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1254,52 +1206,50 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0006: ldstr "Cannot access 'childProcess' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.1
-			IL_0011: ldc.i4.1
-			IL_0012: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0017: dup
-			IL_0018: ldarg.2
-			IL_0019: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_001e: stloc.2
-			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0024: ldstr "cwd"
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_002e: stloc.3
-			IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0034: dup
-			IL_0035: ldstr "detached"
-			IL_003a: ldc.i4.1
-			IL_003b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0040: dup
-			IL_0041: ldstr "stdio"
-			IL_0046: ldstr "ignore"
-			IL_004b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0050: dup
-			IL_0051: ldstr "shell"
-			IL_0056: ldc.i4.1
-			IL_0057: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_005c: dup
-			IL_005d: ldstr "cwd"
-			IL_0062: ldloc.3
-			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0068: stloc.s 4
-			IL_006a: ldloc.1
-			IL_006b: ldstr "spawn"
-			IL_0070: ldstr "ilspy"
-			IL_0075: ldloc.2
-			IL_0076: ldloc.s 4
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_007d: stloc.1
-			IL_007e: ldloc.1
-			IL_007f: stloc.0
-			IL_0080: ldloc.0
-			IL_0081: ldstr "unref"
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_008b: pop
-			IL_008c: ldnull
-			IL_008d: ret
+			IL_0006: stloc.1
+			IL_0007: ldc.i4.1
+			IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_000d: dup
+			IL_000e: ldarg.2
+			IL_000f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0014: stloc.2
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_001a: ldstr "cwd"
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0024: stloc.3
+			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_002a: dup
+			IL_002b: ldstr "detached"
+			IL_0030: ldc.i4.1
+			IL_0031: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0036: dup
+			IL_0037: ldstr "stdio"
+			IL_003c: ldstr "ignore"
+			IL_0041: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0046: dup
+			IL_0047: ldstr "shell"
+			IL_004c: ldc.i4.1
+			IL_004d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0052: dup
+			IL_0053: ldstr "cwd"
+			IL_0058: ldloc.3
+			IL_0059: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005e: stloc.s 4
+			IL_0060: ldloc.1
+			IL_0061: ldstr "spawn"
+			IL_0066: ldstr "ilspy"
+			IL_006b: ldloc.2
+			IL_006c: ldloc.s 4
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0073: stloc.1
+			IL_0074: ldloc.1
+			IL_0075: stloc.0
+			IL_0076: ldloc.0
+			IL_0077: ldstr "unref"
+			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0081: pop
+			IL_0082: ldnull
+			IL_0083: ret
 		} // end of method openInIlSpy::__js_call__
 
 	} // end of class openInIlSpy
@@ -1319,7 +1269,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3158
+					// Method begins at RVA 0x2fff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1343,7 +1293,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x316a
+						// Method begins at RVA 0x3011
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1361,7 +1311,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3161
+					// Method begins at RVA 0x3008
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1381,7 +1331,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3173
+					// Method begins at RVA 0x301a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1405,7 +1355,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3185
+						// Method begins at RVA 0x302c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1423,7 +1373,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x317c
+					// Method begins at RVA 0x3023
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1443,7 +1393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x318e
+					// Method begins at RVA 0x3035
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1463,7 +1413,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3197
+					// Method begins at RVA 0x303e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1481,7 +1431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314f
+				// Method begins at RVA 0x2ff6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1507,10 +1457,10 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2990
+			// Method begins at RVA 0x28cc
 			// Header size: 12
-			// Code size: 1651 (0x673)
-			.maxstack 8
+			// Code size: 1567 (0x61f)
+			.maxstack 9
 			.locals init (
 				[0] object,
 				[1] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L110C23,
@@ -1537,14 +1487,11 @@
 				[22] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process,
 				[23] string,
 				[24] string,
-				[25] object,
-				[26] object[],
-				[27] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[28] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[29] bool,
-				[30] object,
-				[31] object,
-				[32] float64
+				[25] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[26] bool,
+				[27] object,
+				[28] object,
+				[29] float64
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
@@ -1628,456 +1575,432 @@
 			IL_0121: stloc.s 4
 			IL_0123: ldarg.0
 			IL_0124: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0129: ldstr "Cannot access 'path' before initialization"
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0133: stloc.s 21
-			IL_0135: ldarg.0
-			IL_0136: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_013b: ldstr "Cannot access 'projectRoot' before initialization"
-			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0145: stloc.s 25
-			IL_0147: ldc.i4.4
-			IL_0148: newarr [System.Runtime]System.Object
-			IL_014d: dup
-			IL_014e: ldc.i4.0
-			IL_014f: ldloc.s 25
-			IL_0151: stelem.ref
-			IL_0152: dup
-			IL_0153: ldc.i4.1
-			IL_0154: ldstr "tests"
-			IL_0159: stelem.ref
-			IL_015a: dup
-			IL_015b: ldc.i4.2
-			IL_015c: ldstr "Js2IL.Tests"
-			IL_0161: stelem.ref
-			IL_0162: dup
-			IL_0163: ldc.i4.3
-			IL_0164: ldstr "Js2IL.Tests.csproj"
-			IL_0169: stelem.ref
-			IL_016a: stloc.s 26
-			IL_016c: ldloc.s 21
-			IL_016e: ldstr "join"
-			IL_0173: ldloc.s 26
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_017a: stloc.s 21
-			IL_017c: ldloc.s 21
-			IL_017e: stloc.s 5
-			IL_0180: ldloc.s 4
-			IL_0182: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0187: stloc.s 24
-			IL_0189: ldstr "Running test: "
-			IL_018e: ldloc.s 24
-			IL_0190: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0195: stloc.s 24
-			IL_0197: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_019c: ldloc.s 24
-			IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01a3: pop
-			IL_01a4: ldarg.0
-			IL_01a5: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_01aa: ldstr "Cannot access 'childProcess' before initialization"
-			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01b4: stloc.s 21
-			IL_01b6: ldloc.s 4
-			IL_01b8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01bd: stloc.s 24
-			IL_01bf: ldstr "FullyQualifiedName="
-			IL_01c4: ldloc.s 24
-			IL_01c6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01cb: stloc.s 24
-			IL_01cd: ldc.i4.5
-			IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0129: stloc.s 21
+			IL_012b: ldloc.s 21
+			IL_012d: ldstr "join"
+			IL_0132: ldc.i4.4
+			IL_0133: newarr [System.Runtime]System.Object
+			IL_0138: dup
+			IL_0139: ldc.i4.0
+			IL_013a: ldarg.0
+			IL_013b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_0140: stelem.ref
+			IL_0141: dup
+			IL_0142: ldc.i4.1
+			IL_0143: ldstr "tests"
+			IL_0148: stelem.ref
+			IL_0149: dup
+			IL_014a: ldc.i4.2
+			IL_014b: ldstr "Js2IL.Tests"
+			IL_0150: stelem.ref
+			IL_0151: dup
+			IL_0152: ldc.i4.3
+			IL_0153: ldstr "Js2IL.Tests.csproj"
+			IL_0158: stelem.ref
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_015e: stloc.s 21
+			IL_0160: ldloc.s 21
+			IL_0162: stloc.s 5
+			IL_0164: ldloc.s 4
+			IL_0166: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_016b: stloc.s 24
+			IL_016d: ldstr "Running test: "
+			IL_0172: ldloc.s 24
+			IL_0174: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0179: stloc.s 24
+			IL_017b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0180: ldloc.s 24
+			IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0187: pop
+			IL_0188: ldarg.0
+			IL_0189: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_018e: stloc.s 21
+			IL_0190: ldloc.s 4
+			IL_0192: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0197: stloc.s 24
+			IL_0199: ldstr "FullyQualifiedName="
+			IL_019e: ldloc.s 24
+			IL_01a0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a5: stloc.s 24
+			IL_01a7: ldc.i4.5
+			IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01ad: dup
+			IL_01ae: ldstr "test"
+			IL_01b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b8: dup
+			IL_01b9: ldloc.s 5
+			IL_01bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01c0: dup
+			IL_01c1: ldstr "--filter"
+			IL_01c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01cb: dup
+			IL_01cc: ldloc.s 24
+			IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_01d3: dup
-			IL_01d4: ldstr "test"
+			IL_01d4: ldstr "--no-build"
 			IL_01d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01de: dup
-			IL_01df: ldloc.s 5
-			IL_01e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01e6: dup
-			IL_01e7: ldstr "--filter"
-			IL_01ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01f1: dup
-			IL_01f2: ldloc.s 24
-			IL_01f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01f9: dup
-			IL_01fa: ldstr "--no-build"
-			IL_01ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0204: stloc.s 27
-			IL_0206: ldarg.0
-			IL_0207: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_020c: ldstr "Cannot access 'projectRoot' before initialization"
-			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0216: stloc.s 25
-			IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_021d: dup
-			IL_021e: ldstr "stdio"
-			IL_0223: ldstr "inherit"
-			IL_0228: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_022d: dup
-			IL_022e: ldstr "shell"
-			IL_0233: ldc.i4.1
-			IL_0234: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0239: dup
-			IL_023a: ldstr "cwd"
-			IL_023f: ldloc.s 25
-			IL_0241: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0246: stloc.s 28
-			IL_0248: ldloc.s 21
-			IL_024a: ldstr "spawnSync"
-			IL_024f: ldstr "dotnet"
-			IL_0254: ldloc.s 27
-			IL_0256: ldloc.s 28
-			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_025d: stloc.s 21
-			IL_025f: ldloc.s 21
-			IL_0261: stloc.s 6
-			IL_0263: ldloc.s 6
-			IL_0265: ldstr "status"
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026f: stloc.s 21
-			IL_0271: ldloc.s 21
-			IL_0273: ldc.r8 0.0
-			IL_027c: box [System.Runtime]System.Double
-			IL_0281: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0286: stloc.s 29
-			IL_0288: ldloc.s 29
-			IL_028a: brfalse IL_03e1
+			IL_01de: stloc.s 25
+			IL_01e0: ldloc.s 21
+			IL_01e2: ldstr "spawnSync"
+			IL_01e7: ldstr "dotnet"
+			IL_01ec: ldloc.s 25
+			IL_01ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01f3: dup
+			IL_01f4: ldstr "stdio"
+			IL_01f9: ldstr "inherit"
+			IL_01fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0203: dup
+			IL_0204: ldstr "shell"
+			IL_0209: ldc.i4.1
+			IL_020a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_020f: dup
+			IL_0210: ldstr "cwd"
+			IL_0215: ldarg.0
+			IL_0216: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_021b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0225: stloc.s 21
+			IL_0227: ldloc.s 21
+			IL_0229: stloc.s 6
+			IL_022b: ldloc.s 6
+			IL_022d: ldstr "status"
+			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0237: stloc.s 21
+			IL_0239: ldloc.s 21
+			IL_023b: ldc.r8 0.0
+			IL_0244: box [System.Runtime]System.Double
+			IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_024e: stloc.s 26
+			IL_0250: ldloc.s 26
+			IL_0252: brfalse IL_038d
 
-			IL_028f: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31::.ctor()
-			IL_0294: stloc.s 7
-			IL_0296: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_029b: ldstr "Test failed or not found, retrying with build..."
-			IL_02a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02a5: pop
-			IL_02a6: ldarg.0
-			IL_02a7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_02ac: ldstr "Cannot access 'childProcess' before initialization"
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_02b6: stloc.s 21
-			IL_02b8: ldloc.s 4
-			IL_02ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02bf: stloc.s 24
-			IL_02c1: ldstr "FullyQualifiedName="
-			IL_02c6: ldloc.s 24
-			IL_02c8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02cd: stloc.s 24
-			IL_02cf: ldc.i4.4
-			IL_02d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02d5: dup
-			IL_02d6: ldstr "test"
-			IL_02db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02e0: dup
-			IL_02e1: ldloc.s 5
-			IL_02e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02e8: dup
-			IL_02e9: ldstr "--filter"
-			IL_02ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02f3: dup
-			IL_02f4: ldloc.s 24
-			IL_02f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02fb: stloc.s 27
-			IL_02fd: ldarg.0
-			IL_02fe: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0303: ldstr "Cannot access 'projectRoot' before initialization"
-			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_030d: stloc.s 25
-			IL_030f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0314: dup
-			IL_0315: ldstr "stdio"
-			IL_031a: ldstr "inherit"
-			IL_031f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0324: dup
-			IL_0325: ldstr "shell"
-			IL_032a: ldc.i4.1
-			IL_032b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0330: dup
-			IL_0331: ldstr "cwd"
-			IL_0336: ldloc.s 25
-			IL_0338: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_033d: stloc.s 28
-			IL_033f: ldloc.s 21
-			IL_0341: ldstr "spawnSync"
-			IL_0346: ldstr "dotnet"
-			IL_034b: ldloc.s 27
-			IL_034d: ldloc.s 28
-			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0354: stloc.s 21
-			IL_0356: ldloc.s 21
-			IL_0358: stloc.s 8
-			IL_035a: ldloc.s 8
-			IL_035c: ldstr "status"
-			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0366: stloc.s 21
-			IL_0368: ldloc.s 21
-			IL_036a: ldc.r8 0.0
-			IL_0373: box [System.Runtime]System.Double
-			IL_0378: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_037d: stloc.s 29
-			IL_037f: ldloc.s 29
-			IL_0381: brfalse IL_03e1
+			IL_0257: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31::.ctor()
+			IL_025c: stloc.s 7
+			IL_025e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0263: ldstr "Test failed or not found, retrying with build..."
+			IL_0268: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_026d: pop
+			IL_026e: ldarg.0
+			IL_026f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_0274: stloc.s 21
+			IL_0276: ldloc.s 4
+			IL_0278: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_027d: stloc.s 24
+			IL_027f: ldstr "FullyQualifiedName="
+			IL_0284: ldloc.s 24
+			IL_0286: call string [System.Runtime]System.String::Concat(string, string)
+			IL_028b: stloc.s 24
+			IL_028d: ldc.i4.4
+			IL_028e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0293: dup
+			IL_0294: ldstr "test"
+			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_029e: dup
+			IL_029f: ldloc.s 5
+			IL_02a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02a6: dup
+			IL_02a7: ldstr "--filter"
+			IL_02ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02b1: dup
+			IL_02b2: ldloc.s 24
+			IL_02b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02b9: stloc.s 25
+			IL_02bb: ldloc.s 21
+			IL_02bd: ldstr "spawnSync"
+			IL_02c2: ldstr "dotnet"
+			IL_02c7: ldloc.s 25
+			IL_02c9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02ce: dup
+			IL_02cf: ldstr "stdio"
+			IL_02d4: ldstr "inherit"
+			IL_02d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02de: dup
+			IL_02df: ldstr "shell"
+			IL_02e4: ldc.i4.1
+			IL_02e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02ea: dup
+			IL_02eb: ldstr "cwd"
+			IL_02f0: ldarg.0
+			IL_02f1: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_02f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0300: stloc.s 21
+			IL_0302: ldloc.s 21
+			IL_0304: stloc.s 8
+			IL_0306: ldloc.s 8
+			IL_0308: ldstr "status"
+			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0312: stloc.s 21
+			IL_0314: ldloc.s 21
+			IL_0316: ldc.r8 0.0
+			IL_031f: box [System.Runtime]System.Double
+			IL_0324: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0329: stloc.s 26
+			IL_032b: ldloc.s 26
+			IL_032d: brfalse IL_038d
 
-			IL_0386: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31/Block_L150C34::.ctor()
-			IL_038b: stloc.s 9
-			IL_038d: ldloc.s 4
-			IL_038f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0394: stloc.s 24
-			IL_0396: ldstr "Test "
-			IL_039b: ldloc.s 24
-			IL_039d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03a2: stloc.s 24
-			IL_03a4: ldloc.s 24
-			IL_03a6: ldstr " failed or not found."
-			IL_03ab: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03b0: stloc.s 24
-			IL_03b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03b7: ldloc.s 24
-			IL_03b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_03be: pop
-			IL_03bf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_03c4: stloc.s 22
-			IL_03c6: ldloc.s 22
-			IL_03c8: ldstr "exit"
-			IL_03cd: ldc.r8 1
-			IL_03d6: box [System.Runtime]System.Double
-			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03e0: pop
+			IL_0332: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31/Block_L150C34::.ctor()
+			IL_0337: stloc.s 9
+			IL_0339: ldloc.s 4
+			IL_033b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0340: stloc.s 24
+			IL_0342: ldstr "Test "
+			IL_0347: ldloc.s 24
+			IL_0349: call string [System.Runtime]System.String::Concat(string, string)
+			IL_034e: stloc.s 24
+			IL_0350: ldloc.s 24
+			IL_0352: ldstr " failed or not found."
+			IL_0357: call string [System.Runtime]System.String::Concat(string, string)
+			IL_035c: stloc.s 24
+			IL_035e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0363: ldloc.s 24
+			IL_0365: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_036a: pop
+			IL_036b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0370: stloc.s 22
+			IL_0372: ldloc.s 22
+			IL_0374: ldstr "exit"
+			IL_0379: ldc.r8 1
+			IL_0382: box [System.Runtime]System.Double
+			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_038c: pop
 
-			IL_03e1: ldnull
-			IL_03e2: ldloc.3
-			IL_03e3: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
-			IL_03e8: stloc.s 21
-			IL_03ea: ldloc.s 21
-			IL_03ec: stloc.s 10
-			IL_03ee: ldc.i4.1
-			IL_03ef: newarr [System.Runtime]System.Object
-			IL_03f4: dup
-			IL_03f5: ldc.i4.0
-			IL_03f6: ldarg.0
-			IL_03f7: stelem.ref
-			IL_03f8: ldc.i4.0
-			IL_03f9: ldelem.ref
-			IL_03fa: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_03ff: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_0405: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_040a: ldnull
-			IL_040b: ldloc.2
-			IL_040c: ldloc.s 10
-			IL_040e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0413: stloc.s 21
-			IL_0415: ldloc.s 21
-			IL_0417: brfalse IL_0431
+			IL_038d: ldnull
+			IL_038e: ldloc.3
+			IL_038f: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
+			IL_0394: stloc.s 21
+			IL_0396: ldloc.s 21
+			IL_0398: stloc.s 10
+			IL_039a: ldc.i4.1
+			IL_039b: newarr [System.Runtime]System.Object
+			IL_03a0: dup
+			IL_03a1: ldc.i4.0
+			IL_03a2: ldarg.0
+			IL_03a3: stelem.ref
+			IL_03a4: ldc.i4.0
+			IL_03a5: ldelem.ref
+			IL_03a6: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_03ab: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_03b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_03b6: ldnull
+			IL_03b7: ldloc.2
+			IL_03b8: ldloc.s 10
+			IL_03ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_03bf: stloc.s 21
+			IL_03c1: ldloc.s 21
+			IL_03c3: brfalse IL_03dd
 
-			IL_041c: ldloc.s 21
-			IL_041e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0423: brtrue IL_0431
+			IL_03c8: ldloc.s 21
+			IL_03ca: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03cf: brtrue IL_03dd
 
-			IL_0428: ldloc.s 21
-			IL_042a: stloc.s 31
-			IL_042c: br IL_0439
+			IL_03d4: ldloc.s 21
+			IL_03d6: stloc.s 28
+			IL_03d8: br IL_03e5
 
-			IL_0431: ldc.i4.0
-			IL_0432: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0437: stloc.s 31
+			IL_03dd: ldc.i4.0
+			IL_03de: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03e3: stloc.s 28
 
-			IL_0439: ldloc.s 31
-			IL_043b: stloc.s 11
-			IL_043d: ldloc.s 11
-			IL_043f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0444: ldc.i4.0
-			IL_0445: ceq
-			IL_0447: stloc.s 29
-			IL_0449: ldloc.s 29
-			IL_044b: brfalse IL_0578
+			IL_03e5: ldloc.s 28
+			IL_03e7: stloc.s 11
+			IL_03e9: ldloc.s 11
+			IL_03eb: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03f0: ldc.i4.0
+			IL_03f1: ceq
+			IL_03f3: stloc.s 26
+			IL_03f5: ldloc.s 26
+			IL_03f7: brfalse IL_0524
 
-			IL_0450: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
-			IL_0455: stloc.s 12
-			IL_0457: ldloc.2
-			IL_0458: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_045d: stloc.s 24
-			IL_045f: ldstr "Assembly not found for category '"
-			IL_0464: ldloc.s 24
-			IL_0466: call string [System.Runtime]System.String::Concat(string, string)
-			IL_046b: stloc.s 24
-			IL_046d: ldloc.s 24
-			IL_046f: ldstr "' and test '"
-			IL_0474: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0479: stloc.s 24
-			IL_047b: ldloc.3
-			IL_047c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0481: stloc.s 23
-			IL_0483: ldloc.s 24
-			IL_0485: ldloc.s 23
-			IL_0487: call string [System.Runtime]System.String::Concat(string, string)
-			IL_048c: stloc.s 23
-			IL_048e: ldloc.s 23
-			IL_0490: ldstr "'."
-			IL_0495: call string [System.Runtime]System.String::Concat(string, string)
-			IL_049a: stloc.s 23
-			IL_049c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04a1: ldloc.s 23
-			IL_04a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_04a8: pop
-			IL_04a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04ae: ldstr "Looked under:"
-			IL_04b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_04b8: pop
-			IL_04b9: ldc.i4.1
-			IL_04ba: newarr [System.Runtime]System.Object
-			IL_04bf: dup
-			IL_04c0: ldc.i4.0
-			IL_04c1: ldarg.0
-			IL_04c2: stelem.ref
-			IL_04c3: ldc.i4.0
-			IL_04c4: ldelem.ref
-			IL_04c5: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_04ca: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-			IL_04d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_04d5: ldnull
-			IL_04d6: ldloc.2
-			IL_04d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_04dc: stloc.s 21
-			IL_04de: ldloc.s 21
-			IL_04e0: stloc.s 13
-			IL_04e2: ldc.r8 0.0
-			IL_04eb: stloc.s 14
-			// loop start (head: IL_04ed)
-				IL_04ed: ldloc.s 14
-				IL_04ef: ldloc.s 13
-				IL_04f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_04f6: clt
-				IL_04f8: brfalse IL_0546
+			IL_03fc: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
+			IL_0401: stloc.s 12
+			IL_0403: ldloc.2
+			IL_0404: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0409: stloc.s 24
+			IL_040b: ldstr "Assembly not found for category '"
+			IL_0410: ldloc.s 24
+			IL_0412: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0417: stloc.s 24
+			IL_0419: ldloc.s 24
+			IL_041b: ldstr "' and test '"
+			IL_0420: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0425: stloc.s 24
+			IL_0427: ldloc.3
+			IL_0428: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_042d: stloc.s 23
+			IL_042f: ldloc.s 24
+			IL_0431: ldloc.s 23
+			IL_0433: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0438: stloc.s 23
+			IL_043a: ldloc.s 23
+			IL_043c: ldstr "'."
+			IL_0441: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0446: stloc.s 23
+			IL_0448: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_044d: ldloc.s 23
+			IL_044f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0454: pop
+			IL_0455: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_045a: ldstr "Looked under:"
+			IL_045f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0464: pop
+			IL_0465: ldc.i4.1
+			IL_0466: newarr [System.Runtime]System.Object
+			IL_046b: dup
+			IL_046c: ldc.i4.0
+			IL_046d: ldarg.0
+			IL_046e: stelem.ref
+			IL_046f: ldc.i4.0
+			IL_0470: ldelem.ref
+			IL_0471: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0476: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+			IL_047c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0481: ldnull
+			IL_0482: ldloc.2
+			IL_0483: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0488: stloc.s 21
+			IL_048a: ldloc.s 21
+			IL_048c: stloc.s 13
+			IL_048e: ldc.r8 0.0
+			IL_0497: stloc.s 14
+			// loop start (head: IL_0499)
+				IL_0499: ldloc.s 14
+				IL_049b: ldloc.s 13
+				IL_049d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_04a2: clt
+				IL_04a4: brfalse IL_04f2
 
-				IL_04fd: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
-				IL_0502: stloc.s 15
-				IL_0504: ldloc.s 13
-				IL_0506: ldloc.s 14
-				IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_050d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0512: stloc.s 23
-				IL_0514: ldstr "  - "
-				IL_0519: ldloc.s 23
-				IL_051b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0520: stloc.s 23
-				IL_0522: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0527: ldloc.s 23
-				IL_0529: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_052e: pop
-				IL_052f: ldloc.s 14
-				IL_0531: ldc.r8 1
-				IL_053a: add
-				IL_053b: stloc.s 32
-				IL_053d: ldloc.s 32
-				IL_053f: stloc.s 14
-				IL_0541: br IL_04ed
+				IL_04a9: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
+				IL_04ae: stloc.s 15
+				IL_04b0: ldloc.s 13
+				IL_04b2: ldloc.s 14
+				IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_04b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_04be: stloc.s 23
+				IL_04c0: ldstr "  - "
+				IL_04c5: ldloc.s 23
+				IL_04c7: call string [System.Runtime]System.String::Concat(string, string)
+				IL_04cc: stloc.s 23
+				IL_04ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_04d3: ldloc.s 23
+				IL_04d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_04da: pop
+				IL_04db: ldloc.s 14
+				IL_04dd: ldc.r8 1
+				IL_04e6: add
+				IL_04e7: stloc.s 29
+				IL_04e9: ldloc.s 29
+				IL_04eb: stloc.s 14
+				IL_04ed: br IL_0499
 			// end loop
 
-			IL_0546: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_054b: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_0550: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0555: pop
-			IL_0556: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_055b: stloc.s 22
-			IL_055d: ldloc.s 22
-			IL_055f: ldstr "exit"
-			IL_0564: ldc.r8 1
-			IL_056d: box [System.Runtime]System.Double
-			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0577: pop
+			IL_04f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04f7: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_04fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0501: pop
+			IL_0502: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0507: stloc.s 22
+			IL_0509: ldloc.s 22
+			IL_050b: ldstr "exit"
+			IL_0510: ldc.r8 1
+			IL_0519: box [System.Runtime]System.Double
+			IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0523: pop
 
-			IL_0578: ldloc.s 11
-			IL_057a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_057f: stloc.s 23
-			IL_0581: ldstr "Found assembly: "
-			IL_0586: ldloc.s 23
-			IL_0588: call string [System.Runtime]System.String::Concat(string, string)
-			IL_058d: stloc.s 23
-			IL_058f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0594: ldloc.s 23
-			IL_0596: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_059b: pop
+			IL_0524: ldloc.s 11
+			IL_0526: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_052b: stloc.s 23
+			IL_052d: ldstr "Found assembly: "
+			IL_0532: ldloc.s 23
+			IL_0534: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0539: stloc.s 23
+			IL_053b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0540: ldloc.s 23
+			IL_0542: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0547: pop
 			.try
 			{
-				IL_059c: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
-				IL_05a1: stloc.s 16
-				IL_05a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_05a8: ldstr "Opening in ILSpy..."
-				IL_05ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_05b2: pop
-				IL_05b3: ldc.i4.1
-				IL_05b4: newarr [System.Runtime]System.Object
-				IL_05b9: dup
-				IL_05ba: ldc.i4.0
-				IL_05bb: ldarg.0
-				IL_05bc: stelem.ref
-				IL_05bd: ldc.i4.0
-				IL_05be: ldelem.ref
-				IL_05bf: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-				IL_05c4: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-				IL_05ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_05cf: ldnull
-				IL_05d0: ldloc.s 11
-				IL_05d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-				IL_05d7: pop
-				IL_05d8: leave IL_0661
+				IL_0548: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
+				IL_054d: stloc.s 16
+				IL_054f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0554: ldstr "Opening in ILSpy..."
+				IL_0559: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_055e: pop
+				IL_055f: ldc.i4.1
+				IL_0560: newarr [System.Runtime]System.Object
+				IL_0565: dup
+				IL_0566: ldc.i4.0
+				IL_0567: ldarg.0
+				IL_0568: stelem.ref
+				IL_0569: ldc.i4.0
+				IL_056a: ldelem.ref
+				IL_056b: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+				IL_0570: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0576: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_057b: ldnull
+				IL_057c: ldloc.s 11
+				IL_057e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+				IL_0583: pop
+				IL_0584: leave IL_060d
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_05dd: stloc.s 17
-				IL_05df: ldloc.s 17
-				IL_05e1: dup
-				IL_05e2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_05e7: dup
-				IL_05e8: brtrue IL_05fe
+				IL_0589: stloc.s 17
+				IL_058b: ldloc.s 17
+				IL_058d: dup
+				IL_058e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0593: dup
+				IL_0594: brtrue IL_05aa
 
-				IL_05ed: pop
-				IL_05ee: dup
-				IL_05ef: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_05f4: dup
-				IL_05f5: brtrue IL_060b
+				IL_0599: pop
+				IL_059a: dup
+				IL_059b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_05a0: dup
+				IL_05a1: brtrue IL_05b7
 
-				IL_05fa: pop
-				IL_05fb: pop
-				IL_05fc: rethrow
+				IL_05a6: pop
+				IL_05a7: pop
+				IL_05a8: rethrow
 
-				IL_05fe: pop
-				IL_05ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0604: stloc.s 18
-				IL_0606: br IL_060e
+				IL_05aa: pop
+				IL_05ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_05b0: stloc.s 18
+				IL_05b2: br IL_05ba
 
-				IL_060b: pop
-				IL_060c: stloc.s 18
+				IL_05b7: pop
+				IL_05b8: stloc.s 18
 
-				IL_060e: ldloc.s 18
-				IL_0610: stloc.s 21
-				IL_0612: ldloc.s 21
-				IL_0614: stloc.s 19
-				IL_0616: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
-				IL_061b: stloc.s 20
-				IL_061d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0622: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_0627: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_062c: pop
-				IL_062d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0632: ldloc.s 19
-				IL_0634: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_0639: pop
-				IL_063a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-				IL_063f: stloc.s 22
-				IL_0641: ldloc.s 22
-				IL_0643: ldstr "exit"
-				IL_0648: ldc.r8 1
-				IL_0651: box [System.Runtime]System.Double
-				IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_065b: pop
-				IL_065c: leave IL_0661
+				IL_05ba: ldloc.s 18
+				IL_05bc: stloc.s 21
+				IL_05be: ldloc.s 21
+				IL_05c0: stloc.s 19
+				IL_05c2: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
+				IL_05c7: stloc.s 20
+				IL_05c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_05ce: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_05d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_05d8: pop
+				IL_05d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_05de: ldloc.s 19
+				IL_05e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_05e5: pop
+				IL_05e6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+				IL_05eb: stloc.s 22
+				IL_05ed: ldloc.s 22
+				IL_05ef: ldstr "exit"
+				IL_05f4: ldc.r8 1
+				IL_05fd: box [System.Runtime]System.Double
+				IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0607: pop
+				IL_0608: leave IL_060d
 			} // end handler
 
-			IL_0661: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0666: ldstr "Done!"
-			IL_066b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0670: pop
-			IL_0671: ldnull
-			IL_0672: ret
+			IL_060d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0612: ldstr "Done!"
+			IL_0617: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_061c: pop
+			IL_061d: ldnull
+			IL_061e: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2126,30 +2049,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3088
+			// Method begins at RVA 0x2f66
 			// Header size: 1
-			// Code size: 63 (0x3f)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
-			IL_0032: ldarg.0
-			IL_0033: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0038: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_003d: nop
-			IL_003e: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -2373,7 +2281,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x31a0
+		// Method begins at RVA 0x3047
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x439b
+				// Method begins at RVA 0x433b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -189,7 +189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x43a4
+				// Method begins at RVA 0x4344
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -321,7 +321,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4392
+			// Method begins at RVA 0x4332
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -430,7 +430,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x43f6
+					// Method begins at RVA 0x435f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -448,7 +448,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x43ed
+				// Method begins at RVA 0x4356
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -578,7 +578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x43ff
+				// Method begins at RVA 0x4368
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -606,7 +606,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x441a
+						// Method begins at RVA 0x4383
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -626,7 +626,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4423
+						// Method begins at RVA 0x438c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -646,7 +646,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x442c
+						// Method begins at RVA 0x4395
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -666,7 +666,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4435
+						// Method begins at RVA 0x439e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -686,7 +686,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x443e
+						// Method begins at RVA 0x43a7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -706,7 +706,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4447
+						// Method begins at RVA 0x43b0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -724,7 +724,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4411
+					// Method begins at RVA 0x437a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -742,7 +742,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4408
+				// Method begins at RVA 0x4371
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1096,7 +1096,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4498
+							// Method begins at RVA 0x4401
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1121,7 +1121,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4314
+						// Method begins at RVA 0x42b4
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1160,7 +1160,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x44a1
+							// Method begins at RVA 0x440a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1184,7 +1184,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4344
+						// Method begins at RVA 0x42e4
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
@@ -1257,7 +1257,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4486
+								// Method begins at RVA 0x43ef
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1275,7 +1275,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x447d
+							// Method begins at RVA 0x43e6
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1295,7 +1295,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x448f
+							// Method begins at RVA 0x43f8
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1317,7 +1317,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4474
+						// Method begins at RVA 0x43dd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1342,9 +1342,9 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3edc
+					// Method begins at RVA 0x3e88
 					// Header size: 12
-					// Code size: 1065 (0x429)
+					// Code size: 1055 (0x41f)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1448,7 +1448,7 @@
 					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d4: stloc.s 8
 					IL_00d6: ldloc.s 8
-					IL_00d8: brfalse IL_025a
+					IL_00d8: brfalse IL_0250
 
 					IL_00dd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
 					IL_00e2: stloc.3
@@ -1525,283 +1525,281 @@
 					IL_0184: ldelem.ref
 					IL_0185: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 					IL_018a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_018f: ldstr "Cannot access 'NodeUrl' before initialization"
-					IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0199: stloc.s 18
-					IL_019b: ldc.i4.2
-					IL_019c: newarr [System.Runtime]System.Object
-					IL_01a1: dup
-					IL_01a2: ldc.i4.0
-					IL_01a3: ldloc.2
-					IL_01a4: stelem.ref
-					IL_01a5: dup
-					IL_01a6: ldc.i4.1
-					IL_01a7: ldarg.0
-					IL_01a8: ldc.i4.2
-					IL_01a9: ldelem.ref
-					IL_01aa: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_01af: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_01b4: stelem.ref
-					IL_01b5: stloc.s 16
-					IL_01b7: ldloc.s 18
-					IL_01b9: ldloc.s 16
-					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_01c0: stloc.s 18
-					IL_01c2: ldloc.s 18
-					IL_01c4: ldstr "toString"
-					IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01ce: stloc.s 18
-					IL_01d0: ldloc.s 18
-					IL_01d2: stloc.s 5
-					IL_01d4: ldarg.2
-					IL_01d5: ldstr "resume"
-					IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01df: pop
-					IL_01e0: ldarg.0
-					IL_01e1: ldc.i4.1
-					IL_01e2: ldelem.ref
-					IL_01e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_01e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_01ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01f2: ldc.r8 1
-					IL_01fb: sub
-					IL_01fc: box [System.Runtime]System.Double
-					IL_0201: stloc.s 19
-					IL_0203: ldc.i4.1
-					IL_0204: newarr [System.Runtime]System.Object
-					IL_0209: dup
-					IL_020a: ldc.i4.0
-					IL_020b: ldarg.0
-					IL_020c: ldc.i4.0
-					IL_020d: ldelem.ref
-					IL_020e: stelem.ref
-					IL_020f: ldc.i4.0
-					IL_0210: ldelem.ref
-					IL_0211: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0216: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-					IL_021c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-					IL_0221: ldnull
-					IL_0222: ldloc.s 5
-					IL_0224: ldloc.s 19
-					IL_0226: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-					IL_022b: stloc.s 18
-					IL_022d: ldarg.0
-					IL_022e: ldc.i4.2
-					IL_022f: ldelem.ref
-					IL_0230: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0235: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_023a: stloc.s 7
-					IL_023c: ldloc.s 18
-					IL_023e: ldstr "then"
-					IL_0243: ldloc.s 7
-					IL_0245: ldarg.0
-					IL_0246: ldc.i4.2
-					IL_0247: ldelem.ref
-					IL_0248: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_024d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0257: pop
-					IL_0258: ldnull
-					IL_0259: ret
+					IL_018f: stloc.s 18
+					IL_0191: ldc.i4.2
+					IL_0192: newarr [System.Runtime]System.Object
+					IL_0197: dup
+					IL_0198: ldc.i4.0
+					IL_0199: ldloc.2
+					IL_019a: stelem.ref
+					IL_019b: dup
+					IL_019c: ldc.i4.1
+					IL_019d: ldarg.0
+					IL_019e: ldc.i4.2
+					IL_019f: ldelem.ref
+					IL_01a0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_01a5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_01aa: stelem.ref
+					IL_01ab: stloc.s 16
+					IL_01ad: ldloc.s 18
+					IL_01af: ldloc.s 16
+					IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01b6: stloc.s 18
+					IL_01b8: ldloc.s 18
+					IL_01ba: ldstr "toString"
+					IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01c4: stloc.s 18
+					IL_01c6: ldloc.s 18
+					IL_01c8: stloc.s 5
+					IL_01ca: ldarg.2
+					IL_01cb: ldstr "resume"
+					IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01d5: pop
+					IL_01d6: ldarg.0
+					IL_01d7: ldc.i4.1
+					IL_01d8: ldelem.ref
+					IL_01d9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_01de: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_01e3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01e8: ldc.r8 1
+					IL_01f1: sub
+					IL_01f2: box [System.Runtime]System.Double
+					IL_01f7: stloc.s 19
+					IL_01f9: ldc.i4.1
+					IL_01fa: newarr [System.Runtime]System.Object
+					IL_01ff: dup
+					IL_0200: ldc.i4.0
+					IL_0201: ldarg.0
+					IL_0202: ldc.i4.0
+					IL_0203: ldelem.ref
+					IL_0204: stelem.ref
+					IL_0205: ldc.i4.0
+					IL_0206: ldelem.ref
+					IL_0207: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_020c: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+					IL_0212: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+					IL_0217: ldnull
+					IL_0218: ldloc.s 5
+					IL_021a: ldloc.s 19
+					IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+					IL_0221: stloc.s 18
+					IL_0223: ldarg.0
+					IL_0224: ldc.i4.2
+					IL_0225: ldelem.ref
+					IL_0226: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_022b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0230: stloc.s 7
+					IL_0232: ldloc.s 18
+					IL_0234: ldstr "then"
+					IL_0239: ldloc.s 7
+					IL_023b: ldarg.0
+					IL_023c: ldc.i4.2
+					IL_023d: ldelem.ref
+					IL_023e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0243: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_024d: pop
+					IL_024e: ldnull
+					IL_024f: ret
 
-					IL_025a: ldloc.1
-					IL_025b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0260: stloc.s 11
-					IL_0262: ldloc.s 11
-					IL_0264: ldc.r8 200
-					IL_026d: clt
-					IL_026f: stloc.s 8
-					IL_0271: ldloc.s 8
-					IL_0273: box [System.Runtime]System.Boolean
-					IL_0278: stloc.s 12
-					IL_027a: ldloc.s 12
-					IL_027c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0281: stloc.s 8
-					IL_0283: ldloc.s 8
-					IL_0285: brtrue IL_02b6
+					IL_0250: ldloc.1
+					IL_0251: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0256: stloc.s 11
+					IL_0258: ldloc.s 11
+					IL_025a: ldc.r8 200
+					IL_0263: clt
+					IL_0265: stloc.s 8
+					IL_0267: ldloc.s 8
+					IL_0269: box [System.Runtime]System.Boolean
+					IL_026e: stloc.s 12
+					IL_0270: ldloc.s 12
+					IL_0272: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0277: stloc.s 8
+					IL_0279: ldloc.s 8
+					IL_027b: brtrue IL_02ac
 
-					IL_028a: ldloc.1
-					IL_028b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0290: stloc.s 11
-					IL_0292: ldloc.s 11
-					IL_0294: ldc.r8 300
-					IL_029d: clt
-					IL_029f: ldc.i4.0
-					IL_02a0: ceq
-					IL_02a2: stloc.s 8
-					IL_02a4: ldloc.s 8
-					IL_02a6: box [System.Runtime]System.Boolean
-					IL_02ab: stloc.s 13
-					IL_02ad: ldloc.s 13
-					IL_02af: stloc.s 20
-					IL_02b1: br IL_02ba
+					IL_0280: ldloc.1
+					IL_0281: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0286: stloc.s 11
+					IL_0288: ldloc.s 11
+					IL_028a: ldc.r8 300
+					IL_0293: clt
+					IL_0295: ldc.i4.0
+					IL_0296: ceq
+					IL_0298: stloc.s 8
+					IL_029a: ldloc.s 8
+					IL_029c: box [System.Runtime]System.Boolean
+					IL_02a1: stloc.s 13
+					IL_02a3: ldloc.s 13
+					IL_02a5: stloc.s 20
+					IL_02a7: br IL_02b0
 
-					IL_02b6: ldloc.s 12
-					IL_02b8: stloc.s 20
+					IL_02ac: ldloc.s 12
+					IL_02ae: stloc.s 20
 
-					IL_02ba: ldloc.s 20
-					IL_02bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02c1: stloc.s 8
-					IL_02c3: ldloc.s 8
-					IL_02c5: brfalse IL_0365
+					IL_02b0: ldloc.s 20
+					IL_02b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02b7: stloc.s 8
+					IL_02b9: ldloc.s 8
+					IL_02bb: brfalse IL_035b
 
-					IL_02ca: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
-					IL_02cf: stloc.s 6
-					IL_02d1: ldarg.2
-					IL_02d2: ldstr "resume"
-					IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02dc: pop
-					IL_02dd: ldarg.0
-					IL_02de: ldc.i4.2
-					IL_02df: ldelem.ref
-					IL_02e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_02e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_02ea: stloc.s 7
-					IL_02ec: ldc.i4.3
-					IL_02ed: newarr [System.Runtime]System.Object
-					IL_02f2: dup
-					IL_02f3: ldc.i4.0
-					IL_02f4: ldarg.0
-					IL_02f5: ldc.i4.0
-					IL_02f6: ldelem.ref
-					IL_02f7: stelem.ref
-					IL_02f8: dup
-					IL_02f9: ldc.i4.1
-					IL_02fa: ldarg.0
-					IL_02fb: ldc.i4.1
-					IL_02fc: ldelem.ref
-					IL_02fd: stelem.ref
-					IL_02fe: dup
-					IL_02ff: ldc.i4.2
-					IL_0300: ldarg.0
-					IL_0301: ldc.i4.2
-					IL_0302: ldelem.ref
-					IL_0303: stelem.ref
-					IL_0304: stloc.s 16
-					IL_0306: ldloc.1
-					IL_0307: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_030c: stloc.s 17
-					IL_030e: ldstr "HTTP "
-					IL_0313: ldloc.s 17
-					IL_0315: call string [System.Runtime]System.String::Concat(string, string)
-					IL_031a: stloc.s 17
-					IL_031c: ldloc.s 17
-					IL_031e: ldstr " fetching "
-					IL_0323: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0328: stloc.s 17
-					IL_032a: ldarg.0
-					IL_032b: ldc.i4.1
-					IL_032c: ldelem.ref
-					IL_032d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0332: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0337: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_033c: stloc.s 21
-					IL_033e: ldloc.s 17
-					IL_0340: ldloc.s 21
-					IL_0342: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0347: stloc.s 21
-					IL_0349: ldloc.s 21
-					IL_034b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0350: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0355: stloc.s 18
-					IL_0357: ldloc.s 7
-					IL_0359: ldloc.s 16
-					IL_035b: ldloc.s 18
-					IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-					IL_0362: pop
-					IL_0363: ldnull
-					IL_0364: ret
+					IL_02c0: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
+					IL_02c5: stloc.s 6
+					IL_02c7: ldarg.2
+					IL_02c8: ldstr "resume"
+					IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02d2: pop
+					IL_02d3: ldarg.0
+					IL_02d4: ldc.i4.2
+					IL_02d5: ldelem.ref
+					IL_02d6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02db: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_02e0: stloc.s 7
+					IL_02e2: ldc.i4.3
+					IL_02e3: newarr [System.Runtime]System.Object
+					IL_02e8: dup
+					IL_02e9: ldc.i4.0
+					IL_02ea: ldarg.0
+					IL_02eb: ldc.i4.0
+					IL_02ec: ldelem.ref
+					IL_02ed: stelem.ref
+					IL_02ee: dup
+					IL_02ef: ldc.i4.1
+					IL_02f0: ldarg.0
+					IL_02f1: ldc.i4.1
+					IL_02f2: ldelem.ref
+					IL_02f3: stelem.ref
+					IL_02f4: dup
+					IL_02f5: ldc.i4.2
+					IL_02f6: ldarg.0
+					IL_02f7: ldc.i4.2
+					IL_02f8: ldelem.ref
+					IL_02f9: stelem.ref
+					IL_02fa: stloc.s 16
+					IL_02fc: ldloc.1
+					IL_02fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0302: stloc.s 17
+					IL_0304: ldstr "HTTP "
+					IL_0309: ldloc.s 17
+					IL_030b: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0310: stloc.s 17
+					IL_0312: ldloc.s 17
+					IL_0314: ldstr " fetching "
+					IL_0319: call string [System.Runtime]System.String::Concat(string, string)
+					IL_031e: stloc.s 17
+					IL_0320: ldarg.0
+					IL_0321: ldc.i4.1
+					IL_0322: ldelem.ref
+					IL_0323: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0328: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_032d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0332: stloc.s 21
+					IL_0334: ldloc.s 17
+					IL_0336: ldloc.s 21
+					IL_0338: call string [System.Runtime]System.String::Concat(string, string)
+					IL_033d: stloc.s 21
+					IL_033f: ldloc.s 21
+					IL_0341: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0346: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_034b: stloc.s 18
+					IL_034d: ldloc.s 7
+					IL_034f: ldloc.s 16
+					IL_0351: ldloc.s 18
+					IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_0358: pop
+					IL_0359: ldnull
+					IL_035a: ret
 
-					IL_0365: ldarg.2
-					IL_0366: ldstr "setEncoding"
-					IL_036b: ldstr "utf8"
-					IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0375: pop
-					IL_0376: ldloc.0
-					IL_0377: ldstr ""
-					IL_037c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0381: ldnull
-					IL_0382: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_0388: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_038d: ldc.i4.4
-					IL_038e: newarr [System.Runtime]System.Object
-					IL_0393: dup
-					IL_0394: ldc.i4.0
-					IL_0395: ldarg.0
-					IL_0396: ldc.i4.0
-					IL_0397: ldelem.ref
-					IL_0398: stelem.ref
-					IL_0399: dup
-					IL_039a: ldc.i4.1
-					IL_039b: ldarg.0
-					IL_039c: ldc.i4.1
-					IL_039d: ldelem.ref
+					IL_035b: ldarg.2
+					IL_035c: ldstr "setEncoding"
+					IL_0361: ldstr "utf8"
+					IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_036b: pop
+					IL_036c: ldloc.0
+					IL_036d: ldstr ""
+					IL_0372: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_0377: ldnull
+					IL_0378: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_037e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_0383: ldc.i4.4
+					IL_0384: newarr [System.Runtime]System.Object
+					IL_0389: dup
+					IL_038a: ldc.i4.0
+					IL_038b: ldarg.0
+					IL_038c: ldc.i4.0
+					IL_038d: ldelem.ref
+					IL_038e: stelem.ref
+					IL_038f: dup
+					IL_0390: ldc.i4.1
+					IL_0391: ldarg.0
+					IL_0392: ldc.i4.1
+					IL_0393: ldelem.ref
+					IL_0394: stelem.ref
+					IL_0395: dup
+					IL_0396: ldc.i4.2
+					IL_0397: ldarg.0
+					IL_0398: ldc.i4.2
+					IL_0399: ldelem.ref
+					IL_039a: stelem.ref
+					IL_039b: dup
+					IL_039c: ldc.i4.3
+					IL_039d: ldloc.0
 					IL_039e: stelem.ref
-					IL_039f: dup
-					IL_03a0: ldc.i4.2
-					IL_03a1: ldarg.0
-					IL_03a2: ldc.i4.2
-					IL_03a3: ldelem.ref
-					IL_03a4: stelem.ref
-					IL_03a5: dup
-					IL_03a6: ldc.i4.3
-					IL_03a7: ldloc.0
-					IL_03a8: stelem.ref
-					IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03b3: ldc.i4.1
-					IL_03b4: conv.r8
-					IL_03b5: ldstr ""
-					IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_03bf: stloc.s 18
-					IL_03c1: ldarg.2
-					IL_03c2: ldstr "on"
-					IL_03c7: ldstr "data"
-					IL_03cc: ldloc.s 18
-					IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_03d3: pop
-					IL_03d4: ldnull
-					IL_03d5: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_03db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_03e0: ldc.i4.4
-					IL_03e1: newarr [System.Runtime]System.Object
-					IL_03e6: dup
-					IL_03e7: ldc.i4.0
-					IL_03e8: ldarg.0
-					IL_03e9: ldc.i4.0
-					IL_03ea: ldelem.ref
-					IL_03eb: stelem.ref
-					IL_03ec: dup
-					IL_03ed: ldc.i4.1
-					IL_03ee: ldarg.0
-					IL_03ef: ldc.i4.1
-					IL_03f0: ldelem.ref
+					IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03a9: ldc.i4.1
+					IL_03aa: conv.r8
+					IL_03ab: ldstr ""
+					IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_03b5: stloc.s 18
+					IL_03b7: ldarg.2
+					IL_03b8: ldstr "on"
+					IL_03bd: ldstr "data"
+					IL_03c2: ldloc.s 18
+					IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03c9: pop
+					IL_03ca: ldnull
+					IL_03cb: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_03d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_03d6: ldc.i4.4
+					IL_03d7: newarr [System.Runtime]System.Object
+					IL_03dc: dup
+					IL_03dd: ldc.i4.0
+					IL_03de: ldarg.0
+					IL_03df: ldc.i4.0
+					IL_03e0: ldelem.ref
+					IL_03e1: stelem.ref
+					IL_03e2: dup
+					IL_03e3: ldc.i4.1
+					IL_03e4: ldarg.0
+					IL_03e5: ldc.i4.1
+					IL_03e6: ldelem.ref
+					IL_03e7: stelem.ref
+					IL_03e8: dup
+					IL_03e9: ldc.i4.2
+					IL_03ea: ldarg.0
+					IL_03eb: ldc.i4.2
+					IL_03ec: ldelem.ref
+					IL_03ed: stelem.ref
+					IL_03ee: dup
+					IL_03ef: ldc.i4.3
+					IL_03f0: ldloc.0
 					IL_03f1: stelem.ref
-					IL_03f2: dup
-					IL_03f3: ldc.i4.2
-					IL_03f4: ldarg.0
-					IL_03f5: ldc.i4.2
-					IL_03f6: ldelem.ref
-					IL_03f7: stelem.ref
-					IL_03f8: dup
-					IL_03f9: ldc.i4.3
-					IL_03fa: ldloc.0
-					IL_03fb: stelem.ref
-					IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0406: ldc.i4.0
-					IL_0407: conv.r8
-					IL_0408: ldstr ""
-					IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_0412: stloc.s 18
-					IL_0414: ldarg.2
-					IL_0415: ldstr "on"
-					IL_041a: ldstr "end"
-					IL_041f: ldloc.s 18
-					IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0426: pop
-					IL_0427: ldnull
-					IL_0428: ret
+					IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03fc: ldc.i4.0
+					IL_03fd: conv.r8
+					IL_03fe: ldstr ""
+					IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0408: stloc.s 18
+					IL_040a: ldarg.2
+					IL_040b: ldstr "on"
+					IL_0410: ldstr "end"
+					IL_0415: ldloc.s 18
+					IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_041c: pop
+					IL_041d: ldnull
+					IL_041e: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1823,7 +1821,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4462
+						// Method begins at RVA 0x43cb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1843,7 +1841,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x446b
+						// Method begins at RVA 0x43d4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1866,7 +1864,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4459
+					// Method begins at RVA 0x43c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1892,9 +1890,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cbc
+				// Method begins at RVA 0x3c8c
 				// Header size: 12
-				// Code size: 516 (0x204)
+				// Code size: 478 (0x1de)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
@@ -1933,186 +1931,176 @@
 					IL_0023: ldelem.ref
 					IL_0024: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 					IL_0029: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_002e: ldstr "Cannot access 'NodeUrl' before initialization"
-					IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0038: stloc.s 8
-					IL_003a: ldloc.s 8
-					IL_003c: ldc.i4.1
-					IL_003d: newarr [System.Runtime]System.Object
-					IL_0042: dup
-					IL_0043: ldc.i4.0
-					IL_0044: ldarg.0
-					IL_0045: ldc.i4.1
-					IL_0046: ldelem.ref
-					IL_0047: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_004c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0051: stelem.ref
-					IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_0057: stloc.s 8
-					IL_0059: ldloc.0
-					IL_005a: ldloc.s 8
-					IL_005c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_0061: leave IL_00d5
+					IL_002e: stloc.s 8
+					IL_0030: ldloc.s 8
+					IL_0032: ldc.i4.1
+					IL_0033: newarr [System.Runtime]System.Object
+					IL_0038: dup
+					IL_0039: ldc.i4.0
+					IL_003a: ldarg.0
+					IL_003b: ldc.i4.1
+					IL_003c: ldelem.ref
+					IL_003d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0042: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0047: stelem.ref
+					IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_004d: stloc.s 8
+					IL_004f: ldloc.0
+					IL_0050: ldloc.s 8
+					IL_0052: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_0057: leave IL_00cb
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
-					IL_0066: stloc.2
-					IL_0067: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope/Block_L76C12::.ctor()
-					IL_006c: stloc.3
-					IL_006d: ldloc.0
-					IL_006e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0073: stloc.s 8
-					IL_0075: ldc.i4.2
-					IL_0076: newarr [System.Runtime]System.Object
-					IL_007b: dup
-					IL_007c: ldc.i4.0
-					IL_007d: ldarg.0
-					IL_007e: ldc.i4.0
-					IL_007f: ldelem.ref
-					IL_0080: stelem.ref
-					IL_0081: dup
-					IL_0082: ldc.i4.1
-					IL_0083: ldarg.0
-					IL_0084: ldc.i4.1
-					IL_0085: ldelem.ref
-					IL_0086: stelem.ref
-					IL_0087: stloc.s 9
-					IL_0089: ldarg.0
-					IL_008a: ldc.i4.1
-					IL_008b: ldelem.ref
-					IL_008c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0091: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0096: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_009b: stloc.s 10
-					IL_009d: ldstr "Invalid URL: "
-					IL_00a2: ldloc.s 10
-					IL_00a4: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00a9: stloc.s 10
-					IL_00ab: ldloc.s 10
-					IL_00ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00b7: stloc.s 11
-					IL_00b9: ldloc.s 8
-					IL_00bb: ldloc.s 9
-					IL_00bd: ldloc.s 11
-					IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-					IL_00c4: pop
-					IL_00c5: ldnull
-					IL_00c6: stloc.s 4
-					IL_00c8: ldnull
-					IL_00c9: stloc.s 4
-					IL_00cb: leave IL_0201
+					IL_005c: stloc.2
+					IL_005d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope/Block_L76C12::.ctor()
+					IL_0062: stloc.3
+					IL_0063: ldloc.0
+					IL_0064: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0069: stloc.s 8
+					IL_006b: ldc.i4.2
+					IL_006c: newarr [System.Runtime]System.Object
+					IL_0071: dup
+					IL_0072: ldc.i4.0
+					IL_0073: ldarg.0
+					IL_0074: ldc.i4.0
+					IL_0075: ldelem.ref
+					IL_0076: stelem.ref
+					IL_0077: dup
+					IL_0078: ldc.i4.1
+					IL_0079: ldarg.0
+					IL_007a: ldc.i4.1
+					IL_007b: ldelem.ref
+					IL_007c: stelem.ref
+					IL_007d: stloc.s 9
+					IL_007f: ldarg.0
+					IL_0080: ldc.i4.1
+					IL_0081: ldelem.ref
+					IL_0082: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0087: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_008c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0091: stloc.s 10
+					IL_0093: ldstr "Invalid URL: "
+					IL_0098: ldloc.s 10
+					IL_009a: call string [System.Runtime]System.String::Concat(string, string)
+					IL_009f: stloc.s 10
+					IL_00a1: ldloc.s 10
+					IL_00a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00ad: stloc.s 11
+					IL_00af: ldloc.s 8
+					IL_00b1: ldloc.s 9
+					IL_00b3: ldloc.s 11
+					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_00ba: pop
+					IL_00bb: ldnull
+					IL_00bc: stloc.s 4
+					IL_00be: ldnull
+					IL_00bf: stloc.s 4
+					IL_00c1: leave IL_01db
 
-					IL_00d0: leave IL_00d5
+					IL_00c6: leave IL_00cb
 				} // end handler
 
-				IL_00d5: ldloc.0
-				IL_00d6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_00db: ldstr "protocol"
-				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00e5: ldstr "https:"
-				IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00ef: stloc.s 12
-				IL_00f1: ldloc.s 12
-				IL_00f3: brfalse IL_011a
+				IL_00cb: ldloc.0
+				IL_00cc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_00d1: ldstr "protocol"
+				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00db: ldstr "https:"
+				IL_00e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00e5: stloc.s 12
+				IL_00e7: ldloc.s 12
+				IL_00e9: brfalse IL_0102
 
-				IL_00f8: ldarg.0
-				IL_00f9: ldc.i4.0
-				IL_00fa: ldelem.ref
-				IL_00fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_0100: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-				IL_0105: ldstr "Cannot access 'https' before initialization"
-				IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_010f: stloc.s 11
-				IL_0111: ldloc.s 11
-				IL_0113: stloc.s 5
-				IL_0115: br IL_0137
+				IL_00ee: ldarg.0
+				IL_00ef: ldc.i4.0
+				IL_00f0: ldelem.ref
+				IL_00f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00f6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00fb: stloc.s 5
+				IL_00fd: br IL_0111
 
-				IL_011a: ldarg.0
-				IL_011b: ldc.i4.0
-				IL_011c: ldelem.ref
-				IL_011d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_0122: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-				IL_0127: ldstr "Cannot access 'http' before initialization"
-				IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0131: stloc.s 11
-				IL_0133: ldloc.s 11
-				IL_0135: stloc.s 5
+				IL_0102: ldarg.0
+				IL_0103: ldc.i4.0
+				IL_0104: ldelem.ref
+				IL_0105: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_010a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_010f: stloc.s 5
 
-				IL_0137: ldloc.s 5
-				IL_0139: stloc.s 6
-				IL_013b: ldloc.0
-				IL_013c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_0141: stloc.s 11
-				IL_0143: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0148: dup
-				IL_0149: ldstr "method"
-				IL_014e: ldstr "GET"
-				IL_0153: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0158: dup
-				IL_0159: ldstr "headers"
-				IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0163: dup
-				IL_0164: ldstr "Accept-Encoding"
-				IL_0169: ldstr "identity"
-				IL_016e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0173: dup
-				IL_0174: ldstr "User-Agent"
-				IL_0179: ldstr "js2il-docs-script"
-				IL_017e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0188: stloc.s 13
-				IL_018a: ldnull
-				IL_018b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
-				IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_0196: ldc.i4.3
-				IL_0197: newarr [System.Runtime]System.Object
-				IL_019c: dup
-				IL_019d: ldc.i4.0
-				IL_019e: ldarg.0
-				IL_019f: ldc.i4.0
-				IL_01a0: ldelem.ref
-				IL_01a1: stelem.ref
-				IL_01a2: dup
-				IL_01a3: ldc.i4.1
-				IL_01a4: ldarg.0
-				IL_01a5: ldc.i4.1
-				IL_01a6: ldelem.ref
-				IL_01a7: stelem.ref
-				IL_01a8: dup
-				IL_01a9: ldc.i4.2
-				IL_01aa: ldloc.0
-				IL_01ab: stelem.ref
-				IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_01b6: ldc.i4.1
-				IL_01b7: conv.r8
-				IL_01b8: ldstr ""
-				IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_01c2: stloc.s 8
-				IL_01c4: ldloc.s 6
-				IL_01c6: ldstr "request"
-				IL_01cb: ldloc.s 11
-				IL_01cd: ldloc.s 13
-				IL_01cf: ldloc.s 8
-				IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_01d6: stloc.s 8
-				IL_01d8: ldloc.s 8
-				IL_01da: stloc.s 7
-				IL_01dc: ldloc.s 7
-				IL_01de: ldstr "on"
-				IL_01e3: ldstr "error"
-				IL_01e8: ldloc.0
-				IL_01e9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-				IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_01f3: pop
-				IL_01f4: ldloc.s 7
-				IL_01f6: ldstr "end"
-				IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0200: pop
+				IL_0111: ldloc.s 5
+				IL_0113: stloc.s 6
+				IL_0115: ldloc.0
+				IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_011b: stloc.s 11
+				IL_011d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0122: dup
+				IL_0123: ldstr "method"
+				IL_0128: ldstr "GET"
+				IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0132: dup
+				IL_0133: ldstr "headers"
+				IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_013d: dup
+				IL_013e: ldstr "Accept-Encoding"
+				IL_0143: ldstr "identity"
+				IL_0148: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_014d: dup
+				IL_014e: ldstr "User-Agent"
+				IL_0153: ldstr "js2il-docs-script"
+				IL_0158: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_015d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0162: stloc.s 13
+				IL_0164: ldnull
+				IL_0165: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0170: ldc.i4.3
+				IL_0171: newarr [System.Runtime]System.Object
+				IL_0176: dup
+				IL_0177: ldc.i4.0
+				IL_0178: ldarg.0
+				IL_0179: ldc.i4.0
+				IL_017a: ldelem.ref
+				IL_017b: stelem.ref
+				IL_017c: dup
+				IL_017d: ldc.i4.1
+				IL_017e: ldarg.0
+				IL_017f: ldc.i4.1
+				IL_0180: ldelem.ref
+				IL_0181: stelem.ref
+				IL_0182: dup
+				IL_0183: ldc.i4.2
+				IL_0184: ldloc.0
+				IL_0185: stelem.ref
+				IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0190: ldc.i4.1
+				IL_0191: conv.r8
+				IL_0192: ldstr ""
+				IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_019c: stloc.s 8
+				IL_019e: ldloc.s 6
+				IL_01a0: ldstr "request"
+				IL_01a5: ldloc.s 11
+				IL_01a7: ldloc.s 13
+				IL_01a9: ldloc.s 8
+				IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_01b0: stloc.s 8
+				IL_01b2: ldloc.s 8
+				IL_01b4: stloc.s 7
+				IL_01b6: ldloc.s 7
+				IL_01b8: ldstr "on"
+				IL_01bd: ldstr "error"
+				IL_01c2: ldloc.0
+				IL_01c3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01cd: pop
+				IL_01ce: ldloc.s 7
+				IL_01d0: ldstr "end"
+				IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_01da: pop
 
-				IL_0201: ldloc.s 4
-				IL_0203: ret
+				IL_01db: ldloc.s 4
+				IL_01dd: ret
 			} // end of method ArrowFunction_L72C22::__js_call__
 
 		} // end of class ArrowFunction_L72C22
@@ -2134,7 +2122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4450
+				// Method begins at RVA 0x43b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2227,7 +2215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44aa
+				// Method begins at RVA 0x4413
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2291,7 +2279,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44bc
+					// Method begins at RVA 0x4425
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2315,7 +2303,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x44ce
+						// Method begins at RVA 0x4437
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2333,7 +2321,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44c5
+					// Method begins at RVA 0x442e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2351,7 +2339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44b3
+				// Method begins at RVA 0x441c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2622,7 +2610,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44e0
+					// Method begins at RVA 0x4449
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2642,7 +2630,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44e9
+					// Method begins at RVA 0x4452
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2662,7 +2650,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44f2
+					// Method begins at RVA 0x445b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2682,7 +2670,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44fb
+					// Method begins at RVA 0x4464
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2706,7 +2694,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x450d
+						// Method begins at RVA 0x4476
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2726,7 +2714,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4516
+						// Method begins at RVA 0x447f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2750,7 +2738,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4528
+							// Method begins at RVA 0x4491
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2768,7 +2756,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x451f
+						// Method begins at RVA 0x4488
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2788,7 +2776,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4531
+						// Method begins at RVA 0x449a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2806,7 +2794,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4504
+					// Method begins at RVA 0x446d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2824,7 +2812,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44d7
+				// Method begins at RVA 0x4440
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3265,7 +3253,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4543
+					// Method begins at RVA 0x44ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3283,7 +3271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x453a
+				// Method begins at RVA 0x44a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3512,7 +3500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x454c
+				// Method begins at RVA 0x44b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3645,7 +3633,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x455e
+					// Method begins at RVA 0x44c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3665,7 +3653,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4567
+					// Method begins at RVA 0x44d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3685,7 +3673,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4570
+					// Method begins at RVA 0x44d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3709,7 +3697,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4582
+						// Method begins at RVA 0x44eb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3729,7 +3717,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x458b
+						// Method begins at RVA 0x44f4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3747,7 +3735,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4579
+					// Method begins at RVA 0x44e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3767,7 +3755,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4594
+					// Method begins at RVA 0x44fd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3787,7 +3775,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x459d
+					// Method begins at RVA 0x4506
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3827,7 +3815,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4555
+				// Method begins at RVA 0x44be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3853,7 +3841,7 @@
 			)
 			// Method begins at RVA 0x3234
 			// Header size: 12
-			// Code size: 2681 (0xa79)
+			// Code size: 2633 (0xa49)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4030,7 +4018,7 @@
 
 			IL_00ea: ldloc.0
 			IL_00eb: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00f0: switch (IL_0105, IL_044d, IL_0686, IL_07de)
+			IL_00f0: switch (IL_0105, IL_044d, IL_067c, IL_07d4)
 
 			IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
 			IL_010a: ldstr "argv"
@@ -4234,7 +4222,7 @@
 			IL_034c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0351: stloc.s 25
 			IL_0353: ldloc.s 25
-			IL_0355: brfalse IL_06eb
+			IL_0355: brfalse IL_06e1
 
 			IL_035a: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
 			IL_035f: stloc.s 11
@@ -4464,582 +4452,570 @@
 			IL_053a: ldelem.ref
 			IL_053b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 			IL_0540: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_0545: ldstr "Cannot access 'NodeUrl' before initialization"
-			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_054f: stloc.s 24
-			IL_0551: ldloc.s 14
-			IL_0553: ldstr "filePart"
-			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_055d: stloc.s 30
-			IL_055f: ldloc.s 30
-			IL_0561: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0566: stloc.s 25
-			IL_0568: ldloc.s 25
-			IL_056a: brtrue IL_0582
+			IL_0545: stloc.s 24
+			IL_0547: ldloc.s 14
+			IL_0549: ldstr "filePart"
+			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0553: stloc.s 30
+			IL_0555: ldloc.s 30
+			IL_0557: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_055c: stloc.s 25
+			IL_055e: ldloc.s 25
+			IL_0560: brtrue IL_0578
 
-			IL_056f: ldloc.s 14
-			IL_0571: ldstr "href"
-			IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_057b: stloc.s 31
-			IL_057d: br IL_0586
+			IL_0565: ldloc.s 14
+			IL_0567: ldstr "href"
+			IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0571: stloc.s 31
+			IL_0573: br IL_057c
 
-			IL_0582: ldloc.s 30
-			IL_0584: stloc.s 31
+			IL_0578: ldloc.s 30
+			IL_057a: stloc.s 31
 
-			IL_0586: ldc.i4.2
-			IL_0587: newarr [System.Runtime]System.Object
-			IL_058c: dup
-			IL_058d: ldc.i4.0
-			IL_058e: ldloc.s 31
-			IL_0590: stelem.ref
-			IL_0591: dup
-			IL_0592: ldc.i4.1
-			IL_0593: ldloc.s 12
-			IL_0595: stelem.ref
-			IL_0596: stloc.s 32
-			IL_0598: ldloc.s 24
-			IL_059a: ldloc.s 32
-			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_05a1: stloc.s 24
-			IL_05a3: ldloc.s 24
-			IL_05a5: ldstr "toString"
-			IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_05af: stloc.s 24
-			IL_05b1: ldloc.s 24
-			IL_05b3: stloc.s 16
-			IL_05b5: ldc.i4.1
-			IL_05b6: newarr [System.Runtime]System.Object
-			IL_05bb: dup
-			IL_05bc: ldc.i4.0
-			IL_05bd: ldarg.0
-			IL_05be: ldc.i4.1
-			IL_05bf: ldelem.ref
-			IL_05c0: stelem.ref
-			IL_05c1: ldc.i4.0
-			IL_05c2: ldelem.ref
-			IL_05c3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05c8: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_05ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_05d3: ldnull
-			IL_05d4: ldloc.s 16
-			IL_05d6: ldnull
-			IL_05d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_05dc: stloc.s 24
-			IL_05de: ldloc.0
+			IL_057c: ldc.i4.2
+			IL_057d: newarr [System.Runtime]System.Object
+			IL_0582: dup
+			IL_0583: ldc.i4.0
+			IL_0584: ldloc.s 31
+			IL_0586: stelem.ref
+			IL_0587: dup
+			IL_0588: ldc.i4.1
+			IL_0589: ldloc.s 12
+			IL_058b: stelem.ref
+			IL_058c: stloc.s 32
+			IL_058e: ldloc.s 24
+			IL_0590: ldloc.s 32
+			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0597: stloc.s 24
+			IL_0599: ldloc.s 24
+			IL_059b: ldstr "toString"
+			IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_05a5: stloc.s 24
+			IL_05a7: ldloc.s 24
+			IL_05a9: stloc.s 16
+			IL_05ab: ldc.i4.1
+			IL_05ac: newarr [System.Runtime]System.Object
+			IL_05b1: dup
+			IL_05b2: ldc.i4.0
+			IL_05b3: ldarg.0
+			IL_05b4: ldc.i4.1
+			IL_05b5: ldelem.ref
+			IL_05b6: stelem.ref
+			IL_05b7: ldc.i4.0
+			IL_05b8: ldelem.ref
+			IL_05b9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_05be: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_05c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_05c9: ldnull
+			IL_05ca: ldloc.s 16
+			IL_05cc: ldnull
+			IL_05cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_05d2: stloc.s 24
+			IL_05d4: ldloc.0
+			IL_05d5: ldc.i4.2
+			IL_05d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05db: ldloc.0
+			IL_05dc: ldloc.s 24
+			IL_05de: ldarg.0
 			IL_05df: ldc.i4.2
-			IL_05e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05e5: ldloc.0
-			IL_05e6: ldloc.s 24
-			IL_05e8: ldarg.0
-			IL_05e9: ldc.i4.2
-			IL_05ea: ldloc.0
-			IL_05eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_05f5: ldloc.0
-			IL_05f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05fb: dup
-			IL_05fc: ldc.i4.0
-			IL_05fd: ldloc.1
-			IL_05fe: stelem.ref
-			IL_05ff: dup
-			IL_0600: ldc.i4.1
-			IL_0601: ldloc.2
-			IL_0602: stelem.ref
-			IL_0603: dup
-			IL_0604: ldc.i4.2
-			IL_0605: ldloc.3
+			IL_05e0: ldloc.0
+			IL_05e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_05eb: ldloc.0
+			IL_05ec: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05f1: dup
+			IL_05f2: ldc.i4.0
+			IL_05f3: ldloc.1
+			IL_05f4: stelem.ref
+			IL_05f5: dup
+			IL_05f6: ldc.i4.1
+			IL_05f7: ldloc.2
+			IL_05f8: stelem.ref
+			IL_05f9: dup
+			IL_05fa: ldc.i4.2
+			IL_05fb: ldloc.3
+			IL_05fc: stelem.ref
+			IL_05fd: dup
+			IL_05fe: ldc.i4.3
+			IL_05ff: ldloc.s 4
+			IL_0601: stelem.ref
+			IL_0602: dup
+			IL_0603: ldc.i4.4
+			IL_0604: ldloc.s 5
 			IL_0606: stelem.ref
 			IL_0607: dup
-			IL_0608: ldc.i4.3
-			IL_0609: ldloc.s 4
+			IL_0608: ldc.i4.5
+			IL_0609: ldloc.s 6
 			IL_060b: stelem.ref
 			IL_060c: dup
-			IL_060d: ldc.i4.4
-			IL_060e: ldloc.s 5
+			IL_060d: ldc.i4.6
+			IL_060e: ldloc.s 7
 			IL_0610: stelem.ref
 			IL_0611: dup
-			IL_0612: ldc.i4.5
-			IL_0613: ldloc.s 6
+			IL_0612: ldc.i4.7
+			IL_0613: ldloc.s 8
 			IL_0615: stelem.ref
 			IL_0616: dup
-			IL_0617: ldc.i4.6
-			IL_0618: ldloc.s 7
+			IL_0617: ldc.i4.8
+			IL_0618: ldloc.s 9
 			IL_061a: stelem.ref
 			IL_061b: dup
-			IL_061c: ldc.i4.7
-			IL_061d: ldloc.s 8
-			IL_061f: stelem.ref
-			IL_0620: dup
-			IL_0621: ldc.i4.8
-			IL_0622: ldloc.s 9
-			IL_0624: stelem.ref
-			IL_0625: dup
-			IL_0626: ldc.i4.s 9
-			IL_0628: ldloc.s 10
-			IL_062a: stelem.ref
-			IL_062b: dup
-			IL_062c: ldc.i4.s 10
-			IL_062e: ldloc.s 11
-			IL_0630: stelem.ref
-			IL_0631: dup
-			IL_0632: ldc.i4.s 11
-			IL_0634: ldloc.s 12
-			IL_0636: stelem.ref
-			IL_0637: dup
-			IL_0638: ldc.i4.s 12
-			IL_063a: ldloc.s 13
-			IL_063c: stelem.ref
-			IL_063d: dup
-			IL_063e: ldc.i4.s 13
-			IL_0640: ldloc.s 14
-			IL_0642: stelem.ref
-			IL_0643: dup
-			IL_0644: ldc.i4.s 14
-			IL_0646: ldloc.s 15
-			IL_0648: stelem.ref
-			IL_0649: dup
-			IL_064a: ldc.i4.s 15
-			IL_064c: ldloc.s 16
-			IL_064e: stelem.ref
-			IL_064f: dup
-			IL_0650: ldc.i4.s 16
-			IL_0652: ldloc.s 17
-			IL_0654: stelem.ref
-			IL_0655: dup
-			IL_0656: ldc.i4.s 17
-			IL_0658: ldloc.s 18
-			IL_065a: stelem.ref
-			IL_065b: dup
-			IL_065c: ldc.i4.s 18
-			IL_065e: ldloc.s 19
-			IL_0660: stelem.ref
-			IL_0661: dup
-			IL_0662: ldc.i4.s 19
-			IL_0664: ldloc.s 20
-			IL_0666: stelem.ref
-			IL_0667: dup
-			IL_0668: ldc.i4.s 20
-			IL_066a: ldloc.s 21
-			IL_066c: stelem.ref
-			IL_066d: dup
-			IL_066e: ldc.i4.s 21
-			IL_0670: ldloc.s 22
-			IL_0672: stelem.ref
-			IL_0673: dup
-			IL_0674: ldc.i4.s 22
-			IL_0676: ldloc.s 23
-			IL_0678: stelem.ref
-			IL_0679: pop
-			IL_067a: ldloc.0
-			IL_067b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0680: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0685: ret
+			IL_061c: ldc.i4.s 9
+			IL_061e: ldloc.s 10
+			IL_0620: stelem.ref
+			IL_0621: dup
+			IL_0622: ldc.i4.s 10
+			IL_0624: ldloc.s 11
+			IL_0626: stelem.ref
+			IL_0627: dup
+			IL_0628: ldc.i4.s 11
+			IL_062a: ldloc.s 12
+			IL_062c: stelem.ref
+			IL_062d: dup
+			IL_062e: ldc.i4.s 12
+			IL_0630: ldloc.s 13
+			IL_0632: stelem.ref
+			IL_0633: dup
+			IL_0634: ldc.i4.s 13
+			IL_0636: ldloc.s 14
+			IL_0638: stelem.ref
+			IL_0639: dup
+			IL_063a: ldc.i4.s 14
+			IL_063c: ldloc.s 15
+			IL_063e: stelem.ref
+			IL_063f: dup
+			IL_0640: ldc.i4.s 15
+			IL_0642: ldloc.s 16
+			IL_0644: stelem.ref
+			IL_0645: dup
+			IL_0646: ldc.i4.s 16
+			IL_0648: ldloc.s 17
+			IL_064a: stelem.ref
+			IL_064b: dup
+			IL_064c: ldc.i4.s 17
+			IL_064e: ldloc.s 18
+			IL_0650: stelem.ref
+			IL_0651: dup
+			IL_0652: ldc.i4.s 18
+			IL_0654: ldloc.s 19
+			IL_0656: stelem.ref
+			IL_0657: dup
+			IL_0658: ldc.i4.s 19
+			IL_065a: ldloc.s 20
+			IL_065c: stelem.ref
+			IL_065d: dup
+			IL_065e: ldc.i4.s 20
+			IL_0660: ldloc.s 21
+			IL_0662: stelem.ref
+			IL_0663: dup
+			IL_0664: ldc.i4.s 21
+			IL_0666: ldloc.s 22
+			IL_0668: stelem.ref
+			IL_0669: dup
+			IL_066a: ldc.i4.s 22
+			IL_066c: ldloc.s 23
+			IL_066e: stelem.ref
+			IL_066f: pop
+			IL_0670: ldloc.0
+			IL_0671: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0676: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_067b: ret
 
-			IL_0686: ldloc.0
-			IL_0687: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_068c: stloc.s 24
-			IL_068e: ldloc.s 24
-			IL_0690: stloc.s 8
-			IL_0692: ldloc.s 16
-			IL_0694: stloc.s 24
-			IL_0696: ldloc.s 24
-			IL_0698: stloc.s 10
-			IL_069a: ldloc.s 9
-			IL_069c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06a1: ldc.i4.0
-			IL_06a2: ceq
-			IL_06a4: stloc.s 25
-			IL_06a6: ldloc.s 25
-			IL_06a8: brfalse IL_06e6
+			IL_067c: ldloc.0
+			IL_067d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0682: stloc.s 24
+			IL_0684: ldloc.s 24
+			IL_0686: stloc.s 8
+			IL_0688: ldloc.s 16
+			IL_068a: stloc.s 24
+			IL_068c: ldloc.s 24
+			IL_068e: stloc.s 10
+			IL_0690: ldloc.s 9
+			IL_0692: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0697: ldc.i4.0
+			IL_0698: ceq
+			IL_069a: stloc.s 25
+			IL_069c: ldloc.s 25
+			IL_069e: brfalse IL_06dc
 
-			IL_06ad: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
-			IL_06b2: stloc.s 17
-			IL_06b4: ldloc.s 14
-			IL_06b6: ldstr "fragment"
-			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c0: stloc.s 24
-			IL_06c2: ldloc.s 24
-			IL_06c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06c9: stloc.s 25
-			IL_06cb: ldloc.s 25
-			IL_06cd: brtrue IL_06de
+			IL_06a3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
+			IL_06a8: stloc.s 17
+			IL_06aa: ldloc.s 14
+			IL_06ac: ldstr "fragment"
+			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b6: stloc.s 24
+			IL_06b8: ldloc.s 24
+			IL_06ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_06bf: stloc.s 25
+			IL_06c1: ldloc.s 25
+			IL_06c3: brtrue IL_06d4
 
-			IL_06d2: ldstr ""
-			IL_06d7: stloc.s 33
-			IL_06d9: br IL_06e2
+			IL_06c8: ldstr ""
+			IL_06cd: stloc.s 33
+			IL_06cf: br IL_06d8
 
-			IL_06de: ldloc.s 24
-			IL_06e0: stloc.s 33
+			IL_06d4: ldloc.s 24
+			IL_06d6: stloc.s 33
 
-			IL_06e2: ldloc.s 33
-			IL_06e4: stloc.s 9
+			IL_06d8: ldloc.s 33
+			IL_06da: stloc.s 9
 
-			IL_06e6: br IL_07f2
+			IL_06dc: br IL_07e8
 
-			IL_06eb: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_06f0: stloc.s 18
-			IL_06f2: ldloc.1
-			IL_06f3: ldstr "url"
-			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06fd: ldstr "trim"
-			IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0707: stloc.s 24
-			IL_0709: ldloc.s 24
-			IL_070b: stloc.s 19
-			IL_070d: ldc.i4.1
-			IL_070e: newarr [System.Runtime]System.Object
-			IL_0713: dup
-			IL_0714: ldc.i4.0
-			IL_0715: ldarg.0
-			IL_0716: ldc.i4.1
-			IL_0717: ldelem.ref
-			IL_0718: stelem.ref
-			IL_0719: ldc.i4.0
-			IL_071a: ldelem.ref
-			IL_071b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0720: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0726: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_072b: ldnull
-			IL_072c: ldloc.s 19
-			IL_072e: ldnull
-			IL_072f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0734: stloc.s 24
-			IL_0736: ldloc.0
+			IL_06e1: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
+			IL_06e6: stloc.s 18
+			IL_06e8: ldloc.1
+			IL_06e9: ldstr "url"
+			IL_06ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06f3: ldstr "trim"
+			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_06fd: stloc.s 24
+			IL_06ff: ldloc.s 24
+			IL_0701: stloc.s 19
+			IL_0703: ldc.i4.1
+			IL_0704: newarr [System.Runtime]System.Object
+			IL_0709: dup
+			IL_070a: ldc.i4.0
+			IL_070b: ldarg.0
+			IL_070c: ldc.i4.1
+			IL_070d: ldelem.ref
+			IL_070e: stelem.ref
+			IL_070f: ldc.i4.0
+			IL_0710: ldelem.ref
+			IL_0711: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0716: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_071c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0721: ldnull
+			IL_0722: ldloc.s 19
+			IL_0724: ldnull
+			IL_0725: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_072a: stloc.s 24
+			IL_072c: ldloc.0
+			IL_072d: ldc.i4.3
+			IL_072e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0733: ldloc.0
+			IL_0734: ldloc.s 24
+			IL_0736: ldarg.0
 			IL_0737: ldc.i4.3
-			IL_0738: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_073d: ldloc.0
-			IL_073e: ldloc.s 24
-			IL_0740: ldarg.0
-			IL_0741: ldc.i4.3
-			IL_0742: ldloc.0
-			IL_0743: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0748: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_074d: ldloc.0
-			IL_074e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0753: dup
-			IL_0754: ldc.i4.0
-			IL_0755: ldloc.1
-			IL_0756: stelem.ref
-			IL_0757: dup
-			IL_0758: ldc.i4.1
-			IL_0759: ldloc.2
-			IL_075a: stelem.ref
-			IL_075b: dup
-			IL_075c: ldc.i4.2
-			IL_075d: ldloc.3
+			IL_0738: ldloc.0
+			IL_0739: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_073e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0743: ldloc.0
+			IL_0744: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0749: dup
+			IL_074a: ldc.i4.0
+			IL_074b: ldloc.1
+			IL_074c: stelem.ref
+			IL_074d: dup
+			IL_074e: ldc.i4.1
+			IL_074f: ldloc.2
+			IL_0750: stelem.ref
+			IL_0751: dup
+			IL_0752: ldc.i4.2
+			IL_0753: ldloc.3
+			IL_0754: stelem.ref
+			IL_0755: dup
+			IL_0756: ldc.i4.3
+			IL_0757: ldloc.s 4
+			IL_0759: stelem.ref
+			IL_075a: dup
+			IL_075b: ldc.i4.4
+			IL_075c: ldloc.s 5
 			IL_075e: stelem.ref
 			IL_075f: dup
-			IL_0760: ldc.i4.3
-			IL_0761: ldloc.s 4
+			IL_0760: ldc.i4.5
+			IL_0761: ldloc.s 6
 			IL_0763: stelem.ref
 			IL_0764: dup
-			IL_0765: ldc.i4.4
-			IL_0766: ldloc.s 5
+			IL_0765: ldc.i4.6
+			IL_0766: ldloc.s 7
 			IL_0768: stelem.ref
 			IL_0769: dup
-			IL_076a: ldc.i4.5
-			IL_076b: ldloc.s 6
+			IL_076a: ldc.i4.7
+			IL_076b: ldloc.s 8
 			IL_076d: stelem.ref
 			IL_076e: dup
-			IL_076f: ldc.i4.6
-			IL_0770: ldloc.s 7
+			IL_076f: ldc.i4.8
+			IL_0770: ldloc.s 9
 			IL_0772: stelem.ref
 			IL_0773: dup
-			IL_0774: ldc.i4.7
-			IL_0775: ldloc.s 8
-			IL_0777: stelem.ref
-			IL_0778: dup
-			IL_0779: ldc.i4.8
-			IL_077a: ldloc.s 9
-			IL_077c: stelem.ref
-			IL_077d: dup
-			IL_077e: ldc.i4.s 9
-			IL_0780: ldloc.s 10
-			IL_0782: stelem.ref
-			IL_0783: dup
-			IL_0784: ldc.i4.s 10
-			IL_0786: ldloc.s 11
-			IL_0788: stelem.ref
-			IL_0789: dup
-			IL_078a: ldc.i4.s 11
-			IL_078c: ldloc.s 12
-			IL_078e: stelem.ref
-			IL_078f: dup
-			IL_0790: ldc.i4.s 12
-			IL_0792: ldloc.s 13
-			IL_0794: stelem.ref
-			IL_0795: dup
-			IL_0796: ldc.i4.s 13
-			IL_0798: ldloc.s 14
-			IL_079a: stelem.ref
-			IL_079b: dup
-			IL_079c: ldc.i4.s 14
-			IL_079e: ldloc.s 15
-			IL_07a0: stelem.ref
-			IL_07a1: dup
-			IL_07a2: ldc.i4.s 15
-			IL_07a4: ldloc.s 16
-			IL_07a6: stelem.ref
-			IL_07a7: dup
-			IL_07a8: ldc.i4.s 16
-			IL_07aa: ldloc.s 17
-			IL_07ac: stelem.ref
-			IL_07ad: dup
-			IL_07ae: ldc.i4.s 17
-			IL_07b0: ldloc.s 18
-			IL_07b2: stelem.ref
-			IL_07b3: dup
-			IL_07b4: ldc.i4.s 18
-			IL_07b6: ldloc.s 19
-			IL_07b8: stelem.ref
-			IL_07b9: dup
-			IL_07ba: ldc.i4.s 19
-			IL_07bc: ldloc.s 20
-			IL_07be: stelem.ref
-			IL_07bf: dup
-			IL_07c0: ldc.i4.s 20
-			IL_07c2: ldloc.s 21
-			IL_07c4: stelem.ref
-			IL_07c5: dup
-			IL_07c6: ldc.i4.s 21
-			IL_07c8: ldloc.s 22
-			IL_07ca: stelem.ref
-			IL_07cb: dup
-			IL_07cc: ldc.i4.s 22
-			IL_07ce: ldloc.s 23
-			IL_07d0: stelem.ref
-			IL_07d1: pop
-			IL_07d2: ldloc.0
-			IL_07d3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07d8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07dd: ret
+			IL_0774: ldc.i4.s 9
+			IL_0776: ldloc.s 10
+			IL_0778: stelem.ref
+			IL_0779: dup
+			IL_077a: ldc.i4.s 10
+			IL_077c: ldloc.s 11
+			IL_077e: stelem.ref
+			IL_077f: dup
+			IL_0780: ldc.i4.s 11
+			IL_0782: ldloc.s 12
+			IL_0784: stelem.ref
+			IL_0785: dup
+			IL_0786: ldc.i4.s 12
+			IL_0788: ldloc.s 13
+			IL_078a: stelem.ref
+			IL_078b: dup
+			IL_078c: ldc.i4.s 13
+			IL_078e: ldloc.s 14
+			IL_0790: stelem.ref
+			IL_0791: dup
+			IL_0792: ldc.i4.s 14
+			IL_0794: ldloc.s 15
+			IL_0796: stelem.ref
+			IL_0797: dup
+			IL_0798: ldc.i4.s 15
+			IL_079a: ldloc.s 16
+			IL_079c: stelem.ref
+			IL_079d: dup
+			IL_079e: ldc.i4.s 16
+			IL_07a0: ldloc.s 17
+			IL_07a2: stelem.ref
+			IL_07a3: dup
+			IL_07a4: ldc.i4.s 17
+			IL_07a6: ldloc.s 18
+			IL_07a8: stelem.ref
+			IL_07a9: dup
+			IL_07aa: ldc.i4.s 18
+			IL_07ac: ldloc.s 19
+			IL_07ae: stelem.ref
+			IL_07af: dup
+			IL_07b0: ldc.i4.s 19
+			IL_07b2: ldloc.s 20
+			IL_07b4: stelem.ref
+			IL_07b5: dup
+			IL_07b6: ldc.i4.s 20
+			IL_07b8: ldloc.s 21
+			IL_07ba: stelem.ref
+			IL_07bb: dup
+			IL_07bc: ldc.i4.s 21
+			IL_07be: ldloc.s 22
+			IL_07c0: stelem.ref
+			IL_07c1: dup
+			IL_07c2: ldc.i4.s 22
+			IL_07c4: ldloc.s 23
+			IL_07c6: stelem.ref
+			IL_07c7: pop
+			IL_07c8: ldloc.0
+			IL_07c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07ce: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07d3: ret
 
-			IL_07de: ldloc.0
-			IL_07df: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_07e4: stloc.s 24
-			IL_07e6: ldloc.s 24
-			IL_07e8: stloc.s 8
-			IL_07ea: ldloc.s 19
-			IL_07ec: stloc.s 24
-			IL_07ee: ldloc.s 24
-			IL_07f0: stloc.s 10
+			IL_07d4: ldloc.0
+			IL_07d5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_07da: stloc.s 24
+			IL_07dc: ldloc.s 24
+			IL_07de: stloc.s 8
+			IL_07e0: ldloc.s 19
+			IL_07e2: stloc.s 24
+			IL_07e4: ldloc.s 24
+			IL_07e6: stloc.s 10
 
-			IL_07f2: ldloc.s 9
-			IL_07f4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_07f9: ldc.i4.0
-			IL_07fa: ceq
-			IL_07fc: stloc.s 25
-			IL_07fe: ldloc.s 25
-			IL_0800: brfalse IL_0878
+			IL_07e8: ldloc.s 9
+			IL_07ea: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_07ef: ldc.i4.0
+			IL_07f0: ceq
+			IL_07f2: stloc.s 25
+			IL_07f4: ldloc.s 25
+			IL_07f6: brfalse IL_086e
 
-			IL_0805: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
-			IL_080a: stloc.s 20
-			IL_080c: ldloc.1
-			IL_080d: ldstr "section"
-			IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0817: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_081c: stloc.s 29
-			IL_081e: ldstr "Could not infer an element id for section '"
-			IL_0823: ldloc.s 29
-			IL_0825: call string [System.Runtime]System.String::Concat(string, string)
-			IL_082a: stloc.s 29
-			IL_082c: ldloc.s 29
-			IL_082e: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0833: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0838: stloc.s 29
-			IL_083a: ldloc.s 29
-			IL_083c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0841: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0846: stloc.s 24
-			IL_0848: ldloc.0
-			IL_0849: ldc.i4.m1
-			IL_084a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_084f: ldloc.0
-			IL_0850: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0855: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_085a: ldarg.0
-			IL_085b: ldc.i4.1
-			IL_085c: newarr [System.Runtime]System.Object
-			IL_0861: dup
-			IL_0862: ldc.i4.0
-			IL_0863: ldloc.s 24
-			IL_0865: stelem.ref
-			IL_0866: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_086b: pop
-			IL_086c: ldloc.0
-			IL_086d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0872: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0877: ret
+			IL_07fb: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
+			IL_0800: stloc.s 20
+			IL_0802: ldloc.1
+			IL_0803: ldstr "section"
+			IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_080d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0812: stloc.s 29
+			IL_0814: ldstr "Could not infer an element id for section '"
+			IL_0819: ldloc.s 29
+			IL_081b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0820: stloc.s 29
+			IL_0822: ldloc.s 29
+			IL_0824: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0829: call string [System.Runtime]System.String::Concat(string, string)
+			IL_082e: stloc.s 29
+			IL_0830: ldloc.s 29
+			IL_0832: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0837: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_083c: stloc.s 24
+			IL_083e: ldloc.0
+			IL_083f: ldc.i4.m1
+			IL_0840: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0845: ldloc.0
+			IL_0846: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_084b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0850: ldarg.0
+			IL_0851: ldc.i4.1
+			IL_0852: newarr [System.Runtime]System.Object
+			IL_0857: dup
+			IL_0858: ldc.i4.0
+			IL_0859: ldloc.s 24
+			IL_085b: stelem.ref
+			IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0861: pop
+			IL_0862: ldloc.0
+			IL_0863: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0868: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_086d: ret
 
-			IL_0878: ldc.i4.1
-			IL_0879: newarr [System.Runtime]System.Object
-			IL_087e: dup
-			IL_087f: ldc.i4.0
-			IL_0880: ldarg.0
-			IL_0881: ldc.i4.1
-			IL_0882: ldelem.ref
-			IL_0883: stelem.ref
-			IL_0884: ldc.i4.0
-			IL_0885: ldelem.ref
-			IL_0886: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_088b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0891: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0896: ldnull
-			IL_0897: ldloc.s 8
-			IL_0899: ldloc.s 9
-			IL_089b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_08a0: stloc.s 24
-			IL_08a2: ldloc.s 24
-			IL_08a4: stloc.s 21
-			IL_08a6: ldarg.0
-			IL_08a7: ldc.i4.1
-			IL_08a8: ldelem.ref
-			IL_08a9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_08ae: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_08b3: ldstr "Cannot access 'path' before initialization"
-			IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_08bd: stloc.s 24
-			IL_08bf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_08c4: ldstr "cwd"
-			IL_08c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_08ce: stloc.s 30
-			IL_08d0: ldloc.s 24
-			IL_08d2: ldstr "join"
+			IL_086e: ldc.i4.1
+			IL_086f: newarr [System.Runtime]System.Object
+			IL_0874: dup
+			IL_0875: ldc.i4.0
+			IL_0876: ldarg.0
+			IL_0877: ldc.i4.1
+			IL_0878: ldelem.ref
+			IL_0879: stelem.ref
+			IL_087a: ldc.i4.0
+			IL_087b: ldelem.ref
+			IL_087c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0881: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0887: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_088c: ldnull
+			IL_088d: ldloc.s 8
+			IL_088f: ldloc.s 9
+			IL_0891: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0896: stloc.s 24
+			IL_0898: ldloc.s 24
+			IL_089a: stloc.s 21
+			IL_089c: ldarg.0
+			IL_089d: ldc.i4.1
+			IL_089e: ldelem.ref
+			IL_089f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08a4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_08a9: stloc.s 24
+			IL_08ab: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_08b0: ldstr "cwd"
+			IL_08b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_08ba: stloc.s 30
+			IL_08bc: ldloc.s 24
+			IL_08be: ldstr "join"
+			IL_08c3: ldloc.s 30
+			IL_08c5: ldloc.1
+			IL_08c6: ldstr "outFile"
+			IL_08cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_08d5: stloc.s 30
 			IL_08d7: ldloc.s 30
-			IL_08d9: ldloc.1
-			IL_08da: ldstr "outFile"
-			IL_08df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_08e9: stloc.s 30
-			IL_08eb: ldloc.s 30
-			IL_08ed: stloc.s 22
-			IL_08ef: ldloc.s 21
-			IL_08f1: ldstr "html"
-			IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08fb: stloc.s 30
-			IL_08fd: ldloc.1
-			IL_08fe: ldstr "section"
-			IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0908: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_090d: stloc.s 29
-			IL_090f: ldstr "ECMA-262 "
-			IL_0914: ldloc.s 29
-			IL_0916: call string [System.Runtime]System.String::Concat(string, string)
-			IL_091b: stloc.s 29
-			IL_091d: ldnull
-			IL_091e: ldloc.s 30
-			IL_0920: ldloc.s 29
-			IL_0922: ldloc.s 10
-			IL_0924: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-			IL_0929: stloc.s 30
-			IL_092b: ldloc.s 30
-			IL_092d: stloc.s 23
-			IL_092f: ldarg.0
-			IL_0930: ldc.i4.1
-			IL_0931: ldelem.ref
-			IL_0932: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0937: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_093c: ldstr "Cannot access 'fs' before initialization"
-			IL_0941: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0946: stloc.s 30
-			IL_0948: ldloc.s 30
-			IL_094a: ldstr "writeFileSync"
-			IL_094f: ldloc.s 22
-			IL_0951: ldloc.s 23
-			IL_0953: ldstr "utf8"
-			IL_0958: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_095d: pop
-			IL_095e: ldloc.1
-			IL_095f: ldstr "section"
-			IL_0964: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0969: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_096e: stloc.s 29
-			IL_0970: ldstr "Extracted section "
-			IL_0975: ldloc.s 29
+			IL_08d9: stloc.s 22
+			IL_08db: ldloc.s 21
+			IL_08dd: ldstr "html"
+			IL_08e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08e7: stloc.s 30
+			IL_08e9: ldloc.1
+			IL_08ea: ldstr "section"
+			IL_08ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08f9: stloc.s 29
+			IL_08fb: ldstr "ECMA-262 "
+			IL_0900: ldloc.s 29
+			IL_0902: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0907: stloc.s 29
+			IL_0909: ldnull
+			IL_090a: ldloc.s 30
+			IL_090c: ldloc.s 29
+			IL_090e: ldloc.s 10
+			IL_0910: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+			IL_0915: stloc.s 30
+			IL_0917: ldloc.s 30
+			IL_0919: stloc.s 23
+			IL_091b: ldarg.0
+			IL_091c: ldc.i4.1
+			IL_091d: ldelem.ref
+			IL_091e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0923: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0928: ldstr "writeFileSync"
+			IL_092d: ldloc.s 22
+			IL_092f: ldloc.s 23
+			IL_0931: ldstr "utf8"
+			IL_0936: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_093b: pop
+			IL_093c: ldloc.1
+			IL_093d: ldstr "section"
+			IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0947: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_094c: stloc.s 29
+			IL_094e: ldstr "Extracted section "
+			IL_0953: ldloc.s 29
+			IL_0955: call string [System.Runtime]System.String::Concat(string, string)
+			IL_095a: stloc.s 29
+			IL_095c: ldloc.s 29
+			IL_095e: ldstr " (id="
+			IL_0963: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0968: stloc.s 29
+			IL_096a: ldloc.s 9
+			IL_096c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0971: stloc.s 28
+			IL_0973: ldloc.s 29
+			IL_0975: ldloc.s 28
 			IL_0977: call string [System.Runtime]System.String::Concat(string, string)
-			IL_097c: stloc.s 29
-			IL_097e: ldloc.s 29
-			IL_0980: ldstr " (id="
+			IL_097c: stloc.s 28
+			IL_097e: ldloc.s 28
+			IL_0980: ldstr ", tag="
 			IL_0985: call string [System.Runtime]System.String::Concat(string, string)
-			IL_098a: stloc.s 29
-			IL_098c: ldloc.s 9
-			IL_098e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0993: stloc.s 28
-			IL_0995: ldloc.s 29
-			IL_0997: ldloc.s 28
-			IL_0999: call string [System.Runtime]System.String::Concat(string, string)
-			IL_099e: stloc.s 28
-			IL_09a0: ldloc.s 28
-			IL_09a2: ldstr ", tag="
-			IL_09a7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09ac: stloc.s 28
-			IL_09ae: ldloc.s 21
-			IL_09b0: ldstr "tagName"
-			IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_098a: stloc.s 28
+			IL_098c: ldloc.s 21
+			IL_098e: ldstr "tagName"
+			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0998: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_099d: stloc.s 29
+			IL_099f: ldloc.s 28
+			IL_09a1: ldloc.s 29
+			IL_09a3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09a8: stloc.s 29
+			IL_09aa: ldloc.s 29
+			IL_09ac: ldstr ") -> "
+			IL_09b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09b6: stloc.s 29
+			IL_09b8: ldloc.s 22
 			IL_09ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09bf: stloc.s 29
-			IL_09c1: ldloc.s 28
-			IL_09c3: ldloc.s 29
+			IL_09bf: stloc.s 28
+			IL_09c1: ldloc.s 29
+			IL_09c3: ldloc.s 28
 			IL_09c5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09ca: stloc.s 29
-			IL_09cc: ldloc.s 29
-			IL_09ce: ldstr ") -> "
-			IL_09d3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09d8: stloc.s 29
-			IL_09da: ldloc.s 22
-			IL_09dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09e1: stloc.s 28
-			IL_09e3: ldloc.s 29
-			IL_09e5: ldloc.s 28
-			IL_09e7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09ec: stloc.s 28
-			IL_09ee: ldnull
-			IL_09ef: ldloc.s 28
-			IL_09f1: ldloc.s 22
-			IL_09f3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_09f8: stloc.s 30
-			IL_09fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09ff: ldloc.s 30
-			IL_0a01: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a06: pop
-			IL_0a07: ldarg.0
-			IL_0a08: ldc.i4.1
-			IL_0a09: ldelem.ref
-			IL_0a0a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a0f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a14: ldstr "Cannot access 'fs' before initialization"
-			IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0a1e: stloc.s 30
-			IL_0a20: ldloc.s 30
-			IL_0a22: ldstr "readFileSync"
-			IL_0a27: ldloc.s 22
-			IL_0a29: ldstr "utf8"
-			IL_0a2e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a33: stloc.s 30
-			IL_0a35: ldnull
-			IL_0a36: ldloc.s 30
-			IL_0a38: ldloc.s 22
-			IL_0a3a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0a3f: stloc.s 30
-			IL_0a41: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a46: ldloc.s 30
-			IL_0a48: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a4d: pop
-			IL_0a4e: ldloc.0
-			IL_0a4f: ldc.i4.m1
-			IL_0a50: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0a55: ldloc.0
-			IL_0a56: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a5b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0a60: ldarg.0
-			IL_0a61: ldc.i4.1
-			IL_0a62: newarr [System.Runtime]System.Object
-			IL_0a67: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0a6c: pop
-			IL_0a6d: ldloc.0
-			IL_0a6e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a73: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a78: ret
+			IL_09ca: stloc.s 28
+			IL_09cc: ldnull
+			IL_09cd: ldloc.s 28
+			IL_09cf: ldloc.s 22
+			IL_09d1: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_09d6: stloc.s 30
+			IL_09d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09dd: ldloc.s 30
+			IL_09df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09e4: pop
+			IL_09e5: ldarg.0
+			IL_09e6: ldc.i4.1
+			IL_09e7: ldelem.ref
+			IL_09e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_09f2: ldstr "readFileSync"
+			IL_09f7: ldloc.s 22
+			IL_09f9: ldstr "utf8"
+			IL_09fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a03: stloc.s 30
+			IL_0a05: ldnull
+			IL_0a06: ldloc.s 30
+			IL_0a08: ldloc.s 22
+			IL_0a0a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0a0f: stloc.s 30
+			IL_0a11: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a16: ldloc.s 30
+			IL_0a18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a1d: pop
+			IL_0a1e: ldloc.0
+			IL_0a1f: ldc.i4.m1
+			IL_0a20: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0a25: ldloc.0
+			IL_0a26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a2b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0a30: ldarg.0
+			IL_0a31: ldc.i4.1
+			IL_0a32: newarr [System.Runtime]System.Object
+			IL_0a37: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a3c: pop
+			IL_0a3d: ldloc.0
+			IL_0a3e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a43: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a48: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5079,30 +5055,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x43ad
+			// Method begins at RVA 0x434d
 			// Header size: 1
-			// Code size: 63 (0x3f)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0032: ldarg.0
-			IL_0033: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0038: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_003d: nop
-			IL_003e: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -5342,7 +5303,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x45a6
+		// Method begins at RVA 0x450f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x439b
+				// Method begins at RVA 0x433b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -189,7 +189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x43a4
+				// Method begins at RVA 0x4344
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -321,7 +321,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4392
+			// Method begins at RVA 0x4332
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -430,7 +430,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x43f6
+					// Method begins at RVA 0x435f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -448,7 +448,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x43ed
+				// Method begins at RVA 0x4356
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -578,7 +578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x43ff
+				// Method begins at RVA 0x4368
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -606,7 +606,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x441a
+						// Method begins at RVA 0x4383
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -626,7 +626,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4423
+						// Method begins at RVA 0x438c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -646,7 +646,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x442c
+						// Method begins at RVA 0x4395
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -666,7 +666,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4435
+						// Method begins at RVA 0x439e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -686,7 +686,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x443e
+						// Method begins at RVA 0x43a7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -706,7 +706,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4447
+						// Method begins at RVA 0x43b0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -724,7 +724,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4411
+					// Method begins at RVA 0x437a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -742,7 +742,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4408
+				// Method begins at RVA 0x4371
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1096,7 +1096,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4498
+							// Method begins at RVA 0x4401
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1121,7 +1121,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4314
+						// Method begins at RVA 0x42b4
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1160,7 +1160,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x44a1
+							// Method begins at RVA 0x440a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1184,7 +1184,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4344
+						// Method begins at RVA 0x42e4
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
@@ -1257,7 +1257,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4486
+								// Method begins at RVA 0x43ef
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1275,7 +1275,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x447d
+							// Method begins at RVA 0x43e6
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1295,7 +1295,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x448f
+							// Method begins at RVA 0x43f8
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1317,7 +1317,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4474
+						// Method begins at RVA 0x43dd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1342,9 +1342,9 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3edc
+					// Method begins at RVA 0x3e88
 					// Header size: 12
-					// Code size: 1065 (0x429)
+					// Code size: 1055 (0x41f)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1448,7 +1448,7 @@
 					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d4: stloc.s 8
 					IL_00d6: ldloc.s 8
-					IL_00d8: brfalse IL_025a
+					IL_00d8: brfalse IL_0250
 
 					IL_00dd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
 					IL_00e2: stloc.3
@@ -1525,283 +1525,281 @@
 					IL_0184: ldelem.ref
 					IL_0185: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 					IL_018a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_018f: ldstr "Cannot access 'NodeUrl' before initialization"
-					IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0199: stloc.s 18
-					IL_019b: ldc.i4.2
-					IL_019c: newarr [System.Runtime]System.Object
-					IL_01a1: dup
-					IL_01a2: ldc.i4.0
-					IL_01a3: ldloc.2
-					IL_01a4: stelem.ref
-					IL_01a5: dup
-					IL_01a6: ldc.i4.1
-					IL_01a7: ldarg.0
-					IL_01a8: ldc.i4.2
-					IL_01a9: ldelem.ref
-					IL_01aa: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_01af: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_01b4: stelem.ref
-					IL_01b5: stloc.s 16
-					IL_01b7: ldloc.s 18
-					IL_01b9: ldloc.s 16
-					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_01c0: stloc.s 18
-					IL_01c2: ldloc.s 18
-					IL_01c4: ldstr "toString"
-					IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01ce: stloc.s 18
-					IL_01d0: ldloc.s 18
-					IL_01d2: stloc.s 5
-					IL_01d4: ldarg.2
-					IL_01d5: ldstr "resume"
-					IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01df: pop
-					IL_01e0: ldarg.0
-					IL_01e1: ldc.i4.1
-					IL_01e2: ldelem.ref
-					IL_01e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_01e8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_01ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01f2: ldc.r8 1
-					IL_01fb: sub
-					IL_01fc: box [System.Runtime]System.Double
-					IL_0201: stloc.s 19
-					IL_0203: ldc.i4.1
-					IL_0204: newarr [System.Runtime]System.Object
-					IL_0209: dup
-					IL_020a: ldc.i4.0
-					IL_020b: ldarg.0
-					IL_020c: ldc.i4.0
-					IL_020d: ldelem.ref
-					IL_020e: stelem.ref
-					IL_020f: ldc.i4.0
-					IL_0210: ldelem.ref
-					IL_0211: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0216: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-					IL_021c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-					IL_0221: ldnull
-					IL_0222: ldloc.s 5
-					IL_0224: ldloc.s 19
-					IL_0226: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-					IL_022b: stloc.s 18
-					IL_022d: ldarg.0
-					IL_022e: ldc.i4.2
-					IL_022f: ldelem.ref
-					IL_0230: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0235: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_023a: stloc.s 7
-					IL_023c: ldloc.s 18
-					IL_023e: ldstr "then"
-					IL_0243: ldloc.s 7
-					IL_0245: ldarg.0
-					IL_0246: ldc.i4.2
-					IL_0247: ldelem.ref
-					IL_0248: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_024d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0257: pop
-					IL_0258: ldnull
-					IL_0259: ret
+					IL_018f: stloc.s 18
+					IL_0191: ldc.i4.2
+					IL_0192: newarr [System.Runtime]System.Object
+					IL_0197: dup
+					IL_0198: ldc.i4.0
+					IL_0199: ldloc.2
+					IL_019a: stelem.ref
+					IL_019b: dup
+					IL_019c: ldc.i4.1
+					IL_019d: ldarg.0
+					IL_019e: ldc.i4.2
+					IL_019f: ldelem.ref
+					IL_01a0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_01a5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_01aa: stelem.ref
+					IL_01ab: stloc.s 16
+					IL_01ad: ldloc.s 18
+					IL_01af: ldloc.s 16
+					IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01b6: stloc.s 18
+					IL_01b8: ldloc.s 18
+					IL_01ba: ldstr "toString"
+					IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01c4: stloc.s 18
+					IL_01c6: ldloc.s 18
+					IL_01c8: stloc.s 5
+					IL_01ca: ldarg.2
+					IL_01cb: ldstr "resume"
+					IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01d5: pop
+					IL_01d6: ldarg.0
+					IL_01d7: ldc.i4.1
+					IL_01d8: ldelem.ref
+					IL_01d9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_01de: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_01e3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01e8: ldc.r8 1
+					IL_01f1: sub
+					IL_01f2: box [System.Runtime]System.Double
+					IL_01f7: stloc.s 19
+					IL_01f9: ldc.i4.1
+					IL_01fa: newarr [System.Runtime]System.Object
+					IL_01ff: dup
+					IL_0200: ldc.i4.0
+					IL_0201: ldarg.0
+					IL_0202: ldc.i4.0
+					IL_0203: ldelem.ref
+					IL_0204: stelem.ref
+					IL_0205: ldc.i4.0
+					IL_0206: ldelem.ref
+					IL_0207: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_020c: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+					IL_0212: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+					IL_0217: ldnull
+					IL_0218: ldloc.s 5
+					IL_021a: ldloc.s 19
+					IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+					IL_0221: stloc.s 18
+					IL_0223: ldarg.0
+					IL_0224: ldc.i4.2
+					IL_0225: ldelem.ref
+					IL_0226: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_022b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0230: stloc.s 7
+					IL_0232: ldloc.s 18
+					IL_0234: ldstr "then"
+					IL_0239: ldloc.s 7
+					IL_023b: ldarg.0
+					IL_023c: ldc.i4.2
+					IL_023d: ldelem.ref
+					IL_023e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0243: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_024d: pop
+					IL_024e: ldnull
+					IL_024f: ret
 
-					IL_025a: ldloc.1
-					IL_025b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0260: stloc.s 11
-					IL_0262: ldloc.s 11
-					IL_0264: ldc.r8 200
-					IL_026d: clt
-					IL_026f: stloc.s 8
-					IL_0271: ldloc.s 8
-					IL_0273: box [System.Runtime]System.Boolean
-					IL_0278: stloc.s 12
-					IL_027a: ldloc.s 12
-					IL_027c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0281: stloc.s 8
-					IL_0283: ldloc.s 8
-					IL_0285: brtrue IL_02b6
+					IL_0250: ldloc.1
+					IL_0251: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0256: stloc.s 11
+					IL_0258: ldloc.s 11
+					IL_025a: ldc.r8 200
+					IL_0263: clt
+					IL_0265: stloc.s 8
+					IL_0267: ldloc.s 8
+					IL_0269: box [System.Runtime]System.Boolean
+					IL_026e: stloc.s 12
+					IL_0270: ldloc.s 12
+					IL_0272: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0277: stloc.s 8
+					IL_0279: ldloc.s 8
+					IL_027b: brtrue IL_02ac
 
-					IL_028a: ldloc.1
-					IL_028b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0290: stloc.s 11
-					IL_0292: ldloc.s 11
-					IL_0294: ldc.r8 300
-					IL_029d: clt
-					IL_029f: ldc.i4.0
-					IL_02a0: ceq
-					IL_02a2: stloc.s 8
-					IL_02a4: ldloc.s 8
-					IL_02a6: box [System.Runtime]System.Boolean
-					IL_02ab: stloc.s 13
-					IL_02ad: ldloc.s 13
-					IL_02af: stloc.s 20
-					IL_02b1: br IL_02ba
+					IL_0280: ldloc.1
+					IL_0281: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0286: stloc.s 11
+					IL_0288: ldloc.s 11
+					IL_028a: ldc.r8 300
+					IL_0293: clt
+					IL_0295: ldc.i4.0
+					IL_0296: ceq
+					IL_0298: stloc.s 8
+					IL_029a: ldloc.s 8
+					IL_029c: box [System.Runtime]System.Boolean
+					IL_02a1: stloc.s 13
+					IL_02a3: ldloc.s 13
+					IL_02a5: stloc.s 20
+					IL_02a7: br IL_02b0
 
-					IL_02b6: ldloc.s 12
-					IL_02b8: stloc.s 20
+					IL_02ac: ldloc.s 12
+					IL_02ae: stloc.s 20
 
-					IL_02ba: ldloc.s 20
-					IL_02bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02c1: stloc.s 8
-					IL_02c3: ldloc.s 8
-					IL_02c5: brfalse IL_0365
+					IL_02b0: ldloc.s 20
+					IL_02b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02b7: stloc.s 8
+					IL_02b9: ldloc.s 8
+					IL_02bb: brfalse IL_035b
 
-					IL_02ca: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
-					IL_02cf: stloc.s 6
-					IL_02d1: ldarg.2
-					IL_02d2: ldstr "resume"
-					IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02dc: pop
-					IL_02dd: ldarg.0
-					IL_02de: ldc.i4.2
-					IL_02df: ldelem.ref
-					IL_02e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_02e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_02ea: stloc.s 7
-					IL_02ec: ldc.i4.3
-					IL_02ed: newarr [System.Runtime]System.Object
-					IL_02f2: dup
-					IL_02f3: ldc.i4.0
-					IL_02f4: ldarg.0
-					IL_02f5: ldc.i4.0
-					IL_02f6: ldelem.ref
-					IL_02f7: stelem.ref
-					IL_02f8: dup
-					IL_02f9: ldc.i4.1
-					IL_02fa: ldarg.0
-					IL_02fb: ldc.i4.1
-					IL_02fc: ldelem.ref
-					IL_02fd: stelem.ref
-					IL_02fe: dup
-					IL_02ff: ldc.i4.2
-					IL_0300: ldarg.0
-					IL_0301: ldc.i4.2
-					IL_0302: ldelem.ref
-					IL_0303: stelem.ref
-					IL_0304: stloc.s 16
-					IL_0306: ldloc.1
-					IL_0307: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_030c: stloc.s 17
-					IL_030e: ldstr "HTTP "
-					IL_0313: ldloc.s 17
-					IL_0315: call string [System.Runtime]System.String::Concat(string, string)
-					IL_031a: stloc.s 17
-					IL_031c: ldloc.s 17
-					IL_031e: ldstr " fetching "
-					IL_0323: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0328: stloc.s 17
-					IL_032a: ldarg.0
-					IL_032b: ldc.i4.1
-					IL_032c: ldelem.ref
-					IL_032d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0332: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0337: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_033c: stloc.s 21
-					IL_033e: ldloc.s 17
-					IL_0340: ldloc.s 21
-					IL_0342: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0347: stloc.s 21
-					IL_0349: ldloc.s 21
-					IL_034b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0350: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0355: stloc.s 18
-					IL_0357: ldloc.s 7
-					IL_0359: ldloc.s 16
-					IL_035b: ldloc.s 18
-					IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-					IL_0362: pop
-					IL_0363: ldnull
-					IL_0364: ret
+					IL_02c0: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
+					IL_02c5: stloc.s 6
+					IL_02c7: ldarg.2
+					IL_02c8: ldstr "resume"
+					IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02d2: pop
+					IL_02d3: ldarg.0
+					IL_02d4: ldc.i4.2
+					IL_02d5: ldelem.ref
+					IL_02d6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02db: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_02e0: stloc.s 7
+					IL_02e2: ldc.i4.3
+					IL_02e3: newarr [System.Runtime]System.Object
+					IL_02e8: dup
+					IL_02e9: ldc.i4.0
+					IL_02ea: ldarg.0
+					IL_02eb: ldc.i4.0
+					IL_02ec: ldelem.ref
+					IL_02ed: stelem.ref
+					IL_02ee: dup
+					IL_02ef: ldc.i4.1
+					IL_02f0: ldarg.0
+					IL_02f1: ldc.i4.1
+					IL_02f2: ldelem.ref
+					IL_02f3: stelem.ref
+					IL_02f4: dup
+					IL_02f5: ldc.i4.2
+					IL_02f6: ldarg.0
+					IL_02f7: ldc.i4.2
+					IL_02f8: ldelem.ref
+					IL_02f9: stelem.ref
+					IL_02fa: stloc.s 16
+					IL_02fc: ldloc.1
+					IL_02fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0302: stloc.s 17
+					IL_0304: ldstr "HTTP "
+					IL_0309: ldloc.s 17
+					IL_030b: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0310: stloc.s 17
+					IL_0312: ldloc.s 17
+					IL_0314: ldstr " fetching "
+					IL_0319: call string [System.Runtime]System.String::Concat(string, string)
+					IL_031e: stloc.s 17
+					IL_0320: ldarg.0
+					IL_0321: ldc.i4.1
+					IL_0322: ldelem.ref
+					IL_0323: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0328: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_032d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0332: stloc.s 21
+					IL_0334: ldloc.s 17
+					IL_0336: ldloc.s 21
+					IL_0338: call string [System.Runtime]System.String::Concat(string, string)
+					IL_033d: stloc.s 21
+					IL_033f: ldloc.s 21
+					IL_0341: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0346: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_034b: stloc.s 18
+					IL_034d: ldloc.s 7
+					IL_034f: ldloc.s 16
+					IL_0351: ldloc.s 18
+					IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_0358: pop
+					IL_0359: ldnull
+					IL_035a: ret
 
-					IL_0365: ldarg.2
-					IL_0366: ldstr "setEncoding"
-					IL_036b: ldstr "utf8"
-					IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0375: pop
-					IL_0376: ldloc.0
-					IL_0377: ldstr ""
-					IL_037c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0381: ldnull
-					IL_0382: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_0388: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_038d: ldc.i4.4
-					IL_038e: newarr [System.Runtime]System.Object
-					IL_0393: dup
-					IL_0394: ldc.i4.0
-					IL_0395: ldarg.0
-					IL_0396: ldc.i4.0
-					IL_0397: ldelem.ref
-					IL_0398: stelem.ref
-					IL_0399: dup
-					IL_039a: ldc.i4.1
-					IL_039b: ldarg.0
-					IL_039c: ldc.i4.1
-					IL_039d: ldelem.ref
+					IL_035b: ldarg.2
+					IL_035c: ldstr "setEncoding"
+					IL_0361: ldstr "utf8"
+					IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_036b: pop
+					IL_036c: ldloc.0
+					IL_036d: ldstr ""
+					IL_0372: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_0377: ldnull
+					IL_0378: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_037e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_0383: ldc.i4.4
+					IL_0384: newarr [System.Runtime]System.Object
+					IL_0389: dup
+					IL_038a: ldc.i4.0
+					IL_038b: ldarg.0
+					IL_038c: ldc.i4.0
+					IL_038d: ldelem.ref
+					IL_038e: stelem.ref
+					IL_038f: dup
+					IL_0390: ldc.i4.1
+					IL_0391: ldarg.0
+					IL_0392: ldc.i4.1
+					IL_0393: ldelem.ref
+					IL_0394: stelem.ref
+					IL_0395: dup
+					IL_0396: ldc.i4.2
+					IL_0397: ldarg.0
+					IL_0398: ldc.i4.2
+					IL_0399: ldelem.ref
+					IL_039a: stelem.ref
+					IL_039b: dup
+					IL_039c: ldc.i4.3
+					IL_039d: ldloc.0
 					IL_039e: stelem.ref
-					IL_039f: dup
-					IL_03a0: ldc.i4.2
-					IL_03a1: ldarg.0
-					IL_03a2: ldc.i4.2
-					IL_03a3: ldelem.ref
-					IL_03a4: stelem.ref
-					IL_03a5: dup
-					IL_03a6: ldc.i4.3
-					IL_03a7: ldloc.0
-					IL_03a8: stelem.ref
-					IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03b3: ldc.i4.1
-					IL_03b4: conv.r8
-					IL_03b5: ldstr ""
-					IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_03bf: stloc.s 18
-					IL_03c1: ldarg.2
-					IL_03c2: ldstr "on"
-					IL_03c7: ldstr "data"
-					IL_03cc: ldloc.s 18
-					IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_03d3: pop
-					IL_03d4: ldnull
-					IL_03d5: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_03db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_03e0: ldc.i4.4
-					IL_03e1: newarr [System.Runtime]System.Object
-					IL_03e6: dup
-					IL_03e7: ldc.i4.0
-					IL_03e8: ldarg.0
-					IL_03e9: ldc.i4.0
-					IL_03ea: ldelem.ref
-					IL_03eb: stelem.ref
-					IL_03ec: dup
-					IL_03ed: ldc.i4.1
-					IL_03ee: ldarg.0
-					IL_03ef: ldc.i4.1
-					IL_03f0: ldelem.ref
+					IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03a9: ldc.i4.1
+					IL_03aa: conv.r8
+					IL_03ab: ldstr ""
+					IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_03b5: stloc.s 18
+					IL_03b7: ldarg.2
+					IL_03b8: ldstr "on"
+					IL_03bd: ldstr "data"
+					IL_03c2: ldloc.s 18
+					IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03c9: pop
+					IL_03ca: ldnull
+					IL_03cb: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_03d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_03d6: ldc.i4.4
+					IL_03d7: newarr [System.Runtime]System.Object
+					IL_03dc: dup
+					IL_03dd: ldc.i4.0
+					IL_03de: ldarg.0
+					IL_03df: ldc.i4.0
+					IL_03e0: ldelem.ref
+					IL_03e1: stelem.ref
+					IL_03e2: dup
+					IL_03e3: ldc.i4.1
+					IL_03e4: ldarg.0
+					IL_03e5: ldc.i4.1
+					IL_03e6: ldelem.ref
+					IL_03e7: stelem.ref
+					IL_03e8: dup
+					IL_03e9: ldc.i4.2
+					IL_03ea: ldarg.0
+					IL_03eb: ldc.i4.2
+					IL_03ec: ldelem.ref
+					IL_03ed: stelem.ref
+					IL_03ee: dup
+					IL_03ef: ldc.i4.3
+					IL_03f0: ldloc.0
 					IL_03f1: stelem.ref
-					IL_03f2: dup
-					IL_03f3: ldc.i4.2
-					IL_03f4: ldarg.0
-					IL_03f5: ldc.i4.2
-					IL_03f6: ldelem.ref
-					IL_03f7: stelem.ref
-					IL_03f8: dup
-					IL_03f9: ldc.i4.3
-					IL_03fa: ldloc.0
-					IL_03fb: stelem.ref
-					IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0406: ldc.i4.0
-					IL_0407: conv.r8
-					IL_0408: ldstr ""
-					IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_0412: stloc.s 18
-					IL_0414: ldarg.2
-					IL_0415: ldstr "on"
-					IL_041a: ldstr "end"
-					IL_041f: ldloc.s 18
-					IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0426: pop
-					IL_0427: ldnull
-					IL_0428: ret
+					IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03fc: ldc.i4.0
+					IL_03fd: conv.r8
+					IL_03fe: ldstr ""
+					IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0408: stloc.s 18
+					IL_040a: ldarg.2
+					IL_040b: ldstr "on"
+					IL_0410: ldstr "end"
+					IL_0415: ldloc.s 18
+					IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_041c: pop
+					IL_041d: ldnull
+					IL_041e: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1823,7 +1821,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4462
+						// Method begins at RVA 0x43cb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1843,7 +1841,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x446b
+						// Method begins at RVA 0x43d4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1866,7 +1864,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4459
+					// Method begins at RVA 0x43c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1892,9 +1890,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cbc
+				// Method begins at RVA 0x3c8c
 				// Header size: 12
-				// Code size: 516 (0x204)
+				// Code size: 478 (0x1de)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
@@ -1933,186 +1931,176 @@
 					IL_0023: ldelem.ref
 					IL_0024: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 					IL_0029: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_002e: ldstr "Cannot access 'NodeUrl' before initialization"
-					IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0038: stloc.s 8
-					IL_003a: ldloc.s 8
-					IL_003c: ldc.i4.1
-					IL_003d: newarr [System.Runtime]System.Object
-					IL_0042: dup
-					IL_0043: ldc.i4.0
-					IL_0044: ldarg.0
-					IL_0045: ldc.i4.1
-					IL_0046: ldelem.ref
-					IL_0047: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_004c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0051: stelem.ref
-					IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_0057: stloc.s 8
-					IL_0059: ldloc.0
-					IL_005a: ldloc.s 8
-					IL_005c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_0061: leave IL_00d5
+					IL_002e: stloc.s 8
+					IL_0030: ldloc.s 8
+					IL_0032: ldc.i4.1
+					IL_0033: newarr [System.Runtime]System.Object
+					IL_0038: dup
+					IL_0039: ldc.i4.0
+					IL_003a: ldarg.0
+					IL_003b: ldc.i4.1
+					IL_003c: ldelem.ref
+					IL_003d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0042: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0047: stelem.ref
+					IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_004d: stloc.s 8
+					IL_004f: ldloc.0
+					IL_0050: ldloc.s 8
+					IL_0052: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_0057: leave IL_00cb
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
-					IL_0066: stloc.2
-					IL_0067: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope/Block_L76C12::.ctor()
-					IL_006c: stloc.3
-					IL_006d: ldloc.0
-					IL_006e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0073: stloc.s 8
-					IL_0075: ldc.i4.2
-					IL_0076: newarr [System.Runtime]System.Object
-					IL_007b: dup
-					IL_007c: ldc.i4.0
-					IL_007d: ldarg.0
-					IL_007e: ldc.i4.0
-					IL_007f: ldelem.ref
-					IL_0080: stelem.ref
-					IL_0081: dup
-					IL_0082: ldc.i4.1
-					IL_0083: ldarg.0
-					IL_0084: ldc.i4.1
-					IL_0085: ldelem.ref
-					IL_0086: stelem.ref
-					IL_0087: stloc.s 9
-					IL_0089: ldarg.0
-					IL_008a: ldc.i4.1
-					IL_008b: ldelem.ref
-					IL_008c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0091: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0096: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_009b: stloc.s 10
-					IL_009d: ldstr "Invalid URL: "
-					IL_00a2: ldloc.s 10
-					IL_00a4: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00a9: stloc.s 10
-					IL_00ab: ldloc.s 10
-					IL_00ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00b7: stloc.s 11
-					IL_00b9: ldloc.s 8
-					IL_00bb: ldloc.s 9
-					IL_00bd: ldloc.s 11
-					IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-					IL_00c4: pop
-					IL_00c5: ldnull
-					IL_00c6: stloc.s 4
-					IL_00c8: ldnull
-					IL_00c9: stloc.s 4
-					IL_00cb: leave IL_0201
+					IL_005c: stloc.2
+					IL_005d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope/Block_L76C12::.ctor()
+					IL_0062: stloc.3
+					IL_0063: ldloc.0
+					IL_0064: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0069: stloc.s 8
+					IL_006b: ldc.i4.2
+					IL_006c: newarr [System.Runtime]System.Object
+					IL_0071: dup
+					IL_0072: ldc.i4.0
+					IL_0073: ldarg.0
+					IL_0074: ldc.i4.0
+					IL_0075: ldelem.ref
+					IL_0076: stelem.ref
+					IL_0077: dup
+					IL_0078: ldc.i4.1
+					IL_0079: ldarg.0
+					IL_007a: ldc.i4.1
+					IL_007b: ldelem.ref
+					IL_007c: stelem.ref
+					IL_007d: stloc.s 9
+					IL_007f: ldarg.0
+					IL_0080: ldc.i4.1
+					IL_0081: ldelem.ref
+					IL_0082: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0087: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_008c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0091: stloc.s 10
+					IL_0093: ldstr "Invalid URL: "
+					IL_0098: ldloc.s 10
+					IL_009a: call string [System.Runtime]System.String::Concat(string, string)
+					IL_009f: stloc.s 10
+					IL_00a1: ldloc.s 10
+					IL_00a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00ad: stloc.s 11
+					IL_00af: ldloc.s 8
+					IL_00b1: ldloc.s 9
+					IL_00b3: ldloc.s 11
+					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+					IL_00ba: pop
+					IL_00bb: ldnull
+					IL_00bc: stloc.s 4
+					IL_00be: ldnull
+					IL_00bf: stloc.s 4
+					IL_00c1: leave IL_01db
 
-					IL_00d0: leave IL_00d5
+					IL_00c6: leave IL_00cb
 				} // end handler
 
-				IL_00d5: ldloc.0
-				IL_00d6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_00db: ldstr "protocol"
-				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00e5: ldstr "https:"
-				IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00ef: stloc.s 12
-				IL_00f1: ldloc.s 12
-				IL_00f3: brfalse IL_011a
+				IL_00cb: ldloc.0
+				IL_00cc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_00d1: ldstr "protocol"
+				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00db: ldstr "https:"
+				IL_00e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00e5: stloc.s 12
+				IL_00e7: ldloc.s 12
+				IL_00e9: brfalse IL_0102
 
-				IL_00f8: ldarg.0
-				IL_00f9: ldc.i4.0
-				IL_00fa: ldelem.ref
-				IL_00fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_0100: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-				IL_0105: ldstr "Cannot access 'https' before initialization"
-				IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_010f: stloc.s 11
-				IL_0111: ldloc.s 11
-				IL_0113: stloc.s 5
-				IL_0115: br IL_0137
+				IL_00ee: ldarg.0
+				IL_00ef: ldc.i4.0
+				IL_00f0: ldelem.ref
+				IL_00f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00f6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00fb: stloc.s 5
+				IL_00fd: br IL_0111
 
-				IL_011a: ldarg.0
-				IL_011b: ldc.i4.0
-				IL_011c: ldelem.ref
-				IL_011d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_0122: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-				IL_0127: ldstr "Cannot access 'http' before initialization"
-				IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0131: stloc.s 11
-				IL_0133: ldloc.s 11
-				IL_0135: stloc.s 5
+				IL_0102: ldarg.0
+				IL_0103: ldc.i4.0
+				IL_0104: ldelem.ref
+				IL_0105: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_010a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_010f: stloc.s 5
 
-				IL_0137: ldloc.s 5
-				IL_0139: stloc.s 6
-				IL_013b: ldloc.0
-				IL_013c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_0141: stloc.s 11
-				IL_0143: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0148: dup
-				IL_0149: ldstr "method"
-				IL_014e: ldstr "GET"
-				IL_0153: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0158: dup
-				IL_0159: ldstr "headers"
-				IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0163: dup
-				IL_0164: ldstr "Accept-Encoding"
-				IL_0169: ldstr "identity"
-				IL_016e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0173: dup
-				IL_0174: ldstr "User-Agent"
-				IL_0179: ldstr "js2il-docs-script"
-				IL_017e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0188: stloc.s 13
-				IL_018a: ldnull
-				IL_018b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
-				IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_0196: ldc.i4.3
-				IL_0197: newarr [System.Runtime]System.Object
-				IL_019c: dup
-				IL_019d: ldc.i4.0
-				IL_019e: ldarg.0
-				IL_019f: ldc.i4.0
-				IL_01a0: ldelem.ref
-				IL_01a1: stelem.ref
-				IL_01a2: dup
-				IL_01a3: ldc.i4.1
-				IL_01a4: ldarg.0
-				IL_01a5: ldc.i4.1
-				IL_01a6: ldelem.ref
-				IL_01a7: stelem.ref
-				IL_01a8: dup
-				IL_01a9: ldc.i4.2
-				IL_01aa: ldloc.0
-				IL_01ab: stelem.ref
-				IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_01b6: ldc.i4.1
-				IL_01b7: conv.r8
-				IL_01b8: ldstr ""
-				IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_01c2: stloc.s 8
-				IL_01c4: ldloc.s 6
-				IL_01c6: ldstr "request"
-				IL_01cb: ldloc.s 11
-				IL_01cd: ldloc.s 13
-				IL_01cf: ldloc.s 8
-				IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_01d6: stloc.s 8
-				IL_01d8: ldloc.s 8
-				IL_01da: stloc.s 7
-				IL_01dc: ldloc.s 7
-				IL_01de: ldstr "on"
-				IL_01e3: ldstr "error"
-				IL_01e8: ldloc.0
-				IL_01e9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-				IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_01f3: pop
-				IL_01f4: ldloc.s 7
-				IL_01f6: ldstr "end"
-				IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0200: pop
+				IL_0111: ldloc.s 5
+				IL_0113: stloc.s 6
+				IL_0115: ldloc.0
+				IL_0116: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_011b: stloc.s 11
+				IL_011d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0122: dup
+				IL_0123: ldstr "method"
+				IL_0128: ldstr "GET"
+				IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0132: dup
+				IL_0133: ldstr "headers"
+				IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_013d: dup
+				IL_013e: ldstr "Accept-Encoding"
+				IL_0143: ldstr "identity"
+				IL_0148: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_014d: dup
+				IL_014e: ldstr "User-Agent"
+				IL_0153: ldstr "js2il-docs-script"
+				IL_0158: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_015d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0162: stloc.s 13
+				IL_0164: ldnull
+				IL_0165: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0170: ldc.i4.3
+				IL_0171: newarr [System.Runtime]System.Object
+				IL_0176: dup
+				IL_0177: ldc.i4.0
+				IL_0178: ldarg.0
+				IL_0179: ldc.i4.0
+				IL_017a: ldelem.ref
+				IL_017b: stelem.ref
+				IL_017c: dup
+				IL_017d: ldc.i4.1
+				IL_017e: ldarg.0
+				IL_017f: ldc.i4.1
+				IL_0180: ldelem.ref
+				IL_0181: stelem.ref
+				IL_0182: dup
+				IL_0183: ldc.i4.2
+				IL_0184: ldloc.0
+				IL_0185: stelem.ref
+				IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0190: ldc.i4.1
+				IL_0191: conv.r8
+				IL_0192: ldstr ""
+				IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_019c: stloc.s 8
+				IL_019e: ldloc.s 6
+				IL_01a0: ldstr "request"
+				IL_01a5: ldloc.s 11
+				IL_01a7: ldloc.s 13
+				IL_01a9: ldloc.s 8
+				IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_01b0: stloc.s 8
+				IL_01b2: ldloc.s 8
+				IL_01b4: stloc.s 7
+				IL_01b6: ldloc.s 7
+				IL_01b8: ldstr "on"
+				IL_01bd: ldstr "error"
+				IL_01c2: ldloc.0
+				IL_01c3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01cd: pop
+				IL_01ce: ldloc.s 7
+				IL_01d0: ldstr "end"
+				IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_01da: pop
 
-				IL_0201: ldloc.s 4
-				IL_0203: ret
+				IL_01db: ldloc.s 4
+				IL_01dd: ret
 			} // end of method ArrowFunction_L72C22::__js_call__
 
 		} // end of class ArrowFunction_L72C22
@@ -2134,7 +2122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4450
+				// Method begins at RVA 0x43b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2227,7 +2215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44aa
+				// Method begins at RVA 0x4413
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2291,7 +2279,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44bc
+					// Method begins at RVA 0x4425
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2315,7 +2303,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x44ce
+						// Method begins at RVA 0x4437
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2333,7 +2321,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44c5
+					// Method begins at RVA 0x442e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2351,7 +2339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44b3
+				// Method begins at RVA 0x441c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2622,7 +2610,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44e0
+					// Method begins at RVA 0x4449
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2642,7 +2630,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44e9
+					// Method begins at RVA 0x4452
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2662,7 +2650,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44f2
+					// Method begins at RVA 0x445b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2682,7 +2670,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44fb
+					// Method begins at RVA 0x4464
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2706,7 +2694,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x450d
+						// Method begins at RVA 0x4476
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2726,7 +2714,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4516
+						// Method begins at RVA 0x447f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2750,7 +2738,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4528
+							// Method begins at RVA 0x4491
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2768,7 +2756,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x451f
+						// Method begins at RVA 0x4488
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2788,7 +2776,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4531
+						// Method begins at RVA 0x449a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2806,7 +2794,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4504
+					// Method begins at RVA 0x446d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2824,7 +2812,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44d7
+				// Method begins at RVA 0x4440
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3265,7 +3253,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4543
+					// Method begins at RVA 0x44ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3283,7 +3271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x453a
+				// Method begins at RVA 0x44a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3512,7 +3500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x454c
+				// Method begins at RVA 0x44b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3645,7 +3633,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x455e
+					// Method begins at RVA 0x44c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3665,7 +3653,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4567
+					// Method begins at RVA 0x44d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3685,7 +3673,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4570
+					// Method begins at RVA 0x44d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3709,7 +3697,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4582
+						// Method begins at RVA 0x44eb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3729,7 +3717,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x458b
+						// Method begins at RVA 0x44f4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3747,7 +3735,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4579
+					// Method begins at RVA 0x44e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3767,7 +3755,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4594
+					// Method begins at RVA 0x44fd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3787,7 +3775,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x459d
+					// Method begins at RVA 0x4506
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3827,7 +3815,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4555
+				// Method begins at RVA 0x44be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3853,7 +3841,7 @@
 			)
 			// Method begins at RVA 0x3234
 			// Header size: 12
-			// Code size: 2681 (0xa79)
+			// Code size: 2633 (0xa49)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4030,7 +4018,7 @@
 
 			IL_00ea: ldloc.0
 			IL_00eb: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00f0: switch (IL_0105, IL_044d, IL_0686, IL_07de)
+			IL_00f0: switch (IL_0105, IL_044d, IL_067c, IL_07d4)
 
 			IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
 			IL_010a: ldstr "argv"
@@ -4234,7 +4222,7 @@
 			IL_034c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0351: stloc.s 25
 			IL_0353: ldloc.s 25
-			IL_0355: brfalse IL_06eb
+			IL_0355: brfalse IL_06e1
 
 			IL_035a: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
 			IL_035f: stloc.s 11
@@ -4464,582 +4452,570 @@
 			IL_053a: ldelem.ref
 			IL_053b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 			IL_0540: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_0545: ldstr "Cannot access 'NodeUrl' before initialization"
-			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_054f: stloc.s 24
-			IL_0551: ldloc.s 14
-			IL_0553: ldstr "filePart"
-			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_055d: stloc.s 30
-			IL_055f: ldloc.s 30
-			IL_0561: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0566: stloc.s 25
-			IL_0568: ldloc.s 25
-			IL_056a: brtrue IL_0582
+			IL_0545: stloc.s 24
+			IL_0547: ldloc.s 14
+			IL_0549: ldstr "filePart"
+			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0553: stloc.s 30
+			IL_0555: ldloc.s 30
+			IL_0557: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_055c: stloc.s 25
+			IL_055e: ldloc.s 25
+			IL_0560: brtrue IL_0578
 
-			IL_056f: ldloc.s 14
-			IL_0571: ldstr "href"
-			IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_057b: stloc.s 31
-			IL_057d: br IL_0586
+			IL_0565: ldloc.s 14
+			IL_0567: ldstr "href"
+			IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0571: stloc.s 31
+			IL_0573: br IL_057c
 
-			IL_0582: ldloc.s 30
-			IL_0584: stloc.s 31
+			IL_0578: ldloc.s 30
+			IL_057a: stloc.s 31
 
-			IL_0586: ldc.i4.2
-			IL_0587: newarr [System.Runtime]System.Object
-			IL_058c: dup
-			IL_058d: ldc.i4.0
-			IL_058e: ldloc.s 31
-			IL_0590: stelem.ref
-			IL_0591: dup
-			IL_0592: ldc.i4.1
-			IL_0593: ldloc.s 12
-			IL_0595: stelem.ref
-			IL_0596: stloc.s 32
-			IL_0598: ldloc.s 24
-			IL_059a: ldloc.s 32
-			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_05a1: stloc.s 24
-			IL_05a3: ldloc.s 24
-			IL_05a5: ldstr "toString"
-			IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_05af: stloc.s 24
-			IL_05b1: ldloc.s 24
-			IL_05b3: stloc.s 16
-			IL_05b5: ldc.i4.1
-			IL_05b6: newarr [System.Runtime]System.Object
-			IL_05bb: dup
-			IL_05bc: ldc.i4.0
-			IL_05bd: ldarg.0
-			IL_05be: ldc.i4.1
-			IL_05bf: ldelem.ref
-			IL_05c0: stelem.ref
-			IL_05c1: ldc.i4.0
-			IL_05c2: ldelem.ref
-			IL_05c3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05c8: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_05ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_05d3: ldnull
-			IL_05d4: ldloc.s 16
-			IL_05d6: ldnull
-			IL_05d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_05dc: stloc.s 24
-			IL_05de: ldloc.0
+			IL_057c: ldc.i4.2
+			IL_057d: newarr [System.Runtime]System.Object
+			IL_0582: dup
+			IL_0583: ldc.i4.0
+			IL_0584: ldloc.s 31
+			IL_0586: stelem.ref
+			IL_0587: dup
+			IL_0588: ldc.i4.1
+			IL_0589: ldloc.s 12
+			IL_058b: stelem.ref
+			IL_058c: stloc.s 32
+			IL_058e: ldloc.s 24
+			IL_0590: ldloc.s 32
+			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0597: stloc.s 24
+			IL_0599: ldloc.s 24
+			IL_059b: ldstr "toString"
+			IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_05a5: stloc.s 24
+			IL_05a7: ldloc.s 24
+			IL_05a9: stloc.s 16
+			IL_05ab: ldc.i4.1
+			IL_05ac: newarr [System.Runtime]System.Object
+			IL_05b1: dup
+			IL_05b2: ldc.i4.0
+			IL_05b3: ldarg.0
+			IL_05b4: ldc.i4.1
+			IL_05b5: ldelem.ref
+			IL_05b6: stelem.ref
+			IL_05b7: ldc.i4.0
+			IL_05b8: ldelem.ref
+			IL_05b9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_05be: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_05c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_05c9: ldnull
+			IL_05ca: ldloc.s 16
+			IL_05cc: ldnull
+			IL_05cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_05d2: stloc.s 24
+			IL_05d4: ldloc.0
+			IL_05d5: ldc.i4.2
+			IL_05d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05db: ldloc.0
+			IL_05dc: ldloc.s 24
+			IL_05de: ldarg.0
 			IL_05df: ldc.i4.2
-			IL_05e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05e5: ldloc.0
-			IL_05e6: ldloc.s 24
-			IL_05e8: ldarg.0
-			IL_05e9: ldc.i4.2
-			IL_05ea: ldloc.0
-			IL_05eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_05f5: ldloc.0
-			IL_05f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05fb: dup
-			IL_05fc: ldc.i4.0
-			IL_05fd: ldloc.1
-			IL_05fe: stelem.ref
-			IL_05ff: dup
-			IL_0600: ldc.i4.1
-			IL_0601: ldloc.2
-			IL_0602: stelem.ref
-			IL_0603: dup
-			IL_0604: ldc.i4.2
-			IL_0605: ldloc.3
+			IL_05e0: ldloc.0
+			IL_05e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_05eb: ldloc.0
+			IL_05ec: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05f1: dup
+			IL_05f2: ldc.i4.0
+			IL_05f3: ldloc.1
+			IL_05f4: stelem.ref
+			IL_05f5: dup
+			IL_05f6: ldc.i4.1
+			IL_05f7: ldloc.2
+			IL_05f8: stelem.ref
+			IL_05f9: dup
+			IL_05fa: ldc.i4.2
+			IL_05fb: ldloc.3
+			IL_05fc: stelem.ref
+			IL_05fd: dup
+			IL_05fe: ldc.i4.3
+			IL_05ff: ldloc.s 4
+			IL_0601: stelem.ref
+			IL_0602: dup
+			IL_0603: ldc.i4.4
+			IL_0604: ldloc.s 5
 			IL_0606: stelem.ref
 			IL_0607: dup
-			IL_0608: ldc.i4.3
-			IL_0609: ldloc.s 4
+			IL_0608: ldc.i4.5
+			IL_0609: ldloc.s 6
 			IL_060b: stelem.ref
 			IL_060c: dup
-			IL_060d: ldc.i4.4
-			IL_060e: ldloc.s 5
+			IL_060d: ldc.i4.6
+			IL_060e: ldloc.s 7
 			IL_0610: stelem.ref
 			IL_0611: dup
-			IL_0612: ldc.i4.5
-			IL_0613: ldloc.s 6
+			IL_0612: ldc.i4.7
+			IL_0613: ldloc.s 8
 			IL_0615: stelem.ref
 			IL_0616: dup
-			IL_0617: ldc.i4.6
-			IL_0618: ldloc.s 7
+			IL_0617: ldc.i4.8
+			IL_0618: ldloc.s 9
 			IL_061a: stelem.ref
 			IL_061b: dup
-			IL_061c: ldc.i4.7
-			IL_061d: ldloc.s 8
-			IL_061f: stelem.ref
-			IL_0620: dup
-			IL_0621: ldc.i4.8
-			IL_0622: ldloc.s 9
-			IL_0624: stelem.ref
-			IL_0625: dup
-			IL_0626: ldc.i4.s 9
-			IL_0628: ldloc.s 10
-			IL_062a: stelem.ref
-			IL_062b: dup
-			IL_062c: ldc.i4.s 10
-			IL_062e: ldloc.s 11
-			IL_0630: stelem.ref
-			IL_0631: dup
-			IL_0632: ldc.i4.s 11
-			IL_0634: ldloc.s 12
-			IL_0636: stelem.ref
-			IL_0637: dup
-			IL_0638: ldc.i4.s 12
-			IL_063a: ldloc.s 13
-			IL_063c: stelem.ref
-			IL_063d: dup
-			IL_063e: ldc.i4.s 13
-			IL_0640: ldloc.s 14
-			IL_0642: stelem.ref
-			IL_0643: dup
-			IL_0644: ldc.i4.s 14
-			IL_0646: ldloc.s 15
-			IL_0648: stelem.ref
-			IL_0649: dup
-			IL_064a: ldc.i4.s 15
-			IL_064c: ldloc.s 16
-			IL_064e: stelem.ref
-			IL_064f: dup
-			IL_0650: ldc.i4.s 16
-			IL_0652: ldloc.s 17
-			IL_0654: stelem.ref
-			IL_0655: dup
-			IL_0656: ldc.i4.s 17
-			IL_0658: ldloc.s 18
-			IL_065a: stelem.ref
-			IL_065b: dup
-			IL_065c: ldc.i4.s 18
-			IL_065e: ldloc.s 19
-			IL_0660: stelem.ref
-			IL_0661: dup
-			IL_0662: ldc.i4.s 19
-			IL_0664: ldloc.s 20
-			IL_0666: stelem.ref
-			IL_0667: dup
-			IL_0668: ldc.i4.s 20
-			IL_066a: ldloc.s 21
-			IL_066c: stelem.ref
-			IL_066d: dup
-			IL_066e: ldc.i4.s 21
-			IL_0670: ldloc.s 22
-			IL_0672: stelem.ref
-			IL_0673: dup
-			IL_0674: ldc.i4.s 22
-			IL_0676: ldloc.s 23
-			IL_0678: stelem.ref
-			IL_0679: pop
-			IL_067a: ldloc.0
-			IL_067b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0680: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0685: ret
+			IL_061c: ldc.i4.s 9
+			IL_061e: ldloc.s 10
+			IL_0620: stelem.ref
+			IL_0621: dup
+			IL_0622: ldc.i4.s 10
+			IL_0624: ldloc.s 11
+			IL_0626: stelem.ref
+			IL_0627: dup
+			IL_0628: ldc.i4.s 11
+			IL_062a: ldloc.s 12
+			IL_062c: stelem.ref
+			IL_062d: dup
+			IL_062e: ldc.i4.s 12
+			IL_0630: ldloc.s 13
+			IL_0632: stelem.ref
+			IL_0633: dup
+			IL_0634: ldc.i4.s 13
+			IL_0636: ldloc.s 14
+			IL_0638: stelem.ref
+			IL_0639: dup
+			IL_063a: ldc.i4.s 14
+			IL_063c: ldloc.s 15
+			IL_063e: stelem.ref
+			IL_063f: dup
+			IL_0640: ldc.i4.s 15
+			IL_0642: ldloc.s 16
+			IL_0644: stelem.ref
+			IL_0645: dup
+			IL_0646: ldc.i4.s 16
+			IL_0648: ldloc.s 17
+			IL_064a: stelem.ref
+			IL_064b: dup
+			IL_064c: ldc.i4.s 17
+			IL_064e: ldloc.s 18
+			IL_0650: stelem.ref
+			IL_0651: dup
+			IL_0652: ldc.i4.s 18
+			IL_0654: ldloc.s 19
+			IL_0656: stelem.ref
+			IL_0657: dup
+			IL_0658: ldc.i4.s 19
+			IL_065a: ldloc.s 20
+			IL_065c: stelem.ref
+			IL_065d: dup
+			IL_065e: ldc.i4.s 20
+			IL_0660: ldloc.s 21
+			IL_0662: stelem.ref
+			IL_0663: dup
+			IL_0664: ldc.i4.s 21
+			IL_0666: ldloc.s 22
+			IL_0668: stelem.ref
+			IL_0669: dup
+			IL_066a: ldc.i4.s 22
+			IL_066c: ldloc.s 23
+			IL_066e: stelem.ref
+			IL_066f: pop
+			IL_0670: ldloc.0
+			IL_0671: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0676: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_067b: ret
 
-			IL_0686: ldloc.0
-			IL_0687: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_068c: stloc.s 24
-			IL_068e: ldloc.s 24
-			IL_0690: stloc.s 8
-			IL_0692: ldloc.s 16
-			IL_0694: stloc.s 24
-			IL_0696: ldloc.s 24
-			IL_0698: stloc.s 10
-			IL_069a: ldloc.s 9
-			IL_069c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06a1: ldc.i4.0
-			IL_06a2: ceq
-			IL_06a4: stloc.s 25
-			IL_06a6: ldloc.s 25
-			IL_06a8: brfalse IL_06e6
+			IL_067c: ldloc.0
+			IL_067d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0682: stloc.s 24
+			IL_0684: ldloc.s 24
+			IL_0686: stloc.s 8
+			IL_0688: ldloc.s 16
+			IL_068a: stloc.s 24
+			IL_068c: ldloc.s 24
+			IL_068e: stloc.s 10
+			IL_0690: ldloc.s 9
+			IL_0692: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0697: ldc.i4.0
+			IL_0698: ceq
+			IL_069a: stloc.s 25
+			IL_069c: ldloc.s 25
+			IL_069e: brfalse IL_06dc
 
-			IL_06ad: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
-			IL_06b2: stloc.s 17
-			IL_06b4: ldloc.s 14
-			IL_06b6: ldstr "fragment"
-			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c0: stloc.s 24
-			IL_06c2: ldloc.s 24
-			IL_06c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06c9: stloc.s 25
-			IL_06cb: ldloc.s 25
-			IL_06cd: brtrue IL_06de
+			IL_06a3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
+			IL_06a8: stloc.s 17
+			IL_06aa: ldloc.s 14
+			IL_06ac: ldstr "fragment"
+			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b6: stloc.s 24
+			IL_06b8: ldloc.s 24
+			IL_06ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_06bf: stloc.s 25
+			IL_06c1: ldloc.s 25
+			IL_06c3: brtrue IL_06d4
 
-			IL_06d2: ldstr ""
-			IL_06d7: stloc.s 33
-			IL_06d9: br IL_06e2
+			IL_06c8: ldstr ""
+			IL_06cd: stloc.s 33
+			IL_06cf: br IL_06d8
 
-			IL_06de: ldloc.s 24
-			IL_06e0: stloc.s 33
+			IL_06d4: ldloc.s 24
+			IL_06d6: stloc.s 33
 
-			IL_06e2: ldloc.s 33
-			IL_06e4: stloc.s 9
+			IL_06d8: ldloc.s 33
+			IL_06da: stloc.s 9
 
-			IL_06e6: br IL_07f2
+			IL_06dc: br IL_07e8
 
-			IL_06eb: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_06f0: stloc.s 18
-			IL_06f2: ldloc.1
-			IL_06f3: ldstr "url"
-			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06fd: ldstr "trim"
-			IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0707: stloc.s 24
-			IL_0709: ldloc.s 24
-			IL_070b: stloc.s 19
-			IL_070d: ldc.i4.1
-			IL_070e: newarr [System.Runtime]System.Object
-			IL_0713: dup
-			IL_0714: ldc.i4.0
-			IL_0715: ldarg.0
-			IL_0716: ldc.i4.1
-			IL_0717: ldelem.ref
-			IL_0718: stelem.ref
-			IL_0719: ldc.i4.0
-			IL_071a: ldelem.ref
-			IL_071b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0720: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0726: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_072b: ldnull
-			IL_072c: ldloc.s 19
-			IL_072e: ldnull
-			IL_072f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0734: stloc.s 24
-			IL_0736: ldloc.0
+			IL_06e1: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
+			IL_06e6: stloc.s 18
+			IL_06e8: ldloc.1
+			IL_06e9: ldstr "url"
+			IL_06ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06f3: ldstr "trim"
+			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_06fd: stloc.s 24
+			IL_06ff: ldloc.s 24
+			IL_0701: stloc.s 19
+			IL_0703: ldc.i4.1
+			IL_0704: newarr [System.Runtime]System.Object
+			IL_0709: dup
+			IL_070a: ldc.i4.0
+			IL_070b: ldarg.0
+			IL_070c: ldc.i4.1
+			IL_070d: ldelem.ref
+			IL_070e: stelem.ref
+			IL_070f: ldc.i4.0
+			IL_0710: ldelem.ref
+			IL_0711: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0716: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_071c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0721: ldnull
+			IL_0722: ldloc.s 19
+			IL_0724: ldnull
+			IL_0725: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_072a: stloc.s 24
+			IL_072c: ldloc.0
+			IL_072d: ldc.i4.3
+			IL_072e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0733: ldloc.0
+			IL_0734: ldloc.s 24
+			IL_0736: ldarg.0
 			IL_0737: ldc.i4.3
-			IL_0738: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_073d: ldloc.0
-			IL_073e: ldloc.s 24
-			IL_0740: ldarg.0
-			IL_0741: ldc.i4.3
-			IL_0742: ldloc.0
-			IL_0743: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0748: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_074d: ldloc.0
-			IL_074e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0753: dup
-			IL_0754: ldc.i4.0
-			IL_0755: ldloc.1
-			IL_0756: stelem.ref
-			IL_0757: dup
-			IL_0758: ldc.i4.1
-			IL_0759: ldloc.2
-			IL_075a: stelem.ref
-			IL_075b: dup
-			IL_075c: ldc.i4.2
-			IL_075d: ldloc.3
+			IL_0738: ldloc.0
+			IL_0739: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_073e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0743: ldloc.0
+			IL_0744: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0749: dup
+			IL_074a: ldc.i4.0
+			IL_074b: ldloc.1
+			IL_074c: stelem.ref
+			IL_074d: dup
+			IL_074e: ldc.i4.1
+			IL_074f: ldloc.2
+			IL_0750: stelem.ref
+			IL_0751: dup
+			IL_0752: ldc.i4.2
+			IL_0753: ldloc.3
+			IL_0754: stelem.ref
+			IL_0755: dup
+			IL_0756: ldc.i4.3
+			IL_0757: ldloc.s 4
+			IL_0759: stelem.ref
+			IL_075a: dup
+			IL_075b: ldc.i4.4
+			IL_075c: ldloc.s 5
 			IL_075e: stelem.ref
 			IL_075f: dup
-			IL_0760: ldc.i4.3
-			IL_0761: ldloc.s 4
+			IL_0760: ldc.i4.5
+			IL_0761: ldloc.s 6
 			IL_0763: stelem.ref
 			IL_0764: dup
-			IL_0765: ldc.i4.4
-			IL_0766: ldloc.s 5
+			IL_0765: ldc.i4.6
+			IL_0766: ldloc.s 7
 			IL_0768: stelem.ref
 			IL_0769: dup
-			IL_076a: ldc.i4.5
-			IL_076b: ldloc.s 6
+			IL_076a: ldc.i4.7
+			IL_076b: ldloc.s 8
 			IL_076d: stelem.ref
 			IL_076e: dup
-			IL_076f: ldc.i4.6
-			IL_0770: ldloc.s 7
+			IL_076f: ldc.i4.8
+			IL_0770: ldloc.s 9
 			IL_0772: stelem.ref
 			IL_0773: dup
-			IL_0774: ldc.i4.7
-			IL_0775: ldloc.s 8
-			IL_0777: stelem.ref
-			IL_0778: dup
-			IL_0779: ldc.i4.8
-			IL_077a: ldloc.s 9
-			IL_077c: stelem.ref
-			IL_077d: dup
-			IL_077e: ldc.i4.s 9
-			IL_0780: ldloc.s 10
-			IL_0782: stelem.ref
-			IL_0783: dup
-			IL_0784: ldc.i4.s 10
-			IL_0786: ldloc.s 11
-			IL_0788: stelem.ref
-			IL_0789: dup
-			IL_078a: ldc.i4.s 11
-			IL_078c: ldloc.s 12
-			IL_078e: stelem.ref
-			IL_078f: dup
-			IL_0790: ldc.i4.s 12
-			IL_0792: ldloc.s 13
-			IL_0794: stelem.ref
-			IL_0795: dup
-			IL_0796: ldc.i4.s 13
-			IL_0798: ldloc.s 14
-			IL_079a: stelem.ref
-			IL_079b: dup
-			IL_079c: ldc.i4.s 14
-			IL_079e: ldloc.s 15
-			IL_07a0: stelem.ref
-			IL_07a1: dup
-			IL_07a2: ldc.i4.s 15
-			IL_07a4: ldloc.s 16
-			IL_07a6: stelem.ref
-			IL_07a7: dup
-			IL_07a8: ldc.i4.s 16
-			IL_07aa: ldloc.s 17
-			IL_07ac: stelem.ref
-			IL_07ad: dup
-			IL_07ae: ldc.i4.s 17
-			IL_07b0: ldloc.s 18
-			IL_07b2: stelem.ref
-			IL_07b3: dup
-			IL_07b4: ldc.i4.s 18
-			IL_07b6: ldloc.s 19
-			IL_07b8: stelem.ref
-			IL_07b9: dup
-			IL_07ba: ldc.i4.s 19
-			IL_07bc: ldloc.s 20
-			IL_07be: stelem.ref
-			IL_07bf: dup
-			IL_07c0: ldc.i4.s 20
-			IL_07c2: ldloc.s 21
-			IL_07c4: stelem.ref
-			IL_07c5: dup
-			IL_07c6: ldc.i4.s 21
-			IL_07c8: ldloc.s 22
-			IL_07ca: stelem.ref
-			IL_07cb: dup
-			IL_07cc: ldc.i4.s 22
-			IL_07ce: ldloc.s 23
-			IL_07d0: stelem.ref
-			IL_07d1: pop
-			IL_07d2: ldloc.0
-			IL_07d3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07d8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07dd: ret
+			IL_0774: ldc.i4.s 9
+			IL_0776: ldloc.s 10
+			IL_0778: stelem.ref
+			IL_0779: dup
+			IL_077a: ldc.i4.s 10
+			IL_077c: ldloc.s 11
+			IL_077e: stelem.ref
+			IL_077f: dup
+			IL_0780: ldc.i4.s 11
+			IL_0782: ldloc.s 12
+			IL_0784: stelem.ref
+			IL_0785: dup
+			IL_0786: ldc.i4.s 12
+			IL_0788: ldloc.s 13
+			IL_078a: stelem.ref
+			IL_078b: dup
+			IL_078c: ldc.i4.s 13
+			IL_078e: ldloc.s 14
+			IL_0790: stelem.ref
+			IL_0791: dup
+			IL_0792: ldc.i4.s 14
+			IL_0794: ldloc.s 15
+			IL_0796: stelem.ref
+			IL_0797: dup
+			IL_0798: ldc.i4.s 15
+			IL_079a: ldloc.s 16
+			IL_079c: stelem.ref
+			IL_079d: dup
+			IL_079e: ldc.i4.s 16
+			IL_07a0: ldloc.s 17
+			IL_07a2: stelem.ref
+			IL_07a3: dup
+			IL_07a4: ldc.i4.s 17
+			IL_07a6: ldloc.s 18
+			IL_07a8: stelem.ref
+			IL_07a9: dup
+			IL_07aa: ldc.i4.s 18
+			IL_07ac: ldloc.s 19
+			IL_07ae: stelem.ref
+			IL_07af: dup
+			IL_07b0: ldc.i4.s 19
+			IL_07b2: ldloc.s 20
+			IL_07b4: stelem.ref
+			IL_07b5: dup
+			IL_07b6: ldc.i4.s 20
+			IL_07b8: ldloc.s 21
+			IL_07ba: stelem.ref
+			IL_07bb: dup
+			IL_07bc: ldc.i4.s 21
+			IL_07be: ldloc.s 22
+			IL_07c0: stelem.ref
+			IL_07c1: dup
+			IL_07c2: ldc.i4.s 22
+			IL_07c4: ldloc.s 23
+			IL_07c6: stelem.ref
+			IL_07c7: pop
+			IL_07c8: ldloc.0
+			IL_07c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07ce: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07d3: ret
 
-			IL_07de: ldloc.0
-			IL_07df: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_07e4: stloc.s 24
-			IL_07e6: ldloc.s 24
-			IL_07e8: stloc.s 8
-			IL_07ea: ldloc.s 19
-			IL_07ec: stloc.s 24
-			IL_07ee: ldloc.s 24
-			IL_07f0: stloc.s 10
+			IL_07d4: ldloc.0
+			IL_07d5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_07da: stloc.s 24
+			IL_07dc: ldloc.s 24
+			IL_07de: stloc.s 8
+			IL_07e0: ldloc.s 19
+			IL_07e2: stloc.s 24
+			IL_07e4: ldloc.s 24
+			IL_07e6: stloc.s 10
 
-			IL_07f2: ldloc.s 9
-			IL_07f4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_07f9: ldc.i4.0
-			IL_07fa: ceq
-			IL_07fc: stloc.s 25
-			IL_07fe: ldloc.s 25
-			IL_0800: brfalse IL_0878
+			IL_07e8: ldloc.s 9
+			IL_07ea: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_07ef: ldc.i4.0
+			IL_07f0: ceq
+			IL_07f2: stloc.s 25
+			IL_07f4: ldloc.s 25
+			IL_07f6: brfalse IL_086e
 
-			IL_0805: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
-			IL_080a: stloc.s 20
-			IL_080c: ldloc.1
-			IL_080d: ldstr "section"
-			IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0817: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_081c: stloc.s 29
-			IL_081e: ldstr "Could not infer an element id for section '"
-			IL_0823: ldloc.s 29
-			IL_0825: call string [System.Runtime]System.String::Concat(string, string)
-			IL_082a: stloc.s 29
-			IL_082c: ldloc.s 29
-			IL_082e: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0833: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0838: stloc.s 29
-			IL_083a: ldloc.s 29
-			IL_083c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0841: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0846: stloc.s 24
-			IL_0848: ldloc.0
-			IL_0849: ldc.i4.m1
-			IL_084a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_084f: ldloc.0
-			IL_0850: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0855: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_085a: ldarg.0
-			IL_085b: ldc.i4.1
-			IL_085c: newarr [System.Runtime]System.Object
-			IL_0861: dup
-			IL_0862: ldc.i4.0
-			IL_0863: ldloc.s 24
-			IL_0865: stelem.ref
-			IL_0866: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_086b: pop
-			IL_086c: ldloc.0
-			IL_086d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0872: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0877: ret
+			IL_07fb: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
+			IL_0800: stloc.s 20
+			IL_0802: ldloc.1
+			IL_0803: ldstr "section"
+			IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_080d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0812: stloc.s 29
+			IL_0814: ldstr "Could not infer an element id for section '"
+			IL_0819: ldloc.s 29
+			IL_081b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0820: stloc.s 29
+			IL_0822: ldloc.s 29
+			IL_0824: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0829: call string [System.Runtime]System.String::Concat(string, string)
+			IL_082e: stloc.s 29
+			IL_0830: ldloc.s 29
+			IL_0832: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0837: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_083c: stloc.s 24
+			IL_083e: ldloc.0
+			IL_083f: ldc.i4.m1
+			IL_0840: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0845: ldloc.0
+			IL_0846: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_084b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0850: ldarg.0
+			IL_0851: ldc.i4.1
+			IL_0852: newarr [System.Runtime]System.Object
+			IL_0857: dup
+			IL_0858: ldc.i4.0
+			IL_0859: ldloc.s 24
+			IL_085b: stelem.ref
+			IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0861: pop
+			IL_0862: ldloc.0
+			IL_0863: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0868: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_086d: ret
 
-			IL_0878: ldc.i4.1
-			IL_0879: newarr [System.Runtime]System.Object
-			IL_087e: dup
-			IL_087f: ldc.i4.0
-			IL_0880: ldarg.0
-			IL_0881: ldc.i4.1
-			IL_0882: ldelem.ref
-			IL_0883: stelem.ref
-			IL_0884: ldc.i4.0
-			IL_0885: ldelem.ref
-			IL_0886: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_088b: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0891: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0896: ldnull
-			IL_0897: ldloc.s 8
-			IL_0899: ldloc.s 9
-			IL_089b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_08a0: stloc.s 24
-			IL_08a2: ldloc.s 24
-			IL_08a4: stloc.s 21
-			IL_08a6: ldarg.0
-			IL_08a7: ldc.i4.1
-			IL_08a8: ldelem.ref
-			IL_08a9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_08ae: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_08b3: ldstr "Cannot access 'path' before initialization"
-			IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_08bd: stloc.s 24
-			IL_08bf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_08c4: ldstr "cwd"
-			IL_08c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_08ce: stloc.s 30
-			IL_08d0: ldloc.s 24
-			IL_08d2: ldstr "join"
+			IL_086e: ldc.i4.1
+			IL_086f: newarr [System.Runtime]System.Object
+			IL_0874: dup
+			IL_0875: ldc.i4.0
+			IL_0876: ldarg.0
+			IL_0877: ldc.i4.1
+			IL_0878: ldelem.ref
+			IL_0879: stelem.ref
+			IL_087a: ldc.i4.0
+			IL_087b: ldelem.ref
+			IL_087c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0881: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0887: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_088c: ldnull
+			IL_088d: ldloc.s 8
+			IL_088f: ldloc.s 9
+			IL_0891: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_0896: stloc.s 24
+			IL_0898: ldloc.s 24
+			IL_089a: stloc.s 21
+			IL_089c: ldarg.0
+			IL_089d: ldc.i4.1
+			IL_089e: ldelem.ref
+			IL_089f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08a4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_08a9: stloc.s 24
+			IL_08ab: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_08b0: ldstr "cwd"
+			IL_08b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_08ba: stloc.s 30
+			IL_08bc: ldloc.s 24
+			IL_08be: ldstr "join"
+			IL_08c3: ldloc.s 30
+			IL_08c5: ldloc.1
+			IL_08c6: ldstr "outFile"
+			IL_08cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_08d5: stloc.s 30
 			IL_08d7: ldloc.s 30
-			IL_08d9: ldloc.1
-			IL_08da: ldstr "outFile"
-			IL_08df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_08e9: stloc.s 30
-			IL_08eb: ldloc.s 30
-			IL_08ed: stloc.s 22
-			IL_08ef: ldloc.s 21
-			IL_08f1: ldstr "html"
-			IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08fb: stloc.s 30
-			IL_08fd: ldloc.1
-			IL_08fe: ldstr "section"
-			IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0908: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_090d: stloc.s 29
-			IL_090f: ldstr "ECMA-262 "
-			IL_0914: ldloc.s 29
-			IL_0916: call string [System.Runtime]System.String::Concat(string, string)
-			IL_091b: stloc.s 29
-			IL_091d: ldnull
-			IL_091e: ldloc.s 30
-			IL_0920: ldloc.s 29
-			IL_0922: ldloc.s 10
-			IL_0924: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-			IL_0929: stloc.s 30
-			IL_092b: ldloc.s 30
-			IL_092d: stloc.s 23
-			IL_092f: ldarg.0
-			IL_0930: ldc.i4.1
-			IL_0931: ldelem.ref
-			IL_0932: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0937: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_093c: ldstr "Cannot access 'fs' before initialization"
-			IL_0941: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0946: stloc.s 30
-			IL_0948: ldloc.s 30
-			IL_094a: ldstr "writeFileSync"
-			IL_094f: ldloc.s 22
-			IL_0951: ldloc.s 23
-			IL_0953: ldstr "utf8"
-			IL_0958: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_095d: pop
-			IL_095e: ldloc.1
-			IL_095f: ldstr "section"
-			IL_0964: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0969: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_096e: stloc.s 29
-			IL_0970: ldstr "Extracted section "
-			IL_0975: ldloc.s 29
+			IL_08d9: stloc.s 22
+			IL_08db: ldloc.s 21
+			IL_08dd: ldstr "html"
+			IL_08e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08e7: stloc.s 30
+			IL_08e9: ldloc.1
+			IL_08ea: ldstr "section"
+			IL_08ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08f9: stloc.s 29
+			IL_08fb: ldstr "ECMA-262 "
+			IL_0900: ldloc.s 29
+			IL_0902: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0907: stloc.s 29
+			IL_0909: ldnull
+			IL_090a: ldloc.s 30
+			IL_090c: ldloc.s 29
+			IL_090e: ldloc.s 10
+			IL_0910: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+			IL_0915: stloc.s 30
+			IL_0917: ldloc.s 30
+			IL_0919: stloc.s 23
+			IL_091b: ldarg.0
+			IL_091c: ldc.i4.1
+			IL_091d: ldelem.ref
+			IL_091e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0923: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0928: ldstr "writeFileSync"
+			IL_092d: ldloc.s 22
+			IL_092f: ldloc.s 23
+			IL_0931: ldstr "utf8"
+			IL_0936: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_093b: pop
+			IL_093c: ldloc.1
+			IL_093d: ldstr "section"
+			IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0947: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_094c: stloc.s 29
+			IL_094e: ldstr "Extracted section "
+			IL_0953: ldloc.s 29
+			IL_0955: call string [System.Runtime]System.String::Concat(string, string)
+			IL_095a: stloc.s 29
+			IL_095c: ldloc.s 29
+			IL_095e: ldstr " (id="
+			IL_0963: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0968: stloc.s 29
+			IL_096a: ldloc.s 9
+			IL_096c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0971: stloc.s 28
+			IL_0973: ldloc.s 29
+			IL_0975: ldloc.s 28
 			IL_0977: call string [System.Runtime]System.String::Concat(string, string)
-			IL_097c: stloc.s 29
-			IL_097e: ldloc.s 29
-			IL_0980: ldstr " (id="
+			IL_097c: stloc.s 28
+			IL_097e: ldloc.s 28
+			IL_0980: ldstr ", tag="
 			IL_0985: call string [System.Runtime]System.String::Concat(string, string)
-			IL_098a: stloc.s 29
-			IL_098c: ldloc.s 9
-			IL_098e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0993: stloc.s 28
-			IL_0995: ldloc.s 29
-			IL_0997: ldloc.s 28
-			IL_0999: call string [System.Runtime]System.String::Concat(string, string)
-			IL_099e: stloc.s 28
-			IL_09a0: ldloc.s 28
-			IL_09a2: ldstr ", tag="
-			IL_09a7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09ac: stloc.s 28
-			IL_09ae: ldloc.s 21
-			IL_09b0: ldstr "tagName"
-			IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_098a: stloc.s 28
+			IL_098c: ldloc.s 21
+			IL_098e: ldstr "tagName"
+			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0998: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_099d: stloc.s 29
+			IL_099f: ldloc.s 28
+			IL_09a1: ldloc.s 29
+			IL_09a3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09a8: stloc.s 29
+			IL_09aa: ldloc.s 29
+			IL_09ac: ldstr ") -> "
+			IL_09b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09b6: stloc.s 29
+			IL_09b8: ldloc.s 22
 			IL_09ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09bf: stloc.s 29
-			IL_09c1: ldloc.s 28
-			IL_09c3: ldloc.s 29
+			IL_09bf: stloc.s 28
+			IL_09c1: ldloc.s 29
+			IL_09c3: ldloc.s 28
 			IL_09c5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09ca: stloc.s 29
-			IL_09cc: ldloc.s 29
-			IL_09ce: ldstr ") -> "
-			IL_09d3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09d8: stloc.s 29
-			IL_09da: ldloc.s 22
-			IL_09dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09e1: stloc.s 28
-			IL_09e3: ldloc.s 29
-			IL_09e5: ldloc.s 28
-			IL_09e7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09ec: stloc.s 28
-			IL_09ee: ldnull
-			IL_09ef: ldloc.s 28
-			IL_09f1: ldloc.s 22
-			IL_09f3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_09f8: stloc.s 30
-			IL_09fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09ff: ldloc.s 30
-			IL_0a01: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a06: pop
-			IL_0a07: ldarg.0
-			IL_0a08: ldc.i4.1
-			IL_0a09: ldelem.ref
-			IL_0a0a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a0f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a14: ldstr "Cannot access 'fs' before initialization"
-			IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0a1e: stloc.s 30
-			IL_0a20: ldloc.s 30
-			IL_0a22: ldstr "readFileSync"
-			IL_0a27: ldloc.s 22
-			IL_0a29: ldstr "utf8"
-			IL_0a2e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a33: stloc.s 30
-			IL_0a35: ldnull
-			IL_0a36: ldloc.s 30
-			IL_0a38: ldloc.s 22
-			IL_0a3a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0a3f: stloc.s 30
-			IL_0a41: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a46: ldloc.s 30
-			IL_0a48: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a4d: pop
-			IL_0a4e: ldloc.0
-			IL_0a4f: ldc.i4.m1
-			IL_0a50: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0a55: ldloc.0
-			IL_0a56: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a5b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0a60: ldarg.0
-			IL_0a61: ldc.i4.1
-			IL_0a62: newarr [System.Runtime]System.Object
-			IL_0a67: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0a6c: pop
-			IL_0a6d: ldloc.0
-			IL_0a6e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a73: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a78: ret
+			IL_09ca: stloc.s 28
+			IL_09cc: ldnull
+			IL_09cd: ldloc.s 28
+			IL_09cf: ldloc.s 22
+			IL_09d1: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_09d6: stloc.s 30
+			IL_09d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09dd: ldloc.s 30
+			IL_09df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09e4: pop
+			IL_09e5: ldarg.0
+			IL_09e6: ldc.i4.1
+			IL_09e7: ldelem.ref
+			IL_09e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_09f2: ldstr "readFileSync"
+			IL_09f7: ldloc.s 22
+			IL_09f9: ldstr "utf8"
+			IL_09fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a03: stloc.s 30
+			IL_0a05: ldnull
+			IL_0a06: ldloc.s 30
+			IL_0a08: ldloc.s 22
+			IL_0a0a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0a0f: stloc.s 30
+			IL_0a11: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a16: ldloc.s 30
+			IL_0a18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a1d: pop
+			IL_0a1e: ldloc.0
+			IL_0a1f: ldc.i4.m1
+			IL_0a20: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0a25: ldloc.0
+			IL_0a26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a2b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0a30: ldarg.0
+			IL_0a31: ldc.i4.1
+			IL_0a32: newarr [System.Runtime]System.Object
+			IL_0a37: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a3c: pop
+			IL_0a3d: ldloc.0
+			IL_0a3e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a43: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a48: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5079,30 +5055,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x43ad
+			// Method begins at RVA 0x434d
 			// Header size: 1
-			// Code size: 63 (0x3f)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0032: ldarg.0
-			IL_0033: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0038: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_003d: nop
-			IL_003e: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -5342,7 +5303,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x45a6
+		// Method begins at RVA 0x450f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Js2IL.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36a0
+				// Method begins at RVA 0x3642
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 			)
 			// Method begins at RVA 0x22b0
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 32 (0x20)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -55,20 +55,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_0006: ldstr "Cannot access 'fs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "readFileSync"
-			IL_0017: ldarg.2
-			IL_0018: ldstr "utf8"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0022: stloc.0
-			IL_0023: ldloc.0
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ret
+			IL_0006: ldstr "readFileSync"
+			IL_000b: ldarg.2
+			IL_000c: ldstr "utf8"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0016: stloc.0
+			IL_0017: ldloc.0
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_001d: stloc.0
+			IL_001e: ldloc.0
+			IL_001f: ret
 		} // end of method readJson::__js_call__
 
 	} // end of class readJson
@@ -84,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36a9
+				// Method begins at RVA 0x364b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +104,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e8
+			// Method begins at RVA 0x22dc
 			// Header size: 12
 			// Code size: 69 (0x45)
 			.maxstack 8
@@ -168,7 +164,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36b2
+				// Method begins at RVA 0x3654
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -192,7 +188,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x233c
+			// Method begins at RVA 0x2330
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -240,7 +236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36bb
+				// Method begins at RVA 0x365d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -265,7 +261,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x237c
+			// Method begins at RVA 0x2370
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -357,7 +353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36c4
+				// Method begins at RVA 0x3666
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -384,7 +380,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x241c
+			// Method begins at RVA 0x2410
 			// Header size: 12
 			// Code size: 245 (0xf5)
 			.maxstack 8
@@ -512,7 +508,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36d6
+					// Method begins at RVA 0x3678
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,7 +533,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3658
+				// Method begins at RVA 0x3610
 				// Header size: 12
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -570,7 +566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36cd
+				// Method begins at RVA 0x366f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -597,7 +593,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2520
+			// Method begins at RVA 0x2514
 			// Header size: 12
 			// Code size: 129 (0x81)
 			.maxstack 8
@@ -676,7 +672,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36df
+				// Method begins at RVA 0x3681
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -700,7 +696,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36f1
+					// Method begins at RVA 0x3693
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -718,7 +714,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36e8
+				// Method begins at RVA 0x368a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -745,7 +741,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x25b0
+			// Method begins at RVA 0x25a4
 			// Header size: 12
 			// Code size: 613 (0x265)
 			.maxstack 8
@@ -1022,7 +1018,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36fa
+				// Method begins at RVA 0x369c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1046,7 +1042,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x370c
+					// Method begins at RVA 0x36ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1070,7 +1066,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x371e
+						// Method begins at RVA 0x36c0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1088,7 +1084,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3715
+					// Method begins at RVA 0x36b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1106,7 +1102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3703
+				// Method begins at RVA 0x36a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1133,7 +1129,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2840
+			// Method begins at RVA 0x2834
 			// Header size: 12
 			// Code size: 722 (0x2d2)
 			.maxstack 8
@@ -1468,7 +1464,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3727
+				// Method begins at RVA 0x36c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1496,7 +1492,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3742
+						// Method begins at RVA 0x36e4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1516,7 +1512,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x374b
+						// Method begins at RVA 0x36ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1536,7 +1532,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3754
+						// Method begins at RVA 0x36f6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1554,7 +1550,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3739
+					// Method begins at RVA 0x36db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1572,7 +1568,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3730
+				// Method begins at RVA 0x36d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1599,7 +1595,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2b54
+			// Method begins at RVA 0x2b48
 			// Header size: 12
 			// Code size: 781 (0x30d)
 			.maxstack 8
@@ -1941,7 +1937,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x375d
+				// Method begins at RVA 0x36ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1969,7 +1965,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3778
+						// Method begins at RVA 0x371a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1989,7 +1985,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3781
+						// Method begins at RVA 0x3723
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2009,7 +2005,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x378a
+						// Method begins at RVA 0x372c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2033,7 +2029,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x379c
+							// Method begins at RVA 0x373e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2051,7 +2047,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3793
+						// Method begins at RVA 0x3735
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2069,7 +2065,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x376f
+					// Method begins at RVA 0x3711
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2087,7 +2083,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3766
+				// Method begins at RVA 0x3708
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2114,7 +2110,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2e8c
+			// Method begins at RVA 0x2e80
 			// Header size: 12
 			// Code size: 1014 (0x3f6)
 			.maxstack 8
@@ -2541,7 +2537,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37a5
+				// Method begins at RVA 0x3747
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2561,7 +2557,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37ae
+				// Method begins at RVA 0x3750
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2585,7 +2581,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x32c4
+			// Method begins at RVA 0x32b8
 			// Header size: 12
 			// Code size: 278 (0x116)
 			.maxstack 8
@@ -2738,7 +2734,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37b7
+				// Method begins at RVA 0x3759
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2764,9 +2760,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x33f8
+			// Method begins at RVA 0x33ec
 			// Header size: 12
-			// Code size: 595 (0x253)
+			// Code size: 533 (0x215)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2777,241 +2773,224 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] object[],
-				[10] bool,
-				[11] string,
-				[12] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[8] object[],
+				[9] bool,
+				[10] string,
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_0006: ldstr "Cannot access 'path' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.s 7
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::__dirname
-			IL_0018: stloc.s 8
-			IL_001a: ldloc.s 7
-			IL_001c: ldstr "resolve"
-			IL_0021: ldloc.s 8
-			IL_0023: ldstr ".."
-			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002d: stloc.s 8
-			IL_002f: ldloc.s 8
-			IL_0031: stloc.0
-			IL_0032: ldarg.0
-			IL_0033: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_0038: ldstr "Cannot access 'path' before initialization"
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0042: stloc.s 8
-			IL_0044: ldc.i4.4
-			IL_0045: newarr [System.Runtime]System.Object
-			IL_004a: dup
-			IL_004b: ldc.i4.0
-			IL_004c: ldloc.0
+			IL_0001: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::__dirname
+			IL_0006: stloc.s 7
+			IL_0008: ldarg.0
+			IL_0009: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_000e: ldstr "resolve"
+			IL_0013: ldloc.s 7
+			IL_0015: ldstr ".."
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_001f: stloc.s 7
+			IL_0021: ldloc.s 7
+			IL_0023: stloc.0
+			IL_0024: ldarg.0
+			IL_0025: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_002a: stloc.s 7
+			IL_002c: ldc.i4.4
+			IL_002d: newarr [System.Runtime]System.Object
+			IL_0032: dup
+			IL_0033: ldc.i4.0
+			IL_0034: ldloc.0
+			IL_0035: stelem.ref
+			IL_0036: dup
+			IL_0037: ldc.i4.1
+			IL_0038: ldstr "docs"
+			IL_003d: stelem.ref
+			IL_003e: dup
+			IL_003f: ldc.i4.2
+			IL_0040: ldstr "nodejs"
+			IL_0045: stelem.ref
+			IL_0046: dup
+			IL_0047: ldc.i4.3
+			IL_0048: ldstr "NodeSupport.json"
 			IL_004d: stelem.ref
-			IL_004e: dup
-			IL_004f: ldc.i4.1
-			IL_0050: ldstr "docs"
-			IL_0055: stelem.ref
-			IL_0056: dup
-			IL_0057: ldc.i4.2
-			IL_0058: ldstr "nodejs"
-			IL_005d: stelem.ref
-			IL_005e: dup
-			IL_005f: ldc.i4.3
-			IL_0060: ldstr "NodeSupport.json"
-			IL_0065: stelem.ref
-			IL_0066: stloc.s 9
-			IL_0068: ldloc.s 8
-			IL_006a: ldstr "join"
-			IL_006f: ldloc.s 9
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0076: stloc.s 8
-			IL_0078: ldloc.s 8
-			IL_007a: stloc.1
-			IL_007b: ldarg.0
-			IL_007c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_0081: ldstr "Cannot access 'path' before initialization"
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_008b: stloc.s 8
-			IL_008d: ldc.i4.4
-			IL_008e: newarr [System.Runtime]System.Object
-			IL_0093: dup
-			IL_0094: ldc.i4.0
-			IL_0095: ldloc.0
-			IL_0096: stelem.ref
-			IL_0097: dup
-			IL_0098: ldc.i4.1
-			IL_0099: ldstr "docs"
-			IL_009e: stelem.ref
-			IL_009f: dup
-			IL_00a0: ldc.i4.2
-			IL_00a1: ldstr "nodejs"
-			IL_00a6: stelem.ref
-			IL_00a7: dup
-			IL_00a8: ldc.i4.3
-			IL_00a9: ldstr "NodeSupport.md"
-			IL_00ae: stelem.ref
-			IL_00af: stloc.s 9
-			IL_00b1: ldloc.s 8
-			IL_00b3: ldstr "join"
-			IL_00b8: ldloc.s 9
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_00bf: stloc.s 8
-			IL_00c1: ldloc.s 8
-			IL_00c3: stloc.2
-			IL_00c4: ldc.i4.1
-			IL_00c5: newarr [System.Runtime]System.Object
-			IL_00ca: dup
-			IL_00cb: ldc.i4.0
-			IL_00cc: ldarg.0
-			IL_00cd: stelem.ref
-			IL_00ce: ldc.i4.0
-			IL_00cf: ldelem.ref
-			IL_00d0: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_00d5: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00e0: ldnull
-			IL_00e1: ldloc.1
-			IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00e7: stloc.s 8
-			IL_00e9: ldloc.s 8
-			IL_00eb: stloc.3
-			IL_00ec: ldc.i4.0
-			IL_00ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00f2: stloc.s 4
-			IL_00f4: ldc.i4.1
-			IL_00f5: newarr [System.Runtime]System.Object
-			IL_00fa: dup
-			IL_00fb: ldc.i4.0
-			IL_00fc: ldarg.0
-			IL_00fd: stelem.ref
-			IL_00fe: ldc.i4.0
-			IL_00ff: ldelem.ref
-			IL_0100: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_0105: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0110: ldnull
-			IL_0111: ldloc.3
-			IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0117: stloc.s 8
-			IL_0119: ldloc.s 4
-			IL_011b: ldloc.s 8
-			IL_011d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0122: pop
-			IL_0123: ldc.i4.1
-			IL_0124: newarr [System.Runtime]System.Object
-			IL_0129: dup
-			IL_012a: ldc.i4.0
-			IL_012b: ldarg.0
-			IL_012c: stelem.ref
-			IL_012d: ldc.i4.0
-			IL_012e: ldelem.ref
-			IL_012f: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_0134: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_013a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_013f: ldnull
-			IL_0140: ldloc.3
-			IL_0141: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0146: stloc.s 8
-			IL_0148: ldloc.s 4
-			IL_014a: ldloc.s 8
-			IL_014c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0151: pop
-			IL_0152: ldc.i4.1
-			IL_0153: newarr [System.Runtime]System.Object
-			IL_0158: dup
-			IL_0159: ldc.i4.0
-			IL_015a: ldarg.0
-			IL_015b: stelem.ref
-			IL_015c: ldc.i4.0
-			IL_015d: ldelem.ref
-			IL_015e: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_0163: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_0169: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_016e: ldnull
-			IL_016f: ldloc.3
-			IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 4
-			IL_0179: ldloc.s 8
-			IL_017b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0180: pop
-			IL_0181: ldnull
-			IL_0182: ldloc.3
-			IL_0183: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
-			IL_0188: stloc.s 8
-			IL_018a: ldloc.s 8
-			IL_018c: stloc.s 5
-			IL_018e: ldloc.s 5
-			IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0195: stloc.s 10
-			IL_0197: ldloc.s 10
-			IL_0199: brfalse IL_01a8
+			IL_004e: stloc.s 8
+			IL_0050: ldloc.s 7
+			IL_0052: ldstr "join"
+			IL_0057: ldloc.s 8
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_005e: stloc.s 7
+			IL_0060: ldloc.s 7
+			IL_0062: stloc.1
+			IL_0063: ldarg.0
+			IL_0064: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_0069: stloc.s 7
+			IL_006b: ldc.i4.4
+			IL_006c: newarr [System.Runtime]System.Object
+			IL_0071: dup
+			IL_0072: ldc.i4.0
+			IL_0073: ldloc.0
+			IL_0074: stelem.ref
+			IL_0075: dup
+			IL_0076: ldc.i4.1
+			IL_0077: ldstr "docs"
+			IL_007c: stelem.ref
+			IL_007d: dup
+			IL_007e: ldc.i4.2
+			IL_007f: ldstr "nodejs"
+			IL_0084: stelem.ref
+			IL_0085: dup
+			IL_0086: ldc.i4.3
+			IL_0087: ldstr "NodeSupport.md"
+			IL_008c: stelem.ref
+			IL_008d: stloc.s 8
+			IL_008f: ldloc.s 7
+			IL_0091: ldstr "join"
+			IL_0096: ldloc.s 8
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_009d: stloc.s 7
+			IL_009f: ldloc.s 7
+			IL_00a1: stloc.2
+			IL_00a2: ldc.i4.1
+			IL_00a3: newarr [System.Runtime]System.Object
+			IL_00a8: dup
+			IL_00a9: ldc.i4.0
+			IL_00aa: ldarg.0
+			IL_00ab: stelem.ref
+			IL_00ac: ldc.i4.0
+			IL_00ad: ldelem.ref
+			IL_00ae: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_00b3: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00be: ldnull
+			IL_00bf: ldloc.1
+			IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_00c5: stloc.s 7
+			IL_00c7: ldloc.s 7
+			IL_00c9: stloc.3
+			IL_00ca: ldc.i4.0
+			IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d0: stloc.s 4
+			IL_00d2: ldc.i4.1
+			IL_00d3: newarr [System.Runtime]System.Object
+			IL_00d8: dup
+			IL_00d9: ldc.i4.0
+			IL_00da: ldarg.0
+			IL_00db: stelem.ref
+			IL_00dc: ldc.i4.0
+			IL_00dd: ldelem.ref
+			IL_00de: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_00e3: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00ee: ldnull
+			IL_00ef: ldloc.3
+			IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_00f5: stloc.s 7
+			IL_00f7: ldloc.s 4
+			IL_00f9: ldloc.s 7
+			IL_00fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0100: pop
+			IL_0101: ldc.i4.1
+			IL_0102: newarr [System.Runtime]System.Object
+			IL_0107: dup
+			IL_0108: ldc.i4.0
+			IL_0109: ldarg.0
+			IL_010a: stelem.ref
+			IL_010b: ldc.i4.0
+			IL_010c: ldelem.ref
+			IL_010d: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_0112: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_011d: ldnull
+			IL_011e: ldloc.3
+			IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0124: stloc.s 7
+			IL_0126: ldloc.s 4
+			IL_0128: ldloc.s 7
+			IL_012a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_012f: pop
+			IL_0130: ldc.i4.1
+			IL_0131: newarr [System.Runtime]System.Object
+			IL_0136: dup
+			IL_0137: ldc.i4.0
+			IL_0138: ldarg.0
+			IL_0139: stelem.ref
+			IL_013a: ldc.i4.0
+			IL_013b: ldelem.ref
+			IL_013c: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_0141: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_0147: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_014c: ldnull
+			IL_014d: ldloc.3
+			IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0153: stloc.s 7
+			IL_0155: ldloc.s 4
+			IL_0157: ldloc.s 7
+			IL_0159: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_015e: pop
+			IL_015f: ldnull
+			IL_0160: ldloc.3
+			IL_0161: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
+			IL_0166: stloc.s 7
+			IL_0168: ldloc.s 7
+			IL_016a: stloc.s 5
+			IL_016c: ldloc.s 5
+			IL_016e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0173: stloc.s 9
+			IL_0175: ldloc.s 9
+			IL_0177: brfalse IL_0186
 
-			IL_019e: ldloc.s 4
-			IL_01a0: ldloc.s 5
-			IL_01a2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_01a7: pop
+			IL_017c: ldloc.s 4
+			IL_017e: ldloc.s 5
+			IL_0180: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0185: pop
 
-			IL_01a8: ldloc.s 4
-			IL_01aa: ldc.i4.1
-			IL_01ab: newarr [System.Runtime]System.Object
-			IL_01b0: dup
-			IL_01b1: ldc.i4.0
-			IL_01b2: ldstr "\n\n"
-			IL_01b7: stelem.ref
-			IL_01b8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01bd: stloc.s 11
-			IL_01bf: ldstr "\\r?\\n"
-			IL_01c4: ldstr "g"
-			IL_01c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_01ce: stloc.s 12
-			IL_01d0: ldloc.s 11
-			IL_01d2: ldloc.s 12
-			IL_01d4: ldstr "\n"
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.String::Replace(string, object, object)
-			IL_01de: stloc.s 8
-			IL_01e0: ldloc.s 8
-			IL_01e2: stloc.s 6
-			IL_01e4: ldarg.0
-			IL_01e5: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_01ea: ldstr "Cannot access 'fs' before initialization"
-			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01f4: stloc.s 8
-			IL_01f6: ldloc.s 8
-			IL_01f8: ldstr "writeFileSync"
-			IL_01fd: ldloc.2
-			IL_01fe: ldloc.s 6
-			IL_0200: ldstr "utf8"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_020a: pop
-			IL_020b: ldarg.0
-			IL_020c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_0211: ldstr "Cannot access 'path' before initialization"
-			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_021b: stloc.s 8
-			IL_021d: ldloc.s 8
-			IL_021f: ldstr "relative"
-			IL_0224: ldloc.0
-			IL_0225: ldloc.2
-			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_022b: stloc.s 8
-			IL_022d: ldloc.s 8
-			IL_022f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0234: stloc.s 11
-			IL_0236: ldstr "Wrote "
-			IL_023b: ldloc.s 11
-			IL_023d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0242: stloc.s 11
-			IL_0244: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0249: ldloc.s 11
-			IL_024b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0250: pop
-			IL_0251: ldnull
-			IL_0252: ret
+			IL_0186: ldloc.s 4
+			IL_0188: ldc.i4.1
+			IL_0189: newarr [System.Runtime]System.Object
+			IL_018e: dup
+			IL_018f: ldc.i4.0
+			IL_0190: ldstr "\n\n"
+			IL_0195: stelem.ref
+			IL_0196: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_019b: stloc.s 10
+			IL_019d: ldstr "\\r?\\n"
+			IL_01a2: ldstr "g"
+			IL_01a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01ac: stloc.s 11
+			IL_01ae: ldloc.s 10
+			IL_01b0: ldloc.s 11
+			IL_01b2: ldstr "\n"
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.String::Replace(string, object, object)
+			IL_01bc: stloc.s 7
+			IL_01be: ldloc.s 7
+			IL_01c0: stloc.s 6
+			IL_01c2: ldarg.0
+			IL_01c3: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+			IL_01c8: ldstr "writeFileSync"
+			IL_01cd: ldloc.2
+			IL_01ce: ldloc.s 6
+			IL_01d0: ldstr "utf8"
+			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01da: pop
+			IL_01db: ldarg.0
+			IL_01dc: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_01e1: ldstr "relative"
+			IL_01e6: ldloc.0
+			IL_01e7: ldloc.2
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01ed: stloc.s 7
+			IL_01ef: ldloc.s 7
+			IL_01f1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01f6: stloc.s 10
+			IL_01f8: ldstr "Wrote "
+			IL_01fd: ldloc.s 10
+			IL_01ff: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0204: stloc.s 10
+			IL_0206: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_020b: ldloc.s 10
+			IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0212: pop
+			IL_0213: ldnull
+			IL_0214: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -3054,21 +3033,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3681
+			// Method begins at RVA 0x3639
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -3334,7 +3307,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x37c0
+		// Method begins at RVA 0x3762
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Js2IL.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x336e
+					// Method begins at RVA 0x3275
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3365
+				// Method begins at RVA 0x326c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,9 +79,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2630
+			// Method begins at RVA 0x2624
 			// Header size: 12
-			// Code size: 302 (0x12e)
+			// Code size: 247 (0xf7)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -91,10 +91,10 @@
 				[4] object,
 				[5] object,
 				[6] float64,
-				[7] float64,
-				[8] object,
-				[9] object[],
-				[10] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
+				[7] object,
+				[8] object[],
+				[9] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
+				[10] float64,
 				[11] object
 			)
 
@@ -109,102 +109,85 @@
 			IL_001f: stloc.0
 			IL_0020: ldarg.0
 			IL_0021: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-			IL_0026: ldstr "Cannot access 'performance' before initialization"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0026: ldstr "now"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0030: stloc.s 5
 			IL_0032: ldloc.s 5
-			IL_0034: ldstr "now"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_003e: stloc.s 5
-			IL_0040: ldloc.s 5
-			IL_0042: stloc.1
-			IL_0043: ldarg.0
-			IL_0044: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
-			IL_0049: ldstr "Cannot access 'NOW_UNITS_PER_SECOND' before initialization"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0053: stloc.s 5
-			IL_0055: ldarg.3
-			IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 5
-			IL_005f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0064: stloc.s 7
-			IL_0066: ldloc.s 6
-			IL_0068: ldloc.s 7
-			IL_006a: mul
-			IL_006b: stloc.s 7
-			IL_006d: ldloc.1
-			IL_006e: ldloc.s 7
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0075: stloc.s 8
-			IL_0077: ldloc.s 8
-			IL_0079: stloc.2
-			// loop start (head: IL_007a)
-				IL_007a: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L221C1::.ctor()
-				IL_007f: stloc.3
-				IL_0080: ldc.i4.1
-				IL_0081: newarr [System.Runtime]System.Object
-				IL_0086: dup
-				IL_0087: ldc.i4.0
-				IL_0088: ldarg.0
-				IL_0089: stelem.ref
-				IL_008a: stloc.s 9
-				IL_008c: ldloc.s 9
-				IL_008e: ldc.i4.1
-				IL_008f: newarr [System.Runtime]System.Object
-				IL_0094: dup
-				IL_0095: ldc.i4.0
-				IL_0096: ldarg.2
-				IL_0097: stelem.ref
-				IL_0098: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-				IL_009d: ldarg.2
-				IL_009e: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::.ctor(object[], object)
-				IL_00a3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-				IL_00a8: stloc.s 10
-				IL_00aa: ldloc.s 10
-				IL_00ac: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_00b1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_00b6: ldstr "prototype"
-				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-				IL_00c0: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-				IL_00c5: ldloc.s 10
-				IL_00c7: stloc.s 4
-				IL_00c9: ldloc.s 4
-				IL_00cb: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_00d0: callvirt instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
-				IL_00d5: pop
-				IL_00d6: ldloc.0
-				IL_00d7: ldc.r8 1
-				IL_00e0: add
-				IL_00e1: stloc.0
-				IL_00e2: ldarg.0
-				IL_00e3: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-				IL_00e8: ldstr "Cannot access 'performance' before initialization"
-				IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00f2: stloc.s 5
-				IL_00f4: ldloc.s 5
-				IL_00f6: ldstr "now"
-				IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0100: stloc.s 5
-				IL_0102: ldloc.s 5
-				IL_0104: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0109: stloc.s 7
-				IL_010b: ldloc.2
-				IL_010c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0111: stloc.s 6
-				IL_0113: ldloc.s 7
-				IL_0115: ldloc.s 6
-				IL_0117: clt
-				IL_0119: brfalse IL_0123
+			IL_0034: stloc.1
+			IL_0035: ldarg.0
+			IL_0036: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
+			IL_003b: stloc.s 6
+			IL_003d: ldloc.1
+			IL_003e: ldarg.3
+			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0044: ldloc.s 6
+			IL_0046: mul
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_004c: stloc.s 7
+			IL_004e: ldloc.s 7
+			IL_0050: stloc.2
+			// loop start (head: IL_0051)
+				IL_0051: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L221C1::.ctor()
+				IL_0056: stloc.3
+				IL_0057: ldc.i4.1
+				IL_0058: newarr [System.Runtime]System.Object
+				IL_005d: dup
+				IL_005e: ldc.i4.0
+				IL_005f: ldarg.0
+				IL_0060: stelem.ref
+				IL_0061: stloc.s 8
+				IL_0063: ldloc.s 8
+				IL_0065: ldc.i4.1
+				IL_0066: newarr [System.Runtime]System.Object
+				IL_006b: dup
+				IL_006c: ldc.i4.0
+				IL_006d: ldarg.2
+				IL_006e: stelem.ref
+				IL_006f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+				IL_0074: ldarg.2
+				IL_0075: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::.ctor(object[], object)
+				IL_007a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+				IL_007f: stloc.s 9
+				IL_0081: ldloc.s 9
+				IL_0083: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_0088: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+				IL_008d: ldstr "prototype"
+				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+				IL_0097: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+				IL_009c: ldloc.s 9
+				IL_009e: stloc.s 4
+				IL_00a0: ldloc.s 4
+				IL_00a2: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_00a7: callvirt instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
+				IL_00ac: pop
+				IL_00ad: ldloc.0
+				IL_00ae: ldc.r8 1
+				IL_00b7: add
+				IL_00b8: stloc.0
+				IL_00b9: ldarg.0
+				IL_00ba: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+				IL_00bf: ldstr "now"
+				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00c9: stloc.s 5
+				IL_00cb: ldloc.s 5
+				IL_00cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d2: stloc.s 6
+				IL_00d4: ldloc.2
+				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00da: stloc.s 10
+				IL_00dc: ldloc.s 6
+				IL_00de: ldloc.s 10
+				IL_00e0: clt
+				IL_00e2: brfalse IL_00ec
 
-				IL_011e: br IL_007a
+				IL_00e7: br IL_0051
 			// end loop
 
-			IL_0123: ldloc.0
-			IL_0124: box [System.Runtime]System.Double
-			IL_0129: stloc.s 11
-			IL_012b: ldloc.s 11
-			IL_012d: ret
+			IL_00ec: ldloc.0
+			IL_00ed: box [System.Runtime]System.Double
+			IL_00f2: stloc.s 11
+			IL_00f4: ldloc.s 11
+			IL_00f6: ret
 		} // end of method ArrowFunction_L213C23::__js_call__
 
 	} // end of class ArrowFunction_L213C23
@@ -235,7 +218,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3377
+				// Method begins at RVA 0x327e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -262,7 +245,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x276c
+			// Method begins at RVA 0x2728
 			// Header size: 12
 			// Code size: 365 (0x16d)
 			.maxstack 8
@@ -415,7 +398,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3260
+				// Method begins at RVA 0x3167
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -435,7 +418,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3269
+				// Method begins at RVA 0x3170
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -455,7 +438,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3272
+				// Method begins at RVA 0x3179
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -483,7 +466,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x328d
+						// Method begins at RVA 0x3194
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -507,7 +490,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x329f
+							// Method begins at RVA 0x31a6
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -525,7 +508,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3296
+						// Method begins at RVA 0x319d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -543,7 +526,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3284
+					// Method begins at RVA 0x318b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -571,7 +554,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x32ba
+							// Method begins at RVA 0x31c1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -589,7 +572,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32b1
+						// Method begins at RVA 0x31b8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -607,7 +590,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32a8
+					// Method begins at RVA 0x31af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -631,7 +614,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32cc
+						// Method begins at RVA 0x31d3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -649,7 +632,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32c3
+					// Method begins at RVA 0x31ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -667,7 +650,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x327b
+				// Method begins at RVA 0x3182
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -687,7 +670,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32d5
+				// Method begins at RVA 0x31dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -711,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32e7
+					// Method begins at RVA 0x31ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -729,7 +712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32de
+				// Method begins at RVA 0x31e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -757,7 +740,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2950
+			// Method begins at RVA 0x290c
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -806,7 +789,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cb4
+			// Method begins at RVA 0x2bdc
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -876,9 +859,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29ec
+			// Method begins at RVA 0x29a8
 			// Header size: 12
-			// Code size: 697 (0x2b9)
+			// Code size: 552 (0x228)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26,
@@ -893,321 +876,275 @@
 				[9] float64,
 				[10] float64,
 				[11] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75/Block_L73C7,
-				[12] object,
-				[13] object,
+				[12] float64,
+				[13] float64,
 				[14] float64,
 				[15] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29,
 				[16] float64,
 				[17] float64,
 				[18] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36,
 				[19] object,
-				[20] float64,
-				[21] object,
-				[22] object,
-				[23] bool
+				[20] float64
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::_scopes
-			IL_0006: ldc.i4.0
-			IL_0007: ldelem.ref
-			IL_0008: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-			IL_000d: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
-			IL_0012: ldstr "Cannot access 'WORD_SIZE' before initialization"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001c: stloc.s 19
-			IL_001e: ldloc.s 19
-			IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0025: stloc.s 20
-			IL_0027: ldloc.s 20
-			IL_0029: ldc.r8 2
-			IL_0032: div
-			IL_0033: stloc.s 20
-			IL_0035: ldarg.2
-			IL_0036: ldloc.s 20
-			IL_0038: cgt
-			IL_003a: brfalse IL_015d
+			IL_0000: ldarg.2
+			IL_0001: ldarg.0
+			IL_0002: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::_scopes
+			IL_0007: ldc.i4.0
+			IL_0008: ldelem.ref
+			IL_0009: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+			IL_000e: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
+			IL_0013: ldc.r8 2
+			IL_001c: div
+			IL_001d: cgt
+			IL_001f: brfalse IL_0142
 
-			IL_003f: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26::.ctor()
-			IL_0044: stloc.0
-			IL_0045: ldarg.1
-			IL_0046: ldc.r8 32
-			IL_004f: ldarg.2
-			IL_0050: mul
-			IL_0051: add
-			IL_0052: stloc.1
-			IL_0053: ldloc.1
-			IL_0054: ldarg.3
-			IL_0055: cgt
-			IL_0057: brfalse IL_0093
+			IL_0024: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26::.ctor()
+			IL_0029: stloc.0
+			IL_002a: ldarg.1
+			IL_002b: ldc.r8 32
+			IL_0034: ldarg.2
+			IL_0035: mul
+			IL_0036: add
+			IL_0037: stloc.1
+			IL_0038: ldloc.1
+			IL_0039: ldarg.3
+			IL_003a: cgt
+			IL_003c: brfalse IL_0078
 
-			IL_005c: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Block_L60C39::.ctor()
-			IL_0061: stloc.2
-			IL_0062: ldarg.1
-			IL_0063: stloc.3
-			// loop start (head: IL_0064)
-				IL_0064: ldloc.3
-				IL_0065: ldarg.3
-				IL_0066: clt
-				IL_0068: brfalse IL_0091
+			IL_0041: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Block_L60C39::.ctor()
+			IL_0046: stloc.2
+			IL_0047: ldarg.1
+			IL_0048: stloc.3
+			// loop start (head: IL_0049)
+				IL_0049: ldloc.3
+				IL_004a: ldarg.3
+				IL_004b: clt
+				IL_004d: brfalse IL_0076
 
-				IL_006d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Scope_For_L62C9/Block_L62C69::.ctor()
-				IL_0072: stloc.s 4
-				IL_0074: ldloc.3
-				IL_0075: box [System.Runtime]System.Double
-				IL_007a: stloc.s 21
-				IL_007c: ldarg.0
-				IL_007d: ldloc.3
-				IL_007e: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
-				IL_0083: pop
-				IL_0084: ldloc.3
-				IL_0085: ldarg.2
-				IL_0086: add
-				IL_0087: stloc.s 20
-				IL_0089: ldloc.s 20
-				IL_008b: stloc.3
-				IL_008c: br IL_0064
+				IL_0052: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Scope_For_L62C9/Block_L62C69::.ctor()
+				IL_0057: stloc.s 4
+				IL_0059: ldloc.3
+				IL_005a: box [System.Runtime]System.Double
+				IL_005f: stloc.s 19
+				IL_0061: ldarg.0
+				IL_0062: ldloc.3
+				IL_0063: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
+				IL_0068: pop
+				IL_0069: ldloc.3
+				IL_006a: ldarg.2
+				IL_006b: add
+				IL_006c: stloc.s 20
+				IL_006e: ldloc.s 20
+				IL_0070: stloc.3
+				IL_0071: br IL_0049
 			// end loop
 
-			IL_0091: ldnull
-			IL_0092: ret
+			IL_0076: ldnull
+			IL_0077: ret
 
-			IL_0093: ldarg.3
-			IL_0094: conv.i4
-			IL_0095: conv.u4
-			IL_0096: ldc.r8 5
-			IL_009f: conv.i4
-			IL_00a0: shr.un
-			IL_00a1: conv.r.un
-			IL_00a2: stloc.s 20
-			IL_00a4: ldloc.s 20
-			IL_00a6: stloc.s 5
-			IL_00a8: ldarg.1
-			IL_00a9: stloc.s 6
-			// loop start (head: IL_00ab)
-				IL_00ab: ldloc.s 6
-				IL_00ad: ldloc.1
-				IL_00ae: clt
-				IL_00b0: brfalse IL_015b
+			IL_0078: ldarg.3
+			IL_0079: conv.i4
+			IL_007a: conv.u4
+			IL_007b: ldc.r8 5
+			IL_0084: conv.i4
+			IL_0085: shr.un
+			IL_0086: conv.r.un
+			IL_0087: stloc.s 20
+			IL_0089: ldloc.s 20
+			IL_008b: stloc.s 5
+			IL_008d: ldarg.1
+			IL_008e: stloc.s 6
+			// loop start (head: IL_0090)
+				IL_0090: ldloc.s 6
+				IL_0092: ldloc.1
+				IL_0093: clt
+				IL_0095: brfalse IL_0140
 
-				IL_00b5: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75::.ctor()
-				IL_00ba: stloc.s 7
-				IL_00bc: ldloc.s 6
-				IL_00be: conv.i4
-				IL_00bf: conv.u4
-				IL_00c0: ldc.r8 5
-				IL_00c9: conv.i4
-				IL_00ca: shr.un
-				IL_00cb: conv.r.un
-				IL_00cc: stloc.s 20
-				IL_00ce: ldloc.s 20
-				IL_00d0: stloc.s 8
-				IL_00d2: ldloc.s 6
-				IL_00d4: conv.i4
-				IL_00d5: ldc.r8 31
-				IL_00de: conv.i4
-				IL_00df: and
-				IL_00e0: conv.r8
-				IL_00e1: stloc.s 20
-				IL_00e3: ldloc.s 20
-				IL_00e5: stloc.s 9
-				IL_00e7: ldc.r8 1
-				IL_00f0: conv.i4
-				IL_00f1: ldloc.s 9
-				IL_00f3: conv.i4
-				IL_00f4: shl
-				IL_00f5: conv.r8
-				IL_00f6: stloc.s 20
-				IL_00f8: ldloc.s 20
-				IL_00fa: stloc.s 10
-				// loop start (head: IL_00fc)
-					IL_00fc: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75/Block_L73C7::.ctor()
-					IL_0101: stloc.s 11
-					IL_0103: ldarg.0
-					IL_0104: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_0109: ldloc.s 8
-					IL_010b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_0110: stloc.s 20
-					IL_0112: ldloc.s 20
-					IL_0114: stloc.s 20
-					IL_0116: ldloc.s 20
-					IL_0118: conv.i4
-					IL_0119: ldloc.s 10
-					IL_011b: conv.i4
-					IL_011c: or
-					IL_011d: conv.r8
-					IL_011e: stloc.s 20
-					IL_0120: ldarg.0
-					IL_0121: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_0126: ldloc.s 8
-					IL_0128: ldloc.s 20
-					IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_012f: ldloc.s 8
-					IL_0131: ldarg.2
-					IL_0132: add
-					IL_0133: stloc.s 20
-					IL_0135: ldloc.s 20
-					IL_0137: stloc.s 8
-					IL_0139: ldloc.s 8
-					IL_013b: ldloc.s 5
-					IL_013d: cgt
-					IL_013f: ldc.i4.0
-					IL_0140: ceq
-					IL_0142: brfalse IL_014c
+				IL_009a: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75::.ctor()
+				IL_009f: stloc.s 7
+				IL_00a1: ldloc.s 6
+				IL_00a3: conv.i4
+				IL_00a4: conv.u4
+				IL_00a5: ldc.r8 5
+				IL_00ae: conv.i4
+				IL_00af: shr.un
+				IL_00b0: conv.r.un
+				IL_00b1: stloc.s 20
+				IL_00b3: ldloc.s 20
+				IL_00b5: stloc.s 8
+				IL_00b7: ldloc.s 6
+				IL_00b9: conv.i4
+				IL_00ba: ldc.r8 31
+				IL_00c3: conv.i4
+				IL_00c4: and
+				IL_00c5: conv.r8
+				IL_00c6: stloc.s 20
+				IL_00c8: ldloc.s 20
+				IL_00ca: stloc.s 9
+				IL_00cc: ldc.r8 1
+				IL_00d5: conv.i4
+				IL_00d6: ldloc.s 9
+				IL_00d8: conv.i4
+				IL_00d9: shl
+				IL_00da: conv.r8
+				IL_00db: stloc.s 20
+				IL_00dd: ldloc.s 20
+				IL_00df: stloc.s 10
+				// loop start (head: IL_00e1)
+					IL_00e1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75/Block_L73C7::.ctor()
+					IL_00e6: stloc.s 11
+					IL_00e8: ldarg.0
+					IL_00e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_00ee: ldloc.s 8
+					IL_00f0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00f5: stloc.s 20
+					IL_00f7: ldloc.s 20
+					IL_00f9: stloc.s 20
+					IL_00fb: ldloc.s 20
+					IL_00fd: conv.i4
+					IL_00fe: ldloc.s 10
+					IL_0100: conv.i4
+					IL_0101: or
+					IL_0102: conv.r8
+					IL_0103: stloc.s 20
+					IL_0105: ldarg.0
+					IL_0106: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_010b: ldloc.s 8
+					IL_010d: ldloc.s 20
+					IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_0114: ldloc.s 8
+					IL_0116: ldarg.2
+					IL_0117: add
+					IL_0118: stloc.s 20
+					IL_011a: ldloc.s 20
+					IL_011c: stloc.s 8
+					IL_011e: ldloc.s 8
+					IL_0120: ldloc.s 5
+					IL_0122: cgt
+					IL_0124: ldc.i4.0
+					IL_0125: ceq
+					IL_0127: brfalse IL_0131
 
-					IL_0147: br IL_00fc
+					IL_012c: br IL_00e1
 				// end loop
 
-				IL_014c: ldloc.s 6
-				IL_014e: ldarg.2
-				IL_014f: add
-				IL_0150: stloc.s 20
-				IL_0152: ldloc.s 20
-				IL_0154: stloc.s 6
-				IL_0156: br IL_00ab
+				IL_0131: ldloc.s 6
+				IL_0133: ldarg.2
+				IL_0134: add
+				IL_0135: stloc.s 20
+				IL_0137: ldloc.s 20
+				IL_0139: stloc.s 6
+				IL_013b: br IL_0090
 			// end loop
 
-			IL_015b: ldnull
-			IL_015c: ret
+			IL_0140: ldnull
+			IL_0141: ret
 
-			IL_015d: ldarg.1
-			IL_015e: box [System.Runtime]System.Double
-			IL_0163: stloc.s 12
-			IL_0165: ldloc.s 12
-			IL_0167: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_016c: stloc.s 20
-			IL_016e: ldloc.s 20
-			IL_0170: conv.i4
-			IL_0171: conv.u4
-			IL_0172: ldc.r8 5
-			IL_017b: conv.i4
-			IL_017c: shr.un
-			IL_017d: conv.r.un
-			IL_017e: stloc.s 20
-			IL_0180: ldloc.s 20
-			IL_0182: box [System.Runtime]System.Double
-			IL_0187: stloc.s 21
-			IL_0189: ldloc.s 21
-			IL_018b: stloc.s 13
-			IL_018d: ldarg.0
-			IL_018e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_0193: ldloc.s 13
-			IL_0195: unbox.any [System.Runtime]System.Double
-			IL_019a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_019f: stloc.s 20
-			IL_01a1: ldloc.s 20
-			IL_01a3: stloc.s 20
-			IL_01a5: ldloc.s 20
-			IL_01a7: stloc.s 14
-			// loop start (head: IL_01a9)
-				IL_01a9: ldloc.s 12
-				IL_01ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01b0: stloc.s 20
-				IL_01b2: ldloc.s 20
-				IL_01b4: ldarg.3
-				IL_01b5: clt
-				IL_01b7: brfalse IL_029a
+			IL_0142: ldarg.1
+			IL_0143: stloc.s 12
+			IL_0145: ldloc.s 12
+			IL_0147: conv.i4
+			IL_0148: conv.u4
+			IL_0149: ldc.r8 5
+			IL_0152: conv.i4
+			IL_0153: shr.un
+			IL_0154: conv.r.un
+			IL_0155: stloc.s 20
+			IL_0157: ldloc.s 20
+			IL_0159: stloc.s 13
+			IL_015b: ldarg.0
+			IL_015c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0161: ldloc.s 13
+			IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0168: stloc.s 20
+			IL_016a: ldloc.s 20
+			IL_016c: stloc.s 14
+			// loop start (head: IL_016e)
+				IL_016e: ldloc.s 12
+				IL_0170: ldarg.3
+				IL_0171: clt
+				IL_0173: brfalse IL_0217
 
-				IL_01bc: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
-				IL_01c1: stloc.s 15
-				IL_01c3: ldloc.s 12
-				IL_01c5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01ca: stloc.s 20
-				IL_01cc: ldloc.s 20
-				IL_01ce: conv.i4
-				IL_01cf: ldc.r8 31
-				IL_01d8: conv.i4
-				IL_01d9: and
-				IL_01da: conv.r8
-				IL_01db: stloc.s 20
-				IL_01dd: ldloc.s 20
-				IL_01df: stloc.s 16
-				IL_01e1: ldc.r8 1
-				IL_01ea: conv.i4
-				IL_01eb: ldloc.s 16
-				IL_01ed: conv.i4
-				IL_01ee: shl
-				IL_01ef: conv.r8
-				IL_01f0: stloc.s 20
-				IL_01f2: ldloc.s 14
-				IL_01f4: conv.i4
-				IL_01f5: ldloc.s 20
-				IL_01f7: conv.i4
-				IL_01f8: or
-				IL_01f9: conv.r8
-				IL_01fa: stloc.s 20
-				IL_01fc: ldloc.s 20
-				IL_01fe: stloc.s 14
-				IL_0200: ldloc.s 12
-				IL_0202: ldarg.2
-				IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0208: stloc.s 22
-				IL_020a: ldloc.s 22
-				IL_020c: stloc.s 12
-				IL_020e: ldloc.s 12
-				IL_0210: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0215: stloc.s 20
-				IL_0217: ldloc.s 20
-				IL_0219: conv.i4
-				IL_021a: conv.u4
-				IL_021b: ldc.r8 5
-				IL_0224: conv.i4
-				IL_0225: shr.un
-				IL_0226: conv.r.un
-				IL_0227: stloc.s 20
-				IL_0229: ldloc.s 20
-				IL_022b: stloc.s 17
-				IL_022d: ldloc.s 17
-				IL_022f: box [System.Runtime]System.Double
-				IL_0234: stloc.s 21
-				IL_0236: ldloc.s 21
-				IL_0238: ldloc.s 13
-				IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-				IL_023f: stloc.s 23
-				IL_0241: ldloc.s 23
-				IL_0243: brfalse IL_0295
+				IL_0178: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
+				IL_017d: stloc.s 15
+				IL_017f: ldloc.s 12
+				IL_0181: conv.i4
+				IL_0182: ldc.r8 31
+				IL_018b: conv.i4
+				IL_018c: and
+				IL_018d: conv.r8
+				IL_018e: stloc.s 20
+				IL_0190: ldloc.s 20
+				IL_0192: stloc.s 16
+				IL_0194: ldc.r8 1
+				IL_019d: conv.i4
+				IL_019e: ldloc.s 16
+				IL_01a0: conv.i4
+				IL_01a1: shl
+				IL_01a2: conv.r8
+				IL_01a3: stloc.s 20
+				IL_01a5: ldloc.s 14
+				IL_01a7: conv.i4
+				IL_01a8: ldloc.s 20
+				IL_01aa: conv.i4
+				IL_01ab: or
+				IL_01ac: conv.r8
+				IL_01ad: stloc.s 20
+				IL_01af: ldloc.s 20
+				IL_01b1: stloc.s 14
+				IL_01b3: ldloc.s 12
+				IL_01b5: ldarg.2
+				IL_01b6: add
+				IL_01b7: stloc.s 20
+				IL_01b9: ldloc.s 20
+				IL_01bb: stloc.s 12
+				IL_01bd: ldloc.s 12
+				IL_01bf: conv.i4
+				IL_01c0: conv.u4
+				IL_01c1: ldc.r8 5
+				IL_01ca: conv.i4
+				IL_01cb: shr.un
+				IL_01cc: conv.r.un
+				IL_01cd: stloc.s 20
+				IL_01cf: ldloc.s 20
+				IL_01d1: stloc.s 17
+				IL_01d3: ldloc.s 17
+				IL_01d5: ldloc.s 13
+				IL_01d7: ceq
+				IL_01d9: ldc.i4.0
+				IL_01da: ceq
+				IL_01dc: brfalse IL_0212
 
-				IL_0248: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36::.ctor()
-				IL_024d: stloc.s 18
-				IL_024f: ldloc.s 14
-				IL_0251: box [System.Runtime]System.Double
-				IL_0256: stloc.s 21
-				IL_0258: ldarg.0
-				IL_0259: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_025e: ldloc.s 13
-				IL_0260: unbox.any [System.Runtime]System.Double
-				IL_0265: ldloc.s 14
-				IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_026c: ldloc.s 17
-				IL_026e: box [System.Runtime]System.Double
-				IL_0273: stloc.s 21
-				IL_0275: ldloc.s 21
-				IL_0277: stloc.s 13
-				IL_0279: ldarg.0
-				IL_027a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_027f: ldloc.s 13
-				IL_0281: unbox.any [System.Runtime]System.Double
-				IL_0286: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_028b: stloc.s 20
-				IL_028d: ldloc.s 20
-				IL_028f: stloc.s 20
-				IL_0291: ldloc.s 20
-				IL_0293: stloc.s 14
+				IL_01e1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36::.ctor()
+				IL_01e6: stloc.s 18
+				IL_01e8: ldarg.0
+				IL_01e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_01ee: ldloc.s 13
+				IL_01f0: ldloc.s 14
+				IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_01f7: ldloc.s 17
+				IL_01f9: stloc.s 20
+				IL_01fb: ldloc.s 20
+				IL_01fd: stloc.s 13
+				IL_01ff: ldarg.0
+				IL_0200: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_0205: ldloc.s 13
+				IL_0207: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_020c: stloc.s 20
+				IL_020e: ldloc.s 20
+				IL_0210: stloc.s 14
 
-				IL_0295: br IL_01a9
+				IL_0212: br IL_016e
 			// end loop
 
-			IL_029a: ldloc.s 14
-			IL_029c: box [System.Runtime]System.Double
-			IL_02a1: stloc.s 21
-			IL_02a3: ldarg.0
-			IL_02a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_02a9: ldloc.s 13
-			IL_02ab: unbox.any [System.Runtime]System.Double
-			IL_02b0: ldloc.s 14
-			IL_02b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_02b7: ldnull
-			IL_02b8: ret
+			IL_0217: ldarg.0
+			IL_0218: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_021d: ldloc.s 13
+			IL_021f: ldloc.s 14
+			IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_0226: ldnull
+			IL_0227: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1218,7 +1155,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d18
+			// Method begins at RVA 0x2c40
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1282,7 +1219,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a0
+			// Method begins at RVA 0x295c
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -1332,7 +1269,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32f0
+				// Method begins at RVA 0x31f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1352,7 +1289,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32f9
+				// Method begins at RVA 0x3200
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1376,7 +1313,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x330b
+					// Method begins at RVA 0x3212
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1394,7 +1331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3302
+				// Method begins at RVA 0x3209
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1414,7 +1351,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3314
+				// Method begins at RVA 0x321b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1442,7 +1379,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x332f
+						// Method begins at RVA 0x3236
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1460,7 +1397,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3326
+					// Method begins at RVA 0x322d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1478,7 +1415,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x331d
+				// Method begins at RVA 0x3224
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1498,7 +1435,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3338
+				// Method begins at RVA 0x323f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1522,7 +1459,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x334a
+					// Method begins at RVA 0x3251
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1540,7 +1477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3341
+				// Method begins at RVA 0x3248
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1564,7 +1501,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x335c
+					// Method begins at RVA 0x3263
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1582,7 +1519,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3353
+				// Method begins at RVA 0x325a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1612,7 +1549,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28e8
+			// Method begins at RVA 0x28a4
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1669,7 +1606,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d74
+			// Method begins at RVA 0x2c9c
 			// Header size: 12
 			// Code size: 200 (0xc8)
 			.maxstack 8
@@ -1766,7 +1703,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30d0
+			// Method begins at RVA 0x2ff8
 			// Header size: 12
 			// Code size: 120 (0x78)
 			.maxstack 8
@@ -1833,7 +1770,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3154
+			// Method begins at RVA 0x307c
 			// Header size: 12
 			// Code size: 214 (0xd6)
 			.maxstack 8
@@ -1932,7 +1869,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e48
+			// Method begins at RVA 0x2d70
 			// Header size: 12
 			// Code size: 633 (0x279)
 			.maxstack 8
@@ -2166,8 +2103,8 @@
 			69 65 76 65 7d 00 00
 		)
 		// Fields
-		.field public object NOW_UNITS_PER_SECOND
-		.field public object WORD_SIZE
+		.field public float64 NOW_UNITS_PER_SECOND
+		.field public float64 WORD_SIZE
 		.field public object performance
 		.field public object BitArray
 		.field public object PrimeSieve
@@ -2176,24 +2113,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3236
+			// Method begins at RVA 0x315e
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -2211,7 +2139,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1490 (0x5d2)
+		// Code size: 1480 (0x5c8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -2229,610 +2157,608 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldc.r8 1000
-		IL_0010: box [System.Runtime]System.Double
-		IL_0015: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
-		IL_001a: ldloc.0
-		IL_001b: ldc.r8 32
-		IL_0024: box [System.Runtime]System.Double
-		IL_0029: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
-		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0033: dup
-		IL_0034: ldstr "sieveSize"
-		IL_0039: ldc.r8 1000
-		IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0047: dup
-		IL_0048: ldstr "timeLimitSeconds"
-		IL_004d: ldc.r8 5
-		IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_005b: dup
-		IL_005c: ldstr "verbose"
-		IL_0061: ldc.i4.0
-		IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0067: dup
-		IL_0068: ldstr "runtime"
-		IL_006d: ldstr ""
-		IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0077: stloc.1
-		IL_0078: ldarg.1
-		IL_0079: ldstr "perf_hooks"
-		IL_007e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0083: stloc.s 5
-		IL_0085: ldloc.s 5
-		IL_0087: brfalse IL_0098
+		IL_0010: stfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
+		IL_0015: ldloc.0
+		IL_0016: ldc.r8 32
+		IL_001f: stfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
+		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0029: dup
+		IL_002a: ldstr "sieveSize"
+		IL_002f: ldc.r8 1000
+		IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_003d: dup
+		IL_003e: ldstr "timeLimitSeconds"
+		IL_0043: ldc.r8 5
+		IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0051: dup
+		IL_0052: ldstr "verbose"
+		IL_0057: ldc.i4.0
+		IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_005d: dup
+		IL_005e: ldstr "runtime"
+		IL_0063: ldstr ""
+		IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_006d: stloc.1
+		IL_006e: ldarg.1
+		IL_006f: ldstr "perf_hooks"
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0079: stloc.s 5
+		IL_007b: ldloc.s 5
+		IL_007d: brfalse IL_008e
 
-		IL_008c: ldloc.s 5
-		IL_008e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0093: brfalse IL_00a9
+		IL_0082: ldloc.s 5
+		IL_0084: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0089: brfalse IL_009f
 
-		IL_0098: ldloc.s 5
-		IL_009a: ldstr ""
-		IL_009f: ldstr "performance"
-		IL_00a4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_008e: ldloc.s 5
+		IL_0090: ldstr ""
+		IL_0095: ldstr "performance"
+		IL_009a: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_00a9: ldloc.s 5
-		IL_00ab: ldstr "performance"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b5: stloc.s 5
-		IL_00b7: ldloc.0
-		IL_00b8: ldloc.s 5
-		IL_00ba: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-		IL_00bf: ldstr "[\\\\/]"
-		IL_00c4: ldstr ""
-		IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00ce: stloc.s 6
-		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_00d5: ldstr "argv"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00df: ldc.r8 0.0
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00ed: ldstr "split"
-		IL_00f2: ldloc.s 6
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f9: stloc.s 5
-		IL_00fb: ldloc.s 5
-		IL_00fd: stloc.2
-		IL_00fe: ldloc.2
-		IL_00ff: ldloc.2
-		IL_0100: ldstr "length"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_010f: ldc.r8 1
-		IL_0118: sub
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_011e: stloc.s 5
-		IL_0120: ldloc.1
-		IL_0121: ldstr "runtime"
-		IL_0126: ldloc.s 5
-		IL_0128: ldc.i4.1
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_012e: pop
-		IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_0134: ldstr "argv"
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013e: ldstr "includes"
-		IL_0143: ldstr "verbose"
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014d: stloc.s 5
-		IL_014f: ldloc.1
-		IL_0150: ldstr "verbose"
-		IL_0155: ldloc.s 5
-		IL_0157: ldc.i4.1
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_015d: pop
+		IL_009f: ldloc.s 5
+		IL_00a1: ldstr "performance"
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ab: stloc.s 5
+		IL_00ad: ldloc.0
+		IL_00ae: ldloc.s 5
+		IL_00b0: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+		IL_00b5: ldstr "[\\\\/]"
+		IL_00ba: ldstr ""
+		IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00c4: stloc.s 6
+		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_00cb: ldstr "argv"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d5: ldc.r8 0.0
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00e3: ldstr "split"
+		IL_00e8: ldloc.s 6
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ef: stloc.s 5
+		IL_00f1: ldloc.s 5
+		IL_00f3: stloc.2
+		IL_00f4: ldloc.2
+		IL_00f5: ldloc.2
+		IL_00f6: ldstr "length"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0105: ldc.r8 1
+		IL_010e: sub
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0114: stloc.s 5
+		IL_0116: ldloc.1
+		IL_0117: ldstr "runtime"
+		IL_011c: ldloc.s 5
+		IL_011e: ldc.i4.1
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0124: pop
+		IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_012a: ldstr "argv"
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0134: ldstr "includes"
+		IL_0139: ldstr "verbose"
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0143: stloc.s 5
+		IL_0145: ldloc.1
+		IL_0146: ldstr "verbose"
+		IL_014b: ldloc.s 5
+		IL_014d: ldc.i4.1
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0153: pop
+		IL_0154: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_0159: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_015e: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0163: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0168: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_016d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0172: stloc.s 7
-		IL_0174: ldc.i4.1
-		IL_0175: newarr [System.Runtime]System.Object
-		IL_017a: dup
-		IL_017b: ldc.i4.0
-		IL_017c: ldloc.0
-		IL_017d: stelem.ref
-		IL_017e: stloc.s 8
-		IL_0180: ldc.i4.s 10
-		IL_0182: newarr [System.Runtime]System.Object
-		IL_0187: dup
-		IL_0188: ldc.i4.0
-		IL_0189: ldloc.s 7
-		IL_018b: stelem.ref
-		IL_018c: dup
-		IL_018d: ldc.i4.1
-		IL_018e: ldstr "setBitTrue"
-		IL_0193: stelem.ref
-		IL_0194: dup
-		IL_0195: ldc.i4.2
-		IL_0196: ldstr "setBitTrue"
-		IL_019b: stelem.ref
-		IL_019c: dup
-		IL_019d: ldc.i4.3
-		IL_019e: ldc.r8 1
-		IL_01a7: box [System.Runtime]System.Double
-		IL_01ac: stelem.ref
-		IL_01ad: dup
-		IL_01ae: ldc.i4.4
-		IL_01af: ldstr "setBitTrue"
-		IL_01b4: stelem.ref
-		IL_01b5: dup
-		IL_01b6: ldc.i4.5
-		IL_01b7: ldc.i4.0
-		IL_01b8: box [System.Runtime]System.Boolean
-		IL_01bd: stelem.ref
-		IL_01be: dup
-		IL_01bf: ldc.i4.6
-		IL_01c0: ldc.i4.0
-		IL_01c1: box [System.Runtime]System.Boolean
-		IL_01c6: stelem.ref
-		IL_01c7: dup
-		IL_01c8: ldc.i4.7
-		IL_01c9: ldc.i4.0
-		IL_01ca: box [System.Runtime]System.Boolean
-		IL_01cf: stelem.ref
-		IL_01d0: dup
-		IL_01d1: ldc.i4.8
-		IL_01d2: ldc.i4.0
-		IL_01d3: box [System.Runtime]System.Boolean
-		IL_01d8: stelem.ref
-		IL_01d9: dup
-		IL_01da: ldc.i4.s 9
-		IL_01dc: ldloc.s 8
-		IL_01de: stelem.ref
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_01e4: pop
-		IL_01e5: ldc.i4.s 10
-		IL_01e7: newarr [System.Runtime]System.Object
-		IL_01ec: dup
-		IL_01ed: ldc.i4.0
-		IL_01ee: ldloc.s 7
-		IL_01f0: stelem.ref
-		IL_01f1: dup
-		IL_01f2: ldc.i4.1
-		IL_01f3: ldstr "setBitsTrue"
-		IL_01f8: stelem.ref
-		IL_01f9: dup
-		IL_01fa: ldc.i4.2
-		IL_01fb: ldstr "setBitsTrue"
-		IL_0200: stelem.ref
-		IL_0201: dup
-		IL_0202: ldc.i4.3
-		IL_0203: ldc.r8 3
-		IL_020c: box [System.Runtime]System.Double
-		IL_0211: stelem.ref
-		IL_0212: dup
-		IL_0213: ldc.i4.4
-		IL_0214: ldstr "setBitsTrue"
-		IL_0219: stelem.ref
-		IL_021a: dup
-		IL_021b: ldc.i4.5
-		IL_021c: ldc.i4.0
-		IL_021d: box [System.Runtime]System.Boolean
-		IL_0222: stelem.ref
-		IL_0223: dup
-		IL_0224: ldc.i4.6
-		IL_0225: ldc.i4.0
-		IL_0226: box [System.Runtime]System.Boolean
-		IL_022b: stelem.ref
-		IL_022c: dup
-		IL_022d: ldc.i4.7
-		IL_022e: ldc.i4.0
-		IL_022f: box [System.Runtime]System.Boolean
-		IL_0234: stelem.ref
-		IL_0235: dup
-		IL_0236: ldc.i4.8
-		IL_0237: ldc.i4.0
-		IL_0238: box [System.Runtime]System.Boolean
-		IL_023d: stelem.ref
-		IL_023e: dup
-		IL_023f: ldc.i4.s 9
-		IL_0241: ldloc.s 8
-		IL_0243: stelem.ref
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0249: pop
-		IL_024a: ldc.i4.s 10
-		IL_024c: newarr [System.Runtime]System.Object
-		IL_0251: dup
-		IL_0252: ldc.i4.0
-		IL_0253: ldloc.s 7
-		IL_0255: stelem.ref
-		IL_0256: dup
-		IL_0257: ldc.i4.1
-		IL_0258: ldstr "testBitTrue"
-		IL_025d: stelem.ref
-		IL_025e: dup
-		IL_025f: ldc.i4.2
-		IL_0260: ldstr "testBitTrue"
-		IL_0265: stelem.ref
-		IL_0266: dup
-		IL_0267: ldc.i4.3
-		IL_0268: ldc.r8 1
-		IL_0271: box [System.Runtime]System.Double
-		IL_0276: stelem.ref
-		IL_0277: dup
-		IL_0278: ldc.i4.4
-		IL_0279: ldstr "testBitTrue"
-		IL_027e: stelem.ref
-		IL_027f: dup
-		IL_0280: ldc.i4.5
-		IL_0281: ldc.i4.0
-		IL_0282: box [System.Runtime]System.Boolean
-		IL_0287: stelem.ref
-		IL_0288: dup
-		IL_0289: ldc.i4.6
-		IL_028a: ldc.i4.0
-		IL_028b: box [System.Runtime]System.Boolean
-		IL_0290: stelem.ref
-		IL_0291: dup
-		IL_0292: ldc.i4.7
-		IL_0293: ldc.i4.0
-		IL_0294: box [System.Runtime]System.Boolean
-		IL_0299: stelem.ref
-		IL_029a: dup
-		IL_029b: ldc.i4.8
-		IL_029c: ldc.i4.0
-		IL_029d: box [System.Runtime]System.Boolean
-		IL_02a2: stelem.ref
-		IL_02a3: dup
-		IL_02a4: ldc.i4.s 9
-		IL_02a6: ldloc.s 8
-		IL_02a8: stelem.ref
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_02ae: pop
-		IL_02af: ldc.i4.s 10
-		IL_02b1: newarr [System.Runtime]System.Object
-		IL_02b6: dup
-		IL_02b7: ldc.i4.0
-		IL_02b8: ldloc.s 7
-		IL_02ba: stelem.ref
-		IL_02bb: dup
-		IL_02bc: ldc.i4.1
-		IL_02bd: ldstr "searchBitFalse"
-		IL_02c2: stelem.ref
-		IL_02c3: dup
-		IL_02c4: ldc.i4.2
-		IL_02c5: ldstr "searchBitFalse"
-		IL_02ca: stelem.ref
-		IL_02cb: dup
-		IL_02cc: ldc.i4.3
-		IL_02cd: ldc.r8 1
-		IL_02d6: box [System.Runtime]System.Double
-		IL_02db: stelem.ref
-		IL_02dc: dup
-		IL_02dd: ldc.i4.4
-		IL_02de: ldstr "searchBitFalse"
-		IL_02e3: stelem.ref
-		IL_02e4: dup
-		IL_02e5: ldc.i4.5
-		IL_02e6: ldc.i4.0
-		IL_02e7: box [System.Runtime]System.Boolean
-		IL_02ec: stelem.ref
-		IL_02ed: dup
-		IL_02ee: ldc.i4.6
-		IL_02ef: ldc.i4.0
-		IL_02f0: box [System.Runtime]System.Boolean
-		IL_02f5: stelem.ref
-		IL_02f6: dup
-		IL_02f7: ldc.i4.7
-		IL_02f8: ldc.i4.0
-		IL_02f9: box [System.Runtime]System.Boolean
-		IL_02fe: stelem.ref
-		IL_02ff: dup
-		IL_0300: ldc.i4.8
-		IL_0301: ldc.i4.0
-		IL_0302: box [System.Runtime]System.Boolean
-		IL_0307: stelem.ref
-		IL_0308: dup
-		IL_0309: ldc.i4.s 9
-		IL_030b: ldloc.s 8
-		IL_030d: stelem.ref
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0313: pop
-		IL_0314: ldc.i4.1
-		IL_0315: newarr [System.Runtime]System.Object
-		IL_031a: dup
-		IL_031b: ldc.i4.0
-		IL_031c: ldloc.0
-		IL_031d: stelem.ref
-		IL_031e: stloc.s 8
-		IL_0320: ldloc.s 7
-		IL_0322: ldloc.s 8
-		IL_0324: ldc.r8 1
-		IL_032d: box [System.Runtime]System.Double
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0337: stloc.s 5
-		IL_0339: ldloc.0
-		IL_033a: ldloc.s 5
-		IL_033c: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_0163: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0168: stloc.s 7
+		IL_016a: ldc.i4.1
+		IL_016b: newarr [System.Runtime]System.Object
+		IL_0170: dup
+		IL_0171: ldc.i4.0
+		IL_0172: ldloc.0
+		IL_0173: stelem.ref
+		IL_0174: stloc.s 8
+		IL_0176: ldc.i4.s 10
+		IL_0178: newarr [System.Runtime]System.Object
+		IL_017d: dup
+		IL_017e: ldc.i4.0
+		IL_017f: ldloc.s 7
+		IL_0181: stelem.ref
+		IL_0182: dup
+		IL_0183: ldc.i4.1
+		IL_0184: ldstr "setBitTrue"
+		IL_0189: stelem.ref
+		IL_018a: dup
+		IL_018b: ldc.i4.2
+		IL_018c: ldstr "setBitTrue"
+		IL_0191: stelem.ref
+		IL_0192: dup
+		IL_0193: ldc.i4.3
+		IL_0194: ldc.r8 1
+		IL_019d: box [System.Runtime]System.Double
+		IL_01a2: stelem.ref
+		IL_01a3: dup
+		IL_01a4: ldc.i4.4
+		IL_01a5: ldstr "setBitTrue"
+		IL_01aa: stelem.ref
+		IL_01ab: dup
+		IL_01ac: ldc.i4.5
+		IL_01ad: ldc.i4.0
+		IL_01ae: box [System.Runtime]System.Boolean
+		IL_01b3: stelem.ref
+		IL_01b4: dup
+		IL_01b5: ldc.i4.6
+		IL_01b6: ldc.i4.0
+		IL_01b7: box [System.Runtime]System.Boolean
+		IL_01bc: stelem.ref
+		IL_01bd: dup
+		IL_01be: ldc.i4.7
+		IL_01bf: ldc.i4.0
+		IL_01c0: box [System.Runtime]System.Boolean
+		IL_01c5: stelem.ref
+		IL_01c6: dup
+		IL_01c7: ldc.i4.8
+		IL_01c8: ldc.i4.0
+		IL_01c9: box [System.Runtime]System.Boolean
+		IL_01ce: stelem.ref
+		IL_01cf: dup
+		IL_01d0: ldc.i4.s 9
+		IL_01d2: ldloc.s 8
+		IL_01d4: stelem.ref
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_01da: pop
+		IL_01db: ldc.i4.s 10
+		IL_01dd: newarr [System.Runtime]System.Object
+		IL_01e2: dup
+		IL_01e3: ldc.i4.0
+		IL_01e4: ldloc.s 7
+		IL_01e6: stelem.ref
+		IL_01e7: dup
+		IL_01e8: ldc.i4.1
+		IL_01e9: ldstr "setBitsTrue"
+		IL_01ee: stelem.ref
+		IL_01ef: dup
+		IL_01f0: ldc.i4.2
+		IL_01f1: ldstr "setBitsTrue"
+		IL_01f6: stelem.ref
+		IL_01f7: dup
+		IL_01f8: ldc.i4.3
+		IL_01f9: ldc.r8 3
+		IL_0202: box [System.Runtime]System.Double
+		IL_0207: stelem.ref
+		IL_0208: dup
+		IL_0209: ldc.i4.4
+		IL_020a: ldstr "setBitsTrue"
+		IL_020f: stelem.ref
+		IL_0210: dup
+		IL_0211: ldc.i4.5
+		IL_0212: ldc.i4.0
+		IL_0213: box [System.Runtime]System.Boolean
+		IL_0218: stelem.ref
+		IL_0219: dup
+		IL_021a: ldc.i4.6
+		IL_021b: ldc.i4.0
+		IL_021c: box [System.Runtime]System.Boolean
+		IL_0221: stelem.ref
+		IL_0222: dup
+		IL_0223: ldc.i4.7
+		IL_0224: ldc.i4.0
+		IL_0225: box [System.Runtime]System.Boolean
+		IL_022a: stelem.ref
+		IL_022b: dup
+		IL_022c: ldc.i4.8
+		IL_022d: ldc.i4.0
+		IL_022e: box [System.Runtime]System.Boolean
+		IL_0233: stelem.ref
+		IL_0234: dup
+		IL_0235: ldc.i4.s 9
+		IL_0237: ldloc.s 8
+		IL_0239: stelem.ref
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_023f: pop
+		IL_0240: ldc.i4.s 10
+		IL_0242: newarr [System.Runtime]System.Object
+		IL_0247: dup
+		IL_0248: ldc.i4.0
+		IL_0249: ldloc.s 7
+		IL_024b: stelem.ref
+		IL_024c: dup
+		IL_024d: ldc.i4.1
+		IL_024e: ldstr "testBitTrue"
+		IL_0253: stelem.ref
+		IL_0254: dup
+		IL_0255: ldc.i4.2
+		IL_0256: ldstr "testBitTrue"
+		IL_025b: stelem.ref
+		IL_025c: dup
+		IL_025d: ldc.i4.3
+		IL_025e: ldc.r8 1
+		IL_0267: box [System.Runtime]System.Double
+		IL_026c: stelem.ref
+		IL_026d: dup
+		IL_026e: ldc.i4.4
+		IL_026f: ldstr "testBitTrue"
+		IL_0274: stelem.ref
+		IL_0275: dup
+		IL_0276: ldc.i4.5
+		IL_0277: ldc.i4.0
+		IL_0278: box [System.Runtime]System.Boolean
+		IL_027d: stelem.ref
+		IL_027e: dup
+		IL_027f: ldc.i4.6
+		IL_0280: ldc.i4.0
+		IL_0281: box [System.Runtime]System.Boolean
+		IL_0286: stelem.ref
+		IL_0287: dup
+		IL_0288: ldc.i4.7
+		IL_0289: ldc.i4.0
+		IL_028a: box [System.Runtime]System.Boolean
+		IL_028f: stelem.ref
+		IL_0290: dup
+		IL_0291: ldc.i4.8
+		IL_0292: ldc.i4.0
+		IL_0293: box [System.Runtime]System.Boolean
+		IL_0298: stelem.ref
+		IL_0299: dup
+		IL_029a: ldc.i4.s 9
+		IL_029c: ldloc.s 8
+		IL_029e: stelem.ref
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_02a4: pop
+		IL_02a5: ldc.i4.s 10
+		IL_02a7: newarr [System.Runtime]System.Object
+		IL_02ac: dup
+		IL_02ad: ldc.i4.0
+		IL_02ae: ldloc.s 7
+		IL_02b0: stelem.ref
+		IL_02b1: dup
+		IL_02b2: ldc.i4.1
+		IL_02b3: ldstr "searchBitFalse"
+		IL_02b8: stelem.ref
+		IL_02b9: dup
+		IL_02ba: ldc.i4.2
+		IL_02bb: ldstr "searchBitFalse"
+		IL_02c0: stelem.ref
+		IL_02c1: dup
+		IL_02c2: ldc.i4.3
+		IL_02c3: ldc.r8 1
+		IL_02cc: box [System.Runtime]System.Double
+		IL_02d1: stelem.ref
+		IL_02d2: dup
+		IL_02d3: ldc.i4.4
+		IL_02d4: ldstr "searchBitFalse"
+		IL_02d9: stelem.ref
+		IL_02da: dup
+		IL_02db: ldc.i4.5
+		IL_02dc: ldc.i4.0
+		IL_02dd: box [System.Runtime]System.Boolean
+		IL_02e2: stelem.ref
+		IL_02e3: dup
+		IL_02e4: ldc.i4.6
+		IL_02e5: ldc.i4.0
+		IL_02e6: box [System.Runtime]System.Boolean
+		IL_02eb: stelem.ref
+		IL_02ec: dup
+		IL_02ed: ldc.i4.7
+		IL_02ee: ldc.i4.0
+		IL_02ef: box [System.Runtime]System.Boolean
+		IL_02f4: stelem.ref
+		IL_02f5: dup
+		IL_02f6: ldc.i4.8
+		IL_02f7: ldc.i4.0
+		IL_02f8: box [System.Runtime]System.Boolean
+		IL_02fd: stelem.ref
+		IL_02fe: dup
+		IL_02ff: ldc.i4.s 9
+		IL_0301: ldloc.s 8
+		IL_0303: stelem.ref
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0309: pop
+		IL_030a: ldc.i4.1
+		IL_030b: newarr [System.Runtime]System.Object
+		IL_0310: dup
+		IL_0311: ldc.i4.0
+		IL_0312: ldloc.0
+		IL_0313: stelem.ref
+		IL_0314: stloc.s 8
+		IL_0316: ldloc.s 7
+		IL_0318: ldloc.s 8
+		IL_031a: ldc.r8 1
+		IL_0323: box [System.Runtime]System.Double
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_032d: stloc.s 5
+		IL_032f: ldloc.0
+		IL_0330: ldloc.s 5
+		IL_0332: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_0337: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_033c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0341: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0346: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_034b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0350: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0355: stloc.s 7
-		IL_0357: ldc.i4.1
-		IL_0358: newarr [System.Runtime]System.Object
-		IL_035d: dup
-		IL_035e: ldc.i4.0
-		IL_035f: ldloc.0
-		IL_0360: stelem.ref
-		IL_0361: stloc.s 8
-		IL_0363: ldc.i4.s 10
-		IL_0365: newarr [System.Runtime]System.Object
-		IL_036a: dup
-		IL_036b: ldc.i4.0
-		IL_036c: ldloc.s 7
-		IL_036e: stelem.ref
-		IL_036f: dup
-		IL_0370: ldc.i4.1
-		IL_0371: ldstr "runSieve"
-		IL_0376: stelem.ref
-		IL_0377: dup
-		IL_0378: ldc.i4.2
-		IL_0379: ldstr "runSieve"
-		IL_037e: stelem.ref
-		IL_037f: dup
-		IL_0380: ldc.i4.3
-		IL_0381: ldc.r8 0.0
-		IL_038a: box [System.Runtime]System.Double
-		IL_038f: stelem.ref
-		IL_0390: dup
-		IL_0391: ldc.i4.4
-		IL_0392: ldstr "runSieve"
-		IL_0397: stelem.ref
-		IL_0398: dup
-		IL_0399: ldc.i4.5
-		IL_039a: ldc.i4.0
-		IL_039b: box [System.Runtime]System.Boolean
-		IL_03a0: stelem.ref
-		IL_03a1: dup
-		IL_03a2: ldc.i4.6
-		IL_03a3: ldc.i4.0
-		IL_03a4: box [System.Runtime]System.Boolean
-		IL_03a9: stelem.ref
-		IL_03aa: dup
-		IL_03ab: ldc.i4.7
-		IL_03ac: ldc.i4.0
-		IL_03ad: box [System.Runtime]System.Boolean
-		IL_03b2: stelem.ref
-		IL_03b3: dup
-		IL_03b4: ldc.i4.8
-		IL_03b5: ldc.i4.0
-		IL_03b6: box [System.Runtime]System.Boolean
-		IL_03bb: stelem.ref
-		IL_03bc: dup
-		IL_03bd: ldc.i4.s 9
-		IL_03bf: ldloc.s 8
-		IL_03c1: stelem.ref
-		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_03c7: pop
-		IL_03c8: ldc.i4.s 10
-		IL_03ca: newarr [System.Runtime]System.Object
-		IL_03cf: dup
-		IL_03d0: ldc.i4.0
-		IL_03d1: ldloc.s 7
-		IL_03d3: stelem.ref
-		IL_03d4: dup
-		IL_03d5: ldc.i4.1
-		IL_03d6: ldstr "countPrimes"
-		IL_03db: stelem.ref
-		IL_03dc: dup
-		IL_03dd: ldc.i4.2
-		IL_03de: ldstr "countPrimes"
-		IL_03e3: stelem.ref
-		IL_03e4: dup
-		IL_03e5: ldc.i4.3
-		IL_03e6: ldc.r8 0.0
-		IL_03ef: box [System.Runtime]System.Double
-		IL_03f4: stelem.ref
-		IL_03f5: dup
-		IL_03f6: ldc.i4.4
-		IL_03f7: ldstr "countPrimes"
-		IL_03fc: stelem.ref
-		IL_03fd: dup
-		IL_03fe: ldc.i4.5
-		IL_03ff: ldc.i4.0
-		IL_0400: box [System.Runtime]System.Boolean
-		IL_0405: stelem.ref
-		IL_0406: dup
-		IL_0407: ldc.i4.6
-		IL_0408: ldc.i4.0
-		IL_0409: box [System.Runtime]System.Boolean
-		IL_040e: stelem.ref
-		IL_040f: dup
-		IL_0410: ldc.i4.7
-		IL_0411: ldc.i4.0
-		IL_0412: box [System.Runtime]System.Boolean
-		IL_0417: stelem.ref
-		IL_0418: dup
-		IL_0419: ldc.i4.8
-		IL_041a: ldc.i4.0
-		IL_041b: box [System.Runtime]System.Boolean
-		IL_0420: stelem.ref
-		IL_0421: dup
-		IL_0422: ldc.i4.s 9
-		IL_0424: ldloc.s 8
-		IL_0426: stelem.ref
-		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_042c: pop
-		IL_042d: ldc.i4.s 10
-		IL_042f: newarr [System.Runtime]System.Object
-		IL_0434: dup
-		IL_0435: ldc.i4.0
-		IL_0436: ldloc.s 7
-		IL_0438: stelem.ref
-		IL_0439: dup
-		IL_043a: ldc.i4.1
-		IL_043b: ldstr "getPrimes"
-		IL_0440: stelem.ref
-		IL_0441: dup
-		IL_0442: ldc.i4.2
-		IL_0443: ldstr "getPrimes"
-		IL_0448: stelem.ref
-		IL_0449: dup
-		IL_044a: ldc.i4.3
-		IL_044b: ldc.r8 0.0
-		IL_0454: box [System.Runtime]System.Double
-		IL_0459: stelem.ref
-		IL_045a: dup
-		IL_045b: ldc.i4.4
-		IL_045c: ldstr "getPrimes"
-		IL_0461: stelem.ref
-		IL_0462: dup
-		IL_0463: ldc.i4.5
-		IL_0464: ldc.i4.0
-		IL_0465: box [System.Runtime]System.Boolean
-		IL_046a: stelem.ref
-		IL_046b: dup
-		IL_046c: ldc.i4.6
-		IL_046d: ldc.i4.0
-		IL_046e: box [System.Runtime]System.Boolean
-		IL_0473: stelem.ref
-		IL_0474: dup
-		IL_0475: ldc.i4.7
-		IL_0476: ldc.i4.0
-		IL_0477: box [System.Runtime]System.Boolean
-		IL_047c: stelem.ref
-		IL_047d: dup
-		IL_047e: ldc.i4.8
-		IL_047f: ldc.i4.0
-		IL_0480: box [System.Runtime]System.Boolean
-		IL_0485: stelem.ref
-		IL_0486: dup
-		IL_0487: ldc.i4.s 9
-		IL_0489: ldloc.s 8
-		IL_048b: stelem.ref
-		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0491: pop
-		IL_0492: ldc.i4.s 10
-		IL_0494: newarr [System.Runtime]System.Object
-		IL_0499: dup
-		IL_049a: ldc.i4.0
-		IL_049b: ldloc.s 7
-		IL_049d: stelem.ref
-		IL_049e: dup
-		IL_049f: ldc.i4.1
-		IL_04a0: ldstr "validatePrimeCount"
-		IL_04a5: stelem.ref
-		IL_04a6: dup
-		IL_04a7: ldc.i4.2
-		IL_04a8: ldstr "validatePrimeCount"
-		IL_04ad: stelem.ref
-		IL_04ae: dup
-		IL_04af: ldc.i4.3
-		IL_04b0: ldc.r8 1
-		IL_04b9: box [System.Runtime]System.Double
-		IL_04be: stelem.ref
-		IL_04bf: dup
-		IL_04c0: ldc.i4.4
-		IL_04c1: ldstr "validatePrimeCount"
-		IL_04c6: stelem.ref
-		IL_04c7: dup
-		IL_04c8: ldc.i4.5
-		IL_04c9: ldc.i4.0
-		IL_04ca: box [System.Runtime]System.Boolean
-		IL_04cf: stelem.ref
-		IL_04d0: dup
-		IL_04d1: ldc.i4.6
-		IL_04d2: ldc.i4.0
-		IL_04d3: box [System.Runtime]System.Boolean
-		IL_04d8: stelem.ref
-		IL_04d9: dup
-		IL_04da: ldc.i4.7
-		IL_04db: ldc.i4.0
-		IL_04dc: box [System.Runtime]System.Boolean
-		IL_04e1: stelem.ref
-		IL_04e2: dup
-		IL_04e3: ldc.i4.8
-		IL_04e4: ldc.i4.0
-		IL_04e5: box [System.Runtime]System.Boolean
-		IL_04ea: stelem.ref
-		IL_04eb: dup
-		IL_04ec: ldc.i4.s 9
-		IL_04ee: ldloc.s 8
-		IL_04f0: stelem.ref
-		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_04f6: pop
-		IL_04f7: ldc.i4.1
-		IL_04f8: newarr [System.Runtime]System.Object
-		IL_04fd: dup
-		IL_04fe: ldc.i4.0
-		IL_04ff: ldloc.0
-		IL_0500: stelem.ref
-		IL_0501: stloc.s 8
-		IL_0503: ldloc.s 7
-		IL_0505: ldloc.s 8
-		IL_0507: ldc.r8 1
-		IL_0510: box [System.Runtime]System.Double
-		IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_051a: stloc.s 5
-		IL_051c: ldloc.0
-		IL_051d: ldloc.s 5
-		IL_051f: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_0524: ldc.i4.1
-		IL_0525: newarr [System.Runtime]System.Object
-		IL_052a: dup
-		IL_052b: ldc.i4.0
-		IL_052c: ldloc.0
-		IL_052d: stelem.ref
-		IL_052e: ldc.i4.0
-		IL_052f: ldelem.ref
-		IL_0530: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0535: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object, object)
-		IL_053b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0540: ldc.i4.1
-		IL_0541: newarr [System.Runtime]System.Object
-		IL_0546: dup
-		IL_0547: ldc.i4.0
-		IL_0548: ldloc.0
-		IL_0549: stelem.ref
-		IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0554: ldc.i4.1
-		IL_0555: conv.r8
-		IL_0556: ldstr ""
-		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0560: stloc.s 5
-		IL_0562: ldloc.s 5
-		IL_0564: ldstr "runSieveBatch"
-		IL_0569: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_056e: stloc.s 5
-		IL_0570: ldloc.s 5
-		IL_0572: stloc.3
-		IL_0573: ldc.i4.1
-		IL_0574: newarr [System.Runtime]System.Object
-		IL_0579: dup
-		IL_057a: ldc.i4.0
-		IL_057b: ldloc.0
-		IL_057c: stelem.ref
-		IL_057d: ldc.i4.0
-		IL_057e: ldelem.ref
-		IL_057f: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0584: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_058a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_058f: ldc.i4.1
-		IL_0590: newarr [System.Runtime]System.Object
-		IL_0595: dup
-		IL_0596: ldc.i4.0
-		IL_0597: ldloc.0
-		IL_0598: stelem.ref
-		IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_05a3: ldc.i4.1
-		IL_05a4: conv.r8
-		IL_05a5: ldstr ""
-		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_05af: stloc.s 5
-		IL_05b1: ldloc.s 5
-		IL_05b3: ldstr "main"
-		IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_05bd: stloc.s 5
-		IL_05bf: ldloc.s 5
-		IL_05c1: stloc.s 4
-		IL_05c3: ldloc.s 4
-		IL_05c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05ca: ldloc.1
-		IL_05cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-		IL_05d0: pop
-		IL_05d1: ret
+		IL_0346: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_034b: stloc.s 7
+		IL_034d: ldc.i4.1
+		IL_034e: newarr [System.Runtime]System.Object
+		IL_0353: dup
+		IL_0354: ldc.i4.0
+		IL_0355: ldloc.0
+		IL_0356: stelem.ref
+		IL_0357: stloc.s 8
+		IL_0359: ldc.i4.s 10
+		IL_035b: newarr [System.Runtime]System.Object
+		IL_0360: dup
+		IL_0361: ldc.i4.0
+		IL_0362: ldloc.s 7
+		IL_0364: stelem.ref
+		IL_0365: dup
+		IL_0366: ldc.i4.1
+		IL_0367: ldstr "runSieve"
+		IL_036c: stelem.ref
+		IL_036d: dup
+		IL_036e: ldc.i4.2
+		IL_036f: ldstr "runSieve"
+		IL_0374: stelem.ref
+		IL_0375: dup
+		IL_0376: ldc.i4.3
+		IL_0377: ldc.r8 0.0
+		IL_0380: box [System.Runtime]System.Double
+		IL_0385: stelem.ref
+		IL_0386: dup
+		IL_0387: ldc.i4.4
+		IL_0388: ldstr "runSieve"
+		IL_038d: stelem.ref
+		IL_038e: dup
+		IL_038f: ldc.i4.5
+		IL_0390: ldc.i4.0
+		IL_0391: box [System.Runtime]System.Boolean
+		IL_0396: stelem.ref
+		IL_0397: dup
+		IL_0398: ldc.i4.6
+		IL_0399: ldc.i4.0
+		IL_039a: box [System.Runtime]System.Boolean
+		IL_039f: stelem.ref
+		IL_03a0: dup
+		IL_03a1: ldc.i4.7
+		IL_03a2: ldc.i4.0
+		IL_03a3: box [System.Runtime]System.Boolean
+		IL_03a8: stelem.ref
+		IL_03a9: dup
+		IL_03aa: ldc.i4.8
+		IL_03ab: ldc.i4.0
+		IL_03ac: box [System.Runtime]System.Boolean
+		IL_03b1: stelem.ref
+		IL_03b2: dup
+		IL_03b3: ldc.i4.s 9
+		IL_03b5: ldloc.s 8
+		IL_03b7: stelem.ref
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_03bd: pop
+		IL_03be: ldc.i4.s 10
+		IL_03c0: newarr [System.Runtime]System.Object
+		IL_03c5: dup
+		IL_03c6: ldc.i4.0
+		IL_03c7: ldloc.s 7
+		IL_03c9: stelem.ref
+		IL_03ca: dup
+		IL_03cb: ldc.i4.1
+		IL_03cc: ldstr "countPrimes"
+		IL_03d1: stelem.ref
+		IL_03d2: dup
+		IL_03d3: ldc.i4.2
+		IL_03d4: ldstr "countPrimes"
+		IL_03d9: stelem.ref
+		IL_03da: dup
+		IL_03db: ldc.i4.3
+		IL_03dc: ldc.r8 0.0
+		IL_03e5: box [System.Runtime]System.Double
+		IL_03ea: stelem.ref
+		IL_03eb: dup
+		IL_03ec: ldc.i4.4
+		IL_03ed: ldstr "countPrimes"
+		IL_03f2: stelem.ref
+		IL_03f3: dup
+		IL_03f4: ldc.i4.5
+		IL_03f5: ldc.i4.0
+		IL_03f6: box [System.Runtime]System.Boolean
+		IL_03fb: stelem.ref
+		IL_03fc: dup
+		IL_03fd: ldc.i4.6
+		IL_03fe: ldc.i4.0
+		IL_03ff: box [System.Runtime]System.Boolean
+		IL_0404: stelem.ref
+		IL_0405: dup
+		IL_0406: ldc.i4.7
+		IL_0407: ldc.i4.0
+		IL_0408: box [System.Runtime]System.Boolean
+		IL_040d: stelem.ref
+		IL_040e: dup
+		IL_040f: ldc.i4.8
+		IL_0410: ldc.i4.0
+		IL_0411: box [System.Runtime]System.Boolean
+		IL_0416: stelem.ref
+		IL_0417: dup
+		IL_0418: ldc.i4.s 9
+		IL_041a: ldloc.s 8
+		IL_041c: stelem.ref
+		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0422: pop
+		IL_0423: ldc.i4.s 10
+		IL_0425: newarr [System.Runtime]System.Object
+		IL_042a: dup
+		IL_042b: ldc.i4.0
+		IL_042c: ldloc.s 7
+		IL_042e: stelem.ref
+		IL_042f: dup
+		IL_0430: ldc.i4.1
+		IL_0431: ldstr "getPrimes"
+		IL_0436: stelem.ref
+		IL_0437: dup
+		IL_0438: ldc.i4.2
+		IL_0439: ldstr "getPrimes"
+		IL_043e: stelem.ref
+		IL_043f: dup
+		IL_0440: ldc.i4.3
+		IL_0441: ldc.r8 0.0
+		IL_044a: box [System.Runtime]System.Double
+		IL_044f: stelem.ref
+		IL_0450: dup
+		IL_0451: ldc.i4.4
+		IL_0452: ldstr "getPrimes"
+		IL_0457: stelem.ref
+		IL_0458: dup
+		IL_0459: ldc.i4.5
+		IL_045a: ldc.i4.0
+		IL_045b: box [System.Runtime]System.Boolean
+		IL_0460: stelem.ref
+		IL_0461: dup
+		IL_0462: ldc.i4.6
+		IL_0463: ldc.i4.0
+		IL_0464: box [System.Runtime]System.Boolean
+		IL_0469: stelem.ref
+		IL_046a: dup
+		IL_046b: ldc.i4.7
+		IL_046c: ldc.i4.0
+		IL_046d: box [System.Runtime]System.Boolean
+		IL_0472: stelem.ref
+		IL_0473: dup
+		IL_0474: ldc.i4.8
+		IL_0475: ldc.i4.0
+		IL_0476: box [System.Runtime]System.Boolean
+		IL_047b: stelem.ref
+		IL_047c: dup
+		IL_047d: ldc.i4.s 9
+		IL_047f: ldloc.s 8
+		IL_0481: stelem.ref
+		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0487: pop
+		IL_0488: ldc.i4.s 10
+		IL_048a: newarr [System.Runtime]System.Object
+		IL_048f: dup
+		IL_0490: ldc.i4.0
+		IL_0491: ldloc.s 7
+		IL_0493: stelem.ref
+		IL_0494: dup
+		IL_0495: ldc.i4.1
+		IL_0496: ldstr "validatePrimeCount"
+		IL_049b: stelem.ref
+		IL_049c: dup
+		IL_049d: ldc.i4.2
+		IL_049e: ldstr "validatePrimeCount"
+		IL_04a3: stelem.ref
+		IL_04a4: dup
+		IL_04a5: ldc.i4.3
+		IL_04a6: ldc.r8 1
+		IL_04af: box [System.Runtime]System.Double
+		IL_04b4: stelem.ref
+		IL_04b5: dup
+		IL_04b6: ldc.i4.4
+		IL_04b7: ldstr "validatePrimeCount"
+		IL_04bc: stelem.ref
+		IL_04bd: dup
+		IL_04be: ldc.i4.5
+		IL_04bf: ldc.i4.0
+		IL_04c0: box [System.Runtime]System.Boolean
+		IL_04c5: stelem.ref
+		IL_04c6: dup
+		IL_04c7: ldc.i4.6
+		IL_04c8: ldc.i4.0
+		IL_04c9: box [System.Runtime]System.Boolean
+		IL_04ce: stelem.ref
+		IL_04cf: dup
+		IL_04d0: ldc.i4.7
+		IL_04d1: ldc.i4.0
+		IL_04d2: box [System.Runtime]System.Boolean
+		IL_04d7: stelem.ref
+		IL_04d8: dup
+		IL_04d9: ldc.i4.8
+		IL_04da: ldc.i4.0
+		IL_04db: box [System.Runtime]System.Boolean
+		IL_04e0: stelem.ref
+		IL_04e1: dup
+		IL_04e2: ldc.i4.s 9
+		IL_04e4: ldloc.s 8
+		IL_04e6: stelem.ref
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_04ec: pop
+		IL_04ed: ldc.i4.1
+		IL_04ee: newarr [System.Runtime]System.Object
+		IL_04f3: dup
+		IL_04f4: ldc.i4.0
+		IL_04f5: ldloc.0
+		IL_04f6: stelem.ref
+		IL_04f7: stloc.s 8
+		IL_04f9: ldloc.s 7
+		IL_04fb: ldloc.s 8
+		IL_04fd: ldc.r8 1
+		IL_0506: box [System.Runtime]System.Double
+		IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0510: stloc.s 5
+		IL_0512: ldloc.0
+		IL_0513: ldloc.s 5
+		IL_0515: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_051a: ldc.i4.1
+		IL_051b: newarr [System.Runtime]System.Object
+		IL_0520: dup
+		IL_0521: ldc.i4.0
+		IL_0522: ldloc.0
+		IL_0523: stelem.ref
+		IL_0524: ldc.i4.0
+		IL_0525: ldelem.ref
+		IL_0526: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_052b: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object, object)
+		IL_0531: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0536: ldc.i4.1
+		IL_0537: newarr [System.Runtime]System.Object
+		IL_053c: dup
+		IL_053d: ldc.i4.0
+		IL_053e: ldloc.0
+		IL_053f: stelem.ref
+		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_054a: ldc.i4.1
+		IL_054b: conv.r8
+		IL_054c: ldstr ""
+		IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0556: stloc.s 5
+		IL_0558: ldloc.s 5
+		IL_055a: ldstr "runSieveBatch"
+		IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0564: stloc.s 5
+		IL_0566: ldloc.s 5
+		IL_0568: stloc.3
+		IL_0569: ldc.i4.1
+		IL_056a: newarr [System.Runtime]System.Object
+		IL_056f: dup
+		IL_0570: ldc.i4.0
+		IL_0571: ldloc.0
+		IL_0572: stelem.ref
+		IL_0573: ldc.i4.0
+		IL_0574: ldelem.ref
+		IL_0575: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_057a: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_0580: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0585: ldc.i4.1
+		IL_0586: newarr [System.Runtime]System.Object
+		IL_058b: dup
+		IL_058c: ldc.i4.0
+		IL_058d: ldloc.0
+		IL_058e: stelem.ref
+		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0599: ldc.i4.1
+		IL_059a: conv.r8
+		IL_059b: ldstr ""
+		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_05a5: stloc.s 5
+		IL_05a7: ldloc.s 5
+		IL_05a9: ldstr "main"
+		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_05b3: stloc.s 5
+		IL_05b5: ldloc.s 5
+		IL_05b7: stloc.s 4
+		IL_05b9: ldloc.s 4
+		IL_05bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05c0: ldloc.1
+		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+		IL_05c6: pop
+		IL_05c7: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
@@ -2844,7 +2770,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3380
+		// Method begins at RVA 0x3287
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
+++ b/tests/Js2IL.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2627
+				// Method begins at RVA 0x25ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2410
+			// Method begins at RVA 0x23ac
 			// Header size: 12
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2630
+				// Method begins at RVA 0x25b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,9 +119,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2434
+			// Method begins at RVA 0x23d0
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 95 (0x5f)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -143,21 +143,17 @@
 			IL_0035: pop
 			IL_0036: ldarg.0
 			IL_0037: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-			IL_003c: ldstr "Cannot access 'child' before initialization"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0046: stloc.0
-			IL_0047: ldloc.0
-			IL_0048: ldstr "kill"
-			IL_004d: ldstr "SIGTERM"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0057: stloc.0
-			IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_005d: ldstr "kill result:"
-			IL_0062: ldloc.0
-			IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0068: pop
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_003c: ldstr "kill"
+			IL_0041: ldstr "SIGTERM"
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004b: stloc.0
+			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0051: ldstr "kill result:"
+			IL_0056: ldloc.0
+			IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_005c: pop
+			IL_005d: ldnull
+			IL_005e: ret
 		} // end of method ArrowFunction_L24C21::__js_call__
 
 	} // end of class ArrowFunction_L24C21
@@ -173,7 +169,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2639
+				// Method begins at RVA 0x25be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +192,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24ab
+			// Method begins at RVA 0x243b
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -233,7 +229,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2642
+				// Method begins at RVA 0x25c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -258,7 +254,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24c4
+			// Method begins at RVA 0x2454
 			// Header size: 12
 			// Code size: 73 (0x49)
 			.maxstack 8
@@ -316,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x264b
+				// Method begins at RVA 0x25d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -344,7 +340,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x251c
+			// Method begins at RVA 0x24ac
 			// Header size: 12
 			// Code size: 107 (0x6b)
 			.maxstack 8
@@ -409,7 +405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x261e
+				// Method begins at RVA 0x25a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -431,18 +427,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x260a
+			// Method begins at RVA 0x259a
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -460,7 +453,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 765 (0x2fd)
+		// Code size: 665 (0x299)
 		.maxstack 11
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope,
@@ -468,8 +461,7 @@
 			[2] class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope/Block_L5C11,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] object
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
 		IL_0000: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::.ctor()
@@ -533,201 +525,167 @@
 		IL_00b8: ldloc.0
 		IL_00b9: ldloc.3
 		IL_00ba: stfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_00bf: ldloc.0
-		IL_00c0: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_00c5: ldstr "Cannot access 'child' before initialization"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00cf: stloc.3
-		IL_00d0: ldloc.3
-		IL_00d1: ldstr "connected"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00db: stloc.3
-		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e1: ldstr "connected initially:"
-		IL_00e6: ldloc.3
-		IL_00e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00ec: pop
-		IL_00ed: ldloc.0
-		IL_00ee: ldstr ""
-		IL_00f3: stfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::stderr
-		IL_00f8: ldloc.0
-		IL_00f9: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_00fe: ldstr "Cannot access 'child' before initialization"
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0108: stloc.3
-		IL_0109: ldloc.3
-		IL_010a: ldstr "stderr"
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0114: stloc.3
-		IL_0115: ldloc.3
-		IL_0116: ldstr "setEncoding"
-		IL_011b: ldstr "utf8"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0125: pop
-		IL_0126: ldloc.0
-		IL_0127: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_012c: ldstr "Cannot access 'child' before initialization"
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0136: stloc.3
-		IL_0137: ldloc.3
-		IL_0138: ldstr "stderr"
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0142: stloc.3
-		IL_0143: ldc.i4.1
-		IL_0144: newarr [System.Runtime]System.Object
-		IL_0149: dup
-		IL_014a: ldc.i4.0
-		IL_014b: ldloc.0
-		IL_014c: stelem.ref
-		IL_014d: ldc.i4.0
-		IL_014e: ldelem.ref
-		IL_014f: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
-		IL_0154: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L20C25::__js_call__(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope, object, object)
-		IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_015f: ldc.i4.1
-		IL_0160: newarr [System.Runtime]System.Object
-		IL_0165: dup
-		IL_0166: ldc.i4.0
-		IL_0167: ldloc.0
-		IL_0168: stelem.ref
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0173: ldc.i4.1
-		IL_0174: conv.r8
-		IL_0175: ldstr ""
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_017f: stloc.s 6
-		IL_0181: ldloc.3
-		IL_0182: ldstr "on"
-		IL_0187: ldstr "data"
-		IL_018c: ldloc.s 6
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0193: pop
-		IL_0194: ldloc.0
-		IL_0195: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_019a: ldstr "Cannot access 'child' before initialization"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01a4: stloc.s 6
-		IL_01a6: ldc.i4.1
-		IL_01a7: newarr [System.Runtime]System.Object
-		IL_01ac: dup
-		IL_01ad: ldc.i4.0
-		IL_01ae: ldloc.0
-		IL_01af: stelem.ref
-		IL_01b0: ldc.i4.0
-		IL_01b1: ldelem.ref
-		IL_01b2: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
-		IL_01b7: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L24C21::__js_call__(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope, object, object)
-		IL_01bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01c2: ldc.i4.1
-		IL_01c3: newarr [System.Runtime]System.Object
-		IL_01c8: dup
-		IL_01c9: ldc.i4.0
-		IL_01ca: ldloc.0
-		IL_01cb: stelem.ref
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01d6: ldc.i4.1
-		IL_01d7: conv.r8
-		IL_01d8: ldstr ""
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01e2: stloc.3
-		IL_01e3: ldloc.s 6
-		IL_01e5: ldstr "on"
-		IL_01ea: ldstr "message"
-		IL_01ef: ldloc.3
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01f5: pop
-		IL_01f6: ldloc.0
-		IL_01f7: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_01fc: ldstr "Cannot access 'child' before initialization"
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0206: stloc.3
-		IL_0207: ldnull
-		IL_0208: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L30C24::__js_call__(object)
-		IL_020e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0213: ldc.i4.1
-		IL_0214: newarr [System.Runtime]System.Object
-		IL_0219: dup
-		IL_021a: ldc.i4.0
-		IL_021b: ldloc.0
-		IL_021c: stelem.ref
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0227: ldc.i4.0
-		IL_0228: conv.r8
-		IL_0229: ldstr ""
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0233: stloc.s 6
-		IL_0235: ldloc.3
-		IL_0236: ldstr "on"
-		IL_023b: ldstr "disconnect"
-		IL_0240: ldloc.s 6
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0247: pop
-		IL_0248: ldloc.0
-		IL_0249: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_024e: ldstr "Cannot access 'child' before initialization"
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0258: stloc.s 6
-		IL_025a: ldnull
-		IL_025b: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L34C18::__js_call__(object, object, object)
-		IL_0261: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0266: ldc.i4.1
-		IL_0267: newarr [System.Runtime]System.Object
-		IL_026c: dup
-		IL_026d: ldc.i4.0
-		IL_026e: ldloc.0
-		IL_026f: stelem.ref
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_027a: ldc.i4.2
-		IL_027b: conv.r8
-		IL_027c: ldstr ""
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0286: stloc.3
-		IL_0287: ldloc.s 6
-		IL_0289: ldstr "on"
-		IL_028e: ldstr "exit"
-		IL_0293: ldloc.3
-		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0299: pop
-		IL_029a: ldloc.0
-		IL_029b: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_02a0: ldstr "Cannot access 'child' before initialization"
-		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02aa: stloc.3
-		IL_02ab: ldc.i4.1
-		IL_02ac: newarr [System.Runtime]System.Object
-		IL_02b1: dup
-		IL_02b2: ldc.i4.0
-		IL_02b3: ldloc.0
-		IL_02b4: stelem.ref
-		IL_02b5: ldc.i4.0
-		IL_02b6: ldelem.ref
-		IL_02b7: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
-		IL_02bc: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L40C19::__js_call__(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope, object, object, object)
-		IL_02c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_02c7: ldc.i4.1
-		IL_02c8: newarr [System.Runtime]System.Object
-		IL_02cd: dup
-		IL_02ce: ldc.i4.0
-		IL_02cf: ldloc.0
-		IL_02d0: stelem.ref
-		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02db: ldc.i4.2
-		IL_02dc: conv.r8
-		IL_02dd: ldstr ""
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02e7: stloc.s 6
-		IL_02e9: ldloc.3
-		IL_02ea: ldstr "on"
-		IL_02ef: ldstr "close"
-		IL_02f4: ldloc.s 6
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_02fb: pop
-		IL_02fc: ret
+		IL_00bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c4: ldstr "connected initially:"
+		IL_00c9: ldloc.0
+		IL_00ca: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_00cf: ldstr "connected"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00de: pop
+		IL_00df: ldloc.0
+		IL_00e0: ldstr ""
+		IL_00e5: stfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::stderr
+		IL_00ea: ldloc.0
+		IL_00eb: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_00f0: ldstr "stderr"
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fa: ldstr "setEncoding"
+		IL_00ff: ldstr "utf8"
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0109: pop
+		IL_010a: ldc.i4.1
+		IL_010b: newarr [System.Runtime]System.Object
+		IL_0110: dup
+		IL_0111: ldc.i4.0
+		IL_0112: ldloc.0
+		IL_0113: stelem.ref
+		IL_0114: ldc.i4.0
+		IL_0115: ldelem.ref
+		IL_0116: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
+		IL_011b: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L20C25::__js_call__(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope, object, object)
+		IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0126: ldc.i4.1
+		IL_0127: newarr [System.Runtime]System.Object
+		IL_012c: dup
+		IL_012d: ldc.i4.0
+		IL_012e: ldloc.0
+		IL_012f: stelem.ref
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_013a: ldc.i4.1
+		IL_013b: conv.r8
+		IL_013c: ldstr ""
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0146: stloc.3
+		IL_0147: ldloc.0
+		IL_0148: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_014d: ldstr "stderr"
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0157: ldstr "on"
+		IL_015c: ldstr "data"
+		IL_0161: ldloc.3
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0167: pop
+		IL_0168: ldc.i4.1
+		IL_0169: newarr [System.Runtime]System.Object
+		IL_016e: dup
+		IL_016f: ldc.i4.0
+		IL_0170: ldloc.0
+		IL_0171: stelem.ref
+		IL_0172: ldc.i4.0
+		IL_0173: ldelem.ref
+		IL_0174: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
+		IL_0179: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L24C21::__js_call__(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope, object, object)
+		IL_017f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0184: ldc.i4.1
+		IL_0185: newarr [System.Runtime]System.Object
+		IL_018a: dup
+		IL_018b: ldc.i4.0
+		IL_018c: ldloc.0
+		IL_018d: stelem.ref
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0198: ldc.i4.1
+		IL_0199: conv.r8
+		IL_019a: ldstr ""
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01a4: stloc.3
+		IL_01a5: ldloc.0
+		IL_01a6: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_01ab: ldstr "on"
+		IL_01b0: ldstr "message"
+		IL_01b5: ldloc.3
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01bb: pop
+		IL_01bc: ldnull
+		IL_01bd: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L30C24::__js_call__(object)
+		IL_01c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01c8: ldc.i4.1
+		IL_01c9: newarr [System.Runtime]System.Object
+		IL_01ce: dup
+		IL_01cf: ldc.i4.0
+		IL_01d0: ldloc.0
+		IL_01d1: stelem.ref
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01dc: ldc.i4.0
+		IL_01dd: conv.r8
+		IL_01de: ldstr ""
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01e8: stloc.3
+		IL_01e9: ldloc.0
+		IL_01ea: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_01ef: ldstr "on"
+		IL_01f4: ldstr "disconnect"
+		IL_01f9: ldloc.3
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01ff: pop
+		IL_0200: ldnull
+		IL_0201: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L34C18::__js_call__(object, object, object)
+		IL_0207: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_020c: ldc.i4.1
+		IL_020d: newarr [System.Runtime]System.Object
+		IL_0212: dup
+		IL_0213: ldc.i4.0
+		IL_0214: ldloc.0
+		IL_0215: stelem.ref
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0220: ldc.i4.2
+		IL_0221: conv.r8
+		IL_0222: ldstr ""
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_022c: stloc.3
+		IL_022d: ldloc.0
+		IL_022e: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_0233: ldstr "on"
+		IL_0238: ldstr "exit"
+		IL_023d: ldloc.3
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0243: pop
+		IL_0244: ldc.i4.1
+		IL_0245: newarr [System.Runtime]System.Object
+		IL_024a: dup
+		IL_024b: ldc.i4.0
+		IL_024c: ldloc.0
+		IL_024d: stelem.ref
+		IL_024e: ldc.i4.0
+		IL_024f: ldelem.ref
+		IL_0250: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
+		IL_0255: ldftn object Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L40C19::__js_call__(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope, object, object, object)
+		IL_025b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0260: ldc.i4.1
+		IL_0261: newarr [System.Runtime]System.Object
+		IL_0266: dup
+		IL_0267: ldc.i4.0
+		IL_0268: ldloc.0
+		IL_0269: stelem.ref
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0274: ldc.i4.2
+		IL_0275: conv.r8
+		IL_0276: ldstr ""
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0280: stloc.3
+		IL_0281: ldloc.0
+		IL_0282: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_0287: ldstr "on"
+		IL_028c: ldstr "close"
+		IL_0291: ldloc.3
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0297: pop
+		IL_0298: ret
 	} // end of method Require_ChildProcess_Fork_Kill_And_Env::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Kill_And_Env
@@ -747,7 +705,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x265d
+				// Method begins at RVA 0x25e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -773,7 +731,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2594
+			// Method begins at RVA 0x2524
 			// Header size: 12
 			// Code size: 103 (0x67)
 			.maxstack 8
@@ -824,7 +782,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2666
+				// Method begins at RVA 0x25eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -847,7 +805,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2607
+			// Method begins at RVA 0x2597
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -865,7 +823,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2654
+			// Method begins at RVA 0x25d9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -889,7 +847,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x235c
+		// Method begins at RVA 0x22f8
 		// Header size: 12
 		// Code size: 167 (0xa7)
 		.maxstack 8
@@ -966,7 +924,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x266f
+		// Method begins at RVA 0x25f4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
+++ b/tests/Js2IL.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a24
+				// Method begins at RVA 0x295d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x25b0
+			// Method begins at RVA 0x250c
 			// Header size: 12
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a2d
+				// Method begins at RVA 0x2966
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,7 +119,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x25d4
+			// Method begins at RVA 0x2530
 			// Header size: 12
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -160,7 +160,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a3f
+					// Method begins at RVA 0x2978
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -181,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a36
+				// Method begins at RVA 0x296f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -208,9 +208,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x25f8
+			// Method begins at RVA 0x2554
 			// Header size: 12
-			// Code size: 233 (0xe9)
+			// Code size: 223 (0xdf)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C21/Scope/Block_L31C35,
@@ -225,7 +225,7 @@
 			IL_0010: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0015: stloc.1
 			IL_0016: ldloc.1
-			IL_0017: brfalse IL_00b1
+			IL_0017: brfalse IL_00a7
 
 			IL_001c: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C21/Scope/Block_L31C35::.ctor()
 			IL_0021: stloc.0
@@ -245,46 +245,44 @@
 			IL_0057: pop
 			IL_0058: ldarg.0
 			IL_0059: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-			IL_005e: ldstr "Cannot access 'child' before initialization"
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0068: stloc.2
-			IL_0069: ldloc.2
-			IL_006a: ldstr "send"
-			IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0074: dup
-			IL_0075: ldstr "stage"
-			IL_007a: ldstr "parent"
-			IL_007f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0084: dup
-			IL_0085: ldstr "value"
-			IL_008a: ldc.r8 41
-			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009d: stloc.2
-			IL_009e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00a3: ldstr "send result:"
-			IL_00a8: ldloc.2
-			IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00ae: pop
-			IL_00af: ldnull
-			IL_00b0: ret
+			IL_005e: stloc.2
+			IL_005f: ldloc.2
+			IL_0060: ldstr "send"
+			IL_0065: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006a: dup
+			IL_006b: ldstr "stage"
+			IL_0070: ldstr "parent"
+			IL_0075: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_007a: dup
+			IL_007b: ldstr "value"
+			IL_0080: ldc.r8 41
+			IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0093: stloc.2
+			IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0099: ldstr "send result:"
+			IL_009e: ldloc.2
+			IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00a4: pop
+			IL_00a5: ldnull
+			IL_00a6: ret
 
-			IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00b6: ldstr "reply stage:"
-			IL_00bb: ldarg.2
-			IL_00bc: ldstr "stage"
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00cb: pop
-			IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00d1: ldstr "reply value:"
-			IL_00d6: ldarg.2
-			IL_00d7: ldstr "value"
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00e6: pop
-			IL_00e7: ldnull
-			IL_00e8: ret
+			IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ac: ldstr "reply stage:"
+			IL_00b1: ldarg.2
+			IL_00b2: ldstr "stage"
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00c1: pop
+			IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00c7: ldstr "reply value:"
+			IL_00cc: ldarg.2
+			IL_00cd: ldstr "value"
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00dc: pop
+			IL_00dd: ldnull
+			IL_00de: ret
 		} // end of method ArrowFunction_L30C21::__js_call__
 
 	} // end of class ArrowFunction_L30C21
@@ -300,7 +298,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a48
+				// Method begins at RVA 0x2981
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -323,7 +321,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26ed
+			// Method begins at RVA 0x263f
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -358,7 +356,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a51
+				// Method begins at RVA 0x298a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -382,7 +380,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2708
+			// Method begins at RVA 0x2658
 			// Header size: 12
 			// Code size: 53 (0x35)
 			.maxstack 8
@@ -441,7 +439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a5a
+				// Method begins at RVA 0x2993
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -466,7 +464,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x274c
+			// Method begins at RVA 0x269c
 			// Header size: 12
 			// Code size: 73 (0x49)
 			.maxstack 8
@@ -524,7 +522,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a63
+				// Method begins at RVA 0x299c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -552,7 +550,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x27a4
+			// Method begins at RVA 0x26f4
 			// Header size: 12
 			// Code size: 141 (0x8d)
 			.maxstack 8
@@ -628,7 +626,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a1b
+				// Method begins at RVA 0x2954
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -651,18 +649,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a07
+			// Method begins at RVA 0x294b
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -680,7 +675,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1090 (0x442)
+		// Code size: 928 (0x3a0)
 		.maxstack 11
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_MessagePassing/Scope,
@@ -690,8 +685,7 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] bool,
-			[7] object,
-			[8] object
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/Scope::.ctor()
@@ -755,306 +749,252 @@
 		IL_00b8: ldloc.0
 		IL_00b9: ldloc.3
 		IL_00ba: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_00bf: ldloc.0
-		IL_00c0: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_00c5: ldstr "Cannot access 'child' before initialization"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00cf: stloc.3
-		IL_00d0: ldloc.3
-		IL_00d1: ldstr "connected"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00db: stloc.3
-		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e1: ldstr "connected initially:"
-		IL_00e6: ldloc.3
-		IL_00e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00ec: pop
-		IL_00ed: ldloc.0
-		IL_00ee: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_00f3: ldstr "Cannot access 'child' before initialization"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00fd: stloc.3
-		IL_00fe: ldloc.3
-		IL_00ff: ldstr "stdout"
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0109: stloc.3
-		IL_010a: ldloc.3
-		IL_010b: ldc.i4.0
-		IL_010c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0116: stloc.s 6
-		IL_0118: ldloc.s 6
-		IL_011a: box [System.Runtime]System.Boolean
-		IL_011f: stloc.s 7
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0126: ldstr "stdout piped:"
-		IL_012b: ldloc.s 7
-		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0132: pop
-		IL_0133: ldloc.0
-		IL_0134: ldstr ""
-		IL_0139: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stdout
-		IL_013e: ldloc.0
-		IL_013f: ldstr ""
-		IL_0144: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
-		IL_0149: ldloc.0
-		IL_014a: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_014f: ldstr "Cannot access 'child' before initialization"
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0159: stloc.3
-		IL_015a: ldloc.3
-		IL_015b: ldstr "stdout"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0165: stloc.3
-		IL_0166: ldloc.3
-		IL_0167: ldstr "setEncoding"
-		IL_016c: ldstr "utf8"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0176: pop
-		IL_0177: ldloc.0
-		IL_0178: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_017d: ldstr "Cannot access 'child' before initialization"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0187: stloc.3
-		IL_0188: ldloc.3
-		IL_0189: ldstr "stdout"
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0193: stloc.3
-		IL_0194: ldc.i4.1
-		IL_0195: newarr [System.Runtime]System.Object
-		IL_019a: dup
-		IL_019b: ldc.i4.0
-		IL_019c: ldloc.0
-		IL_019d: stelem.ref
-		IL_019e: ldc.i4.0
-		IL_019f: ldelem.ref
-		IL_01a0: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_01a5: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L22C25::__js_call__(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope, object, object)
-		IL_01ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01b0: ldc.i4.1
-		IL_01b1: newarr [System.Runtime]System.Object
-		IL_01b6: dup
-		IL_01b7: ldc.i4.0
-		IL_01b8: ldloc.0
-		IL_01b9: stelem.ref
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01c4: ldc.i4.1
-		IL_01c5: conv.r8
-		IL_01c6: ldstr ""
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01d0: stloc.s 8
-		IL_01d2: ldloc.3
-		IL_01d3: ldstr "on"
-		IL_01d8: ldstr "data"
-		IL_01dd: ldloc.s 8
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01e4: pop
-		IL_01e5: ldloc.0
-		IL_01e6: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_01eb: ldstr "Cannot access 'child' before initialization"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01f5: stloc.s 8
-		IL_01f7: ldloc.s 8
-		IL_01f9: ldstr "stderr"
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0203: stloc.s 8
-		IL_0205: ldloc.s 8
-		IL_0207: ldstr "setEncoding"
-		IL_020c: ldstr "utf8"
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0216: pop
-		IL_0217: ldloc.0
-		IL_0218: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_021d: ldstr "Cannot access 'child' before initialization"
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0227: stloc.s 8
-		IL_0229: ldloc.s 8
-		IL_022b: ldstr "stderr"
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0235: stloc.s 8
-		IL_0237: ldc.i4.1
-		IL_0238: newarr [System.Runtime]System.Object
-		IL_023d: dup
-		IL_023e: ldc.i4.0
-		IL_023f: ldloc.0
-		IL_0240: stelem.ref
-		IL_0241: ldc.i4.0
-		IL_0242: ldelem.ref
-		IL_0243: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_0248: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L26C25::__js_call__(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope, object, object)
-		IL_024e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0253: ldc.i4.1
-		IL_0254: newarr [System.Runtime]System.Object
-		IL_0259: dup
-		IL_025a: ldc.i4.0
-		IL_025b: ldloc.0
-		IL_025c: stelem.ref
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0267: ldc.i4.1
-		IL_0268: conv.r8
-		IL_0269: ldstr ""
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0273: stloc.3
-		IL_0274: ldloc.s 8
-		IL_0276: ldstr "on"
-		IL_027b: ldstr "data"
-		IL_0280: ldloc.3
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0286: pop
-		IL_0287: ldloc.0
-		IL_0288: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_028d: ldstr "Cannot access 'child' before initialization"
-		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0297: stloc.3
-		IL_0298: ldc.i4.1
-		IL_0299: newarr [System.Runtime]System.Object
-		IL_029e: dup
+		IL_00bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c4: ldstr "connected initially:"
+		IL_00c9: ldloc.0
+		IL_00ca: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_00cf: ldstr "connected"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00de: pop
+		IL_00df: ldloc.0
+		IL_00e0: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_00e5: ldstr "stdout"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ef: stloc.3
+		IL_00f0: ldloc.3
+		IL_00f1: ldc.i4.0
+		IL_00f2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_00fc: stloc.s 6
+		IL_00fe: ldloc.s 6
+		IL_0100: box [System.Runtime]System.Boolean
+		IL_0105: stloc.s 7
+		IL_0107: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010c: ldstr "stdout piped:"
+		IL_0111: ldloc.s 7
+		IL_0113: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0118: pop
+		IL_0119: ldloc.0
+		IL_011a: ldstr ""
+		IL_011f: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stdout
+		IL_0124: ldloc.0
+		IL_0125: ldstr ""
+		IL_012a: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
+		IL_012f: ldloc.0
+		IL_0130: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_0135: ldstr "stdout"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013f: ldstr "setEncoding"
+		IL_0144: ldstr "utf8"
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_014e: pop
+		IL_014f: ldc.i4.1
+		IL_0150: newarr [System.Runtime]System.Object
+		IL_0155: dup
+		IL_0156: ldc.i4.0
+		IL_0157: ldloc.0
+		IL_0158: stelem.ref
+		IL_0159: ldc.i4.0
+		IL_015a: ldelem.ref
+		IL_015b: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_0160: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L22C25::__js_call__(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope, object, object)
+		IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_016b: ldc.i4.1
+		IL_016c: newarr [System.Runtime]System.Object
+		IL_0171: dup
+		IL_0172: ldc.i4.0
+		IL_0173: ldloc.0
+		IL_0174: stelem.ref
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_017f: ldc.i4.1
+		IL_0180: conv.r8
+		IL_0181: ldstr ""
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_018b: stloc.3
+		IL_018c: ldloc.0
+		IL_018d: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_0192: ldstr "stdout"
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019c: ldstr "on"
+		IL_01a1: ldstr "data"
+		IL_01a6: ldloc.3
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01ac: pop
+		IL_01ad: ldloc.0
+		IL_01ae: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_01b3: ldstr "stderr"
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01bd: ldstr "setEncoding"
+		IL_01c2: ldstr "utf8"
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01cc: pop
+		IL_01cd: ldc.i4.1
+		IL_01ce: newarr [System.Runtime]System.Object
+		IL_01d3: dup
+		IL_01d4: ldc.i4.0
+		IL_01d5: ldloc.0
+		IL_01d6: stelem.ref
+		IL_01d7: ldc.i4.0
+		IL_01d8: ldelem.ref
+		IL_01d9: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_01de: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L26C25::__js_call__(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope, object, object)
+		IL_01e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01e9: ldc.i4.1
+		IL_01ea: newarr [System.Runtime]System.Object
+		IL_01ef: dup
+		IL_01f0: ldc.i4.0
+		IL_01f1: ldloc.0
+		IL_01f2: stelem.ref
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01fd: ldc.i4.1
+		IL_01fe: conv.r8
+		IL_01ff: ldstr ""
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0209: stloc.3
+		IL_020a: ldloc.0
+		IL_020b: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_0210: ldstr "stderr"
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021a: ldstr "on"
+		IL_021f: ldstr "data"
+		IL_0224: ldloc.3
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_022a: pop
+		IL_022b: ldc.i4.1
+		IL_022c: newarr [System.Runtime]System.Object
+		IL_0231: dup
+		IL_0232: ldc.i4.0
+		IL_0233: ldloc.0
+		IL_0234: stelem.ref
+		IL_0235: ldc.i4.0
+		IL_0236: ldelem.ref
+		IL_0237: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_023c: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C21::__js_call__(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope, object, object)
+		IL_0242: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0247: ldc.i4.1
+		IL_0248: newarr [System.Runtime]System.Object
+		IL_024d: dup
+		IL_024e: ldc.i4.0
+		IL_024f: ldloc.0
+		IL_0250: stelem.ref
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_025b: ldc.i4.1
+		IL_025c: conv.r8
+		IL_025d: ldstr ""
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0267: stloc.3
+		IL_0268: ldloc.0
+		IL_0269: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_026e: ldstr "on"
+		IL_0273: ldstr "message"
+		IL_0278: ldloc.3
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_027e: pop
+		IL_027f: ldnull
+		IL_0280: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L42C24::__js_call__(object)
+		IL_0286: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_028b: ldc.i4.1
+		IL_028c: newarr [System.Runtime]System.Object
+		IL_0291: dup
+		IL_0292: ldc.i4.0
+		IL_0293: ldloc.0
+		IL_0294: stelem.ref
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_029f: ldc.i4.0
-		IL_02a0: ldloc.0
-		IL_02a1: stelem.ref
-		IL_02a2: ldc.i4.0
-		IL_02a3: ldelem.ref
-		IL_02a4: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_02a9: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C21::__js_call__(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope, object, object)
-		IL_02af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02b4: ldc.i4.1
-		IL_02b5: newarr [System.Runtime]System.Object
-		IL_02ba: dup
-		IL_02bb: ldc.i4.0
-		IL_02bc: ldloc.0
-		IL_02bd: stelem.ref
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02c8: ldc.i4.1
-		IL_02c9: conv.r8
-		IL_02ca: ldstr ""
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02d4: stloc.s 8
-		IL_02d6: ldloc.3
-		IL_02d7: ldstr "on"
-		IL_02dc: ldstr "message"
-		IL_02e1: ldloc.s 8
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_02e8: pop
-		IL_02e9: ldloc.0
-		IL_02ea: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_02ef: ldstr "Cannot access 'child' before initialization"
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02f9: stloc.s 8
-		IL_02fb: ldnull
-		IL_02fc: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L42C24::__js_call__(object)
-		IL_0302: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0307: ldc.i4.1
-		IL_0308: newarr [System.Runtime]System.Object
-		IL_030d: dup
-		IL_030e: ldc.i4.0
-		IL_030f: ldloc.0
-		IL_0310: stelem.ref
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_031b: ldc.i4.0
-		IL_031c: conv.r8
-		IL_031d: ldstr ""
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0327: stloc.3
-		IL_0328: ldloc.s 8
-		IL_032a: ldstr "on"
-		IL_032f: ldstr "disconnect"
-		IL_0334: ldloc.3
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_033a: pop
-		IL_033b: ldloc.0
-		IL_033c: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_0341: ldstr "Cannot access 'child' before initialization"
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_034b: stloc.3
-		IL_034c: ldnull
-		IL_034d: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L46C19::__js_call__(object, object)
-		IL_0353: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0358: ldc.i4.1
-		IL_0359: newarr [System.Runtime]System.Object
-		IL_035e: dup
-		IL_035f: ldc.i4.0
-		IL_0360: ldloc.0
-		IL_0361: stelem.ref
-		IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_036c: ldc.i4.1
-		IL_036d: conv.r8
-		IL_036e: ldstr ""
-		IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0378: stloc.s 8
-		IL_037a: ldloc.3
-		IL_037b: ldstr "on"
-		IL_0380: ldstr "error"
-		IL_0385: ldloc.s 8
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_038c: pop
-		IL_038d: ldloc.0
-		IL_038e: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_0393: ldstr "Cannot access 'child' before initialization"
-		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_039d: stloc.s 8
-		IL_039f: ldnull
-		IL_03a0: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L50C18::__js_call__(object, object, object)
-		IL_03a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_03ab: ldc.i4.1
-		IL_03ac: newarr [System.Runtime]System.Object
-		IL_03b1: dup
-		IL_03b2: ldc.i4.0
-		IL_03b3: ldloc.0
-		IL_03b4: stelem.ref
-		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_03bf: ldc.i4.2
-		IL_03c0: conv.r8
-		IL_03c1: ldstr ""
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_03cb: stloc.3
-		IL_03cc: ldloc.s 8
-		IL_03ce: ldstr "on"
-		IL_03d3: ldstr "exit"
-		IL_03d8: ldloc.3
-		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_03de: pop
-		IL_03df: ldloc.0
-		IL_03e0: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_03e5: ldstr "Cannot access 'child' before initialization"
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_03ef: stloc.3
-		IL_03f0: ldc.i4.1
-		IL_03f1: newarr [System.Runtime]System.Object
-		IL_03f6: dup
-		IL_03f7: ldc.i4.0
-		IL_03f8: ldloc.0
-		IL_03f9: stelem.ref
-		IL_03fa: ldc.i4.0
-		IL_03fb: ldelem.ref
-		IL_03fc: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_0401: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L56C19::__js_call__(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope, object, object, object)
-		IL_0407: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_040c: ldc.i4.1
-		IL_040d: newarr [System.Runtime]System.Object
-		IL_0412: dup
-		IL_0413: ldc.i4.0
-		IL_0414: ldloc.0
-		IL_0415: stelem.ref
-		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0420: ldc.i4.2
-		IL_0421: conv.r8
-		IL_0422: ldstr ""
-		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_042c: stloc.s 8
-		IL_042e: ldloc.3
-		IL_042f: ldstr "on"
-		IL_0434: ldstr "close"
-		IL_0439: ldloc.s 8
-		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0440: pop
-		IL_0441: ret
+		IL_02a0: conv.r8
+		IL_02a1: ldstr ""
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_02ab: stloc.3
+		IL_02ac: ldloc.0
+		IL_02ad: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_02b2: ldstr "on"
+		IL_02b7: ldstr "disconnect"
+		IL_02bc: ldloc.3
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_02c2: pop
+		IL_02c3: ldnull
+		IL_02c4: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L46C19::__js_call__(object, object)
+		IL_02ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02cf: ldc.i4.1
+		IL_02d0: newarr [System.Runtime]System.Object
+		IL_02d5: dup
+		IL_02d6: ldc.i4.0
+		IL_02d7: ldloc.0
+		IL_02d8: stelem.ref
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02e3: ldc.i4.1
+		IL_02e4: conv.r8
+		IL_02e5: ldstr ""
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_02ef: stloc.3
+		IL_02f0: ldloc.0
+		IL_02f1: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_02f6: ldstr "on"
+		IL_02fb: ldstr "error"
+		IL_0300: ldloc.3
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0306: pop
+		IL_0307: ldnull
+		IL_0308: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L50C18::__js_call__(object, object, object)
+		IL_030e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0313: ldc.i4.1
+		IL_0314: newarr [System.Runtime]System.Object
+		IL_0319: dup
+		IL_031a: ldc.i4.0
+		IL_031b: ldloc.0
+		IL_031c: stelem.ref
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0327: ldc.i4.2
+		IL_0328: conv.r8
+		IL_0329: ldstr ""
+		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0333: stloc.3
+		IL_0334: ldloc.0
+		IL_0335: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_033a: ldstr "on"
+		IL_033f: ldstr "exit"
+		IL_0344: ldloc.3
+		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_034a: pop
+		IL_034b: ldc.i4.1
+		IL_034c: newarr [System.Runtime]System.Object
+		IL_0351: dup
+		IL_0352: ldc.i4.0
+		IL_0353: ldloc.0
+		IL_0354: stelem.ref
+		IL_0355: ldc.i4.0
+		IL_0356: ldelem.ref
+		IL_0357: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_035c: ldftn object Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L56C19::__js_call__(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope, object, object, object)
+		IL_0362: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0367: ldc.i4.1
+		IL_0368: newarr [System.Runtime]System.Object
+		IL_036d: dup
+		IL_036e: ldc.i4.0
+		IL_036f: ldloc.0
+		IL_0370: stelem.ref
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_037b: ldc.i4.2
+		IL_037c: conv.r8
+		IL_037d: ldstr ""
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0387: stloc.3
+		IL_0388: ldloc.0
+		IL_0389: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_038e: ldstr "on"
+		IL_0393: ldstr "close"
+		IL_0398: ldloc.3
+		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_039e: pop
+		IL_039f: ret
 	} // end of method Require_ChildProcess_Fork_MessagePassing::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_MessagePassing
@@ -1074,7 +1014,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a80
+				// Method begins at RVA 0x29ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1097,7 +1037,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2840
+			// Method begins at RVA 0x2790
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -1137,7 +1077,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a89
+				// Method begins at RVA 0x29b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1164,74 +1104,70 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2870
+			// Method begins at RVA 0x27c0
 			// Header size: 12
-			// Code size: 197 (0xc5)
+			// Code size: 185 (0xb9)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Node.Process,
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing_Child/Scope::fallbackExit
-			IL_0006: ldstr "Cannot access 'fallbackExit' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearTimeout(object)
-			IL_0017: pop
-			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_001d: ldstr "child received:"
-			IL_0022: ldarg.2
-			IL_0023: ldstr "value"
-			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0032: pop
-			IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0038: stloc.1
-			IL_0039: ldarg.2
-			IL_003a: ldstr "value"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0044: ldc.r8 1
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0052: stloc.2
-			IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0058: dup
-			IL_0059: ldstr "stage"
-			IL_005e: ldstr "child"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearTimeout(object)
+			IL_000b: pop
+			IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0011: ldstr "child received:"
+			IL_0016: ldarg.2
+			IL_0017: ldstr "value"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0021: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0026: pop
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_002c: stloc.0
+			IL_002d: ldarg.2
+			IL_002e: ldstr "value"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0038: ldc.r8 1
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0046: stloc.1
+			IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004c: dup
+			IL_004d: ldstr "stage"
+			IL_0052: ldstr "child"
+			IL_0057: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005c: dup
+			IL_005d: ldstr "value"
+			IL_0062: ldloc.1
 			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0068: dup
-			IL_0069: ldstr "value"
-			IL_006e: ldloc.2
-			IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0074: stloc.3
-			IL_0075: ldloc.1
-			IL_0076: ldstr "send"
-			IL_007b: ldloc.3
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0081: stloc.0
-			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0087: ldstr "reply sent:"
-			IL_008c: ldloc.0
-			IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0092: pop
-			IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0098: ldstr "disconnect"
-			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00a2: pop
-			IL_00a3: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_00a8: stloc.1
-			IL_00a9: ldloc.1
-			IL_00aa: ldstr "exit"
-			IL_00af: ldc.r8 0.0
-			IL_00b8: box [System.Runtime]System.Double
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00c2: pop
-			IL_00c3: ldnull
-			IL_00c4: ret
+			IL_0068: stloc.2
+			IL_0069: ldloc.0
+			IL_006a: ldstr "send"
+			IL_006f: ldloc.2
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0075: stloc.3
+			IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_007b: ldstr "reply sent:"
+			IL_0080: ldloc.3
+			IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0086: pop
+			IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_008c: ldstr "disconnect"
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0096: pop
+			IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_009c: stloc.0
+			IL_009d: ldloc.0
+			IL_009e: ldstr "exit"
+			IL_00a3: ldc.r8 0.0
+			IL_00ac: box [System.Runtime]System.Double
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b6: pop
+			IL_00b7: ldnull
+			IL_00b8: ret
 		} // end of method ArrowFunction_L7C23::__js_call__
 
 	} // end of class ArrowFunction_L7C23
@@ -1247,7 +1183,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a92
+				// Method begins at RVA 0x29c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1273,7 +1209,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2944
+			// Method begins at RVA 0x2888
 			// Header size: 12
 			// Code size: 183 (0xb7)
 			.maxstack 8
@@ -1348,18 +1284,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a6c
+			// Method begins at RVA 0x29a5
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_ChildProcess_Fork_MessagePassing_Child/Scope::fallbackExit
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1375,7 +1308,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x24a0
+		// Method begins at RVA 0x23fc
 		// Header size: 12
 		// Code size: 257 (0x101)
 		.maxstack 8
@@ -1485,7 +1418,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a9b
+		// Method begins at RVA 0x29c9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Js2IL.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x295b
+					// Method begins at RVA 0x2855
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26dc
+				// Method begins at RVA 0x2604
 				// Header size: 12
 				// Code size: 36 (0x24)
 				.maxstack 8
@@ -100,7 +100,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2964
+					// Method begins at RVA 0x285e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -125,7 +125,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x270c
+				// Method begins at RVA 0x2634
 				// Header size: 12
 				// Code size: 36 (0x24)
 				.maxstack 8
@@ -171,7 +171,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x296d
+					// Method begins at RVA 0x2867
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,9 +196,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x273c
+				// Method begins at RVA 0x2664
 				// Header size: 12
-				// Code size: 87 (0x57)
+				// Code size: 75 (0x4b)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -216,21 +216,17 @@
 				IL_001d: ldelem.ref
 				IL_001e: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
 				IL_0023: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-				IL_0028: ldstr "Cannot access 'child' before initialization"
-				IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0032: stloc.0
-				IL_0033: ldloc.0
-				IL_0034: ldstr "send"
-				IL_0039: ldstr "shutdown"
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0043: stloc.0
-				IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0049: ldstr "silent true send:"
-				IL_004e: ldloc.0
-				IL_004f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0054: pop
-				IL_0055: ldnull
-				IL_0056: ret
+				IL_0028: ldstr "send"
+				IL_002d: ldstr "shutdown"
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0037: stloc.0
+				IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_003d: ldstr "silent true send:"
+				IL_0042: ldloc.0
+				IL_0043: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0048: pop
+				IL_0049: ldnull
+				IL_004a: ret
 			} // end of method ArrowFunction_L26C25::__js_call__
 
 		} // end of class ArrowFunction_L26C25
@@ -253,7 +249,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2976
+					// Method begins at RVA 0x2870
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -278,7 +274,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x27a0
+				// Method begins at RVA 0x26bc
 				// Header size: 12
 				// Code size: 208 (0xd0)
 				.maxstack 8
@@ -386,18 +382,15 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2947
+				// Method begins at RVA 0x284c
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -417,270 +410,221 @@
 			)
 			// Method begins at RVA 0x221c
 			// Header size: 12
-			// Code size: 755 (0x2f3)
+			// Code size: 613 (0x265)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[3] bool,
-				[4] object,
-				[5] object
+				[4] object
 			)
 
 			IL_0000: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
-			IL_000c: ldstr "Cannot access 'childProcess' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0016: stloc.1
-			IL_0017: ldc.i4.1
-			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_001d: dup
-			IL_001e: ldstr "emit-stdio"
-			IL_0023: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0028: stloc.2
-			IL_0029: ldloc.1
-			IL_002a: ldstr "fork"
-			IL_002f: ldstr "./Require_ChildProcess_Fork_Silent_Child"
-			IL_0034: ldloc.2
-			IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003a: dup
-			IL_003b: ldstr "silent"
-			IL_0040: ldc.i4.1
-			IL_0041: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_004b: stloc.1
-			IL_004c: ldloc.0
-			IL_004d: ldloc.1
-			IL_004e: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0053: ldloc.0
-			IL_0054: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0059: ldstr "Cannot access 'child' before initialization"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0063: stloc.1
-			IL_0064: ldloc.1
-			IL_0065: ldstr "stdout"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006f: stloc.1
-			IL_0070: ldloc.1
-			IL_0071: ldc.i4.0
-			IL_0072: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0077: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_007c: stloc.3
-			IL_007d: ldloc.3
-			IL_007e: box [System.Runtime]System.Boolean
-			IL_0083: stloc.s 4
-			IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_008a: ldstr "silent true stdout piped:"
-			IL_008f: ldloc.s 4
-			IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0096: pop
-			IL_0097: ldloc.0
-			IL_0098: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_009d: ldstr "Cannot access 'child' before initialization"
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a7: stloc.1
-			IL_00a8: ldloc.1
-			IL_00a9: ldstr "stderr"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b3: stloc.1
-			IL_00b4: ldloc.1
-			IL_00b5: ldc.i4.0
-			IL_00b6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00c0: stloc.3
-			IL_00c1: ldloc.3
-			IL_00c2: box [System.Runtime]System.Boolean
-			IL_00c7: stloc.s 4
-			IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00ce: ldstr "silent true stderr piped:"
-			IL_00d3: ldloc.s 4
-			IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00da: pop
-			IL_00db: ldloc.0
-			IL_00dc: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_00e1: ldstr "Cannot access 'child' before initialization"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00eb: stloc.1
-			IL_00ec: ldloc.1
-			IL_00ed: ldstr "connected"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f7: stloc.1
-			IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00fd: ldstr "silent true connected initially:"
-			IL_0102: ldloc.1
-			IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0108: pop
-			IL_0109: ldloc.0
-			IL_010a: ldstr ""
-			IL_010f: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
-			IL_0114: ldloc.0
-			IL_0115: ldstr ""
-			IL_011a: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
-			IL_011f: ldloc.0
-			IL_0120: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0125: ldstr "Cannot access 'child' before initialization"
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_012f: stloc.1
-			IL_0130: ldloc.1
-			IL_0131: ldstr "stdout"
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013b: stloc.1
-			IL_013c: ldloc.1
-			IL_013d: ldstr "setEncoding"
-			IL_0142: ldstr "utf8"
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_014c: pop
-			IL_014d: ldloc.0
-			IL_014e: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0153: ldstr "Cannot access 'child' before initialization"
-			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_015d: stloc.1
-			IL_015e: ldloc.1
-			IL_015f: ldstr "stdout"
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0169: stloc.1
-			IL_016a: ldnull
-			IL_016b: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29::__js_call__(object[], object, object)
-			IL_0171: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0176: ldc.i4.2
-			IL_0177: newarr [System.Runtime]System.Object
-			IL_017c: dup
-			IL_017d: ldc.i4.0
-			IL_017e: ldarg.0
-			IL_017f: stelem.ref
-			IL_0180: dup
-			IL_0181: ldc.i4.1
-			IL_0182: ldloc.0
-			IL_0183: stelem.ref
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_018e: ldc.i4.1
-			IL_018f: conv.r8
-			IL_0190: ldstr ""
-			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_019a: stloc.s 5
-			IL_019c: ldloc.1
-			IL_019d: ldstr "on"
-			IL_01a2: ldstr "data"
-			IL_01a7: ldloc.s 5
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01ae: pop
-			IL_01af: ldloc.0
-			IL_01b0: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_01b5: ldstr "Cannot access 'child' before initialization"
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01bf: stloc.s 5
-			IL_01c1: ldloc.s 5
-			IL_01c3: ldstr "stderr"
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01cd: stloc.s 5
-			IL_01cf: ldloc.s 5
-			IL_01d1: ldstr "setEncoding"
-			IL_01d6: ldstr "utf8"
-			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01e0: pop
-			IL_01e1: ldloc.0
-			IL_01e2: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_01e7: ldstr "Cannot access 'child' before initialization"
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01f1: stloc.s 5
-			IL_01f3: ldloc.s 5
-			IL_01f5: ldstr "stderr"
-			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ff: stloc.s 5
-			IL_0201: ldnull
-			IL_0202: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29::__js_call__(object[], object, object)
-			IL_0208: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_020d: ldc.i4.2
-			IL_020e: newarr [System.Runtime]System.Object
-			IL_0213: dup
-			IL_0214: ldc.i4.0
-			IL_0215: ldarg.0
-			IL_0216: stelem.ref
-			IL_0217: dup
-			IL_0218: ldc.i4.1
-			IL_0219: ldloc.0
-			IL_021a: stelem.ref
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0225: ldc.i4.1
-			IL_0226: conv.r8
-			IL_0227: ldstr ""
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0231: stloc.1
-			IL_0232: ldloc.s 5
-			IL_0234: ldstr "on"
-			IL_0239: ldstr "data"
-			IL_023e: ldloc.1
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0244: pop
-			IL_0245: ldloc.0
-			IL_0246: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_024b: ldstr "Cannot access 'child' before initialization"
-			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0255: stloc.1
-			IL_0256: ldnull
-			IL_0257: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25::__js_call__(object[], object, object)
-			IL_025d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0262: ldc.i4.2
-			IL_0263: newarr [System.Runtime]System.Object
-			IL_0268: dup
-			IL_0269: ldc.i4.0
-			IL_026a: ldarg.0
-			IL_026b: stelem.ref
-			IL_026c: dup
-			IL_026d: ldc.i4.1
-			IL_026e: ldloc.0
-			IL_026f: stelem.ref
-			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_027a: ldc.i4.1
-			IL_027b: conv.r8
-			IL_027c: ldstr ""
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0286: stloc.s 5
-			IL_0288: ldloc.1
-			IL_0289: ldstr "on"
-			IL_028e: ldstr "message"
-			IL_0293: ldloc.s 5
-			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_029a: pop
-			IL_029b: ldloc.0
-			IL_029c: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_02a1: ldstr "Cannot access 'child' before initialization"
-			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_02ab: stloc.s 5
-			IL_02ad: ldnull
-			IL_02ae: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23::__js_call__(object[], object, object)
-			IL_02b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_02b9: ldc.i4.2
-			IL_02ba: newarr [System.Runtime]System.Object
-			IL_02bf: dup
-			IL_02c0: ldc.i4.0
-			IL_02c1: ldarg.0
-			IL_02c2: stelem.ref
-			IL_02c3: dup
-			IL_02c4: ldc.i4.1
-			IL_02c5: ldloc.0
-			IL_02c6: stelem.ref
-			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_02d1: ldc.i4.1
-			IL_02d2: conv.r8
-			IL_02d3: ldstr ""
-			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_02dd: stloc.1
-			IL_02de: ldloc.s 5
-			IL_02e0: ldstr "on"
-			IL_02e5: ldstr "close"
-			IL_02ea: ldloc.1
-			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02f0: pop
-			IL_02f1: ldnull
-			IL_02f2: ret
+			IL_000c: stloc.1
+			IL_000d: ldc.i4.1
+			IL_000e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0013: dup
+			IL_0014: ldstr "emit-stdio"
+			IL_0019: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_001e: stloc.2
+			IL_001f: ldloc.1
+			IL_0020: ldstr "fork"
+			IL_0025: ldstr "./Require_ChildProcess_Fork_Silent_Child"
+			IL_002a: ldloc.2
+			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0030: dup
+			IL_0031: ldstr "silent"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0041: stloc.1
+			IL_0042: ldloc.0
+			IL_0043: ldloc.1
+			IL_0044: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0049: ldloc.0
+			IL_004a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_004f: ldstr "stdout"
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0059: stloc.1
+			IL_005a: ldloc.1
+			IL_005b: ldc.i4.0
+			IL_005c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0066: stloc.3
+			IL_0067: ldloc.3
+			IL_0068: box [System.Runtime]System.Boolean
+			IL_006d: stloc.s 4
+			IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0074: ldstr "silent true stdout piped:"
+			IL_0079: ldloc.s 4
+			IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0080: pop
+			IL_0081: ldloc.0
+			IL_0082: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0087: ldstr "stderr"
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0091: stloc.1
+			IL_0092: ldloc.1
+			IL_0093: ldc.i4.0
+			IL_0094: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0099: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_009e: stloc.3
+			IL_009f: ldloc.3
+			IL_00a0: box [System.Runtime]System.Boolean
+			IL_00a5: stloc.s 4
+			IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ac: ldstr "silent true stderr piped:"
+			IL_00b1: ldloc.s 4
+			IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00b8: pop
+			IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00be: ldstr "silent true connected initially:"
+			IL_00c3: ldloc.0
+			IL_00c4: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_00c9: ldstr "connected"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00d8: pop
+			IL_00d9: ldloc.0
+			IL_00da: ldstr ""
+			IL_00df: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
+			IL_00e4: ldloc.0
+			IL_00e5: ldstr ""
+			IL_00ea: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
+			IL_00ef: ldloc.0
+			IL_00f0: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_00f5: ldstr "stdout"
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ff: ldstr "setEncoding"
+			IL_0104: ldstr "utf8"
+			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_010e: pop
+			IL_010f: ldnull
+			IL_0110: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29::__js_call__(object[], object, object)
+			IL_0116: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_011b: ldc.i4.2
+			IL_011c: newarr [System.Runtime]System.Object
+			IL_0121: dup
+			IL_0122: ldc.i4.0
+			IL_0123: ldarg.0
+			IL_0124: stelem.ref
+			IL_0125: dup
+			IL_0126: ldc.i4.1
+			IL_0127: ldloc.0
+			IL_0128: stelem.ref
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0133: ldc.i4.1
+			IL_0134: conv.r8
+			IL_0135: ldstr ""
+			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_013f: stloc.1
+			IL_0140: ldloc.0
+			IL_0141: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0146: ldstr "stdout"
+			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0150: ldstr "on"
+			IL_0155: ldstr "data"
+			IL_015a: ldloc.1
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0160: pop
+			IL_0161: ldloc.0
+			IL_0162: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0167: ldstr "stderr"
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0171: ldstr "setEncoding"
+			IL_0176: ldstr "utf8"
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0180: pop
+			IL_0181: ldnull
+			IL_0182: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29::__js_call__(object[], object, object)
+			IL_0188: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_018d: ldc.i4.2
+			IL_018e: newarr [System.Runtime]System.Object
+			IL_0193: dup
+			IL_0194: ldc.i4.0
+			IL_0195: ldarg.0
+			IL_0196: stelem.ref
+			IL_0197: dup
+			IL_0198: ldc.i4.1
+			IL_0199: ldloc.0
+			IL_019a: stelem.ref
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_01a5: ldc.i4.1
+			IL_01a6: conv.r8
+			IL_01a7: ldstr ""
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_01b1: stloc.1
+			IL_01b2: ldloc.0
+			IL_01b3: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_01b8: ldstr "stderr"
+			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c2: ldstr "on"
+			IL_01c7: ldstr "data"
+			IL_01cc: ldloc.1
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01d2: pop
+			IL_01d3: ldnull
+			IL_01d4: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25::__js_call__(object[], object, object)
+			IL_01da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_01df: ldc.i4.2
+			IL_01e0: newarr [System.Runtime]System.Object
+			IL_01e5: dup
+			IL_01e6: ldc.i4.0
+			IL_01e7: ldarg.0
+			IL_01e8: stelem.ref
+			IL_01e9: dup
+			IL_01ea: ldc.i4.1
+			IL_01eb: ldloc.0
+			IL_01ec: stelem.ref
+			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_01f7: ldc.i4.1
+			IL_01f8: conv.r8
+			IL_01f9: ldstr ""
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0203: stloc.1
+			IL_0204: ldloc.0
+			IL_0205: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_020a: ldstr "on"
+			IL_020f: ldstr "message"
+			IL_0214: ldloc.1
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_021a: pop
+			IL_021b: ldnull
+			IL_021c: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23::__js_call__(object[], object, object)
+			IL_0222: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0227: ldc.i4.2
+			IL_0228: newarr [System.Runtime]System.Object
+			IL_022d: dup
+			IL_022e: ldc.i4.0
+			IL_022f: ldarg.0
+			IL_0230: stelem.ref
+			IL_0231: dup
+			IL_0232: ldc.i4.1
+			IL_0233: ldloc.0
+			IL_0234: stelem.ref
+			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_023f: ldc.i4.1
+			IL_0240: conv.r8
+			IL_0241: ldstr ""
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_024b: stloc.1
+			IL_024c: ldloc.0
+			IL_024d: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0252: ldstr "on"
+			IL_0257: ldstr "close"
+			IL_025c: ldloc.1
+			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0262: pop
+			IL_0263: ldnull
+			IL_0264: ret
 		} // end of method runSilentTrue::__js_call__
 
 	} // end of class runSilentTrue
@@ -707,7 +651,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2993
+					// Method begins at RVA 0x2882
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -732,9 +676,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x287c
+				// Method begins at RVA 0x2798
 				// Header size: 12
-				// Code size: 87 (0x57)
+				// Code size: 75 (0x4b)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -752,21 +696,17 @@
 				IL_001d: ldelem.ref
 				IL_001e: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope
 				IL_0023: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-				IL_0028: ldstr "Cannot access 'child' before initialization"
-				IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0032: stloc.0
-				IL_0033: ldloc.0
-				IL_0034: ldstr "send"
-				IL_0039: ldstr "shutdown"
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0043: stloc.0
-				IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0049: ldstr "silent false send:"
-				IL_004e: ldloc.0
-				IL_004f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0054: pop
-				IL_0055: ldnull
-				IL_0056: ret
+				IL_0028: ldstr "send"
+				IL_002d: ldstr "shutdown"
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0037: stloc.0
+				IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_003d: ldstr "silent false send:"
+				IL_0042: ldloc.0
+				IL_0043: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0048: pop
+				IL_0049: ldnull
+				IL_004a: ret
 			} // end of method ArrowFunction_L45C25::__js_call__
 
 		} // end of class ArrowFunction_L45C25
@@ -789,7 +729,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x299c
+					// Method begins at RVA 0x288b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -813,7 +753,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28df
+				// Method begins at RVA 0x27ef
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -843,18 +783,15 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x297f
+				// Method begins at RVA 0x2879
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -872,164 +809,139 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x251c
+			// Method begins at RVA 0x2490
 			// Header size: 12
-			// Code size: 435 (0x1b3)
+			// Code size: 359 (0x167)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[3] bool,
-				[4] object,
-				[5] object
+				[4] object
 			)
 
 			IL_0000: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
-			IL_000c: ldstr "Cannot access 'childProcess' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0016: stloc.1
-			IL_0017: ldc.i4.1
-			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_001d: dup
-			IL_001e: ldstr "quiet"
-			IL_0023: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0028: stloc.2
-			IL_0029: ldloc.1
-			IL_002a: ldstr "fork"
-			IL_002f: ldstr "./Require_ChildProcess_Fork_Silent_Child"
-			IL_0034: ldloc.2
-			IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003a: dup
-			IL_003b: ldstr "silent"
-			IL_0040: ldc.i4.0
-			IL_0041: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_004b: stloc.1
-			IL_004c: ldloc.0
-			IL_004d: ldloc.1
-			IL_004e: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0053: ldloc.0
-			IL_0054: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0059: ldstr "Cannot access 'child' before initialization"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0063: stloc.1
-			IL_0064: ldloc.1
-			IL_0065: ldstr "stdout"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006f: stloc.1
-			IL_0070: ldloc.1
-			IL_0071: ldc.i4.0
-			IL_0072: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0077: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_007c: stloc.3
-			IL_007d: ldloc.3
-			IL_007e: box [System.Runtime]System.Boolean
-			IL_0083: stloc.s 4
-			IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_008a: ldstr "silent false stdout null:"
-			IL_008f: ldloc.s 4
-			IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0096: pop
-			IL_0097: ldloc.0
-			IL_0098: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_009d: ldstr "Cannot access 'child' before initialization"
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a7: stloc.1
-			IL_00a8: ldloc.1
-			IL_00a9: ldstr "stderr"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b3: stloc.1
-			IL_00b4: ldloc.1
-			IL_00b5: ldc.i4.0
-			IL_00b6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00c0: stloc.3
-			IL_00c1: ldloc.3
-			IL_00c2: box [System.Runtime]System.Boolean
-			IL_00c7: stloc.s 4
-			IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00ce: ldstr "silent false stderr null:"
-			IL_00d3: ldloc.s 4
-			IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00da: pop
-			IL_00db: ldloc.0
-			IL_00dc: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_00e1: ldstr "Cannot access 'child' before initialization"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00eb: stloc.1
-			IL_00ec: ldloc.1
-			IL_00ed: ldstr "connected"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f7: stloc.1
-			IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00fd: ldstr "silent false connected initially:"
-			IL_0102: ldloc.1
-			IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0108: pop
-			IL_0109: ldloc.0
-			IL_010a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_010f: ldstr "Cannot access 'child' before initialization"
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0119: stloc.1
-			IL_011a: ldnull
-			IL_011b: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L45C25::__js_call__(object[], object, object)
-			IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0126: ldc.i4.2
-			IL_0127: newarr [System.Runtime]System.Object
-			IL_012c: dup
-			IL_012d: ldc.i4.0
-			IL_012e: ldarg.0
-			IL_012f: stelem.ref
-			IL_0130: dup
-			IL_0131: ldc.i4.1
-			IL_0132: ldloc.0
-			IL_0133: stelem.ref
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_013e: ldc.i4.1
-			IL_013f: conv.r8
-			IL_0140: ldstr ""
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_014a: stloc.s 5
-			IL_014c: ldloc.1
-			IL_014d: ldstr "on"
-			IL_0152: ldstr "message"
-			IL_0157: ldloc.s 5
-			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_015e: pop
-			IL_015f: ldloc.0
-			IL_0160: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0165: ldstr "Cannot access 'child' before initialization"
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_016f: stloc.s 5
-			IL_0171: ldnull
-			IL_0172: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L50C23::__js_call__(object, object)
-			IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_017d: ldc.i4.1
-			IL_017e: newarr [System.Runtime]System.Object
-			IL_0183: dup
-			IL_0184: ldc.i4.0
-			IL_0185: ldarg.0
-			IL_0186: stelem.ref
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0191: ldc.i4.1
-			IL_0192: conv.r8
-			IL_0193: ldstr ""
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_019d: stloc.1
-			IL_019e: ldloc.s 5
-			IL_01a0: ldstr "on"
-			IL_01a5: ldstr "close"
-			IL_01aa: ldloc.1
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01b0: pop
-			IL_01b1: ldnull
-			IL_01b2: ret
+			IL_000c: stloc.1
+			IL_000d: ldc.i4.1
+			IL_000e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0013: dup
+			IL_0014: ldstr "quiet"
+			IL_0019: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_001e: stloc.2
+			IL_001f: ldloc.1
+			IL_0020: ldstr "fork"
+			IL_0025: ldstr "./Require_ChildProcess_Fork_Silent_Child"
+			IL_002a: ldloc.2
+			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0030: dup
+			IL_0031: ldstr "silent"
+			IL_0036: ldc.i4.0
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0041: stloc.1
+			IL_0042: ldloc.0
+			IL_0043: ldloc.1
+			IL_0044: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0049: ldloc.0
+			IL_004a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_004f: ldstr "stdout"
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0059: stloc.1
+			IL_005a: ldloc.1
+			IL_005b: ldc.i4.0
+			IL_005c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0066: stloc.3
+			IL_0067: ldloc.3
+			IL_0068: box [System.Runtime]System.Boolean
+			IL_006d: stloc.s 4
+			IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0074: ldstr "silent false stdout null:"
+			IL_0079: ldloc.s 4
+			IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0080: pop
+			IL_0081: ldloc.0
+			IL_0082: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0087: ldstr "stderr"
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0091: stloc.1
+			IL_0092: ldloc.1
+			IL_0093: ldc.i4.0
+			IL_0094: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0099: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_009e: stloc.3
+			IL_009f: ldloc.3
+			IL_00a0: box [System.Runtime]System.Boolean
+			IL_00a5: stloc.s 4
+			IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ac: ldstr "silent false stderr null:"
+			IL_00b1: ldloc.s 4
+			IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00b8: pop
+			IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00be: ldstr "silent false connected initially:"
+			IL_00c3: ldloc.0
+			IL_00c4: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_00c9: ldstr "connected"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00d8: pop
+			IL_00d9: ldnull
+			IL_00da: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L45C25::__js_call__(object[], object, object)
+			IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00e5: ldc.i4.2
+			IL_00e6: newarr [System.Runtime]System.Object
+			IL_00eb: dup
+			IL_00ec: ldc.i4.0
+			IL_00ed: ldarg.0
+			IL_00ee: stelem.ref
+			IL_00ef: dup
+			IL_00f0: ldc.i4.1
+			IL_00f1: ldloc.0
+			IL_00f2: stelem.ref
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00fd: ldc.i4.1
+			IL_00fe: conv.r8
+			IL_00ff: ldstr ""
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0109: stloc.1
+			IL_010a: ldloc.0
+			IL_010b: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0110: ldstr "on"
+			IL_0115: ldstr "message"
+			IL_011a: ldloc.1
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0120: pop
+			IL_0121: ldnull
+			IL_0122: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L50C23::__js_call__(object, object)
+			IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_012d: ldc.i4.1
+			IL_012e: newarr [System.Runtime]System.Object
+			IL_0133: dup
+			IL_0134: ldc.i4.0
+			IL_0135: ldarg.0
+			IL_0136: stelem.ref
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0141: ldc.i4.1
+			IL_0142: conv.r8
+			IL_0143: ldstr ""
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_014d: stloc.1
+			IL_014e: ldloc.0
+			IL_014f: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0154: ldstr "on"
+			IL_0159: ldstr "close"
+			IL_015e: ldloc.1
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0164: pop
+			IL_0165: ldnull
+			IL_0166: ret
 		} // end of method runSilentFalse::__js_call__
 
 	} // end of class runSilentFalse
@@ -1054,7 +966,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x293e
+				// Method begins at RVA 0x2843
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1077,18 +989,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x292a
+			// Method begins at RVA 0x283a
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1213,7 +1122,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29c0
+					// Method begins at RVA 0x28af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1234,7 +1143,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29b7
+				// Method begins at RVA 0x28a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1258,7 +1167,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28f4
+			// Method begins at RVA 0x2804
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1298,7 +1207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ae
+				// Method begins at RVA 0x289d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,7 +1225,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29a5
+			// Method begins at RVA 0x2894
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1445,7 +1354,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29c9
+		// Method begins at RVA 0x28b8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Spawn_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Spawn_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2497
+				// Method begins at RVA 0x2414
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2398
+			// Method begins at RVA 0x232c
 			// Header size: 12
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a0
+				// Method begins at RVA 0x241d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,7 +119,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x23bc
+			// Method begins at RVA 0x2350
 			// Header size: 12
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -159,7 +159,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a9
+				// Method begins at RVA 0x2426
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -183,7 +183,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23de
+			// Method begins at RVA 0x2372
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -217,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b2
+				// Method begins at RVA 0x242f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -244,9 +244,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x23f4
+			// Method begins at RVA 0x2388
 			// Header size: 12
-			// Code size: 131 (0x83)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -277,20 +277,16 @@
 			IL_0052: pop
 			IL_0053: ldarg.0
 			IL_0054: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-			IL_0059: ldstr "Cannot access 'child' before initialization"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0059: ldstr "kill"
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0063: stloc.0
-			IL_0064: ldloc.0
-			IL_0065: ldstr "kill"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_006f: stloc.0
-			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0075: ldstr "kill after close:"
-			IL_007a: ldloc.0
-			IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0080: pop
-			IL_0081: ldnull
-			IL_0082: ret
+			IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0069: ldstr "kill after close:"
+			IL_006e: ldloc.0
+			IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0074: pop
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method ArrowFunction_L29C19::__js_call__
 
 	} // end of class ArrowFunction_L29C19
@@ -313,18 +309,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2483
+			// Method begins at RVA 0x240b
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -342,7 +335,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 828 (0x33c)
+		// Code size: 718 (0x2ce)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Spawn_Basic/Scope,
@@ -351,8 +344,7 @@
 			[3] object,
 			[4] object,
 			[5] bool,
-			[6] object,
-			[7] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_ChildProcess_Spawn_Basic/Scope::.ctor()
@@ -416,212 +408,178 @@
 		IL_00b7: ldloc.0
 		IL_00b8: ldloc.3
 		IL_00b9: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-		IL_00be: ldloc.0
-		IL_00bf: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-		IL_00c4: ldstr "Cannot access 'child' before initialization"
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00ce: stloc.s 4
-		IL_00d0: ldloc.s 4
-		IL_00d2: ldstr "pid"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00dc: stloc.s 4
-		IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e3: ldstr "pid type:"
-		IL_00e8: ldloc.s 4
-		IL_00ea: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00f4: pop
-		IL_00f5: ldloc.0
-		IL_00f6: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-		IL_00fb: ldstr "Cannot access 'child' before initialization"
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0105: stloc.s 4
-		IL_0107: ldloc.s 4
-		IL_0109: ldstr "stdout"
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0113: stloc.s 4
-		IL_0115: ldloc.s 4
-		IL_0117: ldc.i4.0
-		IL_0118: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_011d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0122: stloc.s 5
-		IL_0124: ldloc.s 5
-		IL_0126: box [System.Runtime]System.Boolean
-		IL_012b: stloc.s 6
-		IL_012d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0132: ldstr "stdout piped:"
-		IL_0137: ldloc.s 6
-		IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_013e: pop
-		IL_013f: ldloc.0
-		IL_0140: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-		IL_0145: ldstr "Cannot access 'child' before initialization"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_014f: stloc.s 4
-		IL_0151: ldloc.s 4
-		IL_0153: ldstr "stderr"
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015d: stloc.s 4
-		IL_015f: ldloc.s 4
-		IL_0161: ldc.i4.0
-		IL_0162: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0167: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_016c: stloc.s 5
-		IL_016e: ldloc.s 5
-		IL_0170: box [System.Runtime]System.Boolean
-		IL_0175: stloc.s 6
-		IL_0177: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017c: ldstr "stderr piped:"
-		IL_0181: ldloc.s 6
-		IL_0183: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0188: pop
-		IL_0189: ldloc.0
-		IL_018a: ldstr ""
-		IL_018f: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stdout
-		IL_0194: ldloc.0
-		IL_0195: ldstr ""
-		IL_019a: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
-		IL_019f: ldloc.0
-		IL_01a0: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-		IL_01a5: ldstr "Cannot access 'child' before initialization"
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01af: stloc.s 4
-		IL_01b1: ldloc.s 4
-		IL_01b3: ldstr "stdout"
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01bd: stloc.s 4
-		IL_01bf: ldc.i4.1
-		IL_01c0: newarr [System.Runtime]System.Object
-		IL_01c5: dup
-		IL_01c6: ldc.i4.0
-		IL_01c7: ldloc.0
-		IL_01c8: stelem.ref
-		IL_01c9: ldc.i4.0
-		IL_01ca: ldelem.ref
-		IL_01cb: castclass Modules.Require_ChildProcess_Spawn_Basic/Scope
-		IL_01d0: ldftn object Modules.Require_ChildProcess_Spawn_Basic/ArrowFunction_L17C25::__js_call__(class Modules.Require_ChildProcess_Spawn_Basic/Scope, object, object)
-		IL_01d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01db: ldc.i4.1
-		IL_01dc: newarr [System.Runtime]System.Object
-		IL_01e1: dup
-		IL_01e2: ldc.i4.0
-		IL_01e3: ldloc.0
-		IL_01e4: stelem.ref
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01ef: ldc.i4.1
-		IL_01f0: conv.r8
-		IL_01f1: ldstr ""
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01fb: stloc.s 7
-		IL_01fd: ldloc.s 4
-		IL_01ff: ldstr "on"
-		IL_0204: ldstr "data"
-		IL_0209: ldloc.s 7
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0210: pop
-		IL_0211: ldloc.0
-		IL_0212: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-		IL_0217: ldstr "Cannot access 'child' before initialization"
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0221: stloc.s 7
-		IL_0223: ldloc.s 7
-		IL_0225: ldstr "stderr"
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022f: stloc.s 7
-		IL_0231: ldc.i4.1
-		IL_0232: newarr [System.Runtime]System.Object
-		IL_0237: dup
-		IL_0238: ldc.i4.0
-		IL_0239: ldloc.0
-		IL_023a: stelem.ref
-		IL_023b: ldc.i4.0
-		IL_023c: ldelem.ref
-		IL_023d: castclass Modules.Require_ChildProcess_Spawn_Basic/Scope
-		IL_0242: ldftn object Modules.Require_ChildProcess_Spawn_Basic/ArrowFunction_L21C25::__js_call__(class Modules.Require_ChildProcess_Spawn_Basic/Scope, object, object)
-		IL_0248: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_024d: ldc.i4.1
-		IL_024e: newarr [System.Runtime]System.Object
-		IL_0253: dup
-		IL_0254: ldc.i4.0
-		IL_0255: ldloc.0
-		IL_0256: stelem.ref
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0261: ldc.i4.1
-		IL_0262: conv.r8
-		IL_0263: ldstr ""
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_026d: stloc.s 4
-		IL_026f: ldloc.s 7
-		IL_0271: ldstr "on"
-		IL_0276: ldstr "data"
-		IL_027b: ldloc.s 4
-		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0282: pop
-		IL_0283: ldloc.0
-		IL_0284: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-		IL_0289: ldstr "Cannot access 'child' before initialization"
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0293: stloc.s 4
-		IL_0295: ldnull
-		IL_0296: ldftn object Modules.Require_ChildProcess_Spawn_Basic/ArrowFunction_L25C18::__js_call__(object, object)
-		IL_029c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02a1: ldc.i4.1
-		IL_02a2: newarr [System.Runtime]System.Object
-		IL_02a7: dup
-		IL_02a8: ldc.i4.0
-		IL_02a9: ldloc.0
-		IL_02aa: stelem.ref
-		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02b5: ldc.i4.1
-		IL_02b6: conv.r8
-		IL_02b7: ldstr ""
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02c1: stloc.s 7
-		IL_02c3: ldloc.s 4
-		IL_02c5: ldstr "on"
-		IL_02ca: ldstr "exit"
-		IL_02cf: ldloc.s 7
-		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_02d6: pop
-		IL_02d7: ldloc.0
-		IL_02d8: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-		IL_02dd: ldstr "Cannot access 'child' before initialization"
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02e7: stloc.s 7
-		IL_02e9: ldc.i4.1
-		IL_02ea: newarr [System.Runtime]System.Object
-		IL_02ef: dup
-		IL_02f0: ldc.i4.0
-		IL_02f1: ldloc.0
-		IL_02f2: stelem.ref
-		IL_02f3: ldc.i4.0
-		IL_02f4: ldelem.ref
-		IL_02f5: castclass Modules.Require_ChildProcess_Spawn_Basic/Scope
-		IL_02fa: ldftn object Modules.Require_ChildProcess_Spawn_Basic/ArrowFunction_L29C19::__js_call__(class Modules.Require_ChildProcess_Spawn_Basic/Scope, object, object)
-		IL_0300: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0305: ldc.i4.1
-		IL_0306: newarr [System.Runtime]System.Object
-		IL_030b: dup
-		IL_030c: ldc.i4.0
-		IL_030d: ldloc.0
-		IL_030e: stelem.ref
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0319: ldc.i4.1
-		IL_031a: conv.r8
-		IL_031b: ldstr ""
-		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0325: stloc.s 4
-		IL_0327: ldloc.s 7
-		IL_0329: ldstr "on"
-		IL_032e: ldstr "close"
-		IL_0333: ldloc.s 4
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_033a: pop
-		IL_033b: ret
+		IL_00be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c3: ldstr "pid type:"
+		IL_00c8: ldloc.0
+		IL_00c9: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+		IL_00ce: ldstr "pid"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d8: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_00dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00e2: pop
+		IL_00e3: ldloc.0
+		IL_00e4: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+		IL_00e9: ldstr "stdout"
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f3: stloc.s 4
+		IL_00f5: ldloc.s 4
+		IL_00f7: ldc.i4.0
+		IL_00f8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0102: stloc.s 5
+		IL_0104: ldloc.s 5
+		IL_0106: box [System.Runtime]System.Boolean
+		IL_010b: stloc.s 6
+		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0112: ldstr "stdout piped:"
+		IL_0117: ldloc.s 6
+		IL_0119: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_011e: pop
+		IL_011f: ldloc.0
+		IL_0120: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+		IL_0125: ldstr "stderr"
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012f: stloc.s 4
+		IL_0131: ldloc.s 4
+		IL_0133: ldc.i4.0
+		IL_0134: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0139: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_013e: stloc.s 5
+		IL_0140: ldloc.s 5
+		IL_0142: box [System.Runtime]System.Boolean
+		IL_0147: stloc.s 6
+		IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014e: ldstr "stderr piped:"
+		IL_0153: ldloc.s 6
+		IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_015a: pop
+		IL_015b: ldloc.0
+		IL_015c: ldstr ""
+		IL_0161: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stdout
+		IL_0166: ldloc.0
+		IL_0167: ldstr ""
+		IL_016c: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
+		IL_0171: ldc.i4.1
+		IL_0172: newarr [System.Runtime]System.Object
+		IL_0177: dup
+		IL_0178: ldc.i4.0
+		IL_0179: ldloc.0
+		IL_017a: stelem.ref
+		IL_017b: ldc.i4.0
+		IL_017c: ldelem.ref
+		IL_017d: castclass Modules.Require_ChildProcess_Spawn_Basic/Scope
+		IL_0182: ldftn object Modules.Require_ChildProcess_Spawn_Basic/ArrowFunction_L17C25::__js_call__(class Modules.Require_ChildProcess_Spawn_Basic/Scope, object, object)
+		IL_0188: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_018d: ldc.i4.1
+		IL_018e: newarr [System.Runtime]System.Object
+		IL_0193: dup
+		IL_0194: ldc.i4.0
+		IL_0195: ldloc.0
+		IL_0196: stelem.ref
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01a1: ldc.i4.1
+		IL_01a2: conv.r8
+		IL_01a3: ldstr ""
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01ad: stloc.s 4
+		IL_01af: ldloc.0
+		IL_01b0: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+		IL_01b5: ldstr "stdout"
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01bf: ldstr "on"
+		IL_01c4: ldstr "data"
+		IL_01c9: ldloc.s 4
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01d0: pop
+		IL_01d1: ldc.i4.1
+		IL_01d2: newarr [System.Runtime]System.Object
+		IL_01d7: dup
+		IL_01d8: ldc.i4.0
+		IL_01d9: ldloc.0
+		IL_01da: stelem.ref
+		IL_01db: ldc.i4.0
+		IL_01dc: ldelem.ref
+		IL_01dd: castclass Modules.Require_ChildProcess_Spawn_Basic/Scope
+		IL_01e2: ldftn object Modules.Require_ChildProcess_Spawn_Basic/ArrowFunction_L21C25::__js_call__(class Modules.Require_ChildProcess_Spawn_Basic/Scope, object, object)
+		IL_01e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01ed: ldc.i4.1
+		IL_01ee: newarr [System.Runtime]System.Object
+		IL_01f3: dup
+		IL_01f4: ldc.i4.0
+		IL_01f5: ldloc.0
+		IL_01f6: stelem.ref
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0201: ldc.i4.1
+		IL_0202: conv.r8
+		IL_0203: ldstr ""
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_020d: stloc.s 4
+		IL_020f: ldloc.0
+		IL_0210: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+		IL_0215: ldstr "stderr"
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021f: ldstr "on"
+		IL_0224: ldstr "data"
+		IL_0229: ldloc.s 4
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0230: pop
+		IL_0231: ldnull
+		IL_0232: ldftn object Modules.Require_ChildProcess_Spawn_Basic/ArrowFunction_L25C18::__js_call__(object, object)
+		IL_0238: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_023d: ldc.i4.1
+		IL_023e: newarr [System.Runtime]System.Object
+		IL_0243: dup
+		IL_0244: ldc.i4.0
+		IL_0245: ldloc.0
+		IL_0246: stelem.ref
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0251: ldc.i4.1
+		IL_0252: conv.r8
+		IL_0253: ldstr ""
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_025d: stloc.s 4
+		IL_025f: ldloc.0
+		IL_0260: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+		IL_0265: ldstr "on"
+		IL_026a: ldstr "exit"
+		IL_026f: ldloc.s 4
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0276: pop
+		IL_0277: ldc.i4.1
+		IL_0278: newarr [System.Runtime]System.Object
+		IL_027d: dup
+		IL_027e: ldc.i4.0
+		IL_027f: ldloc.0
+		IL_0280: stelem.ref
+		IL_0281: ldc.i4.0
+		IL_0282: ldelem.ref
+		IL_0283: castclass Modules.Require_ChildProcess_Spawn_Basic/Scope
+		IL_0288: ldftn object Modules.Require_ChildProcess_Spawn_Basic/ArrowFunction_L29C19::__js_call__(class Modules.Require_ChildProcess_Spawn_Basic/Scope, object, object)
+		IL_028e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0293: ldc.i4.1
+		IL_0294: newarr [System.Runtime]System.Object
+		IL_0299: dup
+		IL_029a: ldc.i4.0
+		IL_029b: ldloc.0
+		IL_029c: stelem.ref
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02a7: ldc.i4.1
+		IL_02a8: conv.r8
+		IL_02a9: ldstr ""
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_02b3: stloc.s 4
+		IL_02b5: ldloc.0
+		IL_02b6: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+		IL_02bb: ldstr "on"
+		IL_02c0: ldstr "close"
+		IL_02c5: ldloc.s 4
+		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_02cc: pop
+		IL_02cd: ret
 	} // end of method Require_ChildProcess_Spawn_Basic::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Spawn_Basic
@@ -633,7 +591,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24bb
+		// Method begins at RVA 0x2438
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Js2IL.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3c27
+					// Method begins at RVA 0x3a7a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3c30
+					// Method begins at RVA 0x3a83
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c1e
+				// Method begins at RVA 0x3a71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2790
+			// Method begins at RVA 0x2758
 			// Header size: 12
 			// Code size: 226 (0xe2)
 			.maxstack 8
@@ -204,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c39
+				// Method begins at RVA 0x3a8c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,9 +230,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2890
+			// Method begins at RVA 0x2858
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -240,17 +240,15 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "createHash"
-			IL_0017: ldc.r8 123
-			IL_0020: box [System.Runtime]System.Double
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.0
-			IL_002b: ldloc.0
-			IL_002c: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "createHash"
+			IL_000d: ldc.r8 123
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0020: stloc.0
+			IL_0021: ldloc.0
+			IL_0022: ret
 		} // end of method ArrowFunction_L16C28::__js_call__
 
 	} // end of class ArrowFunction_L16C28
@@ -266,7 +264,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c42
+				// Method begins at RVA 0x3a95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -292,9 +290,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x28cc
+			// Method begins at RVA 0x2888
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -302,16 +300,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "createHash"
-			IL_0017: ldstr "sha3"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0006: ldstr "createHash"
+			IL_000b: ldstr "sha3"
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ret
 		} // end of method ArrowFunction_L17C35::__js_call__
 
 	} // end of class ArrowFunction_L17C35
@@ -327,7 +321,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c4b
+				// Method begins at RVA 0x3a9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -353,9 +347,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x28fc
+			// Method begins at RVA 0x28ac
 			// Header size: 12
-			// Code size: 50 (0x32)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -363,18 +357,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "createHmac"
-			IL_0017: ldc.r8 123
-			IL_0020: box [System.Runtime]System.Double
-			IL_0025: ldstr "key"
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002f: stloc.0
-			IL_0030: ldloc.0
-			IL_0031: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "createHmac"
+			IL_000d: ldc.r8 123
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: ldstr "key"
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0025: stloc.0
+			IL_0026: ldloc.0
+			IL_0027: ret
 		} // end of method ArrowFunction_L18C33::__js_call__
 
 	} // end of class ArrowFunction_L18C33
@@ -390,7 +382,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c54
+				// Method begins at RVA 0x3aa7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -416,9 +408,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x293c
+			// Method begins at RVA 0x28e0
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 29 (0x1d)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -426,17 +418,13 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "createHmac"
-			IL_0017: ldstr "sha3"
-			IL_001c: ldstr "key"
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0026: stloc.0
-			IL_0027: ldloc.0
-			IL_0028: ret
+			IL_0006: ldstr "createHmac"
+			IL_000b: ldstr "sha3"
+			IL_0010: ldstr "key"
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldloc.0
+			IL_001c: ret
 		} // end of method ArrowFunction_L19C40::__js_call__
 
 	} // end of class ArrowFunction_L19C40
@@ -452,7 +440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c5d
+				// Method begins at RVA 0x3ab0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -478,9 +466,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2974
+			// Method begins at RVA 0x290c
 			// Header size: 12
-			// Code size: 42 (0x2a)
+			// Code size: 32 (0x20)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -488,18 +476,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "createHmac"
-			IL_0017: ldstr "sha256"
-			IL_001c: ldc.i4.0
-			IL_001d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0027: stloc.0
-			IL_0028: ldloc.0
-			IL_0029: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "createHmac"
+			IL_000d: ldstr "sha256"
+			IL_0012: ldc.i4.0
+			IL_0013: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_001d: stloc.0
+			IL_001e: ldloc.0
+			IL_001f: ret
 		} // end of method ArrowFunction_L20C27::__js_call__
 
 	} // end of class ArrowFunction_L20C27
@@ -515,7 +501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c66
+				// Method begins at RVA 0x3ab9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -541,9 +527,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x29ac
+			// Method begins at RVA 0x2938
 			// Header size: 12
-			// Code size: 50 (0x32)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -551,18 +537,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "createHmac"
-			IL_0017: ldstr "sha256"
-			IL_001c: ldc.r8 123
-			IL_0025: box [System.Runtime]System.Double
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002f: stloc.0
-			IL_0030: ldloc.0
-			IL_0031: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "createHmac"
+			IL_000d: ldstr "sha256"
+			IL_0012: ldc.r8 123
+			IL_001b: box [System.Runtime]System.Double
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0025: stloc.0
+			IL_0026: ldloc.0
+			IL_0027: ret
 		} // end of method ArrowFunction_L21C29::__js_call__
 
 	} // end of class ArrowFunction_L21C29
@@ -578,7 +562,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c6f
+				// Method begins at RVA 0x3ac2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -604,9 +588,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x29ec
+			// Method begins at RVA 0x296c
 			// Header size: 12
-			// Code size: 87 (0x57)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -614,35 +598,33 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "pbkdf2Sync"
-			IL_0017: ldc.i4.4
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldstr "password"
-			IL_0024: stelem.ref
-			IL_0025: dup
-			IL_0026: ldc.i4.1
-			IL_0027: ldstr "salt"
-			IL_002c: stelem.ref
-			IL_002d: dup
-			IL_002e: ldc.i4.2
-			IL_002f: ldc.r8 1
-			IL_0038: box [System.Runtime]System.Double
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.3
-			IL_0040: ldc.r8 16
-			IL_0049: box [System.Runtime]System.Double
-			IL_004e: stelem.ref
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0054: stloc.0
-			IL_0055: ldloc.0
-			IL_0056: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "pbkdf2Sync"
+			IL_000d: ldc.i4.4
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldstr "password"
+			IL_001a: stelem.ref
+			IL_001b: dup
+			IL_001c: ldc.i4.1
+			IL_001d: ldstr "salt"
+			IL_0022: stelem.ref
+			IL_0023: dup
+			IL_0024: ldc.i4.2
+			IL_0025: ldc.r8 1
+			IL_002e: box [System.Runtime]System.Double
+			IL_0033: stelem.ref
+			IL_0034: dup
+			IL_0035: ldc.i4.3
+			IL_0036: ldc.r8 16
+			IL_003f: box [System.Runtime]System.Double
+			IL_0044: stelem.ref
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_004a: stloc.0
+			IL_004b: ldloc.0
+			IL_004c: ret
 		} // end of method ArrowFunction_L22C35::__js_call__
 
 	} // end of class ArrowFunction_L22C35
@@ -658,7 +640,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c78
+				// Method begins at RVA 0x3acb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -684,9 +666,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a50
+			// Method begins at RVA 0x29c8
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -694,39 +676,37 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "pbkdf2Sync"
-			IL_0017: ldc.i4.5
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldstr "password"
-			IL_0024: stelem.ref
-			IL_0025: dup
-			IL_0026: ldc.i4.1
-			IL_0027: ldstr "salt"
-			IL_002c: stelem.ref
-			IL_002d: dup
-			IL_002e: ldc.i4.2
-			IL_002f: ldc.r8 1
-			IL_0038: box [System.Runtime]System.Double
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.3
-			IL_0040: ldc.r8 16
-			IL_0049: box [System.Runtime]System.Double
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.4
-			IL_0051: ldstr "sha3"
-			IL_0056: stelem.ref
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_005c: stloc.0
-			IL_005d: ldloc.0
-			IL_005e: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "pbkdf2Sync"
+			IL_000d: ldc.i4.5
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldstr "password"
+			IL_001a: stelem.ref
+			IL_001b: dup
+			IL_001c: ldc.i4.1
+			IL_001d: ldstr "salt"
+			IL_0022: stelem.ref
+			IL_0023: dup
+			IL_0024: ldc.i4.2
+			IL_0025: ldc.r8 1
+			IL_002e: box [System.Runtime]System.Double
+			IL_0033: stelem.ref
+			IL_0034: dup
+			IL_0035: ldc.i4.3
+			IL_0036: ldc.r8 16
+			IL_003f: box [System.Runtime]System.Double
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.4
+			IL_0047: ldstr "sha3"
+			IL_004c: stelem.ref
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0052: stloc.0
+			IL_0053: ldloc.0
+			IL_0054: ret
 		} // end of method ArrowFunction_L23C39::__js_call__
 
 	} // end of class ArrowFunction_L23C39
@@ -742,7 +722,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c81
+				// Method begins at RVA 0x3ad4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -768,9 +748,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2abc
+			// Method begins at RVA 0x2a2c
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 94 (0x5e)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -778,40 +758,38 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "pbkdf2Sync"
-			IL_0017: ldc.i4.5
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldc.r8 123
-			IL_0028: box [System.Runtime]System.Double
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldstr "salt"
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.2
-			IL_0038: ldc.r8 1
-			IL_0041: box [System.Runtime]System.Double
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.3
-			IL_0049: ldc.r8 16
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.4
-			IL_005a: ldstr "sha256"
-			IL_005f: stelem.ref
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0065: stloc.0
-			IL_0066: ldloc.0
-			IL_0067: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "pbkdf2Sync"
+			IL_000d: ldc.i4.5
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldc.r8 123
+			IL_001e: box [System.Runtime]System.Double
+			IL_0023: stelem.ref
+			IL_0024: dup
+			IL_0025: ldc.i4.1
+			IL_0026: ldstr "salt"
+			IL_002b: stelem.ref
+			IL_002c: dup
+			IL_002d: ldc.i4.2
+			IL_002e: ldc.r8 1
+			IL_0037: box [System.Runtime]System.Double
+			IL_003c: stelem.ref
+			IL_003d: dup
+			IL_003e: ldc.i4.3
+			IL_003f: ldc.r8 16
+			IL_0048: box [System.Runtime]System.Double
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.4
+			IL_0050: ldstr "sha256"
+			IL_0055: stelem.ref
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_005b: stloc.0
+			IL_005c: ldloc.0
+			IL_005d: ret
 		} // end of method ArrowFunction_L24C36::__js_call__
 
 	} // end of class ArrowFunction_L24C36
@@ -827,7 +805,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c8a
+				// Method begins at RVA 0x3add
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -853,9 +831,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b30
+			// Method begins at RVA 0x2a98
 			// Header size: 12
-			// Code size: 96 (0x60)
+			// Code size: 86 (0x56)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -863,40 +841,38 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "pbkdf2Sync"
-			IL_0017: ldc.i4.5
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldstr "password"
-			IL_0024: stelem.ref
-			IL_0025: dup
-			IL_0026: ldc.i4.1
-			IL_0027: ldc.i4.0
-			IL_0028: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.2
-			IL_0030: ldc.r8 1
-			IL_0039: box [System.Runtime]System.Double
-			IL_003e: stelem.ref
-			IL_003f: dup
-			IL_0040: ldc.i4.3
-			IL_0041: ldc.r8 16
-			IL_004a: box [System.Runtime]System.Double
-			IL_004f: stelem.ref
-			IL_0050: dup
-			IL_0051: ldc.i4.4
-			IL_0052: ldstr "sha256"
-			IL_0057: stelem.ref
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_005d: stloc.0
-			IL_005e: ldloc.0
-			IL_005f: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "pbkdf2Sync"
+			IL_000d: ldc.i4.5
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldstr "password"
+			IL_001a: stelem.ref
+			IL_001b: dup
+			IL_001c: ldc.i4.1
+			IL_001d: ldc.i4.0
+			IL_001e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0023: stelem.ref
+			IL_0024: dup
+			IL_0025: ldc.i4.2
+			IL_0026: ldc.r8 1
+			IL_002f: box [System.Runtime]System.Double
+			IL_0034: stelem.ref
+			IL_0035: dup
+			IL_0036: ldc.i4.3
+			IL_0037: ldc.r8 16
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: stelem.ref
+			IL_0046: dup
+			IL_0047: ldc.i4.4
+			IL_0048: ldstr "sha256"
+			IL_004d: stelem.ref
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0053: stloc.0
+			IL_0054: ldloc.0
+			IL_0055: ret
 		} // end of method ArrowFunction_L25C30::__js_call__
 
 	} // end of class ArrowFunction_L25C30
@@ -912,7 +888,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c93
+				// Method begins at RVA 0x3ae6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -938,9 +914,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b9c
+			// Method begins at RVA 0x2afc
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 76 (0x4c)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -948,38 +924,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "pbkdf2Sync"
-			IL_0017: ldc.i4.5
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldstr "password"
-			IL_0024: stelem.ref
-			IL_0025: dup
-			IL_0026: ldc.i4.1
-			IL_0027: ldstr "salt"
-			IL_002c: stelem.ref
-			IL_002d: dup
-			IL_002e: ldc.i4.2
-			IL_002f: ldstr "1"
-			IL_0034: stelem.ref
-			IL_0035: dup
-			IL_0036: ldc.i4.3
-			IL_0037: ldc.r8 16
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: stelem.ref
-			IL_0046: dup
-			IL_0047: ldc.i4.4
-			IL_0048: ldstr "sha256"
-			IL_004d: stelem.ref
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0053: stloc.0
-			IL_0054: ldloc.0
-			IL_0055: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "pbkdf2Sync"
+			IL_000d: ldc.i4.5
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldstr "password"
+			IL_001a: stelem.ref
+			IL_001b: dup
+			IL_001c: ldc.i4.1
+			IL_001d: ldstr "salt"
+			IL_0022: stelem.ref
+			IL_0023: dup
+			IL_0024: ldc.i4.2
+			IL_0025: ldstr "1"
+			IL_002a: stelem.ref
+			IL_002b: dup
+			IL_002c: ldc.i4.3
+			IL_002d: ldc.r8 16
+			IL_0036: box [System.Runtime]System.Double
+			IL_003b: stelem.ref
+			IL_003c: dup
+			IL_003d: ldc.i4.4
+			IL_003e: ldstr "sha256"
+			IL_0043: stelem.ref
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0049: stloc.0
+			IL_004a: ldloc.0
+			IL_004b: ret
 		} // end of method ArrowFunction_L26C36::__js_call__
 
 	} // end of class ArrowFunction_L26C36
@@ -995,7 +969,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c9c
+				// Method begins at RVA 0x3aef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1021,9 +995,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c00
+			// Method begins at RVA 0x2b54
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1031,39 +1005,37 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "pbkdf2Sync"
-			IL_0017: ldc.i4.5
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldstr "password"
-			IL_0024: stelem.ref
-			IL_0025: dup
-			IL_0026: ldc.i4.1
-			IL_0027: ldstr "salt"
-			IL_002c: stelem.ref
-			IL_002d: dup
-			IL_002e: ldc.i4.2
-			IL_002f: ldc.r8 1.5
-			IL_0038: box [System.Runtime]System.Double
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.3
-			IL_0040: ldc.r8 16
-			IL_0049: box [System.Runtime]System.Double
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.4
-			IL_0051: ldstr "sha256"
-			IL_0056: stelem.ref
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_005c: stloc.0
-			IL_005d: ldloc.0
-			IL_005e: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "pbkdf2Sync"
+			IL_000d: ldc.i4.5
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldstr "password"
+			IL_001a: stelem.ref
+			IL_001b: dup
+			IL_001c: ldc.i4.1
+			IL_001d: ldstr "salt"
+			IL_0022: stelem.ref
+			IL_0023: dup
+			IL_0024: ldc.i4.2
+			IL_0025: ldc.r8 1.5
+			IL_002e: box [System.Runtime]System.Double
+			IL_0033: stelem.ref
+			IL_0034: dup
+			IL_0035: ldc.i4.3
+			IL_0036: ldc.r8 16
+			IL_003f: box [System.Runtime]System.Double
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.4
+			IL_0047: ldstr "sha256"
+			IL_004c: stelem.ref
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0052: stloc.0
+			IL_0053: ldloc.0
+			IL_0054: ret
 		} // end of method ArrowFunction_L27C37::__js_call__
 
 	} // end of class ArrowFunction_L27C37
@@ -1079,7 +1051,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ca5
+				// Method begins at RVA 0x3af8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1105,9 +1077,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c6c
+			// Method begins at RVA 0x2bb8
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1115,39 +1087,37 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "pbkdf2Sync"
-			IL_0017: ldc.i4.5
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldstr "password"
-			IL_0024: stelem.ref
-			IL_0025: dup
-			IL_0026: ldc.i4.1
-			IL_0027: ldstr "salt"
-			IL_002c: stelem.ref
-			IL_002d: dup
-			IL_002e: ldc.i4.2
-			IL_002f: ldc.r8 0.0
-			IL_0038: box [System.Runtime]System.Double
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.3
-			IL_0040: ldc.r8 16
-			IL_0049: box [System.Runtime]System.Double
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.4
-			IL_0051: ldstr "sha256"
-			IL_0056: stelem.ref
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_005c: stloc.0
-			IL_005d: ldloc.0
-			IL_005e: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "pbkdf2Sync"
+			IL_000d: ldc.i4.5
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldstr "password"
+			IL_001a: stelem.ref
+			IL_001b: dup
+			IL_001c: ldc.i4.1
+			IL_001d: ldstr "salt"
+			IL_0022: stelem.ref
+			IL_0023: dup
+			IL_0024: ldc.i4.2
+			IL_0025: ldc.r8 0.0
+			IL_002e: box [System.Runtime]System.Double
+			IL_0033: stelem.ref
+			IL_0034: dup
+			IL_0035: ldc.i4.3
+			IL_0036: ldc.r8 16
+			IL_003f: box [System.Runtime]System.Double
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.4
+			IL_0047: ldstr "sha256"
+			IL_004c: stelem.ref
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0052: stloc.0
+			IL_0053: ldloc.0
+			IL_0054: ret
 		} // end of method ArrowFunction_L28C36::__js_call__
 
 	} // end of class ArrowFunction_L28C36
@@ -1163,7 +1133,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cae
+				// Method begins at RVA 0x3b01
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1189,9 +1159,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2cd8
+			// Method begins at RVA 0x2c1c
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1199,39 +1169,37 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "pbkdf2Sync"
-			IL_0017: ldc.i4.5
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldstr "password"
-			IL_0024: stelem.ref
-			IL_0025: dup
-			IL_0026: ldc.i4.1
-			IL_0027: ldstr "salt"
-			IL_002c: stelem.ref
-			IL_002d: dup
-			IL_002e: ldc.i4.2
-			IL_002f: ldc.r8 1
-			IL_0038: box [System.Runtime]System.Double
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.3
-			IL_0040: ldc.r8 8.5
-			IL_0049: box [System.Runtime]System.Double
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.4
-			IL_0051: ldstr "sha256"
-			IL_0056: stelem.ref
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_005c: stloc.0
-			IL_005d: ldloc.0
-			IL_005e: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "pbkdf2Sync"
+			IL_000d: ldc.i4.5
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldstr "password"
+			IL_001a: stelem.ref
+			IL_001b: dup
+			IL_001c: ldc.i4.1
+			IL_001d: ldstr "salt"
+			IL_0022: stelem.ref
+			IL_0023: dup
+			IL_0024: ldc.i4.2
+			IL_0025: ldc.r8 1
+			IL_002e: box [System.Runtime]System.Double
+			IL_0033: stelem.ref
+			IL_0034: dup
+			IL_0035: ldc.i4.3
+			IL_0036: ldc.r8 8.5
+			IL_003f: box [System.Runtime]System.Double
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.4
+			IL_0047: ldstr "sha256"
+			IL_004c: stelem.ref
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0052: stloc.0
+			IL_0053: ldloc.0
+			IL_0054: ret
 		} // end of method ArrowFunction_L29C33::__js_call__
 
 	} // end of class ArrowFunction_L29C33
@@ -1247,7 +1215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cb7
+				// Method begins at RVA 0x3b0a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1273,9 +1241,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d44
+			// Method begins at RVA 0x2c80
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1284,42 +1252,40 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldc.r8 1
-			IL_001a: neg
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: stloc.1
-			IL_0021: ldloc.0
-			IL_0022: ldstr "pbkdf2Sync"
-			IL_0027: ldc.i4.5
-			IL_0028: newarr [System.Runtime]System.Object
-			IL_002d: dup
-			IL_002e: ldc.i4.0
-			IL_002f: ldstr "password"
-			IL_0034: stelem.ref
-			IL_0035: dup
-			IL_0036: ldc.i4.1
-			IL_0037: ldstr "salt"
-			IL_003c: stelem.ref
-			IL_003d: dup
-			IL_003e: ldc.i4.2
-			IL_003f: ldc.r8 1
-			IL_0048: box [System.Runtime]System.Double
-			IL_004d: stelem.ref
-			IL_004e: dup
-			IL_004f: ldc.i4.3
-			IL_0050: ldloc.1
-			IL_0051: stelem.ref
-			IL_0052: dup
-			IL_0053: ldc.i4.4
-			IL_0054: ldstr "sha256"
-			IL_0059: stelem.ref
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_005f: stloc.0
-			IL_0060: ldloc.0
-			IL_0061: ret
+			IL_0006: stloc.0
+			IL_0007: ldc.r8 1
+			IL_0010: neg
+			IL_0011: box [System.Runtime]System.Double
+			IL_0016: stloc.1
+			IL_0017: ldloc.0
+			IL_0018: ldstr "pbkdf2Sync"
+			IL_001d: ldc.i4.5
+			IL_001e: newarr [System.Runtime]System.Object
+			IL_0023: dup
+			IL_0024: ldc.i4.0
+			IL_0025: ldstr "password"
+			IL_002a: stelem.ref
+			IL_002b: dup
+			IL_002c: ldc.i4.1
+			IL_002d: ldstr "salt"
+			IL_0032: stelem.ref
+			IL_0033: dup
+			IL_0034: ldc.i4.2
+			IL_0035: ldc.r8 1
+			IL_003e: box [System.Runtime]System.Double
+			IL_0043: stelem.ref
+			IL_0044: dup
+			IL_0045: ldc.i4.3
+			IL_0046: ldloc.1
+			IL_0047: stelem.ref
+			IL_0048: dup
+			IL_0049: ldc.i4.4
+			IL_004a: ldstr "sha256"
+			IL_004f: stelem.ref
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0055: stloc.0
+			IL_0056: ldloc.0
+			IL_0057: ret
 		} // end of method ArrowFunction_L30C36::__js_call__
 
 	} // end of class ArrowFunction_L30C36
@@ -1335,7 +1301,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cc0
+				// Method begins at RVA 0x3b13
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1361,9 +1327,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2db4
+			// Method begins at RVA 0x2ce4
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1371,16 +1337,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "randomBytes"
-			IL_0017: ldstr "4"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0006: ldstr "randomBytes"
+			IL_000b: ldstr "4"
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ret
 		} // end of method ArrowFunction_L31C30::__js_call__
 
 	} // end of class ArrowFunction_L31C30
@@ -1396,7 +1358,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cc9
+				// Method begins at RVA 0x3b1c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1422,9 +1384,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2de4
+			// Method begins at RVA 0x2d08
 			// Header size: 12
-			// Code size: 46 (0x2e)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1432,18 +1394,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "Cannot access 'crypto' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "randomBytes"
-			IL_0017: ldc.r8 1
-			IL_0020: neg
-			IL_0021: box [System.Runtime]System.Double
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002b: stloc.0
-			IL_002c: ldloc.0
-			IL_002d: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "randomBytes"
+			IL_000d: ldc.r8 1
+			IL_0016: neg
+			IL_0017: box [System.Runtime]System.Double
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0021: stloc.0
+			IL_0022: ldloc.0
+			IL_0023: ret
 		} // end of method ArrowFunction_L32C34::__js_call__
 
 	} // end of class ArrowFunction_L32C34
@@ -1459,7 +1419,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cd2
+				// Method begins at RVA 0x3b25
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1485,9 +1445,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2e20
+			// Method begins at RVA 0x2d38
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1495,16 +1455,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-			IL_0006: ldstr "Cannot access 'hash' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "digest"
-			IL_0017: ldstr "hex"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0006: ldstr "digest"
+			IL_000b: ldstr "hex"
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ret
 		} // end of method ArrowFunction_L37C26::__js_call__
 
 	} // end of class ArrowFunction_L37C26
@@ -1520,7 +1476,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cdb
+				// Method begins at RVA 0x3b2e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1546,9 +1502,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2e50
+			// Method begins at RVA 0x2d5c
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1556,17 +1512,15 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
-			IL_0006: ldstr "Cannot access 'hmac' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "update"
-			IL_0017: ldc.r8 123
-			IL_0020: box [System.Runtime]System.Double
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.0
-			IL_002b: ldloc.0
-			IL_002c: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "update"
+			IL_000d: ldc.r8 123
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0020: stloc.0
+			IL_0021: ldloc.0
+			IL_0022: ret
 		} // end of method ArrowFunction_L40C30::__js_call__
 
 	} // end of class ArrowFunction_L40C30
@@ -1595,7 +1549,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ced
+					// Method begins at RVA 0x3b40
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1615,7 +1569,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3cf6
+					// Method begins at RVA 0x3b49
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1639,7 +1593,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ce4
+				// Method begins at RVA 0x3b37
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1665,7 +1619,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e8c
+			// Method begins at RVA 0x2d8c
 			// Header size: 12
 			// Code size: 466 (0x1d2)
 			.maxstack 8
@@ -1888,7 +1842,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d1e
+					// Method begins at RVA 0x3b5b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1912,9 +1866,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36c0
+				// Method begins at RVA 0x35a4
 				// Header size: 12
-				// Code size: 55 (0x37)
+				// Code size: 45 (0x2d)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -1926,20 +1880,18 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldstr "abc"
-				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0022: stloc.1
-				IL_0023: ldloc.0
-				IL_0024: ldstr "digest"
-				IL_0029: ldstr "MD5"
-				IL_002e: ldloc.1
-				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0034: stloc.0
-				IL_0035: ldloc.0
-				IL_0036: ret
+				IL_000d: stloc.0
+				IL_000e: ldstr "abc"
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0018: stloc.1
+				IL_0019: ldloc.0
+				IL_001a: ldstr "digest"
+				IL_001f: ldstr "MD5"
+				IL_0024: ldloc.1
+				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_002a: stloc.0
+				IL_002b: ldloc.0
+				IL_002c: ret
 			} // end of method ArrowFunction_L56C56::__js_call__
 
 		} // end of class ArrowFunction_L56C56
@@ -1955,7 +1907,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d27
+					// Method begins at RVA 0x3b64
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1979,9 +1931,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3704
+				// Method begins at RVA 0x35e0
 				// Header size: 12
-				// Code size: 140 (0x8c)
+				// Code size: 130 (0x82)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -1995,57 +1947,55 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldstr "key"
-				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0022: stloc.1
-				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0028: dup
-				IL_0029: ldstr "name"
-				IL_002e: ldstr "HMAC"
-				IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0038: dup
-				IL_0039: ldstr "hash"
-				IL_003e: ldstr "SHA-256"
-				IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0048: stloc.2
-				IL_0049: ldc.i4.5
-				IL_004a: newarr [System.Runtime]System.Object
-				IL_004f: dup
-				IL_0050: ldc.i4.0
-				IL_0051: ldstr "jwk"
-				IL_0056: stelem.ref
-				IL_0057: dup
-				IL_0058: ldc.i4.1
-				IL_0059: ldloc.1
-				IL_005a: stelem.ref
-				IL_005b: dup
-				IL_005c: ldc.i4.2
-				IL_005d: ldloc.2
-				IL_005e: stelem.ref
-				IL_005f: dup
-				IL_0060: ldc.i4.3
-				IL_0061: ldc.i4.0
-				IL_0062: box [System.Runtime]System.Boolean
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.4
-				IL_006a: ldc.i4.1
-				IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0070: dup
-				IL_0071: ldstr "sign"
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_007b: stelem.ref
-				IL_007c: stloc.3
-				IL_007d: ldloc.0
-				IL_007e: ldstr "importKey"
-				IL_0083: ldloc.3
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0089: stloc.0
-				IL_008a: ldloc.0
-				IL_008b: ret
+				IL_000d: stloc.0
+				IL_000e: ldstr "key"
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0018: stloc.1
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_001e: dup
+				IL_001f: ldstr "name"
+				IL_0024: ldstr "HMAC"
+				IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_002e: dup
+				IL_002f: ldstr "hash"
+				IL_0034: ldstr "SHA-256"
+				IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_003e: stloc.2
+				IL_003f: ldc.i4.5
+				IL_0040: newarr [System.Runtime]System.Object
+				IL_0045: dup
+				IL_0046: ldc.i4.0
+				IL_0047: ldstr "jwk"
+				IL_004c: stelem.ref
+				IL_004d: dup
+				IL_004e: ldc.i4.1
+				IL_004f: ldloc.1
+				IL_0050: stelem.ref
+				IL_0051: dup
+				IL_0052: ldc.i4.2
+				IL_0053: ldloc.2
+				IL_0054: stelem.ref
+				IL_0055: dup
+				IL_0056: ldc.i4.3
+				IL_0057: ldc.i4.0
+				IL_0058: box [System.Runtime]System.Boolean
+				IL_005d: stelem.ref
+				IL_005e: dup
+				IL_005f: ldc.i4.4
+				IL_0060: ldc.i4.1
+				IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0066: dup
+				IL_0067: ldstr "sign"
+				IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0071: stelem.ref
+				IL_0072: stloc.3
+				IL_0073: ldloc.0
+				IL_0074: ldstr "importKey"
+				IL_0079: ldloc.3
+				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_007f: stloc.0
+				IL_0080: ldloc.0
+				IL_0081: ret
 			} // end of method ArrowFunction_L57C51::__js_call__
 
 		} // end of class ArrowFunction_L57C51
@@ -2061,7 +2011,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d30
+					// Method begins at RVA 0x3b6d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2085,9 +2035,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x379c
+				// Method begins at RVA 0x3670
 				// Header size: 12
-				// Code size: 131 (0x83)
+				// Code size: 121 (0x79)
 				.maxstack 9
 				.locals init (
 					[0] object,
@@ -2099,52 +2049,50 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_001d: dup
-				IL_001e: ldstr "name"
-				IL_0023: ldstr "HMAC"
-				IL_0028: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_002d: dup
-				IL_002e: ldstr "hash"
-				IL_0033: ldstr "SHA-256"
-				IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_003d: stloc.1
-				IL_003e: ldloc.0
-				IL_003f: ldstr "importKey"
-				IL_0044: ldc.i4.5
-				IL_0045: newarr [System.Runtime]System.Object
-				IL_004a: dup
-				IL_004b: ldc.i4.0
-				IL_004c: ldstr "raw"
-				IL_0051: stelem.ref
-				IL_0052: dup
-				IL_0053: ldc.i4.1
-				IL_0054: ldstr "key"
-				IL_0059: stelem.ref
-				IL_005a: dup
-				IL_005b: ldc.i4.2
-				IL_005c: ldloc.1
-				IL_005d: stelem.ref
-				IL_005e: dup
-				IL_005f: ldc.i4.3
-				IL_0060: ldc.i4.0
-				IL_0061: box [System.Runtime]System.Boolean
-				IL_0066: stelem.ref
-				IL_0067: dup
-				IL_0068: ldc.i4.4
-				IL_0069: ldc.i4.1
-				IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_006f: dup
-				IL_0070: ldstr "sign"
-				IL_0075: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_007a: stelem.ref
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0080: stloc.0
-				IL_0081: ldloc.0
-				IL_0082: ret
+				IL_000d: stloc.0
+				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0013: dup
+				IL_0014: ldstr "name"
+				IL_0019: ldstr "HMAC"
+				IL_001e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0023: dup
+				IL_0024: ldstr "hash"
+				IL_0029: ldstr "SHA-256"
+				IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0033: stloc.1
+				IL_0034: ldloc.0
+				IL_0035: ldstr "importKey"
+				IL_003a: ldc.i4.5
+				IL_003b: newarr [System.Runtime]System.Object
+				IL_0040: dup
+				IL_0041: ldc.i4.0
+				IL_0042: ldstr "raw"
+				IL_0047: stelem.ref
+				IL_0048: dup
+				IL_0049: ldc.i4.1
+				IL_004a: ldstr "key"
+				IL_004f: stelem.ref
+				IL_0050: dup
+				IL_0051: ldc.i4.2
+				IL_0052: ldloc.1
+				IL_0053: stelem.ref
+				IL_0054: dup
+				IL_0055: ldc.i4.3
+				IL_0056: ldc.i4.0
+				IL_0057: box [System.Runtime]System.Boolean
+				IL_005c: stelem.ref
+				IL_005d: dup
+				IL_005e: ldc.i4.4
+				IL_005f: ldc.i4.1
+				IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0065: dup
+				IL_0066: ldstr "sign"
+				IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0070: stelem.ref
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0076: stloc.0
+				IL_0077: ldloc.0
+				IL_0078: ret
 			} // end of method ArrowFunction_L63C53::__js_call__
 
 		} // end of class ArrowFunction_L63C53
@@ -2160,7 +2108,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d39
+					// Method begins at RVA 0x3b76
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2184,9 +2132,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x382c
+				// Method begins at RVA 0x36f8
 				// Header size: 12
-				// Code size: 129 (0x81)
+				// Code size: 119 (0x77)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2200,54 +2148,52 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldstr "key"
-				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0022: stloc.1
-				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0028: dup
-				IL_0029: ldstr "name"
-				IL_002e: ldstr "HMAC"
-				IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0038: dup
-				IL_0039: ldstr "hash"
-				IL_003e: ldstr "SHA-256"
-				IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0048: stloc.2
-				IL_0049: ldc.i4.5
-				IL_004a: newarr [System.Runtime]System.Object
-				IL_004f: dup
-				IL_0050: ldc.i4.0
-				IL_0051: ldstr "raw"
-				IL_0056: stelem.ref
-				IL_0057: dup
-				IL_0058: ldc.i4.1
-				IL_0059: ldloc.1
-				IL_005a: stelem.ref
-				IL_005b: dup
-				IL_005c: ldc.i4.2
-				IL_005d: ldloc.2
-				IL_005e: stelem.ref
-				IL_005f: dup
-				IL_0060: ldc.i4.3
-				IL_0061: ldc.i4.0
-				IL_0062: box [System.Runtime]System.Boolean
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.4
-				IL_006a: ldc.i4.0
-				IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0070: stelem.ref
-				IL_0071: stloc.3
-				IL_0072: ldloc.0
-				IL_0073: ldstr "importKey"
-				IL_0078: ldloc.3
-				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_007e: stloc.0
-				IL_007f: ldloc.0
-				IL_0080: ret
+				IL_000d: stloc.0
+				IL_000e: ldstr "key"
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0018: stloc.1
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_001e: dup
+				IL_001f: ldstr "name"
+				IL_0024: ldstr "HMAC"
+				IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_002e: dup
+				IL_002f: ldstr "hash"
+				IL_0034: ldstr "SHA-256"
+				IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_003e: stloc.2
+				IL_003f: ldc.i4.5
+				IL_0040: newarr [System.Runtime]System.Object
+				IL_0045: dup
+				IL_0046: ldc.i4.0
+				IL_0047: ldstr "raw"
+				IL_004c: stelem.ref
+				IL_004d: dup
+				IL_004e: ldc.i4.1
+				IL_004f: ldloc.1
+				IL_0050: stelem.ref
+				IL_0051: dup
+				IL_0052: ldc.i4.2
+				IL_0053: ldloc.2
+				IL_0054: stelem.ref
+				IL_0055: dup
+				IL_0056: ldc.i4.3
+				IL_0057: ldc.i4.0
+				IL_0058: box [System.Runtime]System.Boolean
+				IL_005d: stelem.ref
+				IL_005e: dup
+				IL_005f: ldc.i4.4
+				IL_0060: ldc.i4.0
+				IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0066: stelem.ref
+				IL_0067: stloc.3
+				IL_0068: ldloc.0
+				IL_0069: ldstr "importKey"
+				IL_006e: ldloc.3
+				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0074: stloc.0
+				IL_0075: ldloc.0
+				IL_0076: ret
 			} // end of method ArrowFunction_L69C57::__js_call__
 
 		} // end of class ArrowFunction_L69C57
@@ -2263,7 +2209,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d42
+					// Method begins at RVA 0x3b7f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2287,9 +2233,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x38bc
+				// Method begins at RVA 0x377c
 				// Header size: 12
-				// Code size: 140 (0x8c)
+				// Code size: 130 (0x82)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2303,57 +2249,55 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldstr "key"
-				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0022: stloc.1
-				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0028: dup
-				IL_0029: ldstr "name"
-				IL_002e: ldstr "HMAC"
-				IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0038: dup
-				IL_0039: ldstr "hash"
-				IL_003e: ldstr "SHA-256"
-				IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0048: stloc.2
-				IL_0049: ldc.i4.5
-				IL_004a: newarr [System.Runtime]System.Object
-				IL_004f: dup
-				IL_0050: ldc.i4.0
-				IL_0051: ldstr "raw"
-				IL_0056: stelem.ref
-				IL_0057: dup
-				IL_0058: ldc.i4.1
-				IL_0059: ldloc.1
-				IL_005a: stelem.ref
-				IL_005b: dup
-				IL_005c: ldc.i4.2
-				IL_005d: ldloc.2
-				IL_005e: stelem.ref
-				IL_005f: dup
-				IL_0060: ldc.i4.3
-				IL_0061: ldc.i4.0
-				IL_0062: box [System.Runtime]System.Boolean
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.4
-				IL_006a: ldc.i4.1
-				IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0070: dup
-				IL_0071: ldstr "SIGN"
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_007b: stelem.ref
-				IL_007c: stloc.3
-				IL_007d: ldloc.0
-				IL_007e: ldstr "importKey"
-				IL_0083: ldloc.3
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0089: stloc.0
-				IL_008a: ldloc.0
-				IL_008b: ret
+				IL_000d: stloc.0
+				IL_000e: ldstr "key"
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0018: stloc.1
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_001e: dup
+				IL_001f: ldstr "name"
+				IL_0024: ldstr "HMAC"
+				IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_002e: dup
+				IL_002f: ldstr "hash"
+				IL_0034: ldstr "SHA-256"
+				IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_003e: stloc.2
+				IL_003f: ldc.i4.5
+				IL_0040: newarr [System.Runtime]System.Object
+				IL_0045: dup
+				IL_0046: ldc.i4.0
+				IL_0047: ldstr "raw"
+				IL_004c: stelem.ref
+				IL_004d: dup
+				IL_004e: ldc.i4.1
+				IL_004f: ldloc.1
+				IL_0050: stelem.ref
+				IL_0051: dup
+				IL_0052: ldc.i4.2
+				IL_0053: ldloc.2
+				IL_0054: stelem.ref
+				IL_0055: dup
+				IL_0056: ldc.i4.3
+				IL_0057: ldc.i4.0
+				IL_0058: box [System.Runtime]System.Boolean
+				IL_005d: stelem.ref
+				IL_005e: dup
+				IL_005f: ldc.i4.4
+				IL_0060: ldc.i4.1
+				IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0066: dup
+				IL_0067: ldstr "SIGN"
+				IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0071: stelem.ref
+				IL_0072: stloc.3
+				IL_0073: ldloc.0
+				IL_0074: ldstr "importKey"
+				IL_0079: ldloc.3
+				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_007f: stloc.0
+				IL_0080: ldloc.0
+				IL_0081: ret
 			} // end of method ArrowFunction_L75C63::__js_call__
 
 		} // end of class ArrowFunction_L75C63
@@ -2369,7 +2313,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d4b
+					// Method begins at RVA 0x3b88
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2393,9 +2337,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3954
+				// Method begins at RVA 0x380c
 				// Header size: 12
-				// Code size: 140 (0x8c)
+				// Code size: 130 (0x82)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2409,57 +2353,55 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldstr "key"
-				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0022: stloc.1
-				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0028: dup
-				IL_0029: ldstr "name"
-				IL_002e: ldstr "HMAC"
-				IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0038: dup
-				IL_0039: ldstr "hash"
-				IL_003e: ldstr "SHA-256"
-				IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0048: stloc.2
-				IL_0049: ldc.i4.5
-				IL_004a: newarr [System.Runtime]System.Object
-				IL_004f: dup
-				IL_0050: ldc.i4.0
-				IL_0051: ldstr "raw"
-				IL_0056: stelem.ref
-				IL_0057: dup
-				IL_0058: ldc.i4.1
-				IL_0059: ldloc.1
-				IL_005a: stelem.ref
-				IL_005b: dup
-				IL_005c: ldc.i4.2
-				IL_005d: ldloc.2
-				IL_005e: stelem.ref
-				IL_005f: dup
-				IL_0060: ldc.i4.3
-				IL_0061: ldc.i4.0
-				IL_0062: box [System.Runtime]System.Boolean
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.4
-				IL_006a: ldc.i4.1
-				IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0070: dup
-				IL_0071: ldstr "encrypt"
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_007b: stelem.ref
-				IL_007c: stloc.3
-				IL_007d: ldloc.0
-				IL_007e: ldstr "importKey"
-				IL_0083: ldloc.3
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0089: stloc.0
-				IL_008a: ldloc.0
-				IL_008b: ret
+				IL_000d: stloc.0
+				IL_000e: ldstr "key"
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0018: stloc.1
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_001e: dup
+				IL_001f: ldstr "name"
+				IL_0024: ldstr "HMAC"
+				IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_002e: dup
+				IL_002f: ldstr "hash"
+				IL_0034: ldstr "SHA-256"
+				IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_003e: stloc.2
+				IL_003f: ldc.i4.5
+				IL_0040: newarr [System.Runtime]System.Object
+				IL_0045: dup
+				IL_0046: ldc.i4.0
+				IL_0047: ldstr "raw"
+				IL_004c: stelem.ref
+				IL_004d: dup
+				IL_004e: ldc.i4.1
+				IL_004f: ldloc.1
+				IL_0050: stelem.ref
+				IL_0051: dup
+				IL_0052: ldc.i4.2
+				IL_0053: ldloc.2
+				IL_0054: stelem.ref
+				IL_0055: dup
+				IL_0056: ldc.i4.3
+				IL_0057: ldc.i4.0
+				IL_0058: box [System.Runtime]System.Boolean
+				IL_005d: stelem.ref
+				IL_005e: dup
+				IL_005f: ldc.i4.4
+				IL_0060: ldc.i4.1
+				IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0066: dup
+				IL_0067: ldstr "encrypt"
+				IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0071: stelem.ref
+				IL_0072: stloc.3
+				IL_0073: ldloc.0
+				IL_0074: ldstr "importKey"
+				IL_0079: ldloc.3
+				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_007f: stloc.0
+				IL_0080: ldloc.0
+				IL_0081: ret
 			} // end of method ArrowFunction_L81C62::__js_call__
 
 		} // end of class ArrowFunction_L81C62
@@ -2475,7 +2417,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d54
+					// Method begins at RVA 0x3b91
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2499,9 +2441,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x39ec
+				// Method begins at RVA 0x389c
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 139 (0x8b)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2515,58 +2457,56 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldc.r8 0.0
-				IL_0021: box [System.Runtime]System.Double
-				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-				IL_002b: stloc.1
-				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0031: dup
-				IL_0032: ldstr "name"
-				IL_0037: ldstr "HMAC"
-				IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0041: dup
-				IL_0042: ldstr "hash"
-				IL_0047: ldstr "SHA-256"
-				IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0051: stloc.2
-				IL_0052: ldc.i4.5
-				IL_0053: newarr [System.Runtime]System.Object
-				IL_0058: dup
-				IL_0059: ldc.i4.0
-				IL_005a: ldstr "raw"
-				IL_005f: stelem.ref
-				IL_0060: dup
-				IL_0061: ldc.i4.1
-				IL_0062: ldloc.1
-				IL_0063: stelem.ref
-				IL_0064: dup
-				IL_0065: ldc.i4.2
-				IL_0066: ldloc.2
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.3
-				IL_006a: ldc.i4.0
-				IL_006b: box [System.Runtime]System.Boolean
-				IL_0070: stelem.ref
-				IL_0071: dup
-				IL_0072: ldc.i4.4
-				IL_0073: ldc.i4.1
-				IL_0074: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0079: dup
-				IL_007a: ldstr "sign"
-				IL_007f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0084: stelem.ref
-				IL_0085: stloc.3
-				IL_0086: ldloc.0
-				IL_0087: ldstr "importKey"
-				IL_008c: ldloc.3
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0092: stloc.0
-				IL_0093: ldloc.0
-				IL_0094: ret
+				IL_000d: stloc.0
+				IL_000e: ldc.r8 0.0
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+				IL_0021: stloc.1
+				IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0027: dup
+				IL_0028: ldstr "name"
+				IL_002d: ldstr "HMAC"
+				IL_0032: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0037: dup
+				IL_0038: ldstr "hash"
+				IL_003d: ldstr "SHA-256"
+				IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0047: stloc.2
+				IL_0048: ldc.i4.5
+				IL_0049: newarr [System.Runtime]System.Object
+				IL_004e: dup
+				IL_004f: ldc.i4.0
+				IL_0050: ldstr "raw"
+				IL_0055: stelem.ref
+				IL_0056: dup
+				IL_0057: ldc.i4.1
+				IL_0058: ldloc.1
+				IL_0059: stelem.ref
+				IL_005a: dup
+				IL_005b: ldc.i4.2
+				IL_005c: ldloc.2
+				IL_005d: stelem.ref
+				IL_005e: dup
+				IL_005f: ldc.i4.3
+				IL_0060: ldc.i4.0
+				IL_0061: box [System.Runtime]System.Boolean
+				IL_0066: stelem.ref
+				IL_0067: dup
+				IL_0068: ldc.i4.4
+				IL_0069: ldc.i4.1
+				IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_006f: dup
+				IL_0070: ldstr "sign"
+				IL_0075: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_007a: stelem.ref
+				IL_007b: stloc.3
+				IL_007c: ldloc.0
+				IL_007d: ldstr "importKey"
+				IL_0082: ldloc.3
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0088: stloc.0
+				IL_0089: ldloc.0
+				IL_008a: ret
 			} // end of method ArrowFunction_L87C53::__js_call__
 
 		} // end of class ArrowFunction_L87C53
@@ -2582,7 +2522,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d5d
+					// Method begins at RVA 0x3b9a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2606,9 +2546,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3a90
+				// Method begins at RVA 0x3934
 				// Header size: 12
-				// Code size: 160 (0xa0)
+				// Code size: 150 (0x96)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2622,61 +2562,59 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldstr "key"
-				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0022: stloc.1
-				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0028: dup
-				IL_0029: ldstr "name"
-				IL_002e: ldstr "HMAC"
-				IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0038: dup
-				IL_0039: ldstr "hash"
-				IL_003e: ldstr "SHA-256"
-				IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0048: dup
-				IL_0049: ldstr "length"
-				IL_004e: ldc.r8 128
-				IL_0057: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-				IL_005c: stloc.2
-				IL_005d: ldc.i4.5
-				IL_005e: newarr [System.Runtime]System.Object
-				IL_0063: dup
-				IL_0064: ldc.i4.0
-				IL_0065: ldstr "raw"
-				IL_006a: stelem.ref
-				IL_006b: dup
-				IL_006c: ldc.i4.1
-				IL_006d: ldloc.1
-				IL_006e: stelem.ref
-				IL_006f: dup
-				IL_0070: ldc.i4.2
-				IL_0071: ldloc.2
-				IL_0072: stelem.ref
-				IL_0073: dup
-				IL_0074: ldc.i4.3
-				IL_0075: ldc.i4.0
-				IL_0076: box [System.Runtime]System.Boolean
-				IL_007b: stelem.ref
-				IL_007c: dup
-				IL_007d: ldc.i4.4
-				IL_007e: ldc.i4.1
-				IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0084: dup
-				IL_0085: ldstr "sign"
-				IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_008f: stelem.ref
-				IL_0090: stloc.3
-				IL_0091: ldloc.0
-				IL_0092: ldstr "importKey"
-				IL_0097: ldloc.3
-				IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_009d: stloc.0
-				IL_009e: ldloc.0
-				IL_009f: ret
+				IL_000d: stloc.0
+				IL_000e: ldstr "key"
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0018: stloc.1
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_001e: dup
+				IL_001f: ldstr "name"
+				IL_0024: ldstr "HMAC"
+				IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_002e: dup
+				IL_002f: ldstr "hash"
+				IL_0034: ldstr "SHA-256"
+				IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_003e: dup
+				IL_003f: ldstr "length"
+				IL_0044: ldc.r8 128
+				IL_004d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+				IL_0052: stloc.2
+				IL_0053: ldc.i4.5
+				IL_0054: newarr [System.Runtime]System.Object
+				IL_0059: dup
+				IL_005a: ldc.i4.0
+				IL_005b: ldstr "raw"
+				IL_0060: stelem.ref
+				IL_0061: dup
+				IL_0062: ldc.i4.1
+				IL_0063: ldloc.1
+				IL_0064: stelem.ref
+				IL_0065: dup
+				IL_0066: ldc.i4.2
+				IL_0067: ldloc.2
+				IL_0068: stelem.ref
+				IL_0069: dup
+				IL_006a: ldc.i4.3
+				IL_006b: ldc.i4.0
+				IL_006c: box [System.Runtime]System.Boolean
+				IL_0071: stelem.ref
+				IL_0072: dup
+				IL_0073: ldc.i4.4
+				IL_0074: ldc.i4.1
+				IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_007a: dup
+				IL_007b: ldstr "sign"
+				IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0085: stelem.ref
+				IL_0086: stloc.3
+				IL_0087: ldloc.0
+				IL_0088: ldstr "importKey"
+				IL_008d: ldloc.3
+				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0093: stloc.0
+				IL_0094: ldloc.0
+				IL_0095: ret
 			} // end of method ArrowFunction_L93C60::__js_call__
 
 		} // end of class ArrowFunction_L93C60
@@ -2692,7 +2630,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d66
+					// Method begins at RVA 0x3ba3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2716,9 +2654,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3b3c
+				// Method begins at RVA 0x39d8
 				// Header size: 12
-				// Code size: 80 (0x50)
+				// Code size: 60 (0x3c)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2731,29 +2669,25 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.1
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
-				IL_0020: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-				IL_0025: ldstr "Cannot access 'verifyOnlyKey' before initialization"
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_002f: stloc.1
-				IL_0030: ldstr "abc"
-				IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_003a: stloc.2
-				IL_003b: ldloc.0
-				IL_003c: ldstr "sign"
-				IL_0041: ldstr "AES-GCM"
-				IL_0046: ldloc.1
-				IL_0047: ldloc.2
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_004d: stloc.1
-				IL_004e: ldloc.1
-				IL_004f: ret
+				IL_000d: stloc.0
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
+				IL_0016: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
+				IL_001b: stloc.1
+				IL_001c: ldstr "abc"
+				IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0026: stloc.2
+				IL_0027: ldloc.0
+				IL_0028: ldstr "sign"
+				IL_002d: ldstr "AES-GCM"
+				IL_0032: ldloc.1
+				IL_0033: ldloc.2
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0039: stloc.1
+				IL_003a: ldloc.1
+				IL_003b: ret
 			} // end of method ArrowFunction_L107C52::__js_call__
 
 		} // end of class ArrowFunction_L107C52
@@ -2769,7 +2703,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d6f
+					// Method begins at RVA 0x3bac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2793,9 +2727,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3b98
+				// Method begins at RVA 0x3a20
 				// Header size: 12
-				// Code size: 80 (0x50)
+				// Code size: 60 (0x3c)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2808,29 +2742,25 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: ldstr "Cannot access 'subtle' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.1
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
-				IL_0020: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-				IL_0025: ldstr "Cannot access 'verifyOnlyKey' before initialization"
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_002f: stloc.1
-				IL_0030: ldstr "abc"
-				IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_003a: stloc.2
-				IL_003b: ldloc.0
-				IL_003c: ldstr "sign"
-				IL_0041: ldstr "HMAC"
-				IL_0046: ldloc.1
-				IL_0047: ldloc.2
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_004d: stloc.1
-				IL_004e: ldloc.1
-				IL_004f: ret
+				IL_000d: stloc.0
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
+				IL_0016: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
+				IL_001b: stloc.1
+				IL_001c: ldstr "abc"
+				IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0026: stloc.2
+				IL_0027: ldloc.0
+				IL_0028: ldstr "sign"
+				IL_002d: ldstr "HMAC"
+				IL_0032: ldloc.1
+				IL_0033: ldloc.2
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0039: stloc.1
+				IL_003a: ldloc.1
+				IL_003b: ret
 			} // end of method ArrowFunction_L108C48::__js_call__
 
 		} // end of class ArrowFunction_L108C48
@@ -2874,21 +2804,15 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cff
+				// Method begins at RVA 0x3b52
 				// Header size: 1
-				// Code size: 30 (0x1e)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_0011: ldarg.0
-				IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_0017: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-				IL_001c: nop
-				IL_001d: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -2904,9 +2828,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x306c
+			// Method begins at RVA 0x2f6c
 			// Header size: 12
-			// Code size: 1586 (0x632)
+			// Code size: 1560 (0x618)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope,
@@ -2948,644 +2872,634 @@
 
 			IL_0048: ldloc.0
 			IL_0049: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_004e: switch (IL_0083, IL_0128, IL_019d, IL_0212, IL_0287, IL_02fc, IL_0371, IL_03e6, IL_045b, IL_050b, IL_0589, IL_0600)
+			IL_004e: switch (IL_0083, IL_0118, IL_018d, IL_0202, IL_0277, IL_02ec, IL_0361, IL_03d6, IL_044b, IL_04f1, IL_056f, IL_05e6)
 
-			IL_0083: ldarg.0
-			IL_0084: ldc.i4.1
-			IL_0085: ldelem.ref
-			IL_0086: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_008b: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0090: ldstr "Cannot access 'crypto' before initialization"
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_009a: stloc.1
-			IL_009b: ldloc.1
-			IL_009c: ldstr "webcrypto"
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a6: stloc.1
-			IL_00a7: ldloc.1
-			IL_00a8: ldstr "subtle"
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b2: stloc.1
-			IL_00b3: ldloc.0
-			IL_00b4: ldloc.1
-			IL_00b5: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-			IL_00ba: ldnull
-			IL_00bb: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L56C56::__js_call__(object[], object)
-			IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00c6: ldc.i4.2
-			IL_00c7: newarr [System.Runtime]System.Object
-			IL_00cc: dup
-			IL_00cd: ldc.i4.0
-			IL_00ce: ldarg.0
-			IL_00cf: ldc.i4.1
-			IL_00d0: ldelem.ref
-			IL_00d1: stelem.ref
-			IL_00d2: dup
-			IL_00d3: ldc.i4.1
-			IL_00d4: ldloc.0
-			IL_00d5: stelem.ref
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00e0: ldc.i4.0
-			IL_00e1: conv.r8
-			IL_00e2: ldstr ""
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00ec: stloc.1
-			IL_00ed: ldc.i4.1
-			IL_00ee: newarr [System.Runtime]System.Object
-			IL_00f3: dup
-			IL_00f4: ldc.i4.0
-			IL_00f5: ldarg.0
-			IL_00f6: ldc.i4.1
-			IL_00f7: ldelem.ref
-			IL_00f8: stelem.ref
-			IL_00f9: ldnull
-			IL_00fa: ldstr "subtle digest unsupported"
-			IL_00ff: ldloc.1
-			IL_0100: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_0105: stloc.1
-			IL_0106: ldloc.0
-			IL_0107: ldc.i4.1
-			IL_0108: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_010d: ldloc.0
-			IL_010e: ldloc.1
-			IL_010f: ldarg.0
-			IL_0110: ldc.i4.1
-			IL_0111: ldloc.0
-			IL_0112: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0117: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_011c: ldloc.0
-			IL_011d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0122: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0127: ret
+			IL_0083: ldloc.0
+			IL_0084: ldarg.0
+			IL_0085: ldc.i4.1
+			IL_0086: ldelem.ref
+			IL_0087: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_008c: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0091: ldstr "webcrypto"
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009b: ldstr "subtle"
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a5: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+			IL_00aa: ldnull
+			IL_00ab: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L56C56::__js_call__(object[], object)
+			IL_00b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00b6: ldc.i4.2
+			IL_00b7: newarr [System.Runtime]System.Object
+			IL_00bc: dup
+			IL_00bd: ldc.i4.0
+			IL_00be: ldarg.0
+			IL_00bf: ldc.i4.1
+			IL_00c0: ldelem.ref
+			IL_00c1: stelem.ref
+			IL_00c2: dup
+			IL_00c3: ldc.i4.1
+			IL_00c4: ldloc.0
+			IL_00c5: stelem.ref
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00d0: ldc.i4.0
+			IL_00d1: conv.r8
+			IL_00d2: ldstr ""
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00dc: stloc.1
+			IL_00dd: ldc.i4.1
+			IL_00de: newarr [System.Runtime]System.Object
+			IL_00e3: dup
+			IL_00e4: ldc.i4.0
+			IL_00e5: ldarg.0
+			IL_00e6: ldc.i4.1
+			IL_00e7: ldelem.ref
+			IL_00e8: stelem.ref
+			IL_00e9: ldnull
+			IL_00ea: ldstr "subtle digest unsupported"
+			IL_00ef: ldloc.1
+			IL_00f0: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_00f5: stloc.1
+			IL_00f6: ldloc.0
+			IL_00f7: ldc.i4.1
+			IL_00f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00fd: ldloc.0
+			IL_00fe: ldloc.1
+			IL_00ff: ldarg.0
+			IL_0100: ldc.i4.1
+			IL_0101: ldloc.0
+			IL_0102: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_010c: ldloc.0
+			IL_010d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0112: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0117: ret
 
-			IL_0128: ldloc.0
-			IL_0129: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited1
-			IL_012e: pop
-			IL_012f: ldnull
-			IL_0130: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L57C51::__js_call__(object[], object)
-			IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_013b: ldc.i4.2
-			IL_013c: newarr [System.Runtime]System.Object
-			IL_0141: dup
-			IL_0142: ldc.i4.0
-			IL_0143: ldarg.0
-			IL_0144: ldc.i4.1
-			IL_0145: ldelem.ref
-			IL_0146: stelem.ref
-			IL_0147: dup
-			IL_0148: ldc.i4.1
-			IL_0149: ldloc.0
-			IL_014a: stelem.ref
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0155: ldc.i4.0
-			IL_0156: conv.r8
-			IL_0157: ldstr ""
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0161: stloc.1
-			IL_0162: ldc.i4.1
-			IL_0163: newarr [System.Runtime]System.Object
-			IL_0168: dup
-			IL_0169: ldc.i4.0
-			IL_016a: ldarg.0
-			IL_016b: ldc.i4.1
-			IL_016c: ldelem.ref
-			IL_016d: stelem.ref
-			IL_016e: ldnull
-			IL_016f: ldstr "subtle import format"
-			IL_0174: ldloc.1
-			IL_0175: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_017a: stloc.1
-			IL_017b: ldloc.0
-			IL_017c: ldc.i4.2
-			IL_017d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0182: ldloc.0
-			IL_0183: ldloc.1
-			IL_0184: ldarg.0
-			IL_0185: ldc.i4.2
-			IL_0186: ldloc.0
-			IL_0187: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_018c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0191: ldloc.0
-			IL_0192: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0197: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_019c: ret
+			IL_0118: ldloc.0
+			IL_0119: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited1
+			IL_011e: pop
+			IL_011f: ldnull
+			IL_0120: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L57C51::__js_call__(object[], object)
+			IL_0126: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_012b: ldc.i4.2
+			IL_012c: newarr [System.Runtime]System.Object
+			IL_0131: dup
+			IL_0132: ldc.i4.0
+			IL_0133: ldarg.0
+			IL_0134: ldc.i4.1
+			IL_0135: ldelem.ref
+			IL_0136: stelem.ref
+			IL_0137: dup
+			IL_0138: ldc.i4.1
+			IL_0139: ldloc.0
+			IL_013a: stelem.ref
+			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0145: ldc.i4.0
+			IL_0146: conv.r8
+			IL_0147: ldstr ""
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0151: stloc.1
+			IL_0152: ldc.i4.1
+			IL_0153: newarr [System.Runtime]System.Object
+			IL_0158: dup
+			IL_0159: ldc.i4.0
+			IL_015a: ldarg.0
+			IL_015b: ldc.i4.1
+			IL_015c: ldelem.ref
+			IL_015d: stelem.ref
+			IL_015e: ldnull
+			IL_015f: ldstr "subtle import format"
+			IL_0164: ldloc.1
+			IL_0165: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_016a: stloc.1
+			IL_016b: ldloc.0
+			IL_016c: ldc.i4.2
+			IL_016d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0172: ldloc.0
+			IL_0173: ldloc.1
+			IL_0174: ldarg.0
+			IL_0175: ldc.i4.2
+			IL_0176: ldloc.0
+			IL_0177: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_017c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0181: ldloc.0
+			IL_0182: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0187: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_018c: ret
 
-			IL_019d: ldloc.0
-			IL_019e: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited2
-			IL_01a3: pop
-			IL_01a4: ldnull
-			IL_01a5: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L63C53::__js_call__(object[], object)
-			IL_01ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_01b0: ldc.i4.2
-			IL_01b1: newarr [System.Runtime]System.Object
-			IL_01b6: dup
-			IL_01b7: ldc.i4.0
-			IL_01b8: ldarg.0
-			IL_01b9: ldc.i4.1
-			IL_01ba: ldelem.ref
-			IL_01bb: stelem.ref
-			IL_01bc: dup
-			IL_01bd: ldc.i4.1
-			IL_01be: ldloc.0
-			IL_01bf: stelem.ref
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01ca: ldc.i4.0
-			IL_01cb: conv.r8
-			IL_01cc: ldstr ""
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_01d6: stloc.1
-			IL_01d7: ldc.i4.1
-			IL_01d8: newarr [System.Runtime]System.Object
-			IL_01dd: dup
-			IL_01de: ldc.i4.0
-			IL_01df: ldarg.0
-			IL_01e0: ldc.i4.1
-			IL_01e1: ldelem.ref
-			IL_01e2: stelem.ref
-			IL_01e3: ldnull
-			IL_01e4: ldstr "subtle import key data"
-			IL_01e9: ldloc.1
-			IL_01ea: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_01ef: stloc.1
-			IL_01f0: ldloc.0
-			IL_01f1: ldc.i4.3
-			IL_01f2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01f7: ldloc.0
-			IL_01f8: ldloc.1
-			IL_01f9: ldarg.0
-			IL_01fa: ldc.i4.3
-			IL_01fb: ldloc.0
-			IL_01fc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0201: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0206: ldloc.0
-			IL_0207: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_020c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0211: ret
+			IL_018d: ldloc.0
+			IL_018e: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited2
+			IL_0193: pop
+			IL_0194: ldnull
+			IL_0195: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L63C53::__js_call__(object[], object)
+			IL_019b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_01a0: ldc.i4.2
+			IL_01a1: newarr [System.Runtime]System.Object
+			IL_01a6: dup
+			IL_01a7: ldc.i4.0
+			IL_01a8: ldarg.0
+			IL_01a9: ldc.i4.1
+			IL_01aa: ldelem.ref
+			IL_01ab: stelem.ref
+			IL_01ac: dup
+			IL_01ad: ldc.i4.1
+			IL_01ae: ldloc.0
+			IL_01af: stelem.ref
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_01ba: ldc.i4.0
+			IL_01bb: conv.r8
+			IL_01bc: ldstr ""
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_01c6: stloc.1
+			IL_01c7: ldc.i4.1
+			IL_01c8: newarr [System.Runtime]System.Object
+			IL_01cd: dup
+			IL_01ce: ldc.i4.0
+			IL_01cf: ldarg.0
+			IL_01d0: ldc.i4.1
+			IL_01d1: ldelem.ref
+			IL_01d2: stelem.ref
+			IL_01d3: ldnull
+			IL_01d4: ldstr "subtle import key data"
+			IL_01d9: ldloc.1
+			IL_01da: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_01df: stloc.1
+			IL_01e0: ldloc.0
+			IL_01e1: ldc.i4.3
+			IL_01e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01e7: ldloc.0
+			IL_01e8: ldloc.1
+			IL_01e9: ldarg.0
+			IL_01ea: ldc.i4.3
+			IL_01eb: ldloc.0
+			IL_01ec: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01f6: ldloc.0
+			IL_01f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01fc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0201: ret
 
-			IL_0212: ldloc.0
-			IL_0213: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited3
-			IL_0218: pop
-			IL_0219: ldnull
-			IL_021a: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L69C57::__js_call__(object[], object)
-			IL_0220: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0225: ldc.i4.2
-			IL_0226: newarr [System.Runtime]System.Object
-			IL_022b: dup
-			IL_022c: ldc.i4.0
-			IL_022d: ldarg.0
-			IL_022e: ldc.i4.1
-			IL_022f: ldelem.ref
-			IL_0230: stelem.ref
-			IL_0231: dup
-			IL_0232: ldc.i4.1
-			IL_0233: ldloc.0
-			IL_0234: stelem.ref
-			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_023f: ldc.i4.0
-			IL_0240: conv.r8
-			IL_0241: ldstr ""
-			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_024b: stloc.1
-			IL_024c: ldc.i4.1
-			IL_024d: newarr [System.Runtime]System.Object
-			IL_0252: dup
-			IL_0253: ldc.i4.0
-			IL_0254: ldarg.0
-			IL_0255: ldc.i4.1
-			IL_0256: ldelem.ref
-			IL_0257: stelem.ref
-			IL_0258: ldnull
-			IL_0259: ldstr "subtle import empty usages"
-			IL_025e: ldloc.1
-			IL_025f: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_0264: stloc.1
-			IL_0265: ldloc.0
-			IL_0266: ldc.i4.4
-			IL_0267: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_026c: ldloc.0
-			IL_026d: ldloc.1
-			IL_026e: ldarg.0
-			IL_026f: ldc.i4.4
-			IL_0270: ldloc.0
-			IL_0271: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0276: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_027b: ldloc.0
-			IL_027c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0281: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0286: ret
+			IL_0202: ldloc.0
+			IL_0203: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited3
+			IL_0208: pop
+			IL_0209: ldnull
+			IL_020a: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L69C57::__js_call__(object[], object)
+			IL_0210: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0215: ldc.i4.2
+			IL_0216: newarr [System.Runtime]System.Object
+			IL_021b: dup
+			IL_021c: ldc.i4.0
+			IL_021d: ldarg.0
+			IL_021e: ldc.i4.1
+			IL_021f: ldelem.ref
+			IL_0220: stelem.ref
+			IL_0221: dup
+			IL_0222: ldc.i4.1
+			IL_0223: ldloc.0
+			IL_0224: stelem.ref
+			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_022f: ldc.i4.0
+			IL_0230: conv.r8
+			IL_0231: ldstr ""
+			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_023b: stloc.1
+			IL_023c: ldc.i4.1
+			IL_023d: newarr [System.Runtime]System.Object
+			IL_0242: dup
+			IL_0243: ldc.i4.0
+			IL_0244: ldarg.0
+			IL_0245: ldc.i4.1
+			IL_0246: ldelem.ref
+			IL_0247: stelem.ref
+			IL_0248: ldnull
+			IL_0249: ldstr "subtle import empty usages"
+			IL_024e: ldloc.1
+			IL_024f: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_0254: stloc.1
+			IL_0255: ldloc.0
+			IL_0256: ldc.i4.4
+			IL_0257: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_025c: ldloc.0
+			IL_025d: ldloc.1
+			IL_025e: ldarg.0
+			IL_025f: ldc.i4.4
+			IL_0260: ldloc.0
+			IL_0261: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0266: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_026b: ldloc.0
+			IL_026c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0271: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0276: ret
 
-			IL_0287: ldloc.0
-			IL_0288: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited4
-			IL_028d: pop
-			IL_028e: ldnull
-			IL_028f: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L75C63::__js_call__(object[], object)
-			IL_0295: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_029a: ldc.i4.2
-			IL_029b: newarr [System.Runtime]System.Object
-			IL_02a0: dup
-			IL_02a1: ldc.i4.0
-			IL_02a2: ldarg.0
-			IL_02a3: ldc.i4.1
-			IL_02a4: ldelem.ref
-			IL_02a5: stelem.ref
-			IL_02a6: dup
-			IL_02a7: ldc.i4.1
-			IL_02a8: ldloc.0
-			IL_02a9: stelem.ref
-			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_02b4: ldc.i4.0
-			IL_02b5: conv.r8
-			IL_02b6: ldstr ""
-			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_02c0: stloc.1
-			IL_02c1: ldc.i4.1
-			IL_02c2: newarr [System.Runtime]System.Object
-			IL_02c7: dup
-			IL_02c8: ldc.i4.0
-			IL_02c9: ldarg.0
-			IL_02ca: ldc.i4.1
-			IL_02cb: ldelem.ref
-			IL_02cc: stelem.ref
-			IL_02cd: ldnull
-			IL_02ce: ldstr "subtle import invalid usage enum"
-			IL_02d3: ldloc.1
-			IL_02d4: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_02d9: stloc.1
-			IL_02da: ldloc.0
-			IL_02db: ldc.i4.5
-			IL_02dc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02e1: ldloc.0
-			IL_02e2: ldloc.1
-			IL_02e3: ldarg.0
-			IL_02e4: ldc.i4.5
-			IL_02e5: ldloc.0
-			IL_02e6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02f0: ldloc.0
-			IL_02f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02fb: ret
+			IL_0277: ldloc.0
+			IL_0278: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited4
+			IL_027d: pop
+			IL_027e: ldnull
+			IL_027f: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L75C63::__js_call__(object[], object)
+			IL_0285: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_028a: ldc.i4.2
+			IL_028b: newarr [System.Runtime]System.Object
+			IL_0290: dup
+			IL_0291: ldc.i4.0
+			IL_0292: ldarg.0
+			IL_0293: ldc.i4.1
+			IL_0294: ldelem.ref
+			IL_0295: stelem.ref
+			IL_0296: dup
+			IL_0297: ldc.i4.1
+			IL_0298: ldloc.0
+			IL_0299: stelem.ref
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_02a4: ldc.i4.0
+			IL_02a5: conv.r8
+			IL_02a6: ldstr ""
+			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_02b0: stloc.1
+			IL_02b1: ldc.i4.1
+			IL_02b2: newarr [System.Runtime]System.Object
+			IL_02b7: dup
+			IL_02b8: ldc.i4.0
+			IL_02b9: ldarg.0
+			IL_02ba: ldc.i4.1
+			IL_02bb: ldelem.ref
+			IL_02bc: stelem.ref
+			IL_02bd: ldnull
+			IL_02be: ldstr "subtle import invalid usage enum"
+			IL_02c3: ldloc.1
+			IL_02c4: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_02c9: stloc.1
+			IL_02ca: ldloc.0
+			IL_02cb: ldc.i4.5
+			IL_02cc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02d1: ldloc.0
+			IL_02d2: ldloc.1
+			IL_02d3: ldarg.0
+			IL_02d4: ldc.i4.5
+			IL_02d5: ldloc.0
+			IL_02d6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02e0: ldloc.0
+			IL_02e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02eb: ret
 
-			IL_02fc: ldloc.0
-			IL_02fd: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited5
-			IL_0302: pop
-			IL_0303: ldnull
-			IL_0304: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L81C62::__js_call__(object[], object)
-			IL_030a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_030f: ldc.i4.2
-			IL_0310: newarr [System.Runtime]System.Object
-			IL_0315: dup
-			IL_0316: ldc.i4.0
-			IL_0317: ldarg.0
-			IL_0318: ldc.i4.1
-			IL_0319: ldelem.ref
-			IL_031a: stelem.ref
-			IL_031b: dup
-			IL_031c: ldc.i4.1
-			IL_031d: ldloc.0
-			IL_031e: stelem.ref
-			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0329: ldc.i4.0
-			IL_032a: conv.r8
-			IL_032b: ldstr ""
-			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0335: stloc.1
-			IL_0336: ldc.i4.1
-			IL_0337: newarr [System.Runtime]System.Object
-			IL_033c: dup
-			IL_033d: ldc.i4.0
-			IL_033e: ldarg.0
-			IL_033f: ldc.i4.1
-			IL_0340: ldelem.ref
-			IL_0341: stelem.ref
-			IL_0342: ldnull
-			IL_0343: ldstr "subtle import unsupported usage"
-			IL_0348: ldloc.1
-			IL_0349: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_034e: stloc.1
-			IL_034f: ldloc.0
-			IL_0350: ldc.i4.6
-			IL_0351: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0356: ldloc.0
-			IL_0357: ldloc.1
-			IL_0358: ldarg.0
-			IL_0359: ldc.i4.6
-			IL_035a: ldloc.0
-			IL_035b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0360: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0365: ldloc.0
-			IL_0366: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0370: ret
+			IL_02ec: ldloc.0
+			IL_02ed: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited5
+			IL_02f2: pop
+			IL_02f3: ldnull
+			IL_02f4: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L81C62::__js_call__(object[], object)
+			IL_02fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_02ff: ldc.i4.2
+			IL_0300: newarr [System.Runtime]System.Object
+			IL_0305: dup
+			IL_0306: ldc.i4.0
+			IL_0307: ldarg.0
+			IL_0308: ldc.i4.1
+			IL_0309: ldelem.ref
+			IL_030a: stelem.ref
+			IL_030b: dup
+			IL_030c: ldc.i4.1
+			IL_030d: ldloc.0
+			IL_030e: stelem.ref
+			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0319: ldc.i4.0
+			IL_031a: conv.r8
+			IL_031b: ldstr ""
+			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0325: stloc.1
+			IL_0326: ldc.i4.1
+			IL_0327: newarr [System.Runtime]System.Object
+			IL_032c: dup
+			IL_032d: ldc.i4.0
+			IL_032e: ldarg.0
+			IL_032f: ldc.i4.1
+			IL_0330: ldelem.ref
+			IL_0331: stelem.ref
+			IL_0332: ldnull
+			IL_0333: ldstr "subtle import unsupported usage"
+			IL_0338: ldloc.1
+			IL_0339: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_033e: stloc.1
+			IL_033f: ldloc.0
+			IL_0340: ldc.i4.6
+			IL_0341: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0346: ldloc.0
+			IL_0347: ldloc.1
+			IL_0348: ldarg.0
+			IL_0349: ldc.i4.6
+			IL_034a: ldloc.0
+			IL_034b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0350: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0355: ldloc.0
+			IL_0356: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_035b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0360: ret
 
-			IL_0371: ldloc.0
-			IL_0372: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited6
-			IL_0377: pop
-			IL_0378: ldnull
-			IL_0379: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L87C53::__js_call__(object[], object)
-			IL_037f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0384: ldc.i4.2
-			IL_0385: newarr [System.Runtime]System.Object
-			IL_038a: dup
-			IL_038b: ldc.i4.0
-			IL_038c: ldarg.0
-			IL_038d: ldc.i4.1
-			IL_038e: ldelem.ref
-			IL_038f: stelem.ref
-			IL_0390: dup
-			IL_0391: ldc.i4.1
-			IL_0392: ldloc.0
-			IL_0393: stelem.ref
-			IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_039e: ldc.i4.0
-			IL_039f: conv.r8
-			IL_03a0: ldstr ""
-			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_03aa: stloc.1
-			IL_03ab: ldc.i4.1
-			IL_03ac: newarr [System.Runtime]System.Object
-			IL_03b1: dup
-			IL_03b2: ldc.i4.0
-			IL_03b3: ldarg.0
-			IL_03b4: ldc.i4.1
-			IL_03b5: ldelem.ref
-			IL_03b6: stelem.ref
-			IL_03b7: ldnull
-			IL_03b8: ldstr "subtle import zero key"
-			IL_03bd: ldloc.1
-			IL_03be: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_03c3: stloc.1
-			IL_03c4: ldloc.0
-			IL_03c5: ldc.i4.7
-			IL_03c6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03cb: ldloc.0
-			IL_03cc: ldloc.1
-			IL_03cd: ldarg.0
-			IL_03ce: ldc.i4.7
-			IL_03cf: ldloc.0
-			IL_03d0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03da: ldloc.0
-			IL_03db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03e5: ret
+			IL_0361: ldloc.0
+			IL_0362: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited6
+			IL_0367: pop
+			IL_0368: ldnull
+			IL_0369: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L87C53::__js_call__(object[], object)
+			IL_036f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0374: ldc.i4.2
+			IL_0375: newarr [System.Runtime]System.Object
+			IL_037a: dup
+			IL_037b: ldc.i4.0
+			IL_037c: ldarg.0
+			IL_037d: ldc.i4.1
+			IL_037e: ldelem.ref
+			IL_037f: stelem.ref
+			IL_0380: dup
+			IL_0381: ldc.i4.1
+			IL_0382: ldloc.0
+			IL_0383: stelem.ref
+			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_038e: ldc.i4.0
+			IL_038f: conv.r8
+			IL_0390: ldstr ""
+			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_039a: stloc.1
+			IL_039b: ldc.i4.1
+			IL_039c: newarr [System.Runtime]System.Object
+			IL_03a1: dup
+			IL_03a2: ldc.i4.0
+			IL_03a3: ldarg.0
+			IL_03a4: ldc.i4.1
+			IL_03a5: ldelem.ref
+			IL_03a6: stelem.ref
+			IL_03a7: ldnull
+			IL_03a8: ldstr "subtle import zero key"
+			IL_03ad: ldloc.1
+			IL_03ae: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_03b3: stloc.1
+			IL_03b4: ldloc.0
+			IL_03b5: ldc.i4.7
+			IL_03b6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03bb: ldloc.0
+			IL_03bc: ldloc.1
+			IL_03bd: ldarg.0
+			IL_03be: ldc.i4.7
+			IL_03bf: ldloc.0
+			IL_03c0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_03ca: ldloc.0
+			IL_03cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03d0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03d5: ret
 
-			IL_03e6: ldloc.0
-			IL_03e7: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited7
-			IL_03ec: pop
-			IL_03ed: ldnull
-			IL_03ee: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L93C60::__js_call__(object[], object)
-			IL_03f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_03f9: ldc.i4.2
-			IL_03fa: newarr [System.Runtime]System.Object
-			IL_03ff: dup
-			IL_0400: ldc.i4.0
-			IL_0401: ldarg.0
-			IL_0402: ldc.i4.1
-			IL_0403: ldelem.ref
-			IL_0404: stelem.ref
-			IL_0405: dup
-			IL_0406: ldc.i4.1
-			IL_0407: ldloc.0
-			IL_0408: stelem.ref
-			IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0413: ldc.i4.0
-			IL_0414: conv.r8
-			IL_0415: ldstr ""
-			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_041f: stloc.1
-			IL_0420: ldc.i4.1
-			IL_0421: newarr [System.Runtime]System.Object
-			IL_0426: dup
-			IL_0427: ldc.i4.0
-			IL_0428: ldarg.0
-			IL_0429: ldc.i4.1
-			IL_042a: ldelem.ref
-			IL_042b: stelem.ref
-			IL_042c: ldnull
-			IL_042d: ldstr "subtle import length mismatch"
-			IL_0432: ldloc.1
-			IL_0433: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_0438: stloc.1
-			IL_0439: ldloc.0
-			IL_043a: ldc.i4.8
-			IL_043b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0440: ldloc.0
-			IL_0441: ldloc.1
-			IL_0442: ldarg.0
-			IL_0443: ldc.i4.8
-			IL_0444: ldloc.0
-			IL_0445: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_044a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_044f: ldloc.0
-			IL_0450: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0455: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_045a: ret
+			IL_03d6: ldloc.0
+			IL_03d7: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited7
+			IL_03dc: pop
+			IL_03dd: ldnull
+			IL_03de: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L93C60::__js_call__(object[], object)
+			IL_03e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_03e9: ldc.i4.2
+			IL_03ea: newarr [System.Runtime]System.Object
+			IL_03ef: dup
+			IL_03f0: ldc.i4.0
+			IL_03f1: ldarg.0
+			IL_03f2: ldc.i4.1
+			IL_03f3: ldelem.ref
+			IL_03f4: stelem.ref
+			IL_03f5: dup
+			IL_03f6: ldc.i4.1
+			IL_03f7: ldloc.0
+			IL_03f8: stelem.ref
+			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0403: ldc.i4.0
+			IL_0404: conv.r8
+			IL_0405: ldstr ""
+			IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_040f: stloc.1
+			IL_0410: ldc.i4.1
+			IL_0411: newarr [System.Runtime]System.Object
+			IL_0416: dup
+			IL_0417: ldc.i4.0
+			IL_0418: ldarg.0
+			IL_0419: ldc.i4.1
+			IL_041a: ldelem.ref
+			IL_041b: stelem.ref
+			IL_041c: ldnull
+			IL_041d: ldstr "subtle import length mismatch"
+			IL_0422: ldloc.1
+			IL_0423: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_0428: stloc.1
+			IL_0429: ldloc.0
+			IL_042a: ldc.i4.8
+			IL_042b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0430: ldloc.0
+			IL_0431: ldloc.1
+			IL_0432: ldarg.0
+			IL_0433: ldc.i4.8
+			IL_0434: ldloc.0
+			IL_0435: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_043a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_043f: ldloc.0
+			IL_0440: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0445: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_044a: ret
 
-			IL_045b: ldloc.0
-			IL_045c: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited8
-			IL_0461: pop
-			IL_0462: ldloc.0
-			IL_0463: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-			IL_0468: ldstr "Cannot access 'subtle' before initialization"
-			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0472: stloc.1
-			IL_0473: ldstr "key"
-			IL_0478: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_047d: stloc.2
-			IL_047e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0483: dup
-			IL_0484: ldstr "name"
-			IL_0489: ldstr "HMAC"
-			IL_048e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0493: dup
-			IL_0494: ldstr "hash"
-			IL_0499: ldstr "SHA-256"
-			IL_049e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04a3: stloc.3
-			IL_04a4: ldc.i4.5
-			IL_04a5: newarr [System.Runtime]System.Object
-			IL_04aa: dup
-			IL_04ab: ldc.i4.0
-			IL_04ac: ldstr "raw"
-			IL_04b1: stelem.ref
-			IL_04b2: dup
-			IL_04b3: ldc.i4.1
-			IL_04b4: ldloc.2
-			IL_04b5: stelem.ref
-			IL_04b6: dup
-			IL_04b7: ldc.i4.2
-			IL_04b8: ldloc.3
-			IL_04b9: stelem.ref
-			IL_04ba: dup
-			IL_04bb: ldc.i4.3
-			IL_04bc: ldc.i4.0
-			IL_04bd: box [System.Runtime]System.Boolean
-			IL_04c2: stelem.ref
-			IL_04c3: dup
-			IL_04c4: ldc.i4.4
-			IL_04c5: ldc.i4.1
-			IL_04c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_04cb: dup
-			IL_04cc: ldstr "verify"
-			IL_04d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04d6: stelem.ref
-			IL_04d7: stloc.s 4
-			IL_04d9: ldloc.1
-			IL_04da: ldstr "importKey"
-			IL_04df: ldloc.s 4
-			IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_04e6: stloc.1
-			IL_04e7: ldloc.0
-			IL_04e8: ldc.i4.s 9
-			IL_04ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04ef: ldloc.0
-			IL_04f0: ldloc.1
-			IL_04f1: ldarg.0
-			IL_04f2: ldc.i4.s 9
-			IL_04f4: ldloc.0
-			IL_04f5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_04ff: ldloc.0
-			IL_0500: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0505: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_050a: ret
+			IL_044b: ldloc.0
+			IL_044c: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited8
+			IL_0451: pop
+			IL_0452: ldloc.0
+			IL_0453: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+			IL_0458: stloc.1
+			IL_0459: ldstr "key"
+			IL_045e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0463: stloc.2
+			IL_0464: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0469: dup
+			IL_046a: ldstr "name"
+			IL_046f: ldstr "HMAC"
+			IL_0474: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0479: dup
+			IL_047a: ldstr "hash"
+			IL_047f: ldstr "SHA-256"
+			IL_0484: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0489: stloc.3
+			IL_048a: ldc.i4.5
+			IL_048b: newarr [System.Runtime]System.Object
+			IL_0490: dup
+			IL_0491: ldc.i4.0
+			IL_0492: ldstr "raw"
+			IL_0497: stelem.ref
+			IL_0498: dup
+			IL_0499: ldc.i4.1
+			IL_049a: ldloc.2
+			IL_049b: stelem.ref
+			IL_049c: dup
+			IL_049d: ldc.i4.2
+			IL_049e: ldloc.3
+			IL_049f: stelem.ref
+			IL_04a0: dup
+			IL_04a1: ldc.i4.3
+			IL_04a2: ldc.i4.0
+			IL_04a3: box [System.Runtime]System.Boolean
+			IL_04a8: stelem.ref
+			IL_04a9: dup
+			IL_04aa: ldc.i4.4
+			IL_04ab: ldc.i4.1
+			IL_04ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_04b1: dup
+			IL_04b2: ldstr "verify"
+			IL_04b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04bc: stelem.ref
+			IL_04bd: stloc.s 4
+			IL_04bf: ldloc.1
+			IL_04c0: ldstr "importKey"
+			IL_04c5: ldloc.s 4
+			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_04cc: stloc.1
+			IL_04cd: ldloc.0
+			IL_04ce: ldc.i4.s 9
+			IL_04d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04d5: ldloc.0
+			IL_04d6: ldloc.1
+			IL_04d7: ldarg.0
+			IL_04d8: ldc.i4.s 9
+			IL_04da: ldloc.0
+			IL_04db: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_04e5: ldloc.0
+			IL_04e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04f0: ret
 
-			IL_050b: ldloc.0
-			IL_050c: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited9
-			IL_0511: stloc.1
-			IL_0512: ldloc.0
-			IL_0513: ldloc.1
-			IL_0514: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-			IL_0519: ldnull
-			IL_051a: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L107C52::__js_call__(object[], object)
-			IL_0520: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0525: ldc.i4.2
-			IL_0526: newarr [System.Runtime]System.Object
-			IL_052b: dup
-			IL_052c: ldc.i4.0
-			IL_052d: ldarg.0
-			IL_052e: ldc.i4.1
-			IL_052f: ldelem.ref
-			IL_0530: stelem.ref
-			IL_0531: dup
+			IL_04f1: ldloc.0
+			IL_04f2: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited9
+			IL_04f7: stloc.1
+			IL_04f8: ldloc.0
+			IL_04f9: ldloc.1
+			IL_04fa: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
+			IL_04ff: ldnull
+			IL_0500: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L107C52::__js_call__(object[], object)
+			IL_0506: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_050b: ldc.i4.2
+			IL_050c: newarr [System.Runtime]System.Object
+			IL_0511: dup
+			IL_0512: ldc.i4.0
+			IL_0513: ldarg.0
+			IL_0514: ldc.i4.1
+			IL_0515: ldelem.ref
+			IL_0516: stelem.ref
+			IL_0517: dup
+			IL_0518: ldc.i4.1
+			IL_0519: ldloc.0
+			IL_051a: stelem.ref
+			IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0525: ldc.i4.0
+			IL_0526: conv.r8
+			IL_0527: ldstr ""
+			IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0531: stloc.1
 			IL_0532: ldc.i4.1
-			IL_0533: ldloc.0
-			IL_0534: stelem.ref
-			IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_053f: ldc.i4.0
-			IL_0540: conv.r8
-			IL_0541: ldstr ""
-			IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_054b: stloc.1
-			IL_054c: ldc.i4.1
-			IL_054d: newarr [System.Runtime]System.Object
-			IL_0552: dup
-			IL_0553: ldc.i4.0
-			IL_0554: ldarg.0
-			IL_0555: ldc.i4.1
-			IL_0556: ldelem.ref
-			IL_0557: stelem.ref
-			IL_0558: ldnull
-			IL_0559: ldstr "subtle sign algorithm"
-			IL_055e: ldloc.1
-			IL_055f: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_0564: stloc.1
-			IL_0565: ldloc.0
-			IL_0566: ldc.i4.s 10
-			IL_0568: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_056d: ldloc.0
-			IL_056e: ldloc.1
-			IL_056f: ldarg.0
-			IL_0570: ldc.i4.s 10
-			IL_0572: ldloc.0
-			IL_0573: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0578: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_057d: ldloc.0
-			IL_057e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0583: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0588: ret
+			IL_0533: newarr [System.Runtime]System.Object
+			IL_0538: dup
+			IL_0539: ldc.i4.0
+			IL_053a: ldarg.0
+			IL_053b: ldc.i4.1
+			IL_053c: ldelem.ref
+			IL_053d: stelem.ref
+			IL_053e: ldnull
+			IL_053f: ldstr "subtle sign algorithm"
+			IL_0544: ldloc.1
+			IL_0545: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_054a: stloc.1
+			IL_054b: ldloc.0
+			IL_054c: ldc.i4.s 10
+			IL_054e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0553: ldloc.0
+			IL_0554: ldloc.1
+			IL_0555: ldarg.0
+			IL_0556: ldc.i4.s 10
+			IL_0558: ldloc.0
+			IL_0559: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_055e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0563: ldloc.0
+			IL_0564: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0569: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_056e: ret
 
-			IL_0589: ldloc.0
-			IL_058a: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited10
-			IL_058f: pop
-			IL_0590: ldnull
-			IL_0591: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L108C48::__js_call__(object[], object)
-			IL_0597: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_059c: ldc.i4.2
-			IL_059d: newarr [System.Runtime]System.Object
-			IL_05a2: dup
-			IL_05a3: ldc.i4.0
-			IL_05a4: ldarg.0
-			IL_05a5: ldc.i4.1
-			IL_05a6: ldelem.ref
-			IL_05a7: stelem.ref
-			IL_05a8: dup
+			IL_056f: ldloc.0
+			IL_0570: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited10
+			IL_0575: pop
+			IL_0576: ldnull
+			IL_0577: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L108C48::__js_call__(object[], object)
+			IL_057d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0582: ldc.i4.2
+			IL_0583: newarr [System.Runtime]System.Object
+			IL_0588: dup
+			IL_0589: ldc.i4.0
+			IL_058a: ldarg.0
+			IL_058b: ldc.i4.1
+			IL_058c: ldelem.ref
+			IL_058d: stelem.ref
+			IL_058e: dup
+			IL_058f: ldc.i4.1
+			IL_0590: ldloc.0
+			IL_0591: stelem.ref
+			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_059c: ldc.i4.0
+			IL_059d: conv.r8
+			IL_059e: ldstr ""
+			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_05a8: stloc.1
 			IL_05a9: ldc.i4.1
-			IL_05aa: ldloc.0
-			IL_05ab: stelem.ref
-			IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_05b6: ldc.i4.0
-			IL_05b7: conv.r8
-			IL_05b8: ldstr ""
-			IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_05c2: stloc.1
-			IL_05c3: ldc.i4.1
-			IL_05c4: newarr [System.Runtime]System.Object
-			IL_05c9: dup
-			IL_05ca: ldc.i4.0
-			IL_05cb: ldarg.0
-			IL_05cc: ldc.i4.1
-			IL_05cd: ldelem.ref
-			IL_05ce: stelem.ref
-			IL_05cf: ldnull
-			IL_05d0: ldstr "subtle sign usage"
-			IL_05d5: ldloc.1
-			IL_05d6: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_05db: stloc.1
-			IL_05dc: ldloc.0
-			IL_05dd: ldc.i4.s 11
-			IL_05df: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05e4: ldloc.0
-			IL_05e5: ldloc.1
-			IL_05e6: ldarg.0
-			IL_05e7: ldc.i4.s 11
-			IL_05e9: ldloc.0
-			IL_05ea: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_05aa: newarr [System.Runtime]System.Object
+			IL_05af: dup
+			IL_05b0: ldc.i4.0
+			IL_05b1: ldarg.0
+			IL_05b2: ldc.i4.1
+			IL_05b3: ldelem.ref
+			IL_05b4: stelem.ref
+			IL_05b5: ldnull
+			IL_05b6: ldstr "subtle sign usage"
+			IL_05bb: ldloc.1
+			IL_05bc: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_05c1: stloc.1
+			IL_05c2: ldloc.0
+			IL_05c3: ldc.i4.s 11
+			IL_05c5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05ca: ldloc.0
+			IL_05cb: ldloc.1
+			IL_05cc: ldarg.0
+			IL_05cd: ldc.i4.s 11
+			IL_05cf: ldloc.0
+			IL_05d0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_05da: ldloc.0
+			IL_05db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05e5: ret
+
+			IL_05e6: ldloc.0
+			IL_05e7: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited11
+			IL_05ec: pop
+			IL_05ed: ldloc.0
+			IL_05ee: ldc.i4.m1
+			IL_05ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_05f4: ldloc.0
 			IL_05f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05fa: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05ff: ret
-
-			IL_0600: ldloc.0
-			IL_0601: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited11
-			IL_0606: pop
-			IL_0607: ldloc.0
-			IL_0608: ldc.i4.m1
-			IL_0609: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_060e: ldloc.0
-			IL_060f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0614: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0619: ldarg.0
-			IL_061a: ldc.i4.1
-			IL_061b: newarr [System.Runtime]System.Object
-			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0625: pop
-			IL_0626: ldloc.0
-			IL_0627: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_062c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0631: ret
+			IL_05fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_05ff: ldarg.0
+			IL_0600: ldc.i4.1
+			IL_0601: newarr [System.Runtime]System.Object
+			IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_060b: pop
+			IL_060c: ldloc.0
+			IL_060d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0612: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0617: ret
 		} // end of method runWebCryptoErrors::__js_call__
 
 	} // end of class runWebCryptoErrors
@@ -3601,7 +3515,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d78
+				// Method begins at RVA 0x3bb5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3624,7 +3538,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x36aa
+			// Method begins at RVA 0x3590
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -3666,24 +3580,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3bf4
+			// Method begins at RVA 0x3a68
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -3701,7 +3606,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1842 (0x732)
+		// Code size: 1786 (0x6fa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_ErrorPaths/Scope,
@@ -4256,145 +4161,129 @@
 		IL_058f: pop
 		IL_0590: ldloc.0
 		IL_0591: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_0596: ldstr "Cannot access 'crypto' before initialization"
-		IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_05a0: stloc.s 4
-		IL_05a2: ldloc.s 4
-		IL_05a4: ldstr "createHash"
-		IL_05a9: ldstr "sha256"
-		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_05b3: stloc.s 4
-		IL_05b5: ldloc.0
-		IL_05b6: ldloc.s 4
-		IL_05b8: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_05bd: ldloc.0
-		IL_05be: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_05c3: ldstr "Cannot access 'hash' before initialization"
-		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_05cd: stloc.s 4
-		IL_05cf: ldloc.s 4
-		IL_05d1: ldstr "update"
-		IL_05d6: ldstr "abc"
-		IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_05e0: pop
-		IL_05e1: ldloc.0
-		IL_05e2: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_05e7: ldstr "Cannot access 'hash' before initialization"
-		IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_05f1: stloc.s 4
-		IL_05f3: ldloc.s 4
-		IL_05f5: ldstr "digest"
-		IL_05fa: ldstr "hex"
-		IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0604: stloc.s 4
-		IL_0606: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_060b: ldstr "digest first:"
-		IL_0610: ldloc.s 4
-		IL_0612: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0617: pop
-		IL_0618: ldc.i4.1
-		IL_0619: newarr [System.Runtime]System.Object
-		IL_061e: dup
-		IL_061f: ldc.i4.0
-		IL_0620: ldloc.0
-		IL_0621: stelem.ref
-		IL_0622: ldc.i4.0
-		IL_0623: ldelem.ref
-		IL_0624: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0629: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_062f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0634: ldc.i4.1
-		IL_0635: newarr [System.Runtime]System.Object
-		IL_063a: dup
-		IL_063b: ldc.i4.0
-		IL_063c: ldloc.0
-		IL_063d: stelem.ref
-		IL_063e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0648: ldc.i4.0
-		IL_0649: conv.r8
-		IL_064a: ldstr ""
-		IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0596: ldstr "createHash"
+		IL_059b: ldstr "sha256"
+		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05a5: stloc.s 4
+		IL_05a7: ldloc.0
+		IL_05a8: ldloc.s 4
+		IL_05aa: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_05af: ldloc.0
+		IL_05b0: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_05b5: ldstr "update"
+		IL_05ba: ldstr "abc"
+		IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05c4: pop
+		IL_05c5: ldloc.0
+		IL_05c6: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_05cb: ldstr "digest"
+		IL_05d0: ldstr "hex"
+		IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05da: stloc.s 4
+		IL_05dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05e1: ldstr "digest first:"
+		IL_05e6: ldloc.s 4
+		IL_05e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_05ed: pop
+		IL_05ee: ldc.i4.1
+		IL_05ef: newarr [System.Runtime]System.Object
+		IL_05f4: dup
+		IL_05f5: ldc.i4.0
+		IL_05f6: ldloc.0
+		IL_05f7: stelem.ref
+		IL_05f8: ldc.i4.0
+		IL_05f9: ldelem.ref
+		IL_05fa: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_05ff: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0605: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_060a: ldc.i4.1
+		IL_060b: newarr [System.Runtime]System.Object
+		IL_0610: dup
+		IL_0611: ldc.i4.0
+		IL_0612: ldloc.0
+		IL_0613: stelem.ref
+		IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0619: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_061e: ldc.i4.0
+		IL_061f: conv.r8
+		IL_0620: ldstr ""
+		IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_062a: stloc.s 4
+		IL_062c: ldnull
+		IL_062d: ldstr "digest twice"
+		IL_0632: ldloc.s 4
+		IL_0634: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
+		IL_0639: pop
+		IL_063a: ldloc.0
+		IL_063b: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0640: ldstr "createHmac"
+		IL_0645: ldstr "sha256"
+		IL_064a: ldstr "key"
+		IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0654: stloc.s 4
-		IL_0656: ldnull
-		IL_0657: ldstr "digest twice"
-		IL_065c: ldloc.s 4
-		IL_065e: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0663: pop
-		IL_0664: ldloc.0
-		IL_0665: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_066a: ldstr "Cannot access 'crypto' before initialization"
-		IL_066f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0674: stloc.s 4
-		IL_0676: ldloc.s 4
-		IL_0678: ldstr "createHmac"
-		IL_067d: ldstr "sha256"
-		IL_0682: ldstr "key"
-		IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_068c: stloc.s 4
-		IL_068e: ldloc.0
-		IL_068f: ldloc.s 4
-		IL_0691: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
-		IL_0696: ldc.i4.1
-		IL_0697: newarr [System.Runtime]System.Object
-		IL_069c: dup
-		IL_069d: ldc.i4.0
-		IL_069e: ldloc.0
-		IL_069f: stelem.ref
-		IL_06a0: ldc.i4.0
-		IL_06a1: ldelem.ref
-		IL_06a2: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_06a7: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_06ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_06b2: ldc.i4.1
-		IL_06b3: newarr [System.Runtime]System.Object
-		IL_06b8: dup
-		IL_06b9: ldc.i4.0
-		IL_06ba: ldloc.0
-		IL_06bb: stelem.ref
-		IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_06c6: ldc.i4.0
-		IL_06c7: conv.r8
-		IL_06c8: ldstr ""
-		IL_06cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_06d2: stloc.s 4
-		IL_06d4: ldnull
-		IL_06d5: ldstr "hmac update type"
-		IL_06da: ldloc.s 4
-		IL_06dc: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_06e1: pop
-		IL_06e2: ldc.i4.1
-		IL_06e3: newarr [System.Runtime]System.Object
-		IL_06e8: dup
-		IL_06e9: ldc.i4.0
-		IL_06ea: ldloc.0
-		IL_06eb: stelem.ref
-		IL_06ec: ldnull
-		IL_06ed: call object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
-		IL_06f2: stloc.s 4
-		IL_06f4: ldnull
-		IL_06f5: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27::__js_call__(object)
-		IL_06fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0700: ldc.i4.1
-		IL_0701: newarr [System.Runtime]System.Object
-		IL_0706: dup
-		IL_0707: ldc.i4.0
-		IL_0708: ldloc.0
-		IL_0709: stelem.ref
-		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_070f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0714: ldc.i4.0
-		IL_0715: conv.r8
-		IL_0716: ldstr ""
-		IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0720: stloc.s 5
-		IL_0722: ldloc.s 4
-		IL_0724: ldstr "then"
-		IL_0729: ldloc.s 5
-		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0730: pop
-		IL_0731: ret
+		IL_0656: ldloc.0
+		IL_0657: ldloc.s 4
+		IL_0659: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
+		IL_065e: ldc.i4.1
+		IL_065f: newarr [System.Runtime]System.Object
+		IL_0664: dup
+		IL_0665: ldc.i4.0
+		IL_0666: ldloc.0
+		IL_0667: stelem.ref
+		IL_0668: ldc.i4.0
+		IL_0669: ldelem.ref
+		IL_066a: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_066f: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0675: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_067a: ldc.i4.1
+		IL_067b: newarr [System.Runtime]System.Object
+		IL_0680: dup
+		IL_0681: ldc.i4.0
+		IL_0682: ldloc.0
+		IL_0683: stelem.ref
+		IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_068e: ldc.i4.0
+		IL_068f: conv.r8
+		IL_0690: ldstr ""
+		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_069a: stloc.s 4
+		IL_069c: ldnull
+		IL_069d: ldstr "hmac update type"
+		IL_06a2: ldloc.s 4
+		IL_06a4: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
+		IL_06a9: pop
+		IL_06aa: ldc.i4.1
+		IL_06ab: newarr [System.Runtime]System.Object
+		IL_06b0: dup
+		IL_06b1: ldc.i4.0
+		IL_06b2: ldloc.0
+		IL_06b3: stelem.ref
+		IL_06b4: ldnull
+		IL_06b5: call object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
+		IL_06ba: stloc.s 4
+		IL_06bc: ldnull
+		IL_06bd: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27::__js_call__(object)
+		IL_06c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_06c8: ldc.i4.1
+		IL_06c9: newarr [System.Runtime]System.Object
+		IL_06ce: dup
+		IL_06cf: ldc.i4.0
+		IL_06d0: ldloc.0
+		IL_06d1: stelem.ref
+		IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_06dc: ldc.i4.0
+		IL_06dd: conv.r8
+		IL_06de: ldstr ""
+		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_06e8: stloc.s 5
+		IL_06ea: ldloc.s 4
+		IL_06ec: ldstr "then"
+		IL_06f1: ldloc.s 5
+		IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_06f8: pop
+		IL_06f9: ret
 	} // end of method Require_Crypto_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Crypto_ErrorPaths
@@ -4406,7 +4295,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3d81
+		// Method begins at RVA 0x3bbe
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
+++ b/tests/Js2IL.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x293f
+				// Method begins at RVA 0x291e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -95,7 +95,7 @@
 			)
 			// Method begins at RVA 0x20e8
 			// Header size: 12
-			// Code size: 2084 (0x824)
+			// Code size: 2062 (0x80e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Crypto_WebCrypto_Subtle/run/Scope,
@@ -106,8 +106,8 @@
 				[5] object,
 				[6] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
 				[7] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-				[8] object,
-				[9] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[8] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[9] object,
 				[10] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
 				[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -191,791 +191,783 @@
 
 			IL_0095: ldloc.0
 			IL_0096: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_009b: switch (IL_00c4, IL_0166, IL_0237, IL_02e9, IL_039b, IL_04c5, IL_05fa, IL_06ce, IL_07df)
+			IL_009b: switch (IL_00c4, IL_0150, IL_0221, IL_02d3, IL_0385, IL_04af, IL_05e4, IL_06b8, IL_07c9)
 
 			IL_00c4: ldarg.0
 			IL_00c5: ldc.i4.1
 			IL_00c6: ldelem.ref
 			IL_00c7: castclass Modules.Require_Crypto_WebCrypto_Subtle/Scope
 			IL_00cc: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/Scope::crypto
-			IL_00d1: ldstr "Cannot access 'crypto' before initialization"
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00db: stloc.s 8
-			IL_00dd: ldloc.s 8
-			IL_00df: ldstr "webcrypto"
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e9: stloc.s 8
-			IL_00eb: ldloc.s 8
-			IL_00ed: ldstr "subtle"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f7: stloc.s 8
-			IL_00f9: ldloc.s 8
-			IL_00fb: stloc.1
-			IL_00fc: ldstr "abc"
-			IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0106: stloc.s 9
-			IL_0108: ldloc.1
-			IL_0109: ldstr "digest"
-			IL_010e: ldstr "SHA-256"
-			IL_0113: ldloc.s 9
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_011a: stloc.s 8
-			IL_011c: ldloc.0
-			IL_011d: ldc.i4.1
-			IL_011e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0123: ldloc.0
-			IL_0124: ldloc.s 8
-			IL_0126: ldarg.0
-			IL_0127: ldc.i4.1
-			IL_0128: ldloc.0
-			IL_0129: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_012e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0133: ldloc.0
-			IL_0134: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00d1: ldstr "webcrypto"
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00db: ldstr "subtle"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e5: stloc.1
+			IL_00e6: ldstr "abc"
+			IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_00f0: stloc.s 8
+			IL_00f2: ldloc.1
+			IL_00f3: ldstr "digest"
+			IL_00f8: ldstr "SHA-256"
+			IL_00fd: ldloc.s 8
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0104: stloc.s 9
+			IL_0106: ldloc.0
+			IL_0107: ldc.i4.1
+			IL_0108: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_010d: ldloc.0
+			IL_010e: ldloc.s 9
+			IL_0110: ldarg.0
+			IL_0111: ldc.i4.1
+			IL_0112: ldloc.0
+			IL_0113: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0118: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_011d: ldloc.0
+			IL_011e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0123: dup
+			IL_0124: ldc.i4.0
+			IL_0125: ldloc.1
+			IL_0126: stelem.ref
+			IL_0127: dup
+			IL_0128: ldc.i4.1
+			IL_0129: ldloc.2
+			IL_012a: stelem.ref
+			IL_012b: dup
+			IL_012c: ldc.i4.2
+			IL_012d: ldloc.3
+			IL_012e: stelem.ref
+			IL_012f: dup
+			IL_0130: ldc.i4.3
+			IL_0131: ldloc.s 4
+			IL_0133: stelem.ref
+			IL_0134: dup
+			IL_0135: ldc.i4.4
+			IL_0136: ldloc.s 5
+			IL_0138: stelem.ref
 			IL_0139: dup
-			IL_013a: ldc.i4.0
-			IL_013b: ldloc.1
-			IL_013c: stelem.ref
-			IL_013d: dup
-			IL_013e: ldc.i4.1
-			IL_013f: ldloc.2
-			IL_0140: stelem.ref
-			IL_0141: dup
-			IL_0142: ldc.i4.2
-			IL_0143: ldloc.3
-			IL_0144: stelem.ref
-			IL_0145: dup
-			IL_0146: ldc.i4.3
-			IL_0147: ldloc.s 4
-			IL_0149: stelem.ref
-			IL_014a: dup
-			IL_014b: ldc.i4.4
-			IL_014c: ldloc.s 5
-			IL_014e: stelem.ref
-			IL_014f: dup
-			IL_0150: ldc.i4.5
-			IL_0151: ldloc.s 6
-			IL_0153: stelem.ref
-			IL_0154: dup
-			IL_0155: ldc.i4.6
-			IL_0156: ldloc.s 7
-			IL_0158: stelem.ref
-			IL_0159: pop
-			IL_015a: ldloc.0
-			IL_015b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0160: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0165: ret
+			IL_013a: ldc.i4.5
+			IL_013b: ldloc.s 6
+			IL_013d: stelem.ref
+			IL_013e: dup
+			IL_013f: ldc.i4.6
+			IL_0140: ldloc.s 7
+			IL_0142: stelem.ref
+			IL_0143: pop
+			IL_0144: ldloc.0
+			IL_0145: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_014a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_014f: ret
 
-			IL_0166: ldloc.0
-			IL_0167: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited1
-			IL_016c: stloc.s 8
-			IL_016e: ldloc.s 8
-			IL_0170: stloc.2
-			IL_0171: ldloc.2
-			IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0177: stloc.s 10
-			IL_0179: ldloc.s 10
-			IL_017b: stloc.3
-			IL_017c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0181: ldstr "digest byteLength:"
-			IL_0186: ldloc.2
-			IL_0187: ldstr "byteLength"
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0191: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0196: pop
-			IL_0197: ldloc.3
-			IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_019d: stloc.s 11
-			IL_019f: ldloc.s 11
-			IL_01a1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_01a6: stloc.s 9
-			IL_01a8: ldloc.s 9
-			IL_01aa: ldstr "toString"
-			IL_01af: ldstr "hex"
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01b9: stloc.s 8
-			IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01c0: ldstr "digest hex:"
-			IL_01c5: ldloc.s 8
-			IL_01c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01cc: pop
-			IL_01cd: ldstr "abc"
-			IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_01d7: stloc.s 9
-			IL_01d9: ldloc.1
-			IL_01da: ldstr "digest"
-			IL_01df: ldstr "SHA-1"
-			IL_01e4: ldloc.s 9
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01eb: stloc.s 8
-			IL_01ed: ldloc.0
-			IL_01ee: ldc.i4.2
-			IL_01ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01f4: ldloc.0
-			IL_01f5: ldloc.s 8
-			IL_01f7: ldarg.0
-			IL_01f8: ldc.i4.2
-			IL_01f9: ldloc.0
-			IL_01fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0204: ldloc.0
-			IL_0205: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0150: ldloc.0
+			IL_0151: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited1
+			IL_0156: stloc.s 9
+			IL_0158: ldloc.s 9
+			IL_015a: stloc.2
+			IL_015b: ldloc.2
+			IL_015c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_0161: stloc.s 10
+			IL_0163: ldloc.s 10
+			IL_0165: stloc.3
+			IL_0166: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_016b: ldstr "digest byteLength:"
+			IL_0170: ldloc.2
+			IL_0171: ldstr "byteLength"
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0180: pop
+			IL_0181: ldloc.3
+			IL_0182: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0187: stloc.s 11
+			IL_0189: ldloc.s 11
+			IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0190: stloc.s 8
+			IL_0192: ldloc.s 8
+			IL_0194: ldstr "toString"
+			IL_0199: ldstr "hex"
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a3: stloc.s 9
+			IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01aa: ldstr "digest hex:"
+			IL_01af: ldloc.s 9
+			IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01b6: pop
+			IL_01b7: ldstr "abc"
+			IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_01c1: stloc.s 8
+			IL_01c3: ldloc.1
+			IL_01c4: ldstr "digest"
+			IL_01c9: ldstr "SHA-1"
+			IL_01ce: ldloc.s 8
+			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01d5: stloc.s 9
+			IL_01d7: ldloc.0
+			IL_01d8: ldc.i4.2
+			IL_01d9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01de: ldloc.0
+			IL_01df: ldloc.s 9
+			IL_01e1: ldarg.0
+			IL_01e2: ldc.i4.2
+			IL_01e3: ldloc.0
+			IL_01e4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01ee: ldloc.0
+			IL_01ef: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01f4: dup
+			IL_01f5: ldc.i4.0
+			IL_01f6: ldloc.1
+			IL_01f7: stelem.ref
+			IL_01f8: dup
+			IL_01f9: ldc.i4.1
+			IL_01fa: ldloc.2
+			IL_01fb: stelem.ref
+			IL_01fc: dup
+			IL_01fd: ldc.i4.2
+			IL_01fe: ldloc.3
+			IL_01ff: stelem.ref
+			IL_0200: dup
+			IL_0201: ldc.i4.3
+			IL_0202: ldloc.s 4
+			IL_0204: stelem.ref
+			IL_0205: dup
+			IL_0206: ldc.i4.4
+			IL_0207: ldloc.s 5
+			IL_0209: stelem.ref
 			IL_020a: dup
-			IL_020b: ldc.i4.0
-			IL_020c: ldloc.1
-			IL_020d: stelem.ref
-			IL_020e: dup
-			IL_020f: ldc.i4.1
-			IL_0210: ldloc.2
-			IL_0211: stelem.ref
-			IL_0212: dup
-			IL_0213: ldc.i4.2
-			IL_0214: ldloc.3
-			IL_0215: stelem.ref
-			IL_0216: dup
-			IL_0217: ldc.i4.3
-			IL_0218: ldloc.s 4
-			IL_021a: stelem.ref
-			IL_021b: dup
-			IL_021c: ldc.i4.4
-			IL_021d: ldloc.s 5
-			IL_021f: stelem.ref
-			IL_0220: dup
-			IL_0221: ldc.i4.5
-			IL_0222: ldloc.s 6
-			IL_0224: stelem.ref
-			IL_0225: dup
-			IL_0226: ldc.i4.6
-			IL_0227: ldloc.s 7
-			IL_0229: stelem.ref
-			IL_022a: pop
-			IL_022b: ldloc.0
-			IL_022c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0231: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0236: ret
+			IL_020b: ldc.i4.5
+			IL_020c: ldloc.s 6
+			IL_020e: stelem.ref
+			IL_020f: dup
+			IL_0210: ldc.i4.6
+			IL_0211: ldloc.s 7
+			IL_0213: stelem.ref
+			IL_0214: pop
+			IL_0215: ldloc.0
+			IL_0216: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_021b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0220: ret
 
-			IL_0237: ldloc.0
-			IL_0238: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited2
-			IL_023d: stloc.s 8
-			IL_023f: ldloc.s 8
-			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0246: stloc.s 10
-			IL_0248: ldloc.s 10
-			IL_024a: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_024f: stloc.s 11
-			IL_0251: ldloc.s 11
-			IL_0253: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0258: stloc.s 9
-			IL_025a: ldloc.s 9
-			IL_025c: ldstr "toString"
-			IL_0261: ldstr "hex"
-			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_026b: stloc.s 8
-			IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0272: ldstr "digest sha1 hex:"
-			IL_0277: ldloc.s 8
-			IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_027e: pop
-			IL_027f: ldstr "abc"
-			IL_0284: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0289: stloc.s 9
-			IL_028b: ldloc.1
-			IL_028c: ldstr "digest"
-			IL_0291: ldstr "SHA-384"
-			IL_0296: ldloc.s 9
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_029d: stloc.s 8
-			IL_029f: ldloc.0
-			IL_02a0: ldc.i4.3
-			IL_02a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02a6: ldloc.0
-			IL_02a7: ldloc.s 8
-			IL_02a9: ldarg.0
-			IL_02aa: ldc.i4.3
-			IL_02ab: ldloc.0
-			IL_02ac: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02b6: ldloc.0
-			IL_02b7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0221: ldloc.0
+			IL_0222: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited2
+			IL_0227: stloc.s 9
+			IL_0229: ldloc.s 9
+			IL_022b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_0230: stloc.s 10
+			IL_0232: ldloc.s 10
+			IL_0234: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0239: stloc.s 11
+			IL_023b: ldloc.s 11
+			IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0242: stloc.s 8
+			IL_0244: ldloc.s 8
+			IL_0246: ldstr "toString"
+			IL_024b: ldstr "hex"
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0255: stloc.s 9
+			IL_0257: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_025c: ldstr "digest sha1 hex:"
+			IL_0261: ldloc.s 9
+			IL_0263: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0268: pop
+			IL_0269: ldstr "abc"
+			IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0273: stloc.s 8
+			IL_0275: ldloc.1
+			IL_0276: ldstr "digest"
+			IL_027b: ldstr "SHA-384"
+			IL_0280: ldloc.s 8
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0287: stloc.s 9
+			IL_0289: ldloc.0
+			IL_028a: ldc.i4.3
+			IL_028b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0290: ldloc.0
+			IL_0291: ldloc.s 9
+			IL_0293: ldarg.0
+			IL_0294: ldc.i4.3
+			IL_0295: ldloc.0
+			IL_0296: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_029b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02a0: ldloc.0
+			IL_02a1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02a6: dup
+			IL_02a7: ldc.i4.0
+			IL_02a8: ldloc.1
+			IL_02a9: stelem.ref
+			IL_02aa: dup
+			IL_02ab: ldc.i4.1
+			IL_02ac: ldloc.2
+			IL_02ad: stelem.ref
+			IL_02ae: dup
+			IL_02af: ldc.i4.2
+			IL_02b0: ldloc.3
+			IL_02b1: stelem.ref
+			IL_02b2: dup
+			IL_02b3: ldc.i4.3
+			IL_02b4: ldloc.s 4
+			IL_02b6: stelem.ref
+			IL_02b7: dup
+			IL_02b8: ldc.i4.4
+			IL_02b9: ldloc.s 5
+			IL_02bb: stelem.ref
 			IL_02bc: dup
-			IL_02bd: ldc.i4.0
-			IL_02be: ldloc.1
-			IL_02bf: stelem.ref
-			IL_02c0: dup
-			IL_02c1: ldc.i4.1
-			IL_02c2: ldloc.2
-			IL_02c3: stelem.ref
-			IL_02c4: dup
-			IL_02c5: ldc.i4.2
-			IL_02c6: ldloc.3
-			IL_02c7: stelem.ref
-			IL_02c8: dup
-			IL_02c9: ldc.i4.3
-			IL_02ca: ldloc.s 4
-			IL_02cc: stelem.ref
-			IL_02cd: dup
-			IL_02ce: ldc.i4.4
-			IL_02cf: ldloc.s 5
-			IL_02d1: stelem.ref
-			IL_02d2: dup
-			IL_02d3: ldc.i4.5
-			IL_02d4: ldloc.s 6
-			IL_02d6: stelem.ref
-			IL_02d7: dup
-			IL_02d8: ldc.i4.6
-			IL_02d9: ldloc.s 7
-			IL_02db: stelem.ref
-			IL_02dc: pop
-			IL_02dd: ldloc.0
-			IL_02de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02e3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02e8: ret
+			IL_02bd: ldc.i4.5
+			IL_02be: ldloc.s 6
+			IL_02c0: stelem.ref
+			IL_02c1: dup
+			IL_02c2: ldc.i4.6
+			IL_02c3: ldloc.s 7
+			IL_02c5: stelem.ref
+			IL_02c6: pop
+			IL_02c7: ldloc.0
+			IL_02c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02cd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d2: ret
 
-			IL_02e9: ldloc.0
-			IL_02ea: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited3
-			IL_02ef: stloc.s 8
-			IL_02f1: ldloc.s 8
-			IL_02f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_02f8: stloc.s 10
-			IL_02fa: ldloc.s 10
-			IL_02fc: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0301: stloc.s 11
-			IL_0303: ldloc.s 11
-			IL_0305: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_030a: stloc.s 9
-			IL_030c: ldloc.s 9
-			IL_030e: ldstr "toString"
-			IL_0313: ldstr "hex"
-			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_031d: stloc.s 8
-			IL_031f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0324: ldstr "digest sha384 hex:"
-			IL_0329: ldloc.s 8
-			IL_032b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0330: pop
-			IL_0331: ldstr "abc"
-			IL_0336: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_033b: stloc.s 9
-			IL_033d: ldloc.1
-			IL_033e: ldstr "digest"
-			IL_0343: ldstr "SHA-512"
-			IL_0348: ldloc.s 9
-			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_034f: stloc.s 8
-			IL_0351: ldloc.0
-			IL_0352: ldc.i4.4
-			IL_0353: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0358: ldloc.0
-			IL_0359: ldloc.s 8
-			IL_035b: ldarg.0
-			IL_035c: ldc.i4.4
-			IL_035d: ldloc.0
-			IL_035e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0363: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0368: ldloc.0
-			IL_0369: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02d3: ldloc.0
+			IL_02d4: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited3
+			IL_02d9: stloc.s 9
+			IL_02db: ldloc.s 9
+			IL_02dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_02e2: stloc.s 10
+			IL_02e4: ldloc.s 10
+			IL_02e6: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_02eb: stloc.s 11
+			IL_02ed: ldloc.s 11
+			IL_02ef: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_02f4: stloc.s 8
+			IL_02f6: ldloc.s 8
+			IL_02f8: ldstr "toString"
+			IL_02fd: ldstr "hex"
+			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0307: stloc.s 9
+			IL_0309: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_030e: ldstr "digest sha384 hex:"
+			IL_0313: ldloc.s 9
+			IL_0315: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_031a: pop
+			IL_031b: ldstr "abc"
+			IL_0320: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0325: stloc.s 8
+			IL_0327: ldloc.1
+			IL_0328: ldstr "digest"
+			IL_032d: ldstr "SHA-512"
+			IL_0332: ldloc.s 8
+			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0339: stloc.s 9
+			IL_033b: ldloc.0
+			IL_033c: ldc.i4.4
+			IL_033d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0342: ldloc.0
+			IL_0343: ldloc.s 9
+			IL_0345: ldarg.0
+			IL_0346: ldc.i4.4
+			IL_0347: ldloc.0
+			IL_0348: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_034d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0352: ldloc.0
+			IL_0353: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0358: dup
+			IL_0359: ldc.i4.0
+			IL_035a: ldloc.1
+			IL_035b: stelem.ref
+			IL_035c: dup
+			IL_035d: ldc.i4.1
+			IL_035e: ldloc.2
+			IL_035f: stelem.ref
+			IL_0360: dup
+			IL_0361: ldc.i4.2
+			IL_0362: ldloc.3
+			IL_0363: stelem.ref
+			IL_0364: dup
+			IL_0365: ldc.i4.3
+			IL_0366: ldloc.s 4
+			IL_0368: stelem.ref
+			IL_0369: dup
+			IL_036a: ldc.i4.4
+			IL_036b: ldloc.s 5
+			IL_036d: stelem.ref
 			IL_036e: dup
-			IL_036f: ldc.i4.0
-			IL_0370: ldloc.1
-			IL_0371: stelem.ref
-			IL_0372: dup
-			IL_0373: ldc.i4.1
-			IL_0374: ldloc.2
-			IL_0375: stelem.ref
-			IL_0376: dup
-			IL_0377: ldc.i4.2
-			IL_0378: ldloc.3
-			IL_0379: stelem.ref
-			IL_037a: dup
-			IL_037b: ldc.i4.3
-			IL_037c: ldloc.s 4
-			IL_037e: stelem.ref
-			IL_037f: dup
-			IL_0380: ldc.i4.4
-			IL_0381: ldloc.s 5
-			IL_0383: stelem.ref
-			IL_0384: dup
-			IL_0385: ldc.i4.5
-			IL_0386: ldloc.s 6
-			IL_0388: stelem.ref
-			IL_0389: dup
-			IL_038a: ldc.i4.6
-			IL_038b: ldloc.s 7
-			IL_038d: stelem.ref
-			IL_038e: pop
-			IL_038f: ldloc.0
-			IL_0390: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0395: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_039a: ret
+			IL_036f: ldc.i4.5
+			IL_0370: ldloc.s 6
+			IL_0372: stelem.ref
+			IL_0373: dup
+			IL_0374: ldc.i4.6
+			IL_0375: ldloc.s 7
+			IL_0377: stelem.ref
+			IL_0378: pop
+			IL_0379: ldloc.0
+			IL_037a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_037f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0384: ret
 
-			IL_039b: ldloc.0
-			IL_039c: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited4
-			IL_03a1: stloc.s 8
-			IL_03a3: ldloc.s 8
-			IL_03a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_03aa: stloc.s 10
-			IL_03ac: ldloc.s 10
-			IL_03ae: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_03b3: stloc.s 11
-			IL_03b5: ldloc.s 11
-			IL_03b7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_03bc: stloc.s 9
-			IL_03be: ldloc.s 9
-			IL_03c0: ldstr "toString"
-			IL_03c5: ldstr "hex"
-			IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03cf: stloc.s 8
-			IL_03d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03d6: ldstr "digest sha512 hex:"
-			IL_03db: ldloc.s 8
-			IL_03dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_03e2: pop
-			IL_03e3: ldstr "key"
-			IL_03e8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_03ed: stloc.s 9
-			IL_03ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03f4: dup
-			IL_03f5: ldstr "name"
-			IL_03fa: ldstr "HMAC"
-			IL_03ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0404: dup
-			IL_0405: ldstr "hash"
-			IL_040a: ldstr "SHA-256"
-			IL_040f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0414: dup
-			IL_0415: ldstr "length"
-			IL_041a: ldc.r8 24
-			IL_0423: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0428: stloc.s 12
-			IL_042a: ldc.i4.5
-			IL_042b: newarr [System.Runtime]System.Object
-			IL_0430: dup
-			IL_0431: ldc.i4.0
-			IL_0432: ldstr "raw"
-			IL_0437: stelem.ref
-			IL_0438: dup
-			IL_0439: ldc.i4.1
-			IL_043a: ldloc.s 9
-			IL_043c: stelem.ref
+			IL_0385: ldloc.0
+			IL_0386: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited4
+			IL_038b: stloc.s 9
+			IL_038d: ldloc.s 9
+			IL_038f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_0394: stloc.s 10
+			IL_0396: ldloc.s 10
+			IL_0398: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_039d: stloc.s 11
+			IL_039f: ldloc.s 11
+			IL_03a1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_03a6: stloc.s 8
+			IL_03a8: ldloc.s 8
+			IL_03aa: ldstr "toString"
+			IL_03af: ldstr "hex"
+			IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03b9: stloc.s 9
+			IL_03bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03c0: ldstr "digest sha512 hex:"
+			IL_03c5: ldloc.s 9
+			IL_03c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_03cc: pop
+			IL_03cd: ldstr "key"
+			IL_03d2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_03d7: stloc.s 8
+			IL_03d9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03de: dup
+			IL_03df: ldstr "name"
+			IL_03e4: ldstr "HMAC"
+			IL_03e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03ee: dup
+			IL_03ef: ldstr "hash"
+			IL_03f4: ldstr "SHA-256"
+			IL_03f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03fe: dup
+			IL_03ff: ldstr "length"
+			IL_0404: ldc.r8 24
+			IL_040d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0412: stloc.s 12
+			IL_0414: ldc.i4.5
+			IL_0415: newarr [System.Runtime]System.Object
+			IL_041a: dup
+			IL_041b: ldc.i4.0
+			IL_041c: ldstr "raw"
+			IL_0421: stelem.ref
+			IL_0422: dup
+			IL_0423: ldc.i4.1
+			IL_0424: ldloc.s 8
+			IL_0426: stelem.ref
+			IL_0427: dup
+			IL_0428: ldc.i4.2
+			IL_0429: ldloc.s 12
+			IL_042b: stelem.ref
+			IL_042c: dup
+			IL_042d: ldc.i4.3
+			IL_042e: ldc.i4.0
+			IL_042f: box [System.Runtime]System.Boolean
+			IL_0434: stelem.ref
+			IL_0435: dup
+			IL_0436: ldc.i4.4
+			IL_0437: ldc.i4.2
+			IL_0438: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_043d: dup
-			IL_043e: ldc.i4.2
-			IL_043f: ldloc.s 12
-			IL_0441: stelem.ref
-			IL_0442: dup
-			IL_0443: ldc.i4.3
-			IL_0444: ldc.i4.0
-			IL_0445: box [System.Runtime]System.Boolean
-			IL_044a: stelem.ref
-			IL_044b: dup
-			IL_044c: ldc.i4.4
-			IL_044d: ldc.i4.2
-			IL_044e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0453: dup
-			IL_0454: ldstr "sign"
-			IL_0459: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_045e: dup
-			IL_045f: ldstr "verify"
-			IL_0464: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0469: stelem.ref
-			IL_046a: stloc.s 13
-			IL_046c: ldloc.1
-			IL_046d: ldstr "importKey"
-			IL_0472: ldloc.s 13
-			IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0479: stloc.s 8
-			IL_047b: ldloc.0
-			IL_047c: ldc.i4.5
-			IL_047d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0482: ldloc.0
-			IL_0483: ldloc.s 8
-			IL_0485: ldarg.0
-			IL_0486: ldc.i4.5
-			IL_0487: ldloc.0
-			IL_0488: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_048d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0492: ldloc.0
-			IL_0493: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_043e: ldstr "sign"
+			IL_0443: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0448: dup
+			IL_0449: ldstr "verify"
+			IL_044e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0453: stelem.ref
+			IL_0454: stloc.s 13
+			IL_0456: ldloc.1
+			IL_0457: ldstr "importKey"
+			IL_045c: ldloc.s 13
+			IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0463: stloc.s 9
+			IL_0465: ldloc.0
+			IL_0466: ldc.i4.5
+			IL_0467: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_046c: ldloc.0
+			IL_046d: ldloc.s 9
+			IL_046f: ldarg.0
+			IL_0470: ldc.i4.5
+			IL_0471: ldloc.0
+			IL_0472: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0477: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_047c: ldloc.0
+			IL_047d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0482: dup
+			IL_0483: ldc.i4.0
+			IL_0484: ldloc.1
+			IL_0485: stelem.ref
+			IL_0486: dup
+			IL_0487: ldc.i4.1
+			IL_0488: ldloc.2
+			IL_0489: stelem.ref
+			IL_048a: dup
+			IL_048b: ldc.i4.2
+			IL_048c: ldloc.3
+			IL_048d: stelem.ref
+			IL_048e: dup
+			IL_048f: ldc.i4.3
+			IL_0490: ldloc.s 4
+			IL_0492: stelem.ref
+			IL_0493: dup
+			IL_0494: ldc.i4.4
+			IL_0495: ldloc.s 5
+			IL_0497: stelem.ref
 			IL_0498: dup
-			IL_0499: ldc.i4.0
-			IL_049a: ldloc.1
-			IL_049b: stelem.ref
-			IL_049c: dup
-			IL_049d: ldc.i4.1
-			IL_049e: ldloc.2
-			IL_049f: stelem.ref
-			IL_04a0: dup
-			IL_04a1: ldc.i4.2
-			IL_04a2: ldloc.3
-			IL_04a3: stelem.ref
-			IL_04a4: dup
-			IL_04a5: ldc.i4.3
-			IL_04a6: ldloc.s 4
-			IL_04a8: stelem.ref
-			IL_04a9: dup
-			IL_04aa: ldc.i4.4
-			IL_04ab: ldloc.s 5
-			IL_04ad: stelem.ref
-			IL_04ae: dup
-			IL_04af: ldc.i4.5
-			IL_04b0: ldloc.s 6
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.6
-			IL_04b5: ldloc.s 7
-			IL_04b7: stelem.ref
-			IL_04b8: pop
-			IL_04b9: ldloc.0
-			IL_04ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04bf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04c4: ret
+			IL_0499: ldc.i4.5
+			IL_049a: ldloc.s 6
+			IL_049c: stelem.ref
+			IL_049d: dup
+			IL_049e: ldc.i4.6
+			IL_049f: ldloc.s 7
+			IL_04a1: stelem.ref
+			IL_04a2: pop
+			IL_04a3: ldloc.0
+			IL_04a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04a9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04ae: ret
 
-			IL_04c5: ldloc.0
-			IL_04c6: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited5
-			IL_04cb: stloc.s 8
-			IL_04cd: ldloc.s 8
-			IL_04cf: stloc.s 4
-			IL_04d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04d6: ldstr "key type:"
-			IL_04db: ldloc.s 4
-			IL_04dd: ldstr "type"
-			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_04ec: pop
-			IL_04ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04f2: ldstr "key algorithm:"
-			IL_04f7: ldloc.s 4
-			IL_04f9: ldstr "algorithm"
-			IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0503: ldstr "name"
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_050d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0512: pop
-			IL_0513: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0518: ldstr "key hash:"
-			IL_051d: ldloc.s 4
-			IL_051f: ldstr "algorithm"
-			IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0529: ldstr "hash"
-			IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0533: ldstr "name"
-			IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_053d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0542: pop
-			IL_0543: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0548: ldstr "key extractable:"
-			IL_054d: ldloc.s 4
-			IL_054f: ldstr "extractable"
-			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0559: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_055e: pop
-			IL_055f: ldloc.s 4
-			IL_0561: ldstr "usages"
-			IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_056b: ldstr "join"
-			IL_0570: ldstr ","
-			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_057a: stloc.s 8
-			IL_057c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0581: ldstr "key usages:"
-			IL_0586: ldloc.s 8
-			IL_0588: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_058d: pop
-			IL_058e: ldstr "abc"
-			IL_0593: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_04af: ldloc.0
+			IL_04b0: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited5
+			IL_04b5: stloc.s 9
+			IL_04b7: ldloc.s 9
+			IL_04b9: stloc.s 4
+			IL_04bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04c0: ldstr "key type:"
+			IL_04c5: ldloc.s 4
+			IL_04c7: ldstr "type"
+			IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_04d6: pop
+			IL_04d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04dc: ldstr "key algorithm:"
+			IL_04e1: ldloc.s 4
+			IL_04e3: ldstr "algorithm"
+			IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04ed: ldstr "name"
+			IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_04fc: pop
+			IL_04fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0502: ldstr "key hash:"
+			IL_0507: ldloc.s 4
+			IL_0509: ldstr "algorithm"
+			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0513: ldstr "hash"
+			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_051d: ldstr "name"
+			IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0527: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_052c: pop
+			IL_052d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0532: ldstr "key extractable:"
+			IL_0537: ldloc.s 4
+			IL_0539: ldstr "extractable"
+			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0543: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0548: pop
+			IL_0549: ldloc.s 4
+			IL_054b: ldstr "usages"
+			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0555: ldstr "join"
+			IL_055a: ldstr ","
+			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0564: stloc.s 9
+			IL_0566: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_056b: ldstr "key usages:"
+			IL_0570: ldloc.s 9
+			IL_0572: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0577: pop
+			IL_0578: ldstr "abc"
+			IL_057d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0582: stloc.s 8
+			IL_0584: ldloc.1
+			IL_0585: ldstr "sign"
+			IL_058a: ldstr "HMAC"
+			IL_058f: ldloc.s 4
+			IL_0591: ldloc.s 8
+			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
 			IL_0598: stloc.s 9
-			IL_059a: ldloc.1
-			IL_059b: ldstr "sign"
-			IL_05a0: ldstr "HMAC"
-			IL_05a5: ldloc.s 4
-			IL_05a7: ldloc.s 9
-			IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_05ae: stloc.s 8
-			IL_05b0: ldloc.0
-			IL_05b1: ldc.i4.6
-			IL_05b2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05b7: ldloc.0
-			IL_05b8: ldloc.s 8
-			IL_05ba: ldarg.0
-			IL_05bb: ldc.i4.6
-			IL_05bc: ldloc.0
-			IL_05bd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_05c7: ldloc.0
-			IL_05c8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_059a: ldloc.0
+			IL_059b: ldc.i4.6
+			IL_059c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05a1: ldloc.0
+			IL_05a2: ldloc.s 9
+			IL_05a4: ldarg.0
+			IL_05a5: ldc.i4.6
+			IL_05a6: ldloc.0
+			IL_05a7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_05b1: ldloc.0
+			IL_05b2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05b7: dup
+			IL_05b8: ldc.i4.0
+			IL_05b9: ldloc.1
+			IL_05ba: stelem.ref
+			IL_05bb: dup
+			IL_05bc: ldc.i4.1
+			IL_05bd: ldloc.2
+			IL_05be: stelem.ref
+			IL_05bf: dup
+			IL_05c0: ldc.i4.2
+			IL_05c1: ldloc.3
+			IL_05c2: stelem.ref
+			IL_05c3: dup
+			IL_05c4: ldc.i4.3
+			IL_05c5: ldloc.s 4
+			IL_05c7: stelem.ref
+			IL_05c8: dup
+			IL_05c9: ldc.i4.4
+			IL_05ca: ldloc.s 5
+			IL_05cc: stelem.ref
 			IL_05cd: dup
-			IL_05ce: ldc.i4.0
-			IL_05cf: ldloc.1
-			IL_05d0: stelem.ref
-			IL_05d1: dup
-			IL_05d2: ldc.i4.1
-			IL_05d3: ldloc.2
-			IL_05d4: stelem.ref
-			IL_05d5: dup
-			IL_05d6: ldc.i4.2
-			IL_05d7: ldloc.3
-			IL_05d8: stelem.ref
-			IL_05d9: dup
-			IL_05da: ldc.i4.3
-			IL_05db: ldloc.s 4
-			IL_05dd: stelem.ref
-			IL_05de: dup
-			IL_05df: ldc.i4.4
-			IL_05e0: ldloc.s 5
-			IL_05e2: stelem.ref
-			IL_05e3: dup
-			IL_05e4: ldc.i4.5
-			IL_05e5: ldloc.s 6
-			IL_05e7: stelem.ref
-			IL_05e8: dup
-			IL_05e9: ldc.i4.6
-			IL_05ea: ldloc.s 7
-			IL_05ec: stelem.ref
-			IL_05ed: pop
-			IL_05ee: ldloc.0
-			IL_05ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05f4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05f9: ret
+			IL_05ce: ldc.i4.5
+			IL_05cf: ldloc.s 6
+			IL_05d1: stelem.ref
+			IL_05d2: dup
+			IL_05d3: ldc.i4.6
+			IL_05d4: ldloc.s 7
+			IL_05d6: stelem.ref
+			IL_05d7: pop
+			IL_05d8: ldloc.0
+			IL_05d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05de: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05e3: ret
 
-			IL_05fa: ldloc.0
-			IL_05fb: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited6
-			IL_0600: stloc.s 8
-			IL_0602: ldloc.s 8
-			IL_0604: stloc.s 5
-			IL_0606: ldloc.s 5
-			IL_0608: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_060d: stloc.s 10
-			IL_060f: ldloc.s 10
-			IL_0611: stloc.s 6
-			IL_0613: ldloc.s 6
-			IL_0615: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_061a: stloc.s 11
-			IL_061c: ldloc.s 11
-			IL_061e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0623: stloc.s 9
-			IL_0625: ldloc.s 9
-			IL_0627: ldstr "toString"
-			IL_062c: ldstr "hex"
-			IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0636: stloc.s 8
-			IL_0638: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_063d: ldstr "signature hex:"
-			IL_0642: ldloc.s 8
-			IL_0644: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0649: pop
-			IL_064a: ldstr "abc"
-			IL_064f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0654: stloc.s 9
-			IL_0656: ldc.i4.4
-			IL_0657: newarr [System.Runtime]System.Object
-			IL_065c: dup
-			IL_065d: ldc.i4.0
-			IL_065e: ldstr "HMAC"
-			IL_0663: stelem.ref
-			IL_0664: dup
-			IL_0665: ldc.i4.1
-			IL_0666: ldloc.s 4
-			IL_0668: stelem.ref
-			IL_0669: dup
-			IL_066a: ldc.i4.2
-			IL_066b: ldloc.s 5
-			IL_066d: stelem.ref
-			IL_066e: dup
-			IL_066f: ldc.i4.3
-			IL_0670: ldloc.s 9
-			IL_0672: stelem.ref
-			IL_0673: stloc.s 13
-			IL_0675: ldloc.1
-			IL_0676: ldstr "verify"
-			IL_067b: ldloc.s 13
-			IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0682: stloc.s 8
-			IL_0684: ldloc.0
-			IL_0685: ldc.i4.7
-			IL_0686: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_068b: ldloc.0
-			IL_068c: ldloc.s 8
-			IL_068e: ldarg.0
-			IL_068f: ldc.i4.7
-			IL_0690: ldloc.0
-			IL_0691: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0696: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_069b: ldloc.0
-			IL_069c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05e4: ldloc.0
+			IL_05e5: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited6
+			IL_05ea: stloc.s 9
+			IL_05ec: ldloc.s 9
+			IL_05ee: stloc.s 5
+			IL_05f0: ldloc.s 5
+			IL_05f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_05f7: stloc.s 10
+			IL_05f9: ldloc.s 10
+			IL_05fb: stloc.s 6
+			IL_05fd: ldloc.s 6
+			IL_05ff: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0604: stloc.s 11
+			IL_0606: ldloc.s 11
+			IL_0608: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_060d: stloc.s 8
+			IL_060f: ldloc.s 8
+			IL_0611: ldstr "toString"
+			IL_0616: ldstr "hex"
+			IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0620: stloc.s 9
+			IL_0622: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0627: ldstr "signature hex:"
+			IL_062c: ldloc.s 9
+			IL_062e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0633: pop
+			IL_0634: ldstr "abc"
+			IL_0639: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_063e: stloc.s 8
+			IL_0640: ldc.i4.4
+			IL_0641: newarr [System.Runtime]System.Object
+			IL_0646: dup
+			IL_0647: ldc.i4.0
+			IL_0648: ldstr "HMAC"
+			IL_064d: stelem.ref
+			IL_064e: dup
+			IL_064f: ldc.i4.1
+			IL_0650: ldloc.s 4
+			IL_0652: stelem.ref
+			IL_0653: dup
+			IL_0654: ldc.i4.2
+			IL_0655: ldloc.s 5
+			IL_0657: stelem.ref
+			IL_0658: dup
+			IL_0659: ldc.i4.3
+			IL_065a: ldloc.s 8
+			IL_065c: stelem.ref
+			IL_065d: stloc.s 13
+			IL_065f: ldloc.1
+			IL_0660: ldstr "verify"
+			IL_0665: ldloc.s 13
+			IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_066c: stloc.s 9
+			IL_066e: ldloc.0
+			IL_066f: ldc.i4.7
+			IL_0670: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0675: ldloc.0
+			IL_0676: ldloc.s 9
+			IL_0678: ldarg.0
+			IL_0679: ldc.i4.7
+			IL_067a: ldloc.0
+			IL_067b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0680: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0685: ldloc.0
+			IL_0686: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_068b: dup
+			IL_068c: ldc.i4.0
+			IL_068d: ldloc.1
+			IL_068e: stelem.ref
+			IL_068f: dup
+			IL_0690: ldc.i4.1
+			IL_0691: ldloc.2
+			IL_0692: stelem.ref
+			IL_0693: dup
+			IL_0694: ldc.i4.2
+			IL_0695: ldloc.3
+			IL_0696: stelem.ref
+			IL_0697: dup
+			IL_0698: ldc.i4.3
+			IL_0699: ldloc.s 4
+			IL_069b: stelem.ref
+			IL_069c: dup
+			IL_069d: ldc.i4.4
+			IL_069e: ldloc.s 5
+			IL_06a0: stelem.ref
 			IL_06a1: dup
-			IL_06a2: ldc.i4.0
-			IL_06a3: ldloc.1
-			IL_06a4: stelem.ref
-			IL_06a5: dup
-			IL_06a6: ldc.i4.1
-			IL_06a7: ldloc.2
-			IL_06a8: stelem.ref
-			IL_06a9: dup
-			IL_06aa: ldc.i4.2
-			IL_06ab: ldloc.3
-			IL_06ac: stelem.ref
-			IL_06ad: dup
-			IL_06ae: ldc.i4.3
-			IL_06af: ldloc.s 4
-			IL_06b1: stelem.ref
-			IL_06b2: dup
-			IL_06b3: ldc.i4.4
-			IL_06b4: ldloc.s 5
-			IL_06b6: stelem.ref
-			IL_06b7: dup
-			IL_06b8: ldc.i4.5
-			IL_06b9: ldloc.s 6
-			IL_06bb: stelem.ref
-			IL_06bc: dup
-			IL_06bd: ldc.i4.6
-			IL_06be: ldloc.s 7
-			IL_06c0: stelem.ref
-			IL_06c1: pop
-			IL_06c2: ldloc.0
-			IL_06c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06c8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06cd: ret
+			IL_06a2: ldc.i4.5
+			IL_06a3: ldloc.s 6
+			IL_06a5: stelem.ref
+			IL_06a6: dup
+			IL_06a7: ldc.i4.6
+			IL_06a8: ldloc.s 7
+			IL_06aa: stelem.ref
+			IL_06ab: pop
+			IL_06ac: ldloc.0
+			IL_06ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06b2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06b7: ret
 
-			IL_06ce: ldloc.0
-			IL_06cf: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited7
-			IL_06d4: stloc.s 8
-			IL_06d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06db: ldstr "verify true:"
-			IL_06e0: ldloc.s 8
-			IL_06e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_06e7: pop
-			IL_06e8: ldloc.s 6
-			IL_06ea: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_06ef: stloc.s 11
-			IL_06f1: ldloc.s 11
-			IL_06f3: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_06f8: stloc.s 9
-			IL_06fa: ldloc.s 9
-			IL_06fc: stloc.s 7
-			IL_06fe: ldloc.s 7
-			IL_0700: ldc.r8 0.0
-			IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_070e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0713: conv.i4
-			IL_0714: ldc.r8 255
-			IL_071d: conv.i4
-			IL_071e: xor
-			IL_071f: conv.r8
-			IL_0720: stloc.s 14
-			IL_0722: ldloc.s 14
-			IL_0724: conv.i4
-			IL_0725: ldc.r8 255
-			IL_072e: conv.i4
-			IL_072f: and
-			IL_0730: conv.r8
-			IL_0731: stloc.s 14
-			IL_0733: ldloc.s 7
-			IL_0735: ldc.r8 0.0
-			IL_073e: ldloc.s 14
-			IL_0740: ldc.i4.1
-			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-			IL_0746: pop
-			IL_0747: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_074c: dup
-			IL_074d: ldstr "name"
-			IL_0752: ldstr "HMAC"
-			IL_0757: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_075c: stloc.s 12
-			IL_075e: ldstr "abc"
-			IL_0763: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0768: stloc.s 9
-			IL_076a: ldc.i4.4
-			IL_076b: newarr [System.Runtime]System.Object
-			IL_0770: dup
-			IL_0771: ldc.i4.0
-			IL_0772: ldloc.s 12
-			IL_0774: stelem.ref
-			IL_0775: dup
-			IL_0776: ldc.i4.1
-			IL_0777: ldloc.s 4
-			IL_0779: stelem.ref
-			IL_077a: dup
-			IL_077b: ldc.i4.2
-			IL_077c: ldloc.s 7
-			IL_077e: stelem.ref
-			IL_077f: dup
-			IL_0780: ldc.i4.3
-			IL_0781: ldloc.s 9
-			IL_0783: stelem.ref
-			IL_0784: stloc.s 13
-			IL_0786: ldloc.1
-			IL_0787: ldstr "verify"
-			IL_078c: ldloc.s 13
-			IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0793: stloc.s 8
-			IL_0795: ldloc.0
-			IL_0796: ldc.i4.8
-			IL_0797: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_079c: ldloc.0
-			IL_079d: ldloc.s 8
-			IL_079f: ldarg.0
-			IL_07a0: ldc.i4.8
-			IL_07a1: ldloc.0
-			IL_07a2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_07ac: ldloc.0
-			IL_07ad: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_06b8: ldloc.0
+			IL_06b9: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited7
+			IL_06be: stloc.s 9
+			IL_06c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06c5: ldstr "verify true:"
+			IL_06ca: ldloc.s 9
+			IL_06cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_06d1: pop
+			IL_06d2: ldloc.s 6
+			IL_06d4: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_06d9: stloc.s 11
+			IL_06db: ldloc.s 11
+			IL_06dd: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_06e2: stloc.s 8
+			IL_06e4: ldloc.s 8
+			IL_06e6: stloc.s 7
+			IL_06e8: ldloc.s 7
+			IL_06ea: ldc.r8 0.0
+			IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_06f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_06fd: conv.i4
+			IL_06fe: ldc.r8 255
+			IL_0707: conv.i4
+			IL_0708: xor
+			IL_0709: conv.r8
+			IL_070a: stloc.s 14
+			IL_070c: ldloc.s 14
+			IL_070e: conv.i4
+			IL_070f: ldc.r8 255
+			IL_0718: conv.i4
+			IL_0719: and
+			IL_071a: conv.r8
+			IL_071b: stloc.s 14
+			IL_071d: ldloc.s 7
+			IL_071f: ldc.r8 0.0
+			IL_0728: ldloc.s 14
+			IL_072a: ldc.i4.1
+			IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+			IL_0730: pop
+			IL_0731: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0736: dup
+			IL_0737: ldstr "name"
+			IL_073c: ldstr "HMAC"
+			IL_0741: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0746: stloc.s 12
+			IL_0748: ldstr "abc"
+			IL_074d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0752: stloc.s 8
+			IL_0754: ldc.i4.4
+			IL_0755: newarr [System.Runtime]System.Object
+			IL_075a: dup
+			IL_075b: ldc.i4.0
+			IL_075c: ldloc.s 12
+			IL_075e: stelem.ref
+			IL_075f: dup
+			IL_0760: ldc.i4.1
+			IL_0761: ldloc.s 4
+			IL_0763: stelem.ref
+			IL_0764: dup
+			IL_0765: ldc.i4.2
+			IL_0766: ldloc.s 7
+			IL_0768: stelem.ref
+			IL_0769: dup
+			IL_076a: ldc.i4.3
+			IL_076b: ldloc.s 8
+			IL_076d: stelem.ref
+			IL_076e: stloc.s 13
+			IL_0770: ldloc.1
+			IL_0771: ldstr "verify"
+			IL_0776: ldloc.s 13
+			IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_077d: stloc.s 9
+			IL_077f: ldloc.0
+			IL_0780: ldc.i4.8
+			IL_0781: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0786: ldloc.0
+			IL_0787: ldloc.s 9
+			IL_0789: ldarg.0
+			IL_078a: ldc.i4.8
+			IL_078b: ldloc.0
+			IL_078c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0791: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0796: ldloc.0
+			IL_0797: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_079c: dup
+			IL_079d: ldc.i4.0
+			IL_079e: ldloc.1
+			IL_079f: stelem.ref
+			IL_07a0: dup
+			IL_07a1: ldc.i4.1
+			IL_07a2: ldloc.2
+			IL_07a3: stelem.ref
+			IL_07a4: dup
+			IL_07a5: ldc.i4.2
+			IL_07a6: ldloc.3
+			IL_07a7: stelem.ref
+			IL_07a8: dup
+			IL_07a9: ldc.i4.3
+			IL_07aa: ldloc.s 4
+			IL_07ac: stelem.ref
+			IL_07ad: dup
+			IL_07ae: ldc.i4.4
+			IL_07af: ldloc.s 5
+			IL_07b1: stelem.ref
 			IL_07b2: dup
-			IL_07b3: ldc.i4.0
-			IL_07b4: ldloc.1
-			IL_07b5: stelem.ref
-			IL_07b6: dup
-			IL_07b7: ldc.i4.1
-			IL_07b8: ldloc.2
-			IL_07b9: stelem.ref
-			IL_07ba: dup
-			IL_07bb: ldc.i4.2
-			IL_07bc: ldloc.3
-			IL_07bd: stelem.ref
-			IL_07be: dup
-			IL_07bf: ldc.i4.3
-			IL_07c0: ldloc.s 4
-			IL_07c2: stelem.ref
-			IL_07c3: dup
-			IL_07c4: ldc.i4.4
-			IL_07c5: ldloc.s 5
-			IL_07c7: stelem.ref
-			IL_07c8: dup
-			IL_07c9: ldc.i4.5
-			IL_07ca: ldloc.s 6
-			IL_07cc: stelem.ref
-			IL_07cd: dup
-			IL_07ce: ldc.i4.6
-			IL_07cf: ldloc.s 7
-			IL_07d1: stelem.ref
-			IL_07d2: pop
-			IL_07d3: ldloc.0
-			IL_07d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07de: ret
+			IL_07b3: ldc.i4.5
+			IL_07b4: ldloc.s 6
+			IL_07b6: stelem.ref
+			IL_07b7: dup
+			IL_07b8: ldc.i4.6
+			IL_07b9: ldloc.s 7
+			IL_07bb: stelem.ref
+			IL_07bc: pop
+			IL_07bd: ldloc.0
+			IL_07be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07c3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07c8: ret
 
-			IL_07df: ldloc.0
-			IL_07e0: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited8
-			IL_07e5: stloc.s 8
-			IL_07e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07ec: ldstr "verify false:"
-			IL_07f1: ldloc.s 8
-			IL_07f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_07f8: pop
-			IL_07f9: ldloc.0
-			IL_07fa: ldc.i4.m1
-			IL_07fb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0800: ldloc.0
-			IL_0801: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0806: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_080b: ldarg.0
-			IL_080c: ldc.i4.1
-			IL_080d: newarr [System.Runtime]System.Object
-			IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0817: pop
-			IL_0818: ldloc.0
-			IL_0819: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_081e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0823: ret
+			IL_07c9: ldloc.0
+			IL_07ca: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited8
+			IL_07cf: stloc.s 9
+			IL_07d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07d6: ldstr "verify false:"
+			IL_07db: ldloc.s 9
+			IL_07dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_07e2: pop
+			IL_07e3: ldloc.0
+			IL_07e4: ldc.i4.m1
+			IL_07e5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07ea: ldloc.0
+			IL_07eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_07f5: ldarg.0
+			IL_07f6: ldc.i4.1
+			IL_07f7: newarr [System.Runtime]System.Object
+			IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0801: pop
+			IL_0802: ldloc.0
+			IL_0803: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0808: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_080d: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -991,7 +983,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2948
+				// Method begins at RVA 0x2927
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1014,7 +1006,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2918
+			// Method begins at RVA 0x2902
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -1045,18 +1037,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x292b
+			// Method begins at RVA 0x2915
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_Crypto_WebCrypto_Subtle/Scope::crypto
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1149,7 +1138,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2951
+		// Method begins at RVA 0x2930
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/tests/Js2IL.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f6d
+				// Method begins at RVA 0x2ec9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2f88
+						// Method begins at RVA 0x2ee4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f7f
+					// Method begins at RVA 0x2edb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f76
+				// Method begins at RVA 0x2ed2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,9 +116,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b8
+			// Method begins at RVA 0x21a4
 			// Header size: 12
-			// Code size: 1161 (0x489)
+			// Code size: 1133 (0x46d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope,
@@ -232,384 +232,376 @@
 
 			IL_00bb: ldloc.0
 			IL_00bc: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c1: switch (IL_00da, IL_02d6, IL_038e, IL_023d, IL_0382)
+			IL_00c1: switch (IL_00da, IL_02ba, IL_0372, IL_0221, IL_0366)
 
 			IL_00da: ldarg.0
 			IL_00db: ldc.i4.1
 			IL_00dc: ldelem.ref
 			IL_00dd: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 			IL_00e2: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_00e7: ldstr "Cannot access 'EventEmitter' before initialization"
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00f1: stloc.s 12
-			IL_00f3: ldloc.s 12
-			IL_00f5: ldc.i4.0
-			IL_00f6: newarr [System.Runtime]System.Object
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0100: stloc.s 12
-			IL_0102: ldloc.s 12
-			IL_0104: stloc.1
-			IL_0105: ldarg.0
-			IL_0106: ldc.i4.1
-			IL_0107: ldelem.ref
-			IL_0108: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_010d: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_0112: ldstr "Cannot access 'events' before initialization"
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_011c: stloc.s 12
-			IL_011e: ldloc.s 12
-			IL_0120: ldstr "on"
-			IL_0125: ldloc.1
-			IL_0126: ldstr "tick"
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0130: stloc.s 12
-			IL_0132: ldloc.s 12
-			IL_0134: stloc.2
-			IL_0135: ldloc.1
-			IL_0136: ldstr "emit"
-			IL_013b: ldstr "tick"
-			IL_0140: ldc.r8 1
-			IL_0149: box [System.Runtime]System.Double
-			IL_014e: ldc.r8 2
-			IL_0157: box [System.Runtime]System.Double
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0161: pop
-			IL_0162: ldloc.1
-			IL_0163: ldstr "emit"
-			IL_0168: ldstr "tick"
-			IL_016d: ldc.r8 3
-			IL_0176: box [System.Runtime]System.Double
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0180: pop
-			IL_0181: ldc.r8 0.0
-			IL_018a: stloc.3
-			IL_018b: ldloc.2
-			IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_0191: stloc.s 4
+			IL_00e7: ldc.i4.0
+			IL_00e8: newarr [System.Runtime]System.Object
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00f2: stloc.s 12
+			IL_00f4: ldloc.s 12
+			IL_00f6: stloc.1
+			IL_00f7: ldarg.0
+			IL_00f8: ldc.i4.1
+			IL_00f9: ldelem.ref
+			IL_00fa: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_00ff: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_0104: ldstr "on"
+			IL_0109: ldloc.1
+			IL_010a: ldstr "tick"
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0114: stloc.s 12
+			IL_0116: ldloc.s 12
+			IL_0118: stloc.2
+			IL_0119: ldloc.1
+			IL_011a: ldstr "emit"
+			IL_011f: ldstr "tick"
+			IL_0124: ldc.r8 1
+			IL_012d: box [System.Runtime]System.Double
+			IL_0132: ldc.r8 2
+			IL_013b: box [System.Runtime]System.Double
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0145: pop
+			IL_0146: ldloc.1
+			IL_0147: ldstr "emit"
+			IL_014c: ldstr "tick"
+			IL_0151: ldc.r8 3
+			IL_015a: box [System.Runtime]System.Double
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0164: pop
+			IL_0165: ldc.r8 0.0
+			IL_016e: stloc.3
+			IL_016f: ldloc.2
+			IL_0170: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_0175: stloc.s 4
+			IL_0177: ldc.i4.0
+			IL_0178: stloc.s 5
+			IL_017a: ldc.i4.0
+			IL_017b: stloc.s 6
+			IL_017d: ldloc.0
+			IL_017e: ldc.i4.0
+			IL_017f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0184: ldloc.0
+			IL_0185: ldc.i4.0
+			IL_0186: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_018b: ldloc.0
+			IL_018c: ldc.i4.0
+			IL_018d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0192: ldloc.0
 			IL_0193: ldc.i4.0
-			IL_0194: stloc.s 5
-			IL_0196: ldc.i4.0
-			IL_0197: stloc.s 6
-			IL_0199: ldloc.0
-			IL_019a: ldc.i4.0
-			IL_019b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01a0: ldloc.0
-			IL_01a1: ldc.i4.0
-			IL_01a2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_01a7: ldloc.0
-			IL_01a8: ldc.i4.0
-			IL_01a9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01ae: ldloc.0
-			IL_01af: ldc.i4.0
-			IL_01b0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0194: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_01b5: ldloc.s 4
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_01bc: stloc.s 12
-			IL_01be: ldloc.0
-			IL_01bf: ldc.i4.3
-			IL_01c0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01c5: ldloc.0
-			IL_01c6: ldloc.s 12
-			IL_01c8: ldarg.0
-			IL_01c9: ldc.i4.1
-			IL_01ca: ldloc.0
-			IL_01cb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01d0: ldc.i4.1
-			IL_01d1: ldstr "_pendingException"
-			IL_01d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_01db: ldloc.0
-			IL_01dc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01e1: dup
-			IL_01e2: ldc.i4.0
-			IL_01e3: ldloc.1
+			IL_0199: ldloc.s 4
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_01a0: stloc.s 12
+			IL_01a2: ldloc.0
+			IL_01a3: ldc.i4.3
+			IL_01a4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01a9: ldloc.0
+			IL_01aa: ldloc.s 12
+			IL_01ac: ldarg.0
+			IL_01ad: ldc.i4.1
+			IL_01ae: ldloc.0
+			IL_01af: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01b4: ldc.i4.1
+			IL_01b5: ldstr "_pendingException"
+			IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_01bf: ldloc.0
+			IL_01c0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01c5: dup
+			IL_01c6: ldc.i4.0
+			IL_01c7: ldloc.1
+			IL_01c8: stelem.ref
+			IL_01c9: dup
+			IL_01ca: ldc.i4.1
+			IL_01cb: ldloc.2
+			IL_01cc: stelem.ref
+			IL_01cd: dup
+			IL_01ce: ldc.i4.2
+			IL_01cf: ldloc.3
+			IL_01d0: box [System.Runtime]System.Double
+			IL_01d5: stelem.ref
+			IL_01d6: dup
+			IL_01d7: ldc.i4.3
+			IL_01d8: ldloc.s 4
+			IL_01da: stelem.ref
+			IL_01db: dup
+			IL_01dc: ldc.i4.4
+			IL_01dd: ldloc.s 5
+			IL_01df: box [System.Runtime]System.Boolean
 			IL_01e4: stelem.ref
 			IL_01e5: dup
-			IL_01e6: ldc.i4.1
-			IL_01e7: ldloc.2
-			IL_01e8: stelem.ref
-			IL_01e9: dup
-			IL_01ea: ldc.i4.2
-			IL_01eb: ldloc.3
-			IL_01ec: box [System.Runtime]System.Double
-			IL_01f1: stelem.ref
-			IL_01f2: dup
-			IL_01f3: ldc.i4.3
-			IL_01f4: ldloc.s 4
-			IL_01f6: stelem.ref
-			IL_01f7: dup
-			IL_01f8: ldc.i4.4
-			IL_01f9: ldloc.s 5
-			IL_01fb: box [System.Runtime]System.Boolean
-			IL_0200: stelem.ref
-			IL_0201: dup
-			IL_0202: ldc.i4.5
-			IL_0203: ldloc.s 6
-			IL_0205: box [System.Runtime]System.Boolean
-			IL_020a: stelem.ref
-			IL_020b: dup
-			IL_020c: ldc.i4.6
-			IL_020d: ldloc.s 7
-			IL_020f: stelem.ref
-			IL_0210: dup
-			IL_0211: ldc.i4.7
-			IL_0212: ldloc.s 8
-			IL_0214: stelem.ref
-			IL_0215: dup
-			IL_0216: ldc.i4.8
-			IL_0217: ldloc.s 9
-			IL_0219: stelem.ref
-			IL_021a: dup
-			IL_021b: ldc.i4.s 9
-			IL_021d: ldloc.s 10
-			IL_021f: box [System.Runtime]System.Boolean
-			IL_0224: stelem.ref
-			IL_0225: dup
-			IL_0226: ldc.i4.s 10
-			IL_0228: ldloc.s 11
-			IL_022a: box [System.Runtime]System.Boolean
-			IL_022f: stelem.ref
-			IL_0230: pop
-			IL_0231: ldloc.0
-			IL_0232: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0237: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_023c: ret
+			IL_01e6: ldc.i4.5
+			IL_01e7: ldloc.s 6
+			IL_01e9: box [System.Runtime]System.Boolean
+			IL_01ee: stelem.ref
+			IL_01ef: dup
+			IL_01f0: ldc.i4.6
+			IL_01f1: ldloc.s 7
+			IL_01f3: stelem.ref
+			IL_01f4: dup
+			IL_01f5: ldc.i4.7
+			IL_01f6: ldloc.s 8
+			IL_01f8: stelem.ref
+			IL_01f9: dup
+			IL_01fa: ldc.i4.8
+			IL_01fb: ldloc.s 9
+			IL_01fd: stelem.ref
+			IL_01fe: dup
+			IL_01ff: ldc.i4.s 9
+			IL_0201: ldloc.s 10
+			IL_0203: box [System.Runtime]System.Boolean
+			IL_0208: stelem.ref
+			IL_0209: dup
+			IL_020a: ldc.i4.s 10
+			IL_020c: ldloc.s 11
+			IL_020e: box [System.Runtime]System.Boolean
+			IL_0213: stelem.ref
+			IL_0214: pop
+			IL_0215: ldloc.0
+			IL_0216: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_021b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0220: ret
 
-			IL_023d: ldloc.0
-			IL_023e: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited1
-			IL_0243: stloc.s 12
-			IL_0245: ldloc.s 12
-			IL_0247: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_024c: stloc.s 13
-			IL_024e: ldloc.s 13
-			IL_0250: brtrue IL_02ce
+			IL_0221: ldloc.0
+			IL_0222: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited1
+			IL_0227: stloc.s 12
+			IL_0229: ldloc.s 12
+			IL_022b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0230: stloc.s 13
+			IL_0232: ldloc.s 13
+			IL_0234: brtrue IL_02b2
 
-			IL_0255: ldloc.s 12
-			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_025c: stloc.s 12
-			IL_025e: ldloc.s 12
-			IL_0260: stloc.s 7
-			IL_0262: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope_ForOf_L14C13/Block_L14C37::.ctor()
-			IL_0267: stloc.s 8
-			IL_0269: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_026e: ldloc.s 7
-			IL_0270: ldstr "length"
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_027f: pop
-			IL_0280: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0285: ldloc.s 7
-			IL_0287: ldc.r8 0.0
-			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0295: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_029a: pop
-			IL_029b: ldloc.3
-			IL_029c: ldc.r8 1
-			IL_02a5: add
-			IL_02a6: stloc.3
-			IL_02a7: ldloc.3
-			IL_02a8: ldc.r8 2
-			IL_02b1: ceq
-			IL_02b3: brfalse IL_02c4
+			IL_0239: ldloc.s 12
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_0240: stloc.s 12
+			IL_0242: ldloc.s 12
+			IL_0244: stloc.s 7
+			IL_0246: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope_ForOf_L14C13/Block_L14C37::.ctor()
+			IL_024b: stloc.s 8
+			IL_024d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0252: ldloc.s 7
+			IL_0254: ldstr "length"
+			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0263: pop
+			IL_0264: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0269: ldloc.s 7
+			IL_026b: ldc.r8 0.0
+			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_027e: pop
+			IL_027f: ldloc.3
+			IL_0280: ldc.r8 1
+			IL_0289: add
+			IL_028a: stloc.3
+			IL_028b: ldloc.3
+			IL_028c: ldc.r8 2
+			IL_0295: ceq
+			IL_0297: brfalse IL_02a8
 
-			IL_02b8: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope_ForOf_L14C13/Block_L14C37/Block_L18C21::.ctor()
-			IL_02bd: stloc.s 9
-			IL_02bf: br IL_02c9
+			IL_029c: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope_ForOf_L14C13/Block_L14C37/Block_L18C21::.ctor()
+			IL_02a1: stloc.s 9
+			IL_02a3: br IL_02ad
 
-			IL_02c4: br IL_01b5
+			IL_02a8: br IL_0199
 
-			IL_02c9: br IL_02e9
+			IL_02ad: br IL_02cd
 
-			IL_02ce: ldc.i4.1
-			IL_02cf: stloc.s 5
-			IL_02d1: br IL_02e9
+			IL_02b2: ldc.i4.1
+			IL_02b3: stloc.s 5
+			IL_02b5: br IL_02cd
 
-			IL_02d6: ldloc.0
-			IL_02d7: ldc.i4.1
-			IL_02d8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02dd: ldloc.0
-			IL_02de: ldc.i4.0
-			IL_02df: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02e4: br IL_02e9
+			IL_02ba: ldloc.0
+			IL_02bb: ldc.i4.1
+			IL_02bc: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02c1: ldloc.0
+			IL_02c2: ldc.i4.0
+			IL_02c3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02c8: br IL_02cd
 
-			IL_02e9: ldloc.s 5
-			IL_02eb: brtrue IL_0389
+			IL_02cd: ldloc.s 5
+			IL_02cf: brtrue IL_036d
 
-			IL_02f0: ldloc.s 6
-			IL_02f2: brtrue IL_0389
+			IL_02d4: ldloc.s 6
+			IL_02d6: brtrue IL_036d
 
-			IL_02f7: ldc.i4.1
-			IL_02f8: stloc.s 6
-			IL_02fa: ldloc.s 4
-			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_0301: stloc.s 12
-			IL_0303: ldloc.0
-			IL_0304: ldc.i4.4
-			IL_0305: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_030a: ldloc.0
-			IL_030b: ldloc.s 12
-			IL_030d: ldarg.0
-			IL_030e: ldc.i4.2
-			IL_030f: ldloc.0
-			IL_0310: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0315: ldc.i4.2
-			IL_0316: ldstr "_pendingException"
-			IL_031b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0320: ldloc.0
-			IL_0321: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0326: dup
-			IL_0327: ldc.i4.0
-			IL_0328: ldloc.1
+			IL_02db: ldc.i4.1
+			IL_02dc: stloc.s 6
+			IL_02de: ldloc.s 4
+			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_02e5: stloc.s 12
+			IL_02e7: ldloc.0
+			IL_02e8: ldc.i4.4
+			IL_02e9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02ee: ldloc.0
+			IL_02ef: ldloc.s 12
+			IL_02f1: ldarg.0
+			IL_02f2: ldc.i4.2
+			IL_02f3: ldloc.0
+			IL_02f4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02f9: ldc.i4.2
+			IL_02fa: ldstr "_pendingException"
+			IL_02ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0304: ldloc.0
+			IL_0305: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_030a: dup
+			IL_030b: ldc.i4.0
+			IL_030c: ldloc.1
+			IL_030d: stelem.ref
+			IL_030e: dup
+			IL_030f: ldc.i4.1
+			IL_0310: ldloc.2
+			IL_0311: stelem.ref
+			IL_0312: dup
+			IL_0313: ldc.i4.2
+			IL_0314: ldloc.3
+			IL_0315: box [System.Runtime]System.Double
+			IL_031a: stelem.ref
+			IL_031b: dup
+			IL_031c: ldc.i4.3
+			IL_031d: ldloc.s 4
+			IL_031f: stelem.ref
+			IL_0320: dup
+			IL_0321: ldc.i4.4
+			IL_0322: ldloc.s 5
+			IL_0324: box [System.Runtime]System.Boolean
 			IL_0329: stelem.ref
 			IL_032a: dup
-			IL_032b: ldc.i4.1
-			IL_032c: ldloc.2
-			IL_032d: stelem.ref
-			IL_032e: dup
-			IL_032f: ldc.i4.2
-			IL_0330: ldloc.3
-			IL_0331: box [System.Runtime]System.Double
-			IL_0336: stelem.ref
-			IL_0337: dup
-			IL_0338: ldc.i4.3
-			IL_0339: ldloc.s 4
-			IL_033b: stelem.ref
-			IL_033c: dup
-			IL_033d: ldc.i4.4
-			IL_033e: ldloc.s 5
-			IL_0340: box [System.Runtime]System.Boolean
-			IL_0345: stelem.ref
-			IL_0346: dup
-			IL_0347: ldc.i4.5
-			IL_0348: ldloc.s 6
-			IL_034a: box [System.Runtime]System.Boolean
-			IL_034f: stelem.ref
-			IL_0350: dup
-			IL_0351: ldc.i4.6
-			IL_0352: ldloc.s 7
-			IL_0354: stelem.ref
-			IL_0355: dup
-			IL_0356: ldc.i4.7
-			IL_0357: ldloc.s 8
-			IL_0359: stelem.ref
-			IL_035a: dup
-			IL_035b: ldc.i4.8
-			IL_035c: ldloc.s 9
-			IL_035e: stelem.ref
-			IL_035f: dup
-			IL_0360: ldc.i4.s 9
-			IL_0362: ldloc.s 10
-			IL_0364: box [System.Runtime]System.Boolean
-			IL_0369: stelem.ref
-			IL_036a: dup
-			IL_036b: ldc.i4.s 10
-			IL_036d: ldloc.s 11
-			IL_036f: box [System.Runtime]System.Boolean
-			IL_0374: stelem.ref
-			IL_0375: pop
-			IL_0376: ldloc.0
-			IL_0377: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_037c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0381: ret
+			IL_032b: ldc.i4.5
+			IL_032c: ldloc.s 6
+			IL_032e: box [System.Runtime]System.Boolean
+			IL_0333: stelem.ref
+			IL_0334: dup
+			IL_0335: ldc.i4.6
+			IL_0336: ldloc.s 7
+			IL_0338: stelem.ref
+			IL_0339: dup
+			IL_033a: ldc.i4.7
+			IL_033b: ldloc.s 8
+			IL_033d: stelem.ref
+			IL_033e: dup
+			IL_033f: ldc.i4.8
+			IL_0340: ldloc.s 9
+			IL_0342: stelem.ref
+			IL_0343: dup
+			IL_0344: ldc.i4.s 9
+			IL_0346: ldloc.s 10
+			IL_0348: box [System.Runtime]System.Boolean
+			IL_034d: stelem.ref
+			IL_034e: dup
+			IL_034f: ldc.i4.s 10
+			IL_0351: ldloc.s 11
+			IL_0353: box [System.Runtime]System.Boolean
+			IL_0358: stelem.ref
+			IL_0359: pop
+			IL_035a: ldloc.0
+			IL_035b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0360: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0365: ret
 
-			IL_0382: ldloc.0
-			IL_0383: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited2
-			IL_0388: pop
+			IL_0366: ldloc.0
+			IL_0367: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited2
+			IL_036c: pop
 
-			IL_0389: br IL_03a1
+			IL_036d: br IL_0385
 
-			IL_038e: ldloc.0
-			IL_038f: ldc.i4.1
-			IL_0390: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0395: ldloc.0
-			IL_0396: ldc.i4.0
-			IL_0397: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_039c: br IL_03a1
+			IL_0372: ldloc.0
+			IL_0373: ldc.i4.1
+			IL_0374: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0379: ldloc.0
+			IL_037a: ldc.i4.0
+			IL_037b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0380: br IL_0385
 
-			IL_03a1: ldloc.0
-			IL_03a2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_03a7: stloc.s 10
-			IL_03a9: ldloc.s 10
-			IL_03ab: brfalse IL_03e8
+			IL_0385: ldloc.0
+			IL_0386: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_038b: stloc.s 10
+			IL_038d: ldloc.s 10
+			IL_038f: brfalse IL_03cc
 
-			IL_03b0: ldloc.0
-			IL_03b1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_03b6: stloc.s 12
-			IL_03b8: ldloc.0
-			IL_03b9: ldc.i4.m1
-			IL_03ba: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03bf: ldloc.0
-			IL_03c0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_03ca: ldarg.0
-			IL_03cb: ldc.i4.1
-			IL_03cc: newarr [System.Runtime]System.Object
-			IL_03d1: dup
-			IL_03d2: ldc.i4.0
-			IL_03d3: ldloc.s 12
-			IL_03d5: stelem.ref
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03db: pop
-			IL_03dc: ldloc.0
-			IL_03dd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03e2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03e7: ret
+			IL_0394: ldloc.0
+			IL_0395: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_039a: stloc.s 12
+			IL_039c: ldloc.0
+			IL_039d: ldc.i4.m1
+			IL_039e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03a3: ldloc.0
+			IL_03a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_03ae: ldarg.0
+			IL_03af: ldc.i4.1
+			IL_03b0: newarr [System.Runtime]System.Object
+			IL_03b5: dup
+			IL_03b6: ldc.i4.0
+			IL_03b7: ldloc.s 12
+			IL_03b9: stelem.ref
+			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03bf: pop
+			IL_03c0: ldloc.0
+			IL_03c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03c6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03cb: ret
 
-			IL_03e8: ldloc.0
-			IL_03e9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_03ee: stloc.s 11
-			IL_03f0: ldloc.s 11
-			IL_03f2: brfalse IL_042f
+			IL_03cc: ldloc.0
+			IL_03cd: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_03d2: stloc.s 11
+			IL_03d4: ldloc.s 11
+			IL_03d6: brfalse IL_0413
 
-			IL_03f7: ldloc.0
-			IL_03f8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_03fd: stloc.s 12
-			IL_03ff: ldloc.0
-			IL_0400: ldc.i4.m1
-			IL_0401: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0406: ldloc.0
-			IL_0407: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_040c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0411: ldarg.0
-			IL_0412: ldc.i4.1
-			IL_0413: newarr [System.Runtime]System.Object
-			IL_0418: dup
-			IL_0419: ldc.i4.0
-			IL_041a: ldloc.s 12
-			IL_041c: stelem.ref
-			IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0422: pop
-			IL_0423: ldloc.0
-			IL_0424: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0429: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_042e: ret
+			IL_03db: ldloc.0
+			IL_03dc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_03e1: stloc.s 12
+			IL_03e3: ldloc.0
+			IL_03e4: ldc.i4.m1
+			IL_03e5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03ea: ldloc.0
+			IL_03eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03f5: ldarg.0
+			IL_03f6: ldc.i4.1
+			IL_03f7: newarr [System.Runtime]System.Object
+			IL_03fc: dup
+			IL_03fd: ldc.i4.0
+			IL_03fe: ldloc.s 12
+			IL_0400: stelem.ref
+			IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0406: pop
+			IL_0407: ldloc.0
+			IL_0408: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_040d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0412: ret
 
-			IL_042f: ldloc.1
-			IL_0430: ldstr "emit"
-			IL_0435: ldstr "tick"
-			IL_043a: ldc.r8 99
-			IL_0443: box [System.Runtime]System.Double
-			IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_044d: pop
-			IL_044e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0453: ldstr "break-done"
-			IL_0458: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_045d: pop
-			IL_045e: ldloc.0
-			IL_045f: ldc.i4.m1
-			IL_0460: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0465: ldloc.0
-			IL_0466: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_046b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0470: ldarg.0
-			IL_0471: ldc.i4.1
-			IL_0472: newarr [System.Runtime]System.Object
-			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_047c: pop
-			IL_047d: ldloc.0
-			IL_047e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0483: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0488: ret
+			IL_0413: ldloc.1
+			IL_0414: ldstr "emit"
+			IL_0419: ldstr "tick"
+			IL_041e: ldc.r8 99
+			IL_0427: box [System.Runtime]System.Double
+			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0431: pop
+			IL_0432: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0437: ldstr "break-done"
+			IL_043c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0441: pop
+			IL_0442: ldloc.0
+			IL_0443: ldc.i4.m1
+			IL_0444: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0449: ldloc.0
+			IL_044a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_044f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0454: ldarg.0
+			IL_0455: ldc.i4.1
+			IL_0456: newarr [System.Runtime]System.Object
+			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0460: pop
+			IL_0461: ldloc.0
+			IL_0462: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0467: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_046c: ret
 		} // end of method runOnBreak::__js_call__
 
 	} // end of class runOnBreak
@@ -642,7 +634,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fae
+						// Method begins at RVA 0x2eff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -666,7 +658,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2fc0
+							// Method begins at RVA 0x2f11
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -684,7 +676,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fb7
+						// Method begins at RVA 0x2f08
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -704,7 +696,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fc9
+						// Method begins at RVA 0x2f1a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -728,7 +720,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fa5
+					// Method begins at RVA 0x2ef6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -752,9 +744,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bb4
+				// Method begins at RVA 0x2b34
 				// Header size: 12
-				// Code size: 910 (0x38e)
+				// Code size: 896 (0x380)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope,
@@ -862,7 +854,7 @@
 
 				IL_00b0: ldloc.0
 				IL_00b1: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_00b6: switch (IL_00d3, IL_0334, IL_01f6, IL_02a1, IL_019e, IL_0295)
+				IL_00b6: switch (IL_00d3, IL_0326, IL_01e8, IL_0293, IL_0190, IL_0287)
 
 				IL_00d3: ldloc.0
 				IL_00d4: ldc.i4.0
@@ -874,303 +866,299 @@
 				IL_00e2: ldelem.ref
 				IL_00e3: castclass Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope
 				IL_00e8: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
-				IL_00ed: ldstr "Cannot access 'iterator' before initialization"
-				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00f7: stloc.s 11
-				IL_00f9: ldloc.s 11
-				IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-				IL_0100: stloc.2
-				IL_0101: ldc.i4.0
-				IL_0102: stloc.3
-				IL_0103: ldc.i4.0
-				IL_0104: stloc.s 4
+				IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+				IL_00f2: stloc.2
+				IL_00f3: ldc.i4.0
+				IL_00f4: stloc.3
+				IL_00f5: ldc.i4.0
+				IL_00f6: stloc.s 4
+				IL_00f8: ldloc.0
+				IL_00f9: ldc.i4.0
+				IL_00fa: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_00ff: ldloc.0
+				IL_0100: ldc.i4.0
+				IL_0101: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
 				IL_0106: ldloc.0
 				IL_0107: ldc.i4.0
-				IL_0108: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_0108: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
 				IL_010d: ldloc.0
 				IL_010e: ldc.i4.0
-				IL_010f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-				IL_0114: ldloc.0
-				IL_0115: ldc.i4.0
-				IL_0116: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_011b: ldloc.0
-				IL_011c: ldc.i4.0
-				IL_011d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_010f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-				IL_0122: ldloc.2
-				IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-				IL_0128: stloc.s 11
-				IL_012a: ldloc.0
-				IL_012b: ldc.i4.4
-				IL_012c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_0131: ldloc.0
-				IL_0132: ldloc.s 11
-				IL_0134: ldarg.0
-				IL_0135: ldc.i4.1
-				IL_0136: ldloc.0
-				IL_0137: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-				IL_013c: ldc.i4.2
-				IL_013d: ldstr "_pendingException"
-				IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-				IL_0147: ldloc.0
-				IL_0148: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-				IL_014d: dup
-				IL_014e: ldc.i4.0
-				IL_014f: ldloc.1
-				IL_0150: stelem.ref
-				IL_0151: dup
-				IL_0152: ldc.i4.1
-				IL_0153: ldloc.2
-				IL_0154: stelem.ref
-				IL_0155: dup
-				IL_0156: ldc.i4.2
-				IL_0157: ldloc.3
-				IL_0158: box [System.Runtime]System.Boolean
-				IL_015d: stelem.ref
-				IL_015e: dup
-				IL_015f: ldc.i4.3
-				IL_0160: ldloc.s 4
-				IL_0162: box [System.Runtime]System.Boolean
-				IL_0167: stelem.ref
-				IL_0168: dup
-				IL_0169: ldc.i4.4
-				IL_016a: ldloc.s 5
-				IL_016c: stelem.ref
-				IL_016d: dup
-				IL_016e: ldc.i4.5
-				IL_016f: ldloc.s 6
-				IL_0171: stelem.ref
-				IL_0172: dup
-				IL_0173: ldc.i4.6
-				IL_0174: ldloc.s 7
-				IL_0176: box [System.Runtime]System.Boolean
-				IL_017b: stelem.ref
-				IL_017c: dup
-				IL_017d: ldc.i4.7
-				IL_017e: ldloc.s 8
-				IL_0180: box [System.Runtime]System.Boolean
-				IL_0185: stelem.ref
-				IL_0186: dup
-				IL_0187: ldc.i4.8
-				IL_0188: ldloc.s 9
-				IL_018a: stelem.ref
-				IL_018b: dup
-				IL_018c: ldc.i4.s 9
-				IL_018e: ldloc.s 10
-				IL_0190: stelem.ref
-				IL_0191: pop
-				IL_0192: ldloc.0
-				IL_0193: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0198: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_019d: ret
+				IL_0114: ldloc.2
+				IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+				IL_011a: stloc.s 11
+				IL_011c: ldloc.0
+				IL_011d: ldc.i4.4
+				IL_011e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_0123: ldloc.0
+				IL_0124: ldloc.s 11
+				IL_0126: ldarg.0
+				IL_0127: ldc.i4.1
+				IL_0128: ldloc.0
+				IL_0129: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+				IL_012e: ldc.i4.2
+				IL_012f: ldstr "_pendingException"
+				IL_0134: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+				IL_0139: ldloc.0
+				IL_013a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+				IL_013f: dup
+				IL_0140: ldc.i4.0
+				IL_0141: ldloc.1
+				IL_0142: stelem.ref
+				IL_0143: dup
+				IL_0144: ldc.i4.1
+				IL_0145: ldloc.2
+				IL_0146: stelem.ref
+				IL_0147: dup
+				IL_0148: ldc.i4.2
+				IL_0149: ldloc.3
+				IL_014a: box [System.Runtime]System.Boolean
+				IL_014f: stelem.ref
+				IL_0150: dup
+				IL_0151: ldc.i4.3
+				IL_0152: ldloc.s 4
+				IL_0154: box [System.Runtime]System.Boolean
+				IL_0159: stelem.ref
+				IL_015a: dup
+				IL_015b: ldc.i4.4
+				IL_015c: ldloc.s 5
+				IL_015e: stelem.ref
+				IL_015f: dup
+				IL_0160: ldc.i4.5
+				IL_0161: ldloc.s 6
+				IL_0163: stelem.ref
+				IL_0164: dup
+				IL_0165: ldc.i4.6
+				IL_0166: ldloc.s 7
+				IL_0168: box [System.Runtime]System.Boolean
+				IL_016d: stelem.ref
+				IL_016e: dup
+				IL_016f: ldc.i4.7
+				IL_0170: ldloc.s 8
+				IL_0172: box [System.Runtime]System.Boolean
+				IL_0177: stelem.ref
+				IL_0178: dup
+				IL_0179: ldc.i4.8
+				IL_017a: ldloc.s 9
+				IL_017c: stelem.ref
+				IL_017d: dup
+				IL_017e: ldc.i4.s 9
+				IL_0180: ldloc.s 10
+				IL_0182: stelem.ref
+				IL_0183: pop
+				IL_0184: ldloc.0
+				IL_0185: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_018a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_018f: ret
 
-				IL_019e: ldloc.0
-				IL_019f: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited1
-				IL_01a4: stloc.s 11
-				IL_01a6: ldloc.s 11
-				IL_01a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_01ad: stloc.s 12
-				IL_01af: ldloc.s 12
-				IL_01b1: brtrue IL_01ef
+				IL_0190: ldloc.0
+				IL_0191: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited1
+				IL_0196: stloc.s 11
+				IL_0198: ldloc.s 11
+				IL_019a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+				IL_019f: stloc.s 12
+				IL_01a1: ldloc.s 12
+				IL_01a3: brtrue IL_01e1
 
-				IL_01b6: ldloc.s 11
-				IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_01bd: stloc.s 11
-				IL_01bf: ldloc.s 11
-				IL_01c1: stloc.s 5
-				IL_01c3: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Scope_ForOf_L33C17/Block_L33C41::.ctor()
-				IL_01c8: stloc.s 6
-				IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_01cf: ldloc.s 5
-				IL_01d1: ldc.r8 0.0
-				IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_01e4: pop
-				IL_01e5: br IL_0122
+				IL_01a8: ldloc.s 11
+				IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+				IL_01af: stloc.s 11
+				IL_01b1: ldloc.s 11
+				IL_01b3: stloc.s 5
+				IL_01b5: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Scope_ForOf_L33C17/Block_L33C41::.ctor()
+				IL_01ba: stloc.s 6
+				IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_01c1: ldloc.s 5
+				IL_01c3: ldc.r8 0.0
+				IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_01d6: pop
+				IL_01d7: br IL_0114
 
-				IL_01ea: br IL_0209
+				IL_01dc: br IL_01fb
 
-				IL_01ef: ldc.i4.1
-				IL_01f0: stloc.3
-				IL_01f1: br IL_0209
+				IL_01e1: ldc.i4.1
+				IL_01e2: stloc.3
+				IL_01e3: br IL_01fb
 
-				IL_01f6: ldloc.0
-				IL_01f7: ldc.i4.1
-				IL_01f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_01fd: ldloc.0
-				IL_01fe: ldc.i4.0
-				IL_01ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_0204: br IL_0209
+				IL_01e8: ldloc.0
+				IL_01e9: ldc.i4.1
+				IL_01ea: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_01ef: ldloc.0
+				IL_01f0: ldc.i4.0
+				IL_01f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_01f6: br IL_01fb
 
-				IL_0209: ldloc.3
-				IL_020a: brtrue IL_029c
+				IL_01fb: ldloc.3
+				IL_01fc: brtrue IL_028e
 
-				IL_020f: ldloc.s 4
-				IL_0211: brtrue IL_029c
+				IL_0201: ldloc.s 4
+				IL_0203: brtrue IL_028e
 
-				IL_0216: ldc.i4.1
-				IL_0217: stloc.s 4
-				IL_0219: ldloc.2
-				IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-				IL_021f: stloc.s 11
-				IL_0221: ldloc.0
-				IL_0222: ldc.i4.5
-				IL_0223: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_0228: ldloc.0
-				IL_0229: ldloc.s 11
-				IL_022b: ldarg.0
-				IL_022c: ldc.i4.2
-				IL_022d: ldloc.0
-				IL_022e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-				IL_0233: ldc.i4.3
-				IL_0234: ldstr "_pendingException"
-				IL_0239: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-				IL_023e: ldloc.0
-				IL_023f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-				IL_0244: dup
-				IL_0245: ldc.i4.0
-				IL_0246: ldloc.1
-				IL_0247: stelem.ref
-				IL_0248: dup
-				IL_0249: ldc.i4.1
-				IL_024a: ldloc.2
-				IL_024b: stelem.ref
-				IL_024c: dup
-				IL_024d: ldc.i4.2
-				IL_024e: ldloc.3
-				IL_024f: box [System.Runtime]System.Boolean
-				IL_0254: stelem.ref
-				IL_0255: dup
-				IL_0256: ldc.i4.3
-				IL_0257: ldloc.s 4
-				IL_0259: box [System.Runtime]System.Boolean
-				IL_025e: stelem.ref
-				IL_025f: dup
-				IL_0260: ldc.i4.4
-				IL_0261: ldloc.s 5
-				IL_0263: stelem.ref
-				IL_0264: dup
-				IL_0265: ldc.i4.5
-				IL_0266: ldloc.s 6
-				IL_0268: stelem.ref
-				IL_0269: dup
-				IL_026a: ldc.i4.6
-				IL_026b: ldloc.s 7
-				IL_026d: box [System.Runtime]System.Boolean
-				IL_0272: stelem.ref
-				IL_0273: dup
-				IL_0274: ldc.i4.7
-				IL_0275: ldloc.s 8
-				IL_0277: box [System.Runtime]System.Boolean
-				IL_027c: stelem.ref
-				IL_027d: dup
-				IL_027e: ldc.i4.8
-				IL_027f: ldloc.s 9
-				IL_0281: stelem.ref
-				IL_0282: dup
-				IL_0283: ldc.i4.s 9
-				IL_0285: ldloc.s 10
-				IL_0287: stelem.ref
-				IL_0288: pop
-				IL_0289: ldloc.0
-				IL_028a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_028f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_0294: ret
+				IL_0208: ldc.i4.1
+				IL_0209: stloc.s 4
+				IL_020b: ldloc.2
+				IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+				IL_0211: stloc.s 11
+				IL_0213: ldloc.0
+				IL_0214: ldc.i4.5
+				IL_0215: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_021a: ldloc.0
+				IL_021b: ldloc.s 11
+				IL_021d: ldarg.0
+				IL_021e: ldc.i4.2
+				IL_021f: ldloc.0
+				IL_0220: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+				IL_0225: ldc.i4.3
+				IL_0226: ldstr "_pendingException"
+				IL_022b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+				IL_0230: ldloc.0
+				IL_0231: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+				IL_0236: dup
+				IL_0237: ldc.i4.0
+				IL_0238: ldloc.1
+				IL_0239: stelem.ref
+				IL_023a: dup
+				IL_023b: ldc.i4.1
+				IL_023c: ldloc.2
+				IL_023d: stelem.ref
+				IL_023e: dup
+				IL_023f: ldc.i4.2
+				IL_0240: ldloc.3
+				IL_0241: box [System.Runtime]System.Boolean
+				IL_0246: stelem.ref
+				IL_0247: dup
+				IL_0248: ldc.i4.3
+				IL_0249: ldloc.s 4
+				IL_024b: box [System.Runtime]System.Boolean
+				IL_0250: stelem.ref
+				IL_0251: dup
+				IL_0252: ldc.i4.4
+				IL_0253: ldloc.s 5
+				IL_0255: stelem.ref
+				IL_0256: dup
+				IL_0257: ldc.i4.5
+				IL_0258: ldloc.s 6
+				IL_025a: stelem.ref
+				IL_025b: dup
+				IL_025c: ldc.i4.6
+				IL_025d: ldloc.s 7
+				IL_025f: box [System.Runtime]System.Boolean
+				IL_0264: stelem.ref
+				IL_0265: dup
+				IL_0266: ldc.i4.7
+				IL_0267: ldloc.s 8
+				IL_0269: box [System.Runtime]System.Boolean
+				IL_026e: stelem.ref
+				IL_026f: dup
+				IL_0270: ldc.i4.8
+				IL_0271: ldloc.s 9
+				IL_0273: stelem.ref
+				IL_0274: dup
+				IL_0275: ldc.i4.s 9
+				IL_0277: ldloc.s 10
+				IL_0279: stelem.ref
+				IL_027a: pop
+				IL_027b: ldloc.0
+				IL_027c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_0281: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_0286: ret
 
-				IL_0295: ldloc.0
-				IL_0296: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited2
-				IL_029b: pop
+				IL_0287: ldloc.0
+				IL_0288: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited2
+				IL_028d: pop
 
-				IL_029c: br IL_02b4
+				IL_028e: br IL_02a6
 
-				IL_02a1: ldloc.0
-				IL_02a2: ldc.i4.1
-				IL_02a3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_02a8: ldloc.0
-				IL_02a9: ldc.i4.0
-				IL_02aa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_02af: br IL_02b4
+				IL_0293: ldloc.0
+				IL_0294: ldc.i4.1
+				IL_0295: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_029a: ldloc.0
+				IL_029b: ldc.i4.0
+				IL_029c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_02a1: br IL_02a6
 
-				IL_02b4: ldloc.0
-				IL_02b5: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_02ba: stloc.s 7
-				IL_02bc: ldloc.s 7
-				IL_02be: brfalse IL_02d8
+				IL_02a6: ldloc.0
+				IL_02a7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_02ac: stloc.s 7
+				IL_02ae: ldloc.s 7
+				IL_02b0: brfalse IL_02ca
 
-				IL_02c3: ldloc.0
-				IL_02c4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_02c9: stloc.s 11
-				IL_02cb: ldloc.0
-				IL_02cc: ldloc.s 11
-				IL_02ce: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_02d3: br IL_0334
+				IL_02b5: ldloc.0
+				IL_02b6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_02bb: stloc.s 11
+				IL_02bd: ldloc.0
+				IL_02be: ldloc.s 11
+				IL_02c0: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_02c5: br IL_0326
 
-				IL_02d8: ldloc.0
-				IL_02d9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_02de: stloc.s 8
-				IL_02e0: ldloc.s 8
-				IL_02e2: brfalse IL_031f
+				IL_02ca: ldloc.0
+				IL_02cb: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_02d0: stloc.s 8
+				IL_02d2: ldloc.s 8
+				IL_02d4: brfalse IL_0311
 
-				IL_02e7: ldloc.0
-				IL_02e8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-				IL_02ed: stloc.s 11
-				IL_02ef: ldloc.0
-				IL_02f0: ldc.i4.m1
-				IL_02f1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_02f6: ldloc.0
-				IL_02f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_02fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-				IL_0301: ldarg.0
-				IL_0302: ldc.i4.1
-				IL_0303: newarr [System.Runtime]System.Object
-				IL_0308: dup
-				IL_0309: ldc.i4.0
-				IL_030a: ldloc.s 11
-				IL_030c: stelem.ref
-				IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-				IL_0312: pop
-				IL_0313: ldloc.0
-				IL_0314: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0319: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_031e: ret
+				IL_02d9: ldloc.0
+				IL_02da: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+				IL_02df: stloc.s 11
+				IL_02e1: ldloc.0
+				IL_02e2: ldc.i4.m1
+				IL_02e3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_02e8: ldloc.0
+				IL_02e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_02ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+				IL_02f3: ldarg.0
+				IL_02f4: ldc.i4.1
+				IL_02f5: newarr [System.Runtime]System.Object
+				IL_02fa: dup
+				IL_02fb: ldc.i4.0
+				IL_02fc: ldloc.s 11
+				IL_02fe: stelem.ref
+				IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+				IL_0304: pop
+				IL_0305: ldloc.0
+				IL_0306: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_030b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_0310: ret
 
-				IL_031f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0324: ldstr "NO_REJECT"
-				IL_0329: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_032e: pop
-				IL_032f: br IL_0363
+				IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0316: ldstr "NO_REJECT"
+				IL_031b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0320: pop
+				IL_0321: br IL_0355
 
-				IL_0334: ldloc.0
-				IL_0335: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_033a: stloc.s 11
-				IL_033c: ldloc.0
-				IL_033d: ldc.i4.0
-				IL_033e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_0343: ldloc.s 11
-				IL_0345: stloc.s 9
-				IL_0347: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Block_L37C16::.ctor()
-				IL_034c: stloc.s 10
-				IL_034e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0353: ldstr "iter-reject"
-				IL_0358: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_035d: pop
-				IL_035e: br IL_0363
+				IL_0326: ldloc.0
+				IL_0327: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_032c: stloc.s 11
+				IL_032e: ldloc.0
+				IL_032f: ldc.i4.0
+				IL_0330: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_0335: ldloc.s 11
+				IL_0337: stloc.s 9
+				IL_0339: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Block_L37C16::.ctor()
+				IL_033e: stloc.s 10
+				IL_0340: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0345: ldstr "iter-reject"
+				IL_034a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_034f: pop
+				IL_0350: br IL_0355
 
-				IL_0363: ldloc.0
-				IL_0364: ldc.i4.m1
-				IL_0365: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_036a: ldloc.0
-				IL_036b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0370: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-				IL_0375: ldarg.0
-				IL_0376: ldc.i4.1
-				IL_0377: newarr [System.Runtime]System.Object
-				IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-				IL_0381: pop
-				IL_0382: ldloc.0
-				IL_0383: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0388: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_038d: ret
+				IL_0355: ldloc.0
+				IL_0356: ldc.i4.m1
+				IL_0357: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_035c: ldloc.0
+				IL_035d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_0362: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+				IL_0367: ldarg.0
+				IL_0368: ldc.i4.1
+				IL_0369: newarr [System.Runtime]System.Object
+				IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+				IL_0373: pop
+				IL_0374: ldloc.0
+				IL_0375: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_037a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_037f: ret
 			} // end of method ArrowFunction_L31C17::__js_call__
 
 		} // end of class ArrowFunction_L31C17
@@ -1191,18 +1179,15 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f91
+				// Method begins at RVA 0x2eed
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -1218,9 +1203,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2650
+			// Method begins at RVA 0x2620
 			// Header size: 12
-			// Code size: 420 (0x1a4)
+			// Code size: 396 (0x18c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope,
@@ -1283,129 +1268,121 @@
 
 			IL_006e: ldloc.0
 			IL_006f: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0074: switch (IL_0081, IL_0172)
+			IL_0074: switch (IL_0081, IL_015a)
 
 			IL_0081: ldarg.0
 			IL_0082: ldc.i4.1
 			IL_0083: ldelem.ref
 			IL_0084: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 			IL_0089: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_008e: ldstr "Cannot access 'EventEmitter' before initialization"
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0098: stloc.3
-			IL_0099: ldloc.3
-			IL_009a: ldc.i4.0
-			IL_009b: newarr [System.Runtime]System.Object
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00a5: stloc.3
-			IL_00a6: ldloc.3
-			IL_00a7: stloc.1
-			IL_00a8: ldarg.0
-			IL_00a9: ldc.i4.1
-			IL_00aa: ldelem.ref
-			IL_00ab: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00b0: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00b5: ldstr "Cannot access 'events' before initialization"
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00bf: stloc.3
-			IL_00c0: ldloc.3
-			IL_00c1: ldstr "on"
-			IL_00c6: ldloc.1
-			IL_00c7: ldstr "data"
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00d1: stloc.3
-			IL_00d2: ldloc.0
-			IL_00d3: ldloc.3
-			IL_00d4: stfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
-			IL_00d9: ldnull
-			IL_00da: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17::__js_call__(object[], object)
-			IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00e5: ldc.i4.2
-			IL_00e6: newarr [System.Runtime]System.Object
-			IL_00eb: dup
-			IL_00ec: ldc.i4.0
-			IL_00ed: ldarg.0
-			IL_00ee: ldc.i4.1
-			IL_00ef: ldelem.ref
-			IL_00f0: stelem.ref
-			IL_00f1: dup
-			IL_00f2: ldc.i4.1
-			IL_00f3: ldloc.0
-			IL_00f4: stelem.ref
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00ff: ldc.i4.0
-			IL_0100: conv.r8
-			IL_0101: ldstr ""
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance(object, float64, string)
-			IL_010b: stloc.3
-			IL_010c: ldc.i4.0
-			IL_010d: newarr [System.Runtime]System.Object
-			IL_0112: stloc.s 4
-			IL_0114: ldloc.3
-			IL_0115: ldc.i4.1
-			IL_0116: newarr [System.Runtime]System.Object
-			IL_011b: dup
-			IL_011c: ldc.i4.0
-			IL_011d: ldarg.0
-			IL_011e: ldc.i4.1
-			IL_011f: ldelem.ref
-			IL_0120: stelem.ref
-			IL_0121: ldloc.s 4
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0128: stloc.3
-			IL_0129: ldloc.3
-			IL_012a: stloc.2
-			IL_012b: ldloc.1
-			IL_012c: ldstr "emit"
-			IL_0131: ldstr "error"
-			IL_0136: ldstr "E1"
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0140: pop
-			IL_0141: ldloc.0
-			IL_0142: ldc.i4.1
-			IL_0143: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0148: ldloc.0
-			IL_0149: ldloc.2
-			IL_014a: ldarg.0
-			IL_014b: ldc.i4.1
-			IL_014c: ldloc.0
-			IL_014d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0152: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0157: ldloc.0
-			IL_0158: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_015d: dup
-			IL_015e: ldc.i4.0
-			IL_015f: ldloc.1
-			IL_0160: stelem.ref
-			IL_0161: dup
-			IL_0162: ldc.i4.1
-			IL_0163: ldloc.2
-			IL_0164: stelem.ref
-			IL_0165: pop
-			IL_0166: ldloc.0
-			IL_0167: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_016c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0171: ret
+			IL_008e: ldc.i4.0
+			IL_008f: newarr [System.Runtime]System.Object
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0099: stloc.3
+			IL_009a: ldloc.3
+			IL_009b: stloc.1
+			IL_009c: ldarg.0
+			IL_009d: ldc.i4.1
+			IL_009e: ldelem.ref
+			IL_009f: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_00a4: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00a9: ldstr "on"
+			IL_00ae: ldloc.1
+			IL_00af: ldstr "data"
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00b9: stloc.3
+			IL_00ba: ldloc.0
+			IL_00bb: ldloc.3
+			IL_00bc: stfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
+			IL_00c1: ldnull
+			IL_00c2: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17::__js_call__(object[], object)
+			IL_00c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00cd: ldc.i4.2
+			IL_00ce: newarr [System.Runtime]System.Object
+			IL_00d3: dup
+			IL_00d4: ldc.i4.0
+			IL_00d5: ldarg.0
+			IL_00d6: ldc.i4.1
+			IL_00d7: ldelem.ref
+			IL_00d8: stelem.ref
+			IL_00d9: dup
+			IL_00da: ldc.i4.1
+			IL_00db: ldloc.0
+			IL_00dc: stelem.ref
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00e7: ldc.i4.0
+			IL_00e8: conv.r8
+			IL_00e9: ldstr ""
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance(object, float64, string)
+			IL_00f3: stloc.3
+			IL_00f4: ldc.i4.0
+			IL_00f5: newarr [System.Runtime]System.Object
+			IL_00fa: stloc.s 4
+			IL_00fc: ldloc.3
+			IL_00fd: ldc.i4.1
+			IL_00fe: newarr [System.Runtime]System.Object
+			IL_0103: dup
+			IL_0104: ldc.i4.0
+			IL_0105: ldarg.0
+			IL_0106: ldc.i4.1
+			IL_0107: ldelem.ref
+			IL_0108: stelem.ref
+			IL_0109: ldloc.s 4
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0110: stloc.3
+			IL_0111: ldloc.3
+			IL_0112: stloc.2
+			IL_0113: ldloc.1
+			IL_0114: ldstr "emit"
+			IL_0119: ldstr "error"
+			IL_011e: ldstr "E1"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0128: pop
+			IL_0129: ldloc.0
+			IL_012a: ldc.i4.1
+			IL_012b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0130: ldloc.0
+			IL_0131: ldloc.2
+			IL_0132: ldarg.0
+			IL_0133: ldc.i4.1
+			IL_0134: ldloc.0
+			IL_0135: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_013f: ldloc.0
+			IL_0140: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0145: dup
+			IL_0146: ldc.i4.0
+			IL_0147: ldloc.1
+			IL_0148: stelem.ref
+			IL_0149: dup
+			IL_014a: ldc.i4.1
+			IL_014b: ldloc.2
+			IL_014c: stelem.ref
+			IL_014d: pop
+			IL_014e: ldloc.0
+			IL_014f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0154: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0159: ret
 
-			IL_0172: ldloc.0
-			IL_0173: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::_awaited1
-			IL_0178: pop
-			IL_0179: ldloc.0
-			IL_017a: ldc.i4.m1
-			IL_017b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_015a: ldloc.0
+			IL_015b: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::_awaited1
+			IL_0160: pop
+			IL_0161: ldloc.0
+			IL_0162: ldc.i4.m1
+			IL_0163: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0168: ldloc.0
+			IL_0169: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_016e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0173: ldarg.0
+			IL_0174: ldc.i4.1
+			IL_0175: newarr [System.Runtime]System.Object
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_017f: pop
 			IL_0180: ldloc.0
 			IL_0181: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_018b: ldarg.0
-			IL_018c: ldc.i4.1
-			IL_018d: newarr [System.Runtime]System.Object
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0197: pop
-			IL_0198: ldloc.0
-			IL_0199: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_019e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01a3: ret
+			IL_0186: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_018b: ret
 		} // end of method runOnErrorReject::__js_call__
 
 	} // end of class runOnErrorReject
@@ -1431,7 +1408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fd2
+				// Method begins at RVA 0x2f23
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1455,9 +1432,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2800
+			// Method begins at RVA 0x27b8
 			// Header size: 12
-			// Code size: 441 (0x1b9)
+			// Code size: 413 (0x19d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope,
@@ -1524,115 +1501,107 @@
 
 			IL_0072: ldloc.0
 			IL_0073: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0078: switch (IL_0085, IL_0139)
+			IL_0078: switch (IL_0085, IL_011d)
 
 			IL_0085: ldarg.0
 			IL_0086: ldc.i4.1
 			IL_0087: ldelem.ref
 			IL_0088: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 			IL_008d: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_0092: ldstr "Cannot access 'EventEmitter' before initialization"
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_009c: stloc.s 4
-			IL_009e: ldloc.s 4
-			IL_00a0: ldc.i4.0
-			IL_00a1: newarr [System.Runtime]System.Object
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00ab: stloc.s 4
-			IL_00ad: ldloc.s 4
-			IL_00af: stloc.1
-			IL_00b0: ldarg.0
-			IL_00b1: ldc.i4.1
-			IL_00b2: ldelem.ref
-			IL_00b3: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00b8: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00bd: ldstr "Cannot access 'events' before initialization"
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c7: stloc.s 4
-			IL_00c9: ldloc.s 4
-			IL_00cb: ldstr "once"
-			IL_00d0: ldloc.1
-			IL_00d1: ldstr "ready"
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00db: stloc.s 4
-			IL_00dd: ldloc.s 4
-			IL_00df: stloc.2
-			IL_00e0: ldloc.1
-			IL_00e1: ldstr "emit"
-			IL_00e6: ldstr "ready"
-			IL_00eb: ldstr "ok"
-			IL_00f0: ldc.r8 42
-			IL_00f9: box [System.Runtime]System.Double
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0103: pop
-			IL_0104: ldloc.0
-			IL_0105: ldc.i4.1
-			IL_0106: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_010b: ldloc.0
-			IL_010c: ldloc.2
-			IL_010d: ldarg.0
-			IL_010e: ldc.i4.1
-			IL_010f: ldloc.0
-			IL_0110: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0115: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_011a: ldloc.0
-			IL_011b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0120: dup
-			IL_0121: ldc.i4.0
-			IL_0122: ldloc.1
-			IL_0123: stelem.ref
-			IL_0124: dup
-			IL_0125: ldc.i4.1
-			IL_0126: ldloc.2
-			IL_0127: stelem.ref
-			IL_0128: dup
-			IL_0129: ldc.i4.2
-			IL_012a: ldloc.3
-			IL_012b: stelem.ref
-			IL_012c: pop
-			IL_012d: ldloc.0
-			IL_012e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0133: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0138: ret
+			IL_0092: ldc.i4.0
+			IL_0093: newarr [System.Runtime]System.Object
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_009d: stloc.s 4
+			IL_009f: ldloc.s 4
+			IL_00a1: stloc.1
+			IL_00a2: ldarg.0
+			IL_00a3: ldc.i4.1
+			IL_00a4: ldelem.ref
+			IL_00a5: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_00aa: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00af: ldstr "once"
+			IL_00b4: ldloc.1
+			IL_00b5: ldstr "ready"
+			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00bf: stloc.s 4
+			IL_00c1: ldloc.s 4
+			IL_00c3: stloc.2
+			IL_00c4: ldloc.1
+			IL_00c5: ldstr "emit"
+			IL_00ca: ldstr "ready"
+			IL_00cf: ldstr "ok"
+			IL_00d4: ldc.r8 42
+			IL_00dd: box [System.Runtime]System.Double
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00e7: pop
+			IL_00e8: ldloc.0
+			IL_00e9: ldc.i4.1
+			IL_00ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00ef: ldloc.0
+			IL_00f0: ldloc.2
+			IL_00f1: ldarg.0
+			IL_00f2: ldc.i4.1
+			IL_00f3: ldloc.0
+			IL_00f4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00fe: ldloc.0
+			IL_00ff: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0104: dup
+			IL_0105: ldc.i4.0
+			IL_0106: ldloc.1
+			IL_0107: stelem.ref
+			IL_0108: dup
+			IL_0109: ldc.i4.1
+			IL_010a: ldloc.2
+			IL_010b: stelem.ref
+			IL_010c: dup
+			IL_010d: ldc.i4.2
+			IL_010e: ldloc.3
+			IL_010f: stelem.ref
+			IL_0110: pop
+			IL_0111: ldloc.0
+			IL_0112: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0117: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_011c: ret
 
-			IL_0139: ldloc.0
-			IL_013a: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope::_awaited1
-			IL_013f: stloc.s 4
-			IL_0141: ldloc.s 4
-			IL_0143: stloc.3
-			IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0149: ldloc.3
-			IL_014a: ldstr "length"
-			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0159: pop
-			IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_015f: ldloc.3
-			IL_0160: ldc.r8 0.0
-			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_016e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0173: pop
-			IL_0174: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0179: ldloc.3
-			IL_017a: ldc.r8 1
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0188: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_018d: pop
-			IL_018e: ldloc.0
-			IL_018f: ldc.i4.m1
-			IL_0190: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0195: ldloc.0
-			IL_0196: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01a0: ldarg.0
-			IL_01a1: ldc.i4.1
-			IL_01a2: newarr [System.Runtime]System.Object
-			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01ac: pop
-			IL_01ad: ldloc.0
-			IL_01ae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01b8: ret
+			IL_011d: ldloc.0
+			IL_011e: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope::_awaited1
+			IL_0123: stloc.s 4
+			IL_0125: ldloc.s 4
+			IL_0127: stloc.3
+			IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012d: ldloc.3
+			IL_012e: ldstr "length"
+			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_013d: pop
+			IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0143: ldloc.3
+			IL_0144: ldc.r8 0.0
+			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0157: pop
+			IL_0158: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_015d: ldloc.3
+			IL_015e: ldc.r8 1
+			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0171: pop
+			IL_0172: ldloc.0
+			IL_0173: ldc.i4.m1
+			IL_0174: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0179: ldloc.0
+			IL_017a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_017f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0184: ldarg.0
+			IL_0185: ldc.i4.1
+			IL_0186: newarr [System.Runtime]System.Object
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0190: pop
+			IL_0191: ldloc.0
+			IL_0192: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0197: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_019c: ret
 		} // end of method runOnceResolve::__js_call__
 
 	} // end of class runOnceResolve
@@ -1661,7 +1630,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fe4
+					// Method begins at RVA 0x2f35
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1681,7 +1650,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fed
+					// Method begins at RVA 0x2f3e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1705,7 +1674,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fdb
+				// Method begins at RVA 0x2f2c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1729,9 +1698,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29c8
+			// Method begins at RVA 0x2964
 			// Header size: 12
-			// Code size: 460 (0x1cc)
+			// Code size: 432 (0x1b0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope,
@@ -1808,130 +1777,122 @@
 
 			IL_007c: ldloc.0
 			IL_007d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0082: switch (IL_0093, IL_0172, IL_0156)
+			IL_0082: switch (IL_0093, IL_0156, IL_013a)
 
 			IL_0093: ldarg.0
 			IL_0094: ldc.i4.1
 			IL_0095: ldelem.ref
 			IL_0096: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 			IL_009b: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_00a0: ldstr "Cannot access 'EventEmitter' before initialization"
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00aa: stloc.s 6
-			IL_00ac: ldloc.s 6
-			IL_00ae: ldc.i4.0
-			IL_00af: newarr [System.Runtime]System.Object
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00b9: stloc.s 6
-			IL_00bb: ldloc.s 6
-			IL_00bd: stloc.1
-			IL_00be: ldarg.0
-			IL_00bf: ldc.i4.1
-			IL_00c0: ldelem.ref
-			IL_00c1: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00c6: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00cb: ldstr "Cannot access 'events' before initialization"
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00d5: stloc.s 6
-			IL_00d7: ldloc.s 6
-			IL_00d9: ldstr "once"
-			IL_00de: ldloc.1
-			IL_00df: ldstr "ready"
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00e9: stloc.s 6
-			IL_00eb: ldloc.s 6
-			IL_00ed: stloc.2
-			IL_00ee: ldloc.1
-			IL_00ef: ldstr "emit"
-			IL_00f4: ldstr "error"
-			IL_00f9: ldstr "boom"
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0103: pop
-			IL_0104: ldloc.0
-			IL_0105: ldc.i4.0
-			IL_0106: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_010b: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L62C6::.ctor()
-			IL_0110: stloc.3
+			IL_00a0: ldc.i4.0
+			IL_00a1: newarr [System.Runtime]System.Object
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00ab: stloc.s 6
+			IL_00ad: ldloc.s 6
+			IL_00af: stloc.1
+			IL_00b0: ldarg.0
+			IL_00b1: ldc.i4.1
+			IL_00b2: ldelem.ref
+			IL_00b3: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_00b8: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00bd: ldstr "once"
+			IL_00c2: ldloc.1
+			IL_00c3: ldstr "ready"
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00cd: stloc.s 6
+			IL_00cf: ldloc.s 6
+			IL_00d1: stloc.2
+			IL_00d2: ldloc.1
+			IL_00d3: ldstr "emit"
+			IL_00d8: ldstr "error"
+			IL_00dd: ldstr "boom"
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00e7: pop
+			IL_00e8: ldloc.0
+			IL_00e9: ldc.i4.0
+			IL_00ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00ef: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L62C6::.ctor()
+			IL_00f4: stloc.3
+			IL_00f5: ldloc.0
+			IL_00f6: ldc.i4.2
+			IL_00f7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00fc: ldloc.0
+			IL_00fd: ldloc.2
+			IL_00fe: ldarg.0
+			IL_00ff: ldc.i4.1
+			IL_0100: ldloc.0
+			IL_0101: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0106: ldc.i4.1
+			IL_0107: ldstr "_pendingException"
+			IL_010c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
 			IL_0111: ldloc.0
-			IL_0112: ldc.i4.2
-			IL_0113: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0118: ldloc.0
-			IL_0119: ldloc.2
-			IL_011a: ldarg.0
-			IL_011b: ldc.i4.1
-			IL_011c: ldloc.0
-			IL_011d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0122: ldc.i4.1
-			IL_0123: ldstr "_pendingException"
-			IL_0128: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_012d: ldloc.0
-			IL_012e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0133: dup
-			IL_0134: ldc.i4.0
-			IL_0135: ldloc.1
-			IL_0136: stelem.ref
-			IL_0137: dup
-			IL_0138: ldc.i4.1
-			IL_0139: ldloc.2
-			IL_013a: stelem.ref
-			IL_013b: dup
-			IL_013c: ldc.i4.2
-			IL_013d: ldloc.3
-			IL_013e: stelem.ref
-			IL_013f: dup
-			IL_0140: ldc.i4.3
-			IL_0141: ldloc.s 4
-			IL_0143: stelem.ref
-			IL_0144: dup
-			IL_0145: ldc.i4.4
-			IL_0146: ldloc.s 5
-			IL_0148: stelem.ref
-			IL_0149: pop
-			IL_014a: ldloc.0
-			IL_014b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0150: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0155: ret
+			IL_0112: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0117: dup
+			IL_0118: ldc.i4.0
+			IL_0119: ldloc.1
+			IL_011a: stelem.ref
+			IL_011b: dup
+			IL_011c: ldc.i4.1
+			IL_011d: ldloc.2
+			IL_011e: stelem.ref
+			IL_011f: dup
+			IL_0120: ldc.i4.2
+			IL_0121: ldloc.3
+			IL_0122: stelem.ref
+			IL_0123: dup
+			IL_0124: ldc.i4.3
+			IL_0125: ldloc.s 4
+			IL_0127: stelem.ref
+			IL_0128: dup
+			IL_0129: ldc.i4.4
+			IL_012a: ldloc.s 5
+			IL_012c: stelem.ref
+			IL_012d: pop
+			IL_012e: ldloc.0
+			IL_012f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0134: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0139: ret
+
+			IL_013a: ldloc.0
+			IL_013b: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope::_awaited1
+			IL_0140: pop
+			IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0146: ldstr "NO_REJECT"
+			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0150: pop
+			IL_0151: br IL_0185
 
 			IL_0156: ldloc.0
-			IL_0157: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope::_awaited1
-			IL_015c: pop
-			IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0162: ldstr "NO_REJECT"
-			IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_016c: pop
-			IL_016d: br IL_01a1
+			IL_0157: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_015c: stloc.s 6
+			IL_015e: ldloc.0
+			IL_015f: ldc.i4.0
+			IL_0160: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0165: ldloc.s 6
+			IL_0167: stloc.s 4
+			IL_0169: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L65C14::.ctor()
+			IL_016e: stloc.s 5
+			IL_0170: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0175: ldstr "once-reject"
+			IL_017a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_017f: pop
+			IL_0180: br IL_0185
 
-			IL_0172: ldloc.0
-			IL_0173: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0178: stloc.s 6
-			IL_017a: ldloc.0
-			IL_017b: ldc.i4.0
-			IL_017c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0181: ldloc.s 6
-			IL_0183: stloc.s 4
-			IL_0185: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L65C14::.ctor()
-			IL_018a: stloc.s 5
-			IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0191: ldstr "once-reject"
-			IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_019b: pop
-			IL_019c: br IL_01a1
-
-			IL_01a1: ldloc.0
-			IL_01a2: ldc.i4.m1
-			IL_01a3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01a8: ldloc.0
-			IL_01a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01b3: ldarg.0
-			IL_01b4: ldc.i4.1
-			IL_01b5: newarr [System.Runtime]System.Object
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01bf: pop
-			IL_01c0: ldloc.0
-			IL_01c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01c6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01cb: ret
+			IL_0185: ldloc.0
+			IL_0186: ldc.i4.m1
+			IL_0187: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_018c: ldloc.0
+			IL_018d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0197: ldarg.0
+			IL_0198: ldc.i4.1
+			IL_0199: newarr [System.Runtime]System.Object
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01a3: pop
+			IL_01a4: ldloc.0
+			IL_01a5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01aa: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01af: ret
 		} // end of method runOnceReject::__js_call__
 
 	} // end of class runOnceReject
@@ -1947,7 +1908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ff6
+				// Method begins at RVA 0x2f47
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1970,7 +1931,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ba0
+			// Method begins at RVA 0x2b20
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -2014,21 +1975,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2f4e
+			// Method begins at RVA 0x2ec0
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -2046,7 +2001,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 346 (0x15a)
+		// Code size: 328 (0x148)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_AsyncHelpers_On_Once/Scope,
@@ -2128,63 +2083,57 @@
 		IL_00ad: ldloc.s 5
 		IL_00af: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
 		IL_00b4: ldloc.0
-		IL_00b5: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-		IL_00ba: ldstr "Cannot access 'events' before initialization"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00c4: stloc.s 5
-		IL_00c6: ldloc.s 5
-		IL_00c8: ldstr "EventEmitter"
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d2: stloc.s 5
-		IL_00d4: ldloc.0
-		IL_00d5: ldloc.s 5
-		IL_00d7: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-		IL_00dc: ldc.i4.1
-		IL_00dd: newarr [System.Runtime]System.Object
-		IL_00e2: dup
-		IL_00e3: ldc.i4.0
-		IL_00e4: ldloc.0
-		IL_00e5: stelem.ref
-		IL_00e6: ldnull
-		IL_00e7: call object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
-		IL_00ec: stloc.s 5
-		IL_00ee: ldloc.s 5
-		IL_00f0: ldstr "then"
-		IL_00f5: ldloc.2
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00fb: stloc.s 5
-		IL_00fd: ldloc.s 5
-		IL_00ff: ldstr "then"
-		IL_0104: ldloc.3
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010a: stloc.s 5
-		IL_010c: ldloc.s 5
-		IL_010e: ldstr "then"
-		IL_0113: ldloc.s 4
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011a: stloc.s 5
-		IL_011c: ldnull
-		IL_011d: ldftn object Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9::__js_call__(object)
-		IL_0123: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0128: ldc.i4.1
-		IL_0129: newarr [System.Runtime]System.Object
-		IL_012e: dup
-		IL_012f: ldc.i4.0
-		IL_0130: ldloc.0
-		IL_0131: stelem.ref
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_013c: ldc.i4.0
-		IL_013d: conv.r8
-		IL_013e: ldstr ""
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0148: stloc.s 6
-		IL_014a: ldloc.s 5
-		IL_014c: ldstr "then"
-		IL_0151: ldloc.s 6
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0158: pop
-		IL_0159: ret
+		IL_00b5: ldloc.0
+		IL_00b6: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+		IL_00bb: ldstr "EventEmitter"
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c5: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
+		IL_00ca: ldc.i4.1
+		IL_00cb: newarr [System.Runtime]System.Object
+		IL_00d0: dup
+		IL_00d1: ldc.i4.0
+		IL_00d2: ldloc.0
+		IL_00d3: stelem.ref
+		IL_00d4: ldnull
+		IL_00d5: call object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
+		IL_00da: stloc.s 5
+		IL_00dc: ldloc.s 5
+		IL_00de: ldstr "then"
+		IL_00e3: ldloc.2
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e9: stloc.s 5
+		IL_00eb: ldloc.s 5
+		IL_00ed: ldstr "then"
+		IL_00f2: ldloc.3
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f8: stloc.s 5
+		IL_00fa: ldloc.s 5
+		IL_00fc: ldstr "then"
+		IL_0101: ldloc.s 4
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0108: stloc.s 5
+		IL_010a: ldnull
+		IL_010b: ldftn object Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9::__js_call__(object)
+		IL_0111: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0116: ldc.i4.1
+		IL_0117: newarr [System.Runtime]System.Object
+		IL_011c: dup
+		IL_011d: ldc.i4.0
+		IL_011e: ldloc.0
+		IL_011f: stelem.ref
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_012a: ldc.i4.0
+		IL_012b: conv.r8
+		IL_012c: ldstr ""
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0136: stloc.s 6
+		IL_0138: ldloc.s 5
+		IL_013a: ldstr "then"
+		IL_013f: ldloc.s 6
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0146: pop
+		IL_0147: ret
 	} // end of method Events_AsyncHelpers_On_Once::__js_module_init__
 
 } // end of class Modules.Events_AsyncHelpers_On_Once
@@ -2196,7 +2145,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2fff
+		// Method begins at RVA 0x2f50
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2960
+					// Method begins at RVA 0x287f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2969
+					// Method begins at RVA 0x2888
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2972
+					// Method begins at RVA 0x2891
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -117,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2957
+				// Method begins at RVA 0x2876
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -143,7 +143,7 @@
 			)
 			// Method begins at RVA 0x20e0
 			// Header size: 12
-			// Code size: 2113 (0x841)
+			// Code size: 1921 (0x781)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope,
@@ -257,7 +257,7 @@
 
 			IL_00a6: ldloc.0
 			IL_00a7: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00ac: switch (IL_00d5, IL_06e6, IL_0775, IL_067c, IL_0373, IL_0424, IL_04cc, IL_0578, IL_0636)
+			IL_00ac: switch (IL_00d5, IL_063a, IL_06b5, IL_05d0, IL_031d, IL_03bc, IL_0452, IL_04ec, IL_0598)
 
 			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_00da: stloc.s 11
@@ -299,741 +299,687 @@
 			IL_0146: ldelem.ref
 			IL_0147: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
 			IL_014c: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_0151: ldstr "Cannot access 'path' before initialization"
-			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_015b: stloc.s 11
-			IL_015d: ldarg.0
-			IL_015e: ldc.i4.1
-			IL_015f: ldelem.ref
-			IL_0160: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0165: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_016a: ldstr "Cannot access 'os' before initialization"
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0174: stloc.s 16
-			IL_0176: ldloc.s 16
-			IL_0178: ldstr "tmpdir"
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0182: stloc.s 16
-			IL_0184: ldloc.1
-			IL_0185: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_018a: stloc.s 15
-			IL_018c: ldstr "js2il-fs-append-"
-			IL_0191: ldloc.s 15
-			IL_0193: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0198: stloc.s 15
-			IL_019a: ldloc.s 15
-			IL_019c: ldstr ".txt"
-			IL_01a1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a6: stloc.s 15
-			IL_01a8: ldloc.s 11
-			IL_01aa: ldstr "join"
-			IL_01af: ldloc.s 16
-			IL_01b1: ldloc.s 15
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01b8: stloc.s 16
-			IL_01ba: ldloc.s 16
-			IL_01bc: stloc.2
-			IL_01bd: ldarg.0
-			IL_01be: ldc.i4.1
-			IL_01bf: ldelem.ref
-			IL_01c0: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_01c5: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_01ca: ldstr "Cannot access 'path' before initialization"
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01d4: stloc.s 16
-			IL_01d6: ldarg.0
-			IL_01d7: ldc.i4.1
-			IL_01d8: ldelem.ref
-			IL_01d9: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_01de: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_01e3: ldstr "Cannot access 'os' before initialization"
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01ed: stloc.s 11
-			IL_01ef: ldloc.s 11
-			IL_01f1: ldstr "tmpdir"
-			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01fb: stloc.s 11
-			IL_01fd: ldloc.1
-			IL_01fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0203: stloc.s 15
-			IL_0205: ldstr "js2il-fs-append-"
-			IL_020a: ldloc.s 15
-			IL_020c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0211: stloc.s 15
-			IL_0213: ldloc.s 15
-			IL_0215: ldstr "-renamed.txt"
-			IL_021a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021f: stloc.s 15
-			IL_0221: ldloc.s 16
-			IL_0223: ldstr "join"
-			IL_0228: ldloc.s 11
-			IL_022a: ldloc.s 15
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0231: stloc.s 11
-			IL_0233: ldloc.s 11
-			IL_0235: stloc.3
-			IL_0236: ldloc.0
-			IL_0237: ldc.i4.0
-			IL_0238: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_023d: ldloc.0
-			IL_023e: ldc.i4.0
-			IL_023f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0244: ldloc.0
-			IL_0245: ldc.i4.0
-			IL_0246: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_024b: ldloc.0
-			IL_024c: ldc.i4.0
-			IL_024d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0252: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L12C8::.ctor()
-			IL_0257: stloc.s 4
-			IL_0259: ldarg.0
-			IL_025a: ldc.i4.1
-			IL_025b: ldelem.ref
-			IL_025c: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0261: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0266: ldstr "Cannot access 'fs' before initialization"
-			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0270: stloc.s 11
-			IL_0272: ldloc.s 11
-			IL_0274: ldstr "rmSync"
-			IL_0279: ldloc.2
-			IL_027a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_027f: dup
-			IL_0280: ldstr "force"
-			IL_0285: ldc.i4.1
-			IL_0286: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0290: pop
-			IL_0291: ldarg.0
-			IL_0292: ldc.i4.1
-			IL_0293: ldelem.ref
-			IL_0294: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0299: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_029e: ldstr "Cannot access 'fs' before initialization"
-			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_02a8: stloc.s 11
-			IL_02aa: ldloc.s 11
-			IL_02ac: ldstr "rmSync"
-			IL_02b1: ldloc.3
-			IL_02b2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02b7: dup
-			IL_02b8: ldstr "force"
-			IL_02bd: ldc.i4.1
-			IL_02be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02c8: pop
-			IL_02c9: ldarg.0
-			IL_02ca: ldc.i4.1
-			IL_02cb: ldelem.ref
-			IL_02cc: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_02d1: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_02d6: ldstr "Cannot access 'fs' before initialization"
-			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_02e0: stloc.s 11
-			IL_02e2: ldloc.s 11
-			IL_02e4: ldstr "promises"
-			IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ee: stloc.s 11
-			IL_02f0: ldloc.s 11
-			IL_02f2: ldstr "writeFile"
-			IL_02f7: ldloc.2
-			IL_02f8: ldstr "a"
-			IL_02fd: ldstr "utf8"
-			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0307: stloc.s 11
-			IL_0309: ldloc.0
-			IL_030a: ldc.i4.4
-			IL_030b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0310: ldloc.0
-			IL_0311: ldloc.s 11
-			IL_0313: ldarg.0
-			IL_0314: ldc.i4.1
-			IL_0315: ldloc.0
-			IL_0316: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_031b: ldc.i4.3
-			IL_031c: ldstr "_pendingException"
-			IL_0321: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0326: ldloc.0
-			IL_0327: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_032c: dup
-			IL_032d: ldc.i4.0
-			IL_032e: ldloc.1
-			IL_032f: stelem.ref
-			IL_0330: dup
-			IL_0331: ldc.i4.1
-			IL_0332: ldloc.2
-			IL_0333: stelem.ref
-			IL_0334: dup
-			IL_0335: ldc.i4.2
-			IL_0336: ldloc.3
-			IL_0337: stelem.ref
-			IL_0338: dup
-			IL_0339: ldc.i4.3
-			IL_033a: ldloc.s 4
-			IL_033c: stelem.ref
-			IL_033d: dup
-			IL_033e: ldc.i4.4
-			IL_033f: ldloc.s 5
-			IL_0341: stelem.ref
-			IL_0342: dup
-			IL_0343: ldc.i4.5
-			IL_0344: ldloc.s 6
-			IL_0346: stelem.ref
-			IL_0347: dup
-			IL_0348: ldc.i4.6
-			IL_0349: ldloc.s 7
-			IL_034b: stelem.ref
-			IL_034c: dup
-			IL_034d: ldc.i4.7
-			IL_034e: ldloc.s 8
-			IL_0350: stelem.ref
-			IL_0351: dup
-			IL_0352: ldc.i4.8
-			IL_0353: ldloc.s 9
-			IL_0355: box [System.Runtime]System.Boolean
-			IL_035a: stelem.ref
-			IL_035b: dup
-			IL_035c: ldc.i4.s 9
-			IL_035e: ldloc.s 10
-			IL_0360: box [System.Runtime]System.Boolean
-			IL_0365: stelem.ref
-			IL_0366: pop
-			IL_0367: ldloc.0
-			IL_0368: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0372: ret
+			IL_0151: stloc.s 11
+			IL_0153: ldarg.0
+			IL_0154: ldc.i4.1
+			IL_0155: ldelem.ref
+			IL_0156: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_015b: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
+			IL_0160: ldstr "tmpdir"
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_016a: stloc.s 16
+			IL_016c: ldloc.1
+			IL_016d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0172: stloc.s 15
+			IL_0174: ldstr "js2il-fs-append-"
+			IL_0179: ldloc.s 15
+			IL_017b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0180: stloc.s 15
+			IL_0182: ldloc.s 15
+			IL_0184: ldstr ".txt"
+			IL_0189: call string [System.Runtime]System.String::Concat(string, string)
+			IL_018e: stloc.s 15
+			IL_0190: ldloc.s 11
+			IL_0192: ldstr "join"
+			IL_0197: ldloc.s 16
+			IL_0199: ldloc.s 15
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01a0: stloc.s 16
+			IL_01a2: ldloc.s 16
+			IL_01a4: stloc.2
+			IL_01a5: ldarg.0
+			IL_01a6: ldc.i4.1
+			IL_01a7: ldelem.ref
+			IL_01a8: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_01ad: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
+			IL_01b2: stloc.s 16
+			IL_01b4: ldarg.0
+			IL_01b5: ldc.i4.1
+			IL_01b6: ldelem.ref
+			IL_01b7: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_01bc: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
+			IL_01c1: ldstr "tmpdir"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01cb: stloc.s 11
+			IL_01cd: ldloc.1
+			IL_01ce: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d3: stloc.s 15
+			IL_01d5: ldstr "js2il-fs-append-"
+			IL_01da: ldloc.s 15
+			IL_01dc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e1: stloc.s 15
+			IL_01e3: ldloc.s 15
+			IL_01e5: ldstr "-renamed.txt"
+			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ef: stloc.s 15
+			IL_01f1: ldloc.s 16
+			IL_01f3: ldstr "join"
+			IL_01f8: ldloc.s 11
+			IL_01fa: ldloc.s 15
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0201: stloc.s 11
+			IL_0203: ldloc.s 11
+			IL_0205: stloc.3
+			IL_0206: ldloc.0
+			IL_0207: ldc.i4.0
+			IL_0208: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_020d: ldloc.0
+			IL_020e: ldc.i4.0
+			IL_020f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0214: ldloc.0
+			IL_0215: ldc.i4.0
+			IL_0216: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_021b: ldloc.0
+			IL_021c: ldc.i4.0
+			IL_021d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0222: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L12C8::.ctor()
+			IL_0227: stloc.s 4
+			IL_0229: ldarg.0
+			IL_022a: ldc.i4.1
+			IL_022b: ldelem.ref
+			IL_022c: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0231: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0236: stloc.s 11
+			IL_0238: ldloc.s 11
+			IL_023a: ldstr "rmSync"
+			IL_023f: ldloc.2
+			IL_0240: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0245: dup
+			IL_0246: ldstr "force"
+			IL_024b: ldc.i4.1
+			IL_024c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0256: pop
+			IL_0257: ldarg.0
+			IL_0258: ldc.i4.1
+			IL_0259: ldelem.ref
+			IL_025a: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_025f: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0264: stloc.s 11
+			IL_0266: ldloc.s 11
+			IL_0268: ldstr "rmSync"
+			IL_026d: ldloc.3
+			IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0273: dup
+			IL_0274: ldstr "force"
+			IL_0279: ldc.i4.1
+			IL_027a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0284: pop
+			IL_0285: ldarg.0
+			IL_0286: ldc.i4.1
+			IL_0287: ldelem.ref
+			IL_0288: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_028d: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0292: ldstr "promises"
+			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029c: ldstr "writeFile"
+			IL_02a1: ldloc.2
+			IL_02a2: ldstr "a"
+			IL_02a7: ldstr "utf8"
+			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_02b1: stloc.s 11
+			IL_02b3: ldloc.0
+			IL_02b4: ldc.i4.4
+			IL_02b5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02ba: ldloc.0
+			IL_02bb: ldloc.s 11
+			IL_02bd: ldarg.0
+			IL_02be: ldc.i4.1
+			IL_02bf: ldloc.0
+			IL_02c0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02c5: ldc.i4.3
+			IL_02c6: ldstr "_pendingException"
+			IL_02cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02d0: ldloc.0
+			IL_02d1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02d6: dup
+			IL_02d7: ldc.i4.0
+			IL_02d8: ldloc.1
+			IL_02d9: stelem.ref
+			IL_02da: dup
+			IL_02db: ldc.i4.1
+			IL_02dc: ldloc.2
+			IL_02dd: stelem.ref
+			IL_02de: dup
+			IL_02df: ldc.i4.2
+			IL_02e0: ldloc.3
+			IL_02e1: stelem.ref
+			IL_02e2: dup
+			IL_02e3: ldc.i4.3
+			IL_02e4: ldloc.s 4
+			IL_02e6: stelem.ref
+			IL_02e7: dup
+			IL_02e8: ldc.i4.4
+			IL_02e9: ldloc.s 5
+			IL_02eb: stelem.ref
+			IL_02ec: dup
+			IL_02ed: ldc.i4.5
+			IL_02ee: ldloc.s 6
+			IL_02f0: stelem.ref
+			IL_02f1: dup
+			IL_02f2: ldc.i4.6
+			IL_02f3: ldloc.s 7
+			IL_02f5: stelem.ref
+			IL_02f6: dup
+			IL_02f7: ldc.i4.7
+			IL_02f8: ldloc.s 8
+			IL_02fa: stelem.ref
+			IL_02fb: dup
+			IL_02fc: ldc.i4.8
+			IL_02fd: ldloc.s 9
+			IL_02ff: box [System.Runtime]System.Boolean
+			IL_0304: stelem.ref
+			IL_0305: dup
+			IL_0306: ldc.i4.s 9
+			IL_0308: ldloc.s 10
+			IL_030a: box [System.Runtime]System.Boolean
+			IL_030f: stelem.ref
+			IL_0310: pop
+			IL_0311: ldloc.0
+			IL_0312: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0317: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_031c: ret
 
-			IL_0373: ldloc.0
-			IL_0374: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited1
-			IL_0379: pop
-			IL_037a: ldarg.0
-			IL_037b: ldc.i4.1
-			IL_037c: ldelem.ref
-			IL_037d: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0382: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0387: ldstr "Cannot access 'fs' before initialization"
-			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0391: stloc.s 11
-			IL_0393: ldloc.s 11
-			IL_0395: ldstr "promises"
-			IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_039f: stloc.s 11
-			IL_03a1: ldloc.s 11
-			IL_03a3: ldstr "appendFile"
-			IL_03a8: ldloc.2
-			IL_03a9: ldstr "b"
-			IL_03ae: ldstr "utf8"
-			IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_03b8: stloc.s 11
-			IL_03ba: ldloc.0
-			IL_03bb: ldc.i4.5
-			IL_03bc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03c1: ldloc.0
-			IL_03c2: ldloc.s 11
-			IL_03c4: ldarg.0
-			IL_03c5: ldc.i4.2
-			IL_03c6: ldloc.0
-			IL_03c7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03cc: ldc.i4.3
-			IL_03cd: ldstr "_pendingException"
-			IL_03d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03d7: ldloc.0
-			IL_03d8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03dd: dup
-			IL_03de: ldc.i4.0
-			IL_03df: ldloc.1
-			IL_03e0: stelem.ref
-			IL_03e1: dup
-			IL_03e2: ldc.i4.1
-			IL_03e3: ldloc.2
-			IL_03e4: stelem.ref
-			IL_03e5: dup
-			IL_03e6: ldc.i4.2
-			IL_03e7: ldloc.3
-			IL_03e8: stelem.ref
-			IL_03e9: dup
-			IL_03ea: ldc.i4.3
-			IL_03eb: ldloc.s 4
-			IL_03ed: stelem.ref
-			IL_03ee: dup
-			IL_03ef: ldc.i4.4
-			IL_03f0: ldloc.s 5
-			IL_03f2: stelem.ref
-			IL_03f3: dup
-			IL_03f4: ldc.i4.5
-			IL_03f5: ldloc.s 6
-			IL_03f7: stelem.ref
-			IL_03f8: dup
-			IL_03f9: ldc.i4.6
-			IL_03fa: ldloc.s 7
-			IL_03fc: stelem.ref
-			IL_03fd: dup
-			IL_03fe: ldc.i4.7
-			IL_03ff: ldloc.s 8
-			IL_0401: stelem.ref
-			IL_0402: dup
-			IL_0403: ldc.i4.8
-			IL_0404: ldloc.s 9
-			IL_0406: box [System.Runtime]System.Boolean
-			IL_040b: stelem.ref
-			IL_040c: dup
-			IL_040d: ldc.i4.s 9
-			IL_040f: ldloc.s 10
-			IL_0411: box [System.Runtime]System.Boolean
+			IL_031d: ldloc.0
+			IL_031e: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited1
+			IL_0323: pop
+			IL_0324: ldarg.0
+			IL_0325: ldc.i4.1
+			IL_0326: ldelem.ref
+			IL_0327: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_032c: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0331: ldstr "promises"
+			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033b: ldstr "appendFile"
+			IL_0340: ldloc.2
+			IL_0341: ldstr "b"
+			IL_0346: ldstr "utf8"
+			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0350: stloc.s 11
+			IL_0352: ldloc.0
+			IL_0353: ldc.i4.5
+			IL_0354: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0359: ldloc.0
+			IL_035a: ldloc.s 11
+			IL_035c: ldarg.0
+			IL_035d: ldc.i4.2
+			IL_035e: ldloc.0
+			IL_035f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0364: ldc.i4.3
+			IL_0365: ldstr "_pendingException"
+			IL_036a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_036f: ldloc.0
+			IL_0370: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0375: dup
+			IL_0376: ldc.i4.0
+			IL_0377: ldloc.1
+			IL_0378: stelem.ref
+			IL_0379: dup
+			IL_037a: ldc.i4.1
+			IL_037b: ldloc.2
+			IL_037c: stelem.ref
+			IL_037d: dup
+			IL_037e: ldc.i4.2
+			IL_037f: ldloc.3
+			IL_0380: stelem.ref
+			IL_0381: dup
+			IL_0382: ldc.i4.3
+			IL_0383: ldloc.s 4
+			IL_0385: stelem.ref
+			IL_0386: dup
+			IL_0387: ldc.i4.4
+			IL_0388: ldloc.s 5
+			IL_038a: stelem.ref
+			IL_038b: dup
+			IL_038c: ldc.i4.5
+			IL_038d: ldloc.s 6
+			IL_038f: stelem.ref
+			IL_0390: dup
+			IL_0391: ldc.i4.6
+			IL_0392: ldloc.s 7
+			IL_0394: stelem.ref
+			IL_0395: dup
+			IL_0396: ldc.i4.7
+			IL_0397: ldloc.s 8
+			IL_0399: stelem.ref
+			IL_039a: dup
+			IL_039b: ldc.i4.8
+			IL_039c: ldloc.s 9
+			IL_039e: box [System.Runtime]System.Boolean
+			IL_03a3: stelem.ref
+			IL_03a4: dup
+			IL_03a5: ldc.i4.s 9
+			IL_03a7: ldloc.s 10
+			IL_03a9: box [System.Runtime]System.Boolean
+			IL_03ae: stelem.ref
+			IL_03af: pop
+			IL_03b0: ldloc.0
+			IL_03b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03b6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03bb: ret
+
+			IL_03bc: ldloc.0
+			IL_03bd: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited2
+			IL_03c2: pop
+			IL_03c3: ldarg.0
+			IL_03c4: ldc.i4.1
+			IL_03c5: ldelem.ref
+			IL_03c6: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_03cb: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_03d0: ldstr "promises"
+			IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03da: ldstr "rename"
+			IL_03df: ldloc.2
+			IL_03e0: ldloc.3
+			IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03e6: stloc.s 11
+			IL_03e8: ldloc.0
+			IL_03e9: ldc.i4.6
+			IL_03ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03ef: ldloc.0
+			IL_03f0: ldloc.s 11
+			IL_03f2: ldarg.0
+			IL_03f3: ldc.i4.3
+			IL_03f4: ldloc.0
+			IL_03f5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03fa: ldc.i4.3
+			IL_03fb: ldstr "_pendingException"
+			IL_0400: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0405: ldloc.0
+			IL_0406: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_040b: dup
+			IL_040c: ldc.i4.0
+			IL_040d: ldloc.1
+			IL_040e: stelem.ref
+			IL_040f: dup
+			IL_0410: ldc.i4.1
+			IL_0411: ldloc.2
+			IL_0412: stelem.ref
+			IL_0413: dup
+			IL_0414: ldc.i4.2
+			IL_0415: ldloc.3
 			IL_0416: stelem.ref
-			IL_0417: pop
-			IL_0418: ldloc.0
-			IL_0419: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_041e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0423: ret
+			IL_0417: dup
+			IL_0418: ldc.i4.3
+			IL_0419: ldloc.s 4
+			IL_041b: stelem.ref
+			IL_041c: dup
+			IL_041d: ldc.i4.4
+			IL_041e: ldloc.s 5
+			IL_0420: stelem.ref
+			IL_0421: dup
+			IL_0422: ldc.i4.5
+			IL_0423: ldloc.s 6
+			IL_0425: stelem.ref
+			IL_0426: dup
+			IL_0427: ldc.i4.6
+			IL_0428: ldloc.s 7
+			IL_042a: stelem.ref
+			IL_042b: dup
+			IL_042c: ldc.i4.7
+			IL_042d: ldloc.s 8
+			IL_042f: stelem.ref
+			IL_0430: dup
+			IL_0431: ldc.i4.8
+			IL_0432: ldloc.s 9
+			IL_0434: box [System.Runtime]System.Boolean
+			IL_0439: stelem.ref
+			IL_043a: dup
+			IL_043b: ldc.i4.s 9
+			IL_043d: ldloc.s 10
+			IL_043f: box [System.Runtime]System.Boolean
+			IL_0444: stelem.ref
+			IL_0445: pop
+			IL_0446: ldloc.0
+			IL_0447: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_044c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0451: ret
 
-			IL_0424: ldloc.0
-			IL_0425: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited2
-			IL_042a: pop
-			IL_042b: ldarg.0
-			IL_042c: ldc.i4.1
-			IL_042d: ldelem.ref
-			IL_042e: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0433: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0438: ldstr "Cannot access 'fs' before initialization"
-			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0442: stloc.s 11
-			IL_0444: ldloc.s 11
-			IL_0446: ldstr "promises"
-			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0450: stloc.s 11
-			IL_0452: ldloc.s 11
-			IL_0454: ldstr "rename"
-			IL_0459: ldloc.2
-			IL_045a: ldloc.3
-			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0460: stloc.s 11
-			IL_0462: ldloc.0
-			IL_0463: ldc.i4.6
-			IL_0464: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0469: ldloc.0
-			IL_046a: ldloc.s 11
-			IL_046c: ldarg.0
-			IL_046d: ldc.i4.3
-			IL_046e: ldloc.0
-			IL_046f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0474: ldc.i4.3
-			IL_0475: ldstr "_pendingException"
-			IL_047a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_047f: ldloc.0
-			IL_0480: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0485: dup
-			IL_0486: ldc.i4.0
-			IL_0487: ldloc.1
-			IL_0488: stelem.ref
-			IL_0489: dup
-			IL_048a: ldc.i4.1
-			IL_048b: ldloc.2
-			IL_048c: stelem.ref
-			IL_048d: dup
-			IL_048e: ldc.i4.2
-			IL_048f: ldloc.3
-			IL_0490: stelem.ref
-			IL_0491: dup
-			IL_0492: ldc.i4.3
-			IL_0493: ldloc.s 4
-			IL_0495: stelem.ref
-			IL_0496: dup
-			IL_0497: ldc.i4.4
-			IL_0498: ldloc.s 5
-			IL_049a: stelem.ref
-			IL_049b: dup
-			IL_049c: ldc.i4.5
-			IL_049d: ldloc.s 6
-			IL_049f: stelem.ref
-			IL_04a0: dup
-			IL_04a1: ldc.i4.6
-			IL_04a2: ldloc.s 7
-			IL_04a4: stelem.ref
+			IL_0452: ldloc.0
+			IL_0453: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited3
+			IL_0458: pop
+			IL_0459: ldarg.0
+			IL_045a: ldc.i4.1
+			IL_045b: ldelem.ref
+			IL_045c: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0461: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0466: ldstr "promises"
+			IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0470: ldstr "readFile"
+			IL_0475: ldloc.3
+			IL_0476: ldstr "utf8"
+			IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0480: stloc.s 11
+			IL_0482: ldloc.0
+			IL_0483: ldc.i4.7
+			IL_0484: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0489: ldloc.0
+			IL_048a: ldloc.s 11
+			IL_048c: ldarg.0
+			IL_048d: ldc.i4.4
+			IL_048e: ldloc.0
+			IL_048f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0494: ldc.i4.3
+			IL_0495: ldstr "_pendingException"
+			IL_049a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_049f: ldloc.0
+			IL_04a0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_04a5: dup
-			IL_04a6: ldc.i4.7
-			IL_04a7: ldloc.s 8
-			IL_04a9: stelem.ref
-			IL_04aa: dup
-			IL_04ab: ldc.i4.8
-			IL_04ac: ldloc.s 9
-			IL_04ae: box [System.Runtime]System.Boolean
-			IL_04b3: stelem.ref
-			IL_04b4: dup
-			IL_04b5: ldc.i4.s 9
-			IL_04b7: ldloc.s 10
-			IL_04b9: box [System.Runtime]System.Boolean
-			IL_04be: stelem.ref
-			IL_04bf: pop
-			IL_04c0: ldloc.0
-			IL_04c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04c6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04cb: ret
+			IL_04a6: ldc.i4.0
+			IL_04a7: ldloc.1
+			IL_04a8: stelem.ref
+			IL_04a9: dup
+			IL_04aa: ldc.i4.1
+			IL_04ab: ldloc.2
+			IL_04ac: stelem.ref
+			IL_04ad: dup
+			IL_04ae: ldc.i4.2
+			IL_04af: ldloc.3
+			IL_04b0: stelem.ref
+			IL_04b1: dup
+			IL_04b2: ldc.i4.3
+			IL_04b3: ldloc.s 4
+			IL_04b5: stelem.ref
+			IL_04b6: dup
+			IL_04b7: ldc.i4.4
+			IL_04b8: ldloc.s 5
+			IL_04ba: stelem.ref
+			IL_04bb: dup
+			IL_04bc: ldc.i4.5
+			IL_04bd: ldloc.s 6
+			IL_04bf: stelem.ref
+			IL_04c0: dup
+			IL_04c1: ldc.i4.6
+			IL_04c2: ldloc.s 7
+			IL_04c4: stelem.ref
+			IL_04c5: dup
+			IL_04c6: ldc.i4.7
+			IL_04c7: ldloc.s 8
+			IL_04c9: stelem.ref
+			IL_04ca: dup
+			IL_04cb: ldc.i4.8
+			IL_04cc: ldloc.s 9
+			IL_04ce: box [System.Runtime]System.Boolean
+			IL_04d3: stelem.ref
+			IL_04d4: dup
+			IL_04d5: ldc.i4.s 9
+			IL_04d7: ldloc.s 10
+			IL_04d9: box [System.Runtime]System.Boolean
+			IL_04de: stelem.ref
+			IL_04df: pop
+			IL_04e0: ldloc.0
+			IL_04e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04eb: ret
 
-			IL_04cc: ldloc.0
-			IL_04cd: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited3
-			IL_04d2: pop
-			IL_04d3: ldarg.0
-			IL_04d4: ldc.i4.1
-			IL_04d5: ldelem.ref
-			IL_04d6: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_04db: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_04e0: ldstr "Cannot access 'fs' before initialization"
-			IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_04ea: stloc.s 11
-			IL_04ec: ldloc.s 11
-			IL_04ee: ldstr "promises"
-			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04f8: stloc.s 11
-			IL_04fa: ldloc.s 11
-			IL_04fc: ldstr "readFile"
-			IL_0501: ldloc.3
-			IL_0502: ldstr "utf8"
-			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_050c: stloc.s 11
-			IL_050e: ldloc.0
-			IL_050f: ldc.i4.7
-			IL_0510: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0515: ldloc.0
-			IL_0516: ldloc.s 11
-			IL_0518: ldarg.0
-			IL_0519: ldc.i4.4
-			IL_051a: ldloc.0
-			IL_051b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0520: ldc.i4.3
-			IL_0521: ldstr "_pendingException"
-			IL_0526: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_052b: ldloc.0
-			IL_052c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0531: dup
-			IL_0532: ldc.i4.0
-			IL_0533: ldloc.1
-			IL_0534: stelem.ref
-			IL_0535: dup
-			IL_0536: ldc.i4.1
-			IL_0537: ldloc.2
-			IL_0538: stelem.ref
-			IL_0539: dup
-			IL_053a: ldc.i4.2
-			IL_053b: ldloc.3
-			IL_053c: stelem.ref
-			IL_053d: dup
-			IL_053e: ldc.i4.3
-			IL_053f: ldloc.s 4
-			IL_0541: stelem.ref
-			IL_0542: dup
-			IL_0543: ldc.i4.4
-			IL_0544: ldloc.s 5
-			IL_0546: stelem.ref
-			IL_0547: dup
-			IL_0548: ldc.i4.5
-			IL_0549: ldloc.s 6
-			IL_054b: stelem.ref
-			IL_054c: dup
-			IL_054d: ldc.i4.6
-			IL_054e: ldloc.s 7
-			IL_0550: stelem.ref
+			IL_04ec: ldloc.0
+			IL_04ed: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited4
+			IL_04f2: stloc.s 11
+			IL_04f4: ldloc.s 11
+			IL_04f6: stloc.s 5
+			IL_04f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04fd: ldstr "Text:"
+			IL_0502: ldloc.s 5
+			IL_0504: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0509: pop
+			IL_050a: ldarg.0
+			IL_050b: ldc.i4.1
+			IL_050c: ldelem.ref
+			IL_050d: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0512: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0517: ldstr "promises"
+			IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0521: ldstr "unlink"
+			IL_0526: ldloc.3
+			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_052c: stloc.s 11
+			IL_052e: ldloc.0
+			IL_052f: ldc.i4.8
+			IL_0530: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0535: ldloc.0
+			IL_0536: ldloc.s 11
+			IL_0538: ldarg.0
+			IL_0539: ldc.i4.5
+			IL_053a: ldloc.0
+			IL_053b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0540: ldc.i4.3
+			IL_0541: ldstr "_pendingException"
+			IL_0546: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_054b: ldloc.0
+			IL_054c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0551: dup
-			IL_0552: ldc.i4.7
-			IL_0553: ldloc.s 8
-			IL_0555: stelem.ref
-			IL_0556: dup
-			IL_0557: ldc.i4.8
-			IL_0558: ldloc.s 9
-			IL_055a: box [System.Runtime]System.Boolean
-			IL_055f: stelem.ref
-			IL_0560: dup
-			IL_0561: ldc.i4.s 9
-			IL_0563: ldloc.s 10
-			IL_0565: box [System.Runtime]System.Boolean
-			IL_056a: stelem.ref
-			IL_056b: pop
-			IL_056c: ldloc.0
-			IL_056d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0572: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0577: ret
+			IL_0552: ldc.i4.0
+			IL_0553: ldloc.1
+			IL_0554: stelem.ref
+			IL_0555: dup
+			IL_0556: ldc.i4.1
+			IL_0557: ldloc.2
+			IL_0558: stelem.ref
+			IL_0559: dup
+			IL_055a: ldc.i4.2
+			IL_055b: ldloc.3
+			IL_055c: stelem.ref
+			IL_055d: dup
+			IL_055e: ldc.i4.3
+			IL_055f: ldloc.s 4
+			IL_0561: stelem.ref
+			IL_0562: dup
+			IL_0563: ldc.i4.4
+			IL_0564: ldloc.s 5
+			IL_0566: stelem.ref
+			IL_0567: dup
+			IL_0568: ldc.i4.5
+			IL_0569: ldloc.s 6
+			IL_056b: stelem.ref
+			IL_056c: dup
+			IL_056d: ldc.i4.6
+			IL_056e: ldloc.s 7
+			IL_0570: stelem.ref
+			IL_0571: dup
+			IL_0572: ldc.i4.7
+			IL_0573: ldloc.s 8
+			IL_0575: stelem.ref
+			IL_0576: dup
+			IL_0577: ldc.i4.8
+			IL_0578: ldloc.s 9
+			IL_057a: box [System.Runtime]System.Boolean
+			IL_057f: stelem.ref
+			IL_0580: dup
+			IL_0581: ldc.i4.s 9
+			IL_0583: ldloc.s 10
+			IL_0585: box [System.Runtime]System.Boolean
+			IL_058a: stelem.ref
+			IL_058b: pop
+			IL_058c: ldloc.0
+			IL_058d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0592: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0597: ret
 
-			IL_0578: ldloc.0
-			IL_0579: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited4
-			IL_057e: stloc.s 11
-			IL_0580: ldloc.s 11
-			IL_0582: stloc.s 5
-			IL_0584: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0589: ldstr "Text:"
-			IL_058e: ldloc.s 5
-			IL_0590: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0595: pop
-			IL_0596: ldarg.0
-			IL_0597: ldc.i4.1
-			IL_0598: ldelem.ref
-			IL_0599: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_059e: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_05a3: ldstr "Cannot access 'fs' before initialization"
-			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_05ad: stloc.s 11
-			IL_05af: ldloc.s 11
-			IL_05b1: ldstr "promises"
-			IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05bb: stloc.s 11
-			IL_05bd: ldloc.s 11
-			IL_05bf: ldstr "unlink"
-			IL_05c4: ldloc.3
-			IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05ca: stloc.s 11
-			IL_05cc: ldloc.0
-			IL_05cd: ldc.i4.8
-			IL_05ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05d3: ldloc.0
-			IL_05d4: ldloc.s 11
-			IL_05d6: ldarg.0
-			IL_05d7: ldc.i4.5
-			IL_05d8: ldloc.0
-			IL_05d9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05de: ldc.i4.3
-			IL_05df: ldstr "_pendingException"
-			IL_05e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_05e9: ldloc.0
-			IL_05ea: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05ef: dup
-			IL_05f0: ldc.i4.0
-			IL_05f1: ldloc.1
-			IL_05f2: stelem.ref
-			IL_05f3: dup
-			IL_05f4: ldc.i4.1
-			IL_05f5: ldloc.2
-			IL_05f6: stelem.ref
-			IL_05f7: dup
-			IL_05f8: ldc.i4.2
-			IL_05f9: ldloc.3
-			IL_05fa: stelem.ref
-			IL_05fb: dup
-			IL_05fc: ldc.i4.3
-			IL_05fd: ldloc.s 4
-			IL_05ff: stelem.ref
-			IL_0600: dup
-			IL_0601: ldc.i4.4
-			IL_0602: ldloc.s 5
-			IL_0604: stelem.ref
-			IL_0605: dup
-			IL_0606: ldc.i4.5
-			IL_0607: ldloc.s 6
-			IL_0609: stelem.ref
-			IL_060a: dup
-			IL_060b: ldc.i4.6
-			IL_060c: ldloc.s 7
-			IL_060e: stelem.ref
-			IL_060f: dup
-			IL_0610: ldc.i4.7
-			IL_0611: ldloc.s 8
-			IL_0613: stelem.ref
-			IL_0614: dup
-			IL_0615: ldc.i4.8
-			IL_0616: ldloc.s 9
-			IL_0618: box [System.Runtime]System.Boolean
-			IL_061d: stelem.ref
-			IL_061e: dup
-			IL_061f: ldc.i4.s 9
-			IL_0621: ldloc.s 10
-			IL_0623: box [System.Runtime]System.Boolean
-			IL_0628: stelem.ref
-			IL_0629: pop
-			IL_062a: ldloc.0
-			IL_062b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0630: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0635: ret
+			IL_0598: ldloc.0
+			IL_0599: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
+			IL_059e: pop
+			IL_059f: ldarg.0
+			IL_05a0: ldc.i4.1
+			IL_05a1: ldelem.ref
+			IL_05a2: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_05a7: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_05ac: ldstr "existsSync"
+			IL_05b1: ldloc.3
+			IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05b7: stloc.s 11
+			IL_05b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05be: ldstr "ExistsAfterUnlink:"
+			IL_05c3: ldloc.s 11
+			IL_05c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_05ca: pop
+			IL_05cb: br IL_064d
 
-			IL_0636: ldloc.0
-			IL_0637: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
-			IL_063c: pop
-			IL_063d: ldarg.0
-			IL_063e: ldc.i4.1
-			IL_063f: ldelem.ref
-			IL_0640: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0645: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_064a: ldstr "Cannot access 'fs' before initialization"
-			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0654: stloc.s 11
-			IL_0656: ldloc.s 11
-			IL_0658: ldstr "existsSync"
-			IL_065d: ldloc.3
-			IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0663: stloc.s 11
-			IL_0665: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_066a: ldstr "ExistsAfterUnlink:"
-			IL_066f: ldloc.s 11
-			IL_0671: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0676: pop
-			IL_0677: br IL_06f9
+			IL_05d0: ldloc.0
+			IL_05d1: ldc.i4.1
+			IL_05d2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_05d7: ldloc.0
+			IL_05d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_05dd: stloc.s 11
+			IL_05df: ldloc.0
+			IL_05e0: ldc.i4.0
+			IL_05e1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_05e6: ldloc.0
+			IL_05e7: ldc.i4.0
+			IL_05e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_05ed: ldloc.s 11
+			IL_05ef: stloc.s 6
+			IL_05f1: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
+			IL_05f6: stloc.s 7
+			IL_05f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05fd: stloc.s 17
+			IL_05ff: ldloc.s 6
+			IL_0601: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0606: stloc.s 18
+			IL_0608: ldloc.s 18
+			IL_060a: brfalse IL_0622
 
-			IL_067c: ldloc.0
-			IL_067d: ldc.i4.1
-			IL_067e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0683: ldloc.0
-			IL_0684: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0689: stloc.s 11
-			IL_068b: ldloc.0
-			IL_068c: ldc.i4.0
-			IL_068d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0692: ldloc.0
-			IL_0693: ldc.i4.0
-			IL_0694: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0699: ldloc.s 11
-			IL_069b: stloc.s 6
-			IL_069d: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
-			IL_06a2: stloc.s 7
-			IL_06a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06a9: stloc.s 17
-			IL_06ab: ldloc.s 6
-			IL_06ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06b2: stloc.s 18
-			IL_06b4: ldloc.s 18
-			IL_06b6: brfalse IL_06ce
+			IL_060f: ldloc.s 6
+			IL_0611: ldstr "message"
+			IL_0616: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_061b: stloc.s 20
+			IL_061d: br IL_0626
 
-			IL_06bb: ldloc.s 6
-			IL_06bd: ldstr "message"
-			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c7: stloc.s 20
-			IL_06c9: br IL_06d2
+			IL_0622: ldloc.s 6
+			IL_0624: stloc.s 20
 
-			IL_06ce: ldloc.s 6
-			IL_06d0: stloc.s 20
+			IL_0626: ldloc.s 17
+			IL_0628: ldstr "Error:"
+			IL_062d: ldloc.s 20
+			IL_062f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0634: pop
+			IL_0635: br IL_064d
 
-			IL_06d2: ldloc.s 17
-			IL_06d4: ldstr "Error:"
-			IL_06d9: ldloc.s 20
-			IL_06db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_06e0: pop
-			IL_06e1: br IL_06f9
+			IL_063a: ldloc.0
+			IL_063b: ldc.i4.1
+			IL_063c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0641: ldloc.0
+			IL_0642: ldc.i4.0
+			IL_0643: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0648: br IL_064d
 
+			IL_064d: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L27C14::.ctor()
+			IL_0652: stloc.s 8
+			IL_0654: ldarg.0
+			IL_0655: ldc.i4.1
+			IL_0656: ldelem.ref
+			IL_0657: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_065c: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0661: stloc.s 11
+			IL_0663: ldloc.s 11
+			IL_0665: ldstr "rmSync"
+			IL_066a: ldloc.2
+			IL_066b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0670: dup
+			IL_0671: ldstr "force"
+			IL_0676: ldc.i4.1
+			IL_0677: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_067c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0681: pop
+			IL_0682: ldarg.0
+			IL_0683: ldc.i4.1
+			IL_0684: ldelem.ref
+			IL_0685: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_068a: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_068f: stloc.s 11
+			IL_0691: ldloc.s 11
+			IL_0693: ldstr "rmSync"
+			IL_0698: ldloc.3
+			IL_0699: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_069e: dup
+			IL_069f: ldstr "force"
+			IL_06a4: ldc.i4.1
+			IL_06a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_06aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_06af: pop
+			IL_06b0: br IL_06c8
+
+			IL_06b5: ldloc.0
+			IL_06b6: ldc.i4.1
+			IL_06b7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_06bc: ldloc.0
+			IL_06bd: ldc.i4.0
+			IL_06be: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_06c3: br IL_06c8
+
+			IL_06c8: ldloc.0
+			IL_06c9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_06ce: stloc.s 9
+			IL_06d0: ldloc.s 9
+			IL_06d2: brfalse IL_070f
+
+			IL_06d7: ldloc.0
+			IL_06d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_06dd: stloc.s 11
+			IL_06df: ldloc.0
+			IL_06e0: ldc.i4.m1
+			IL_06e1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_06e6: ldloc.0
-			IL_06e7: ldc.i4.1
-			IL_06e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_06ed: ldloc.0
-			IL_06ee: ldc.i4.0
-			IL_06ef: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_06f4: br IL_06f9
+			IL_06e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_06f1: ldarg.0
+			IL_06f2: ldc.i4.1
+			IL_06f3: newarr [System.Runtime]System.Object
+			IL_06f8: dup
+			IL_06f9: ldc.i4.0
+			IL_06fa: ldloc.s 11
+			IL_06fc: stelem.ref
+			IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0702: pop
+			IL_0703: ldloc.0
+			IL_0704: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0709: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_070e: ret
 
-			IL_06f9: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L27C14::.ctor()
-			IL_06fe: stloc.s 8
-			IL_0700: ldarg.0
-			IL_0701: ldc.i4.1
-			IL_0702: ldelem.ref
-			IL_0703: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0708: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_070d: ldstr "Cannot access 'fs' before initialization"
-			IL_0712: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0717: stloc.s 11
-			IL_0719: ldloc.s 11
-			IL_071b: ldstr "rmSync"
-			IL_0720: ldloc.2
-			IL_0721: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0726: dup
-			IL_0727: ldstr "force"
-			IL_072c: ldc.i4.1
-			IL_072d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0737: pop
+			IL_070f: ldloc.0
+			IL_0710: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0715: stloc.s 10
+			IL_0717: ldloc.s 10
+			IL_0719: brfalse IL_0756
+
+			IL_071e: ldloc.0
+			IL_071f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0724: stloc.s 11
+			IL_0726: ldloc.0
+			IL_0727: ldc.i4.m1
+			IL_0728: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_072d: ldloc.0
+			IL_072e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0733: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
 			IL_0738: ldarg.0
 			IL_0739: ldc.i4.1
-			IL_073a: ldelem.ref
-			IL_073b: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0740: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0745: ldstr "Cannot access 'fs' before initialization"
-			IL_074a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_074f: stloc.s 11
-			IL_0751: ldloc.s 11
-			IL_0753: ldstr "rmSync"
-			IL_0758: ldloc.3
-			IL_0759: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_075e: dup
-			IL_075f: ldstr "force"
-			IL_0764: ldc.i4.1
-			IL_0765: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_076f: pop
-			IL_0770: br IL_0788
+			IL_073a: newarr [System.Runtime]System.Object
+			IL_073f: dup
+			IL_0740: ldc.i4.0
+			IL_0741: ldloc.s 11
+			IL_0743: stelem.ref
+			IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0749: pop
+			IL_074a: ldloc.0
+			IL_074b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0750: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0755: ret
 
+			IL_0756: ldloc.0
+			IL_0757: ldc.i4.m1
+			IL_0758: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_075d: ldloc.0
+			IL_075e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0763: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0768: ldarg.0
+			IL_0769: ldc.i4.1
+			IL_076a: newarr [System.Runtime]System.Object
+			IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0774: pop
 			IL_0775: ldloc.0
-			IL_0776: ldc.i4.1
-			IL_0777: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_077c: ldloc.0
-			IL_077d: ldc.i4.0
-			IL_077e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0783: br IL_0788
-
-			IL_0788: ldloc.0
-			IL_0789: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_078e: stloc.s 9
-			IL_0790: ldloc.s 9
-			IL_0792: brfalse IL_07cf
-
-			IL_0797: ldloc.0
-			IL_0798: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_079d: stloc.s 11
-			IL_079f: ldloc.0
-			IL_07a0: ldc.i4.m1
-			IL_07a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07a6: ldloc.0
-			IL_07a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_07b1: ldarg.0
-			IL_07b2: ldc.i4.1
-			IL_07b3: newarr [System.Runtime]System.Object
-			IL_07b8: dup
-			IL_07b9: ldc.i4.0
-			IL_07ba: ldloc.s 11
-			IL_07bc: stelem.ref
-			IL_07bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_07c2: pop
-			IL_07c3: ldloc.0
-			IL_07c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07c9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07ce: ret
-
-			IL_07cf: ldloc.0
-			IL_07d0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_07d5: stloc.s 10
-			IL_07d7: ldloc.s 10
-			IL_07d9: brfalse IL_0816
-
-			IL_07de: ldloc.0
-			IL_07df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_07e4: stloc.s 11
-			IL_07e6: ldloc.0
-			IL_07e7: ldc.i4.m1
-			IL_07e8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07ed: ldloc.0
-			IL_07ee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_07f8: ldarg.0
-			IL_07f9: ldc.i4.1
-			IL_07fa: newarr [System.Runtime]System.Object
-			IL_07ff: dup
-			IL_0800: ldc.i4.0
-			IL_0801: ldloc.s 11
-			IL_0803: stelem.ref
-			IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0809: pop
-			IL_080a: ldloc.0
-			IL_080b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0810: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0815: ret
-
-			IL_0816: ldloc.0
-			IL_0817: ldc.i4.m1
-			IL_0818: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_081d: ldloc.0
-			IL_081e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0823: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0828: ldarg.0
-			IL_0829: ldc.i4.1
-			IL_082a: newarr [System.Runtime]System.Object
-			IL_082f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0834: pop
-			IL_0835: ldloc.0
-			IL_0836: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_083b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0840: ret
+			IL_0776: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_077b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0780: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1055,24 +1001,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x292d
+			// Method begins at RVA 0x286d
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1157,7 +1094,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x297b
+		// Method begins at RVA 0x289a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ad5
+					// Method begins at RVA 0x2a5a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ade
+					// Method begins at RVA 0x2a63
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ae7
+					// Method begins at RVA 0x2a6c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -121,7 +121,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2acc
+				// Method begins at RVA 0x2a51
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +147,7 @@
 			)
 			// Method begins at RVA 0x20e0
 			// Header size: 12
-			// Code size: 2486 (0x9b6)
+			// Code size: 2396 (0x95c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope,
@@ -290,7 +290,7 @@
 
 			IL_00ce: ldloc.0
 			IL_00cf: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00d4: switch (IL_0101, IL_0893, IL_08ea, IL_0829, IL_0337, IL_0453, IL_0535, IL_05ef, IL_06a1, IL_0744)
+			IL_00d4: switch (IL_0101, IL_0843, IL_0890, IL_07d9, IL_02f5, IL_0411, IL_04f3, IL_05ad, IL_065f, IL_0702)
 
 			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_0106: stloc.s 16
@@ -332,933 +332,909 @@
 			IL_0172: ldelem.ref
 			IL_0173: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
 			IL_0178: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
-			IL_017d: ldstr "Cannot access 'path' before initialization"
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0187: stloc.s 16
-			IL_0189: ldarg.0
-			IL_018a: ldc.i4.1
-			IL_018b: ldelem.ref
-			IL_018c: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0191: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
-			IL_0196: ldstr "Cannot access 'os' before initialization"
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01a0: stloc.s 21
-			IL_01a2: ldloc.s 21
-			IL_01a4: ldstr "tmpdir"
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01ae: stloc.s 21
-			IL_01b0: ldloc.1
-			IL_01b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01b6: stloc.s 20
-			IL_01b8: ldstr "js2il-fs-open-position-"
-			IL_01bd: ldloc.s 20
-			IL_01bf: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c4: stloc.s 20
-			IL_01c6: ldloc.s 20
-			IL_01c8: ldstr ".txt"
-			IL_01cd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d2: stloc.s 20
-			IL_01d4: ldloc.s 16
-			IL_01d6: ldstr "join"
-			IL_01db: ldloc.s 21
-			IL_01dd: ldloc.s 20
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01e4: stloc.s 21
-			IL_01e6: ldloc.s 21
-			IL_01e8: stloc.2
-			IL_01e9: ldloc.0
-			IL_01ea: ldc.i4.0
-			IL_01eb: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01f0: ldloc.0
-			IL_01f1: ldc.i4.0
-			IL_01f2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_01f7: ldloc.0
-			IL_01f8: ldc.i4.0
-			IL_01f9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01fe: ldloc.0
-			IL_01ff: ldc.i4.0
-			IL_0200: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0205: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
-			IL_020a: stloc.3
-			IL_020b: ldarg.0
-			IL_020c: ldc.i4.1
-			IL_020d: ldelem.ref
-			IL_020e: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0213: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0218: ldstr "Cannot access 'fs' before initialization"
-			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0222: stloc.s 21
-			IL_0224: ldloc.s 21
-			IL_0226: ldstr "rmSync"
-			IL_022b: ldloc.2
-			IL_022c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0231: dup
-			IL_0232: ldstr "force"
-			IL_0237: ldc.i4.1
-			IL_0238: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0242: pop
-			IL_0243: ldarg.0
-			IL_0244: ldc.i4.1
-			IL_0245: ldelem.ref
-			IL_0246: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_024b: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0250: ldstr "Cannot access 'fs' before initialization"
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_025a: stloc.s 21
-			IL_025c: ldloc.s 21
-			IL_025e: ldstr "writeFileSync"
-			IL_0263: ldloc.2
-			IL_0264: ldstr "hello"
-			IL_0269: ldstr "utf8"
-			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0273: pop
-			IL_0274: ldarg.0
-			IL_0275: ldc.i4.1
-			IL_0276: ldelem.ref
-			IL_0277: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_027c: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0281: ldstr "Cannot access 'fs' before initialization"
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_028b: stloc.s 21
-			IL_028d: ldloc.s 21
-			IL_028f: ldstr "promises"
-			IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0299: stloc.s 21
-			IL_029b: ldloc.s 21
-			IL_029d: ldstr "open"
-			IL_02a2: ldloc.2
-			IL_02a3: ldstr "r+"
-			IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02ad: stloc.s 21
-			IL_02af: ldloc.0
-			IL_02b0: ldc.i4.4
-			IL_02b1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02b6: ldloc.0
-			IL_02b7: ldloc.s 21
-			IL_02b9: ldarg.0
-			IL_02ba: ldc.i4.1
-			IL_02bb: ldloc.0
-			IL_02bc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02c1: ldc.i4.3
-			IL_02c2: ldstr "_pendingException"
-			IL_02c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_02cc: ldloc.0
-			IL_02cd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_017d: stloc.s 16
+			IL_017f: ldarg.0
+			IL_0180: ldc.i4.1
+			IL_0181: ldelem.ref
+			IL_0182: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0187: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
+			IL_018c: ldstr "tmpdir"
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0196: stloc.s 21
+			IL_0198: ldloc.1
+			IL_0199: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_019e: stloc.s 20
+			IL_01a0: ldstr "js2il-fs-open-position-"
+			IL_01a5: ldloc.s 20
+			IL_01a7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ac: stloc.s 20
+			IL_01ae: ldloc.s 20
+			IL_01b0: ldstr ".txt"
+			IL_01b5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ba: stloc.s 20
+			IL_01bc: ldloc.s 16
+			IL_01be: ldstr "join"
+			IL_01c3: ldloc.s 21
+			IL_01c5: ldloc.s 20
+			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01cc: stloc.s 21
+			IL_01ce: ldloc.s 21
+			IL_01d0: stloc.2
+			IL_01d1: ldloc.0
+			IL_01d2: ldc.i4.0
+			IL_01d3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_01d8: ldloc.0
+			IL_01d9: ldc.i4.0
+			IL_01da: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_01df: ldloc.0
+			IL_01e0: ldc.i4.0
+			IL_01e1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01e6: ldloc.0
+			IL_01e7: ldc.i4.0
+			IL_01e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_01ed: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
+			IL_01f2: stloc.3
+			IL_01f3: ldarg.0
+			IL_01f4: ldc.i4.1
+			IL_01f5: ldelem.ref
+			IL_01f6: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_01fb: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0200: stloc.s 21
+			IL_0202: ldloc.s 21
+			IL_0204: ldstr "rmSync"
+			IL_0209: ldloc.2
+			IL_020a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_020f: dup
+			IL_0210: ldstr "force"
+			IL_0215: ldc.i4.1
+			IL_0216: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0220: pop
+			IL_0221: ldarg.0
+			IL_0222: ldc.i4.1
+			IL_0223: ldelem.ref
+			IL_0224: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0229: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_022e: ldstr "writeFileSync"
+			IL_0233: ldloc.2
+			IL_0234: ldstr "hello"
+			IL_0239: ldstr "utf8"
+			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0243: pop
+			IL_0244: ldarg.0
+			IL_0245: ldc.i4.1
+			IL_0246: ldelem.ref
+			IL_0247: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_024c: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0251: ldstr "promises"
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025b: ldstr "open"
+			IL_0260: ldloc.2
+			IL_0261: ldstr "r+"
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_026b: stloc.s 21
+			IL_026d: ldloc.0
+			IL_026e: ldc.i4.4
+			IL_026f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0274: ldloc.0
+			IL_0275: ldloc.s 21
+			IL_0277: ldarg.0
+			IL_0278: ldc.i4.1
+			IL_0279: ldloc.0
+			IL_027a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_027f: ldc.i4.3
+			IL_0280: ldstr "_pendingException"
+			IL_0285: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_028a: ldloc.0
+			IL_028b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0290: dup
+			IL_0291: ldc.i4.0
+			IL_0292: ldloc.1
+			IL_0293: stelem.ref
+			IL_0294: dup
+			IL_0295: ldc.i4.1
+			IL_0296: ldloc.2
+			IL_0297: stelem.ref
+			IL_0298: dup
+			IL_0299: ldc.i4.2
+			IL_029a: ldloc.3
+			IL_029b: stelem.ref
+			IL_029c: dup
+			IL_029d: ldc.i4.3
+			IL_029e: ldloc.s 4
+			IL_02a0: stelem.ref
+			IL_02a1: dup
+			IL_02a2: ldc.i4.4
+			IL_02a3: ldloc.s 5
+			IL_02a5: stelem.ref
+			IL_02a6: dup
+			IL_02a7: ldc.i4.5
+			IL_02a8: ldloc.s 6
+			IL_02aa: stelem.ref
+			IL_02ab: dup
+			IL_02ac: ldc.i4.6
+			IL_02ad: ldloc.s 7
+			IL_02af: stelem.ref
+			IL_02b0: dup
+			IL_02b1: ldc.i4.7
+			IL_02b2: ldloc.s 8
+			IL_02b4: stelem.ref
+			IL_02b5: dup
+			IL_02b6: ldc.i4.8
+			IL_02b7: ldloc.s 9
+			IL_02b9: stelem.ref
+			IL_02ba: dup
+			IL_02bb: ldc.i4.s 9
+			IL_02bd: ldloc.s 10
+			IL_02bf: stelem.ref
+			IL_02c0: dup
+			IL_02c1: ldc.i4.s 10
+			IL_02c3: ldloc.s 11
+			IL_02c5: stelem.ref
+			IL_02c6: dup
+			IL_02c7: ldc.i4.s 11
+			IL_02c9: ldloc.s 12
+			IL_02cb: stelem.ref
+			IL_02cc: dup
+			IL_02cd: ldc.i4.s 12
+			IL_02cf: ldloc.s 13
+			IL_02d1: stelem.ref
 			IL_02d2: dup
-			IL_02d3: ldc.i4.0
-			IL_02d4: ldloc.1
-			IL_02d5: stelem.ref
-			IL_02d6: dup
-			IL_02d7: ldc.i4.1
-			IL_02d8: ldloc.2
-			IL_02d9: stelem.ref
-			IL_02da: dup
-			IL_02db: ldc.i4.2
-			IL_02dc: ldloc.3
-			IL_02dd: stelem.ref
-			IL_02de: dup
-			IL_02df: ldc.i4.3
-			IL_02e0: ldloc.s 4
-			IL_02e2: stelem.ref
-			IL_02e3: dup
-			IL_02e4: ldc.i4.4
-			IL_02e5: ldloc.s 5
+			IL_02d3: ldc.i4.s 13
+			IL_02d5: ldloc.s 14
+			IL_02d7: box [System.Runtime]System.Boolean
+			IL_02dc: stelem.ref
+			IL_02dd: dup
+			IL_02de: ldc.i4.s 14
+			IL_02e0: ldloc.s 15
+			IL_02e2: box [System.Runtime]System.Boolean
 			IL_02e7: stelem.ref
-			IL_02e8: dup
-			IL_02e9: ldc.i4.5
-			IL_02ea: ldloc.s 6
-			IL_02ec: stelem.ref
-			IL_02ed: dup
-			IL_02ee: ldc.i4.6
-			IL_02ef: ldloc.s 7
-			IL_02f1: stelem.ref
-			IL_02f2: dup
-			IL_02f3: ldc.i4.7
-			IL_02f4: ldloc.s 8
-			IL_02f6: stelem.ref
-			IL_02f7: dup
-			IL_02f8: ldc.i4.8
-			IL_02f9: ldloc.s 9
-			IL_02fb: stelem.ref
-			IL_02fc: dup
-			IL_02fd: ldc.i4.s 9
-			IL_02ff: ldloc.s 10
-			IL_0301: stelem.ref
-			IL_0302: dup
-			IL_0303: ldc.i4.s 10
-			IL_0305: ldloc.s 11
-			IL_0307: stelem.ref
-			IL_0308: dup
-			IL_0309: ldc.i4.s 11
-			IL_030b: ldloc.s 12
-			IL_030d: stelem.ref
-			IL_030e: dup
-			IL_030f: ldc.i4.s 12
-			IL_0311: ldloc.s 13
-			IL_0313: stelem.ref
-			IL_0314: dup
-			IL_0315: ldc.i4.s 13
-			IL_0317: ldloc.s 14
-			IL_0319: box [System.Runtime]System.Boolean
-			IL_031e: stelem.ref
-			IL_031f: dup
-			IL_0320: ldc.i4.s 14
-			IL_0322: ldloc.s 15
-			IL_0324: box [System.Runtime]System.Boolean
-			IL_0329: stelem.ref
-			IL_032a: pop
-			IL_032b: ldloc.0
-			IL_032c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0331: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0336: ret
+			IL_02e8: pop
+			IL_02e9: ldloc.0
+			IL_02ea: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02ef: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02f4: ret
 
-			IL_0337: ldloc.0
-			IL_0338: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
-			IL_033d: stloc.s 21
-			IL_033f: ldloc.s 21
-			IL_0341: stloc.s 4
-			IL_0343: ldc.r8 1
-			IL_034c: box [System.Runtime]System.Double
-			IL_0351: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_0356: stloc.s 22
-			IL_0358: ldloc.s 22
-			IL_035a: stloc.s 5
-			IL_035c: ldc.r8 1
-			IL_0365: box [System.Runtime]System.Double
-			IL_036a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_036f: stloc.s 22
-			IL_0371: ldloc.s 22
-			IL_0373: stloc.s 6
-			IL_0375: ldloc.s 5
-			IL_0377: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_037c: stloc.s 18
-			IL_037e: ldloc.s 18
-			IL_0380: box [System.Runtime]System.Double
-			IL_0385: stloc.s 19
-			IL_0387: ldc.i4.4
-			IL_0388: newarr [System.Runtime]System.Object
-			IL_038d: dup
-			IL_038e: ldc.i4.0
-			IL_038f: ldloc.s 5
-			IL_0391: stelem.ref
-			IL_0392: dup
-			IL_0393: ldc.i4.1
-			IL_0394: ldc.r8 0.0
-			IL_039d: box [System.Runtime]System.Double
-			IL_03a2: stelem.ref
-			IL_03a3: dup
-			IL_03a4: ldc.i4.2
-			IL_03a5: ldloc.s 19
-			IL_03a7: stelem.ref
-			IL_03a8: dup
-			IL_03a9: ldc.i4.3
-			IL_03aa: ldc.r8 2
-			IL_03b3: box [System.Runtime]System.Double
-			IL_03b8: stelem.ref
-			IL_03b9: stloc.s 23
-			IL_03bb: ldloc.s 4
-			IL_03bd: ldstr "read"
-			IL_03c2: ldloc.s 23
-			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_03c9: stloc.s 21
-			IL_03cb: ldloc.0
-			IL_03cc: ldc.i4.5
-			IL_03cd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03d2: ldloc.0
-			IL_03d3: ldloc.s 21
-			IL_03d5: ldarg.0
-			IL_03d6: ldc.i4.2
-			IL_03d7: ldloc.0
-			IL_03d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03dd: ldc.i4.3
-			IL_03de: ldstr "_pendingException"
-			IL_03e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03e8: ldloc.0
-			IL_03e9: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02f5: ldloc.0
+			IL_02f6: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
+			IL_02fb: stloc.s 21
+			IL_02fd: ldloc.s 21
+			IL_02ff: stloc.s 4
+			IL_0301: ldc.r8 1
+			IL_030a: box [System.Runtime]System.Double
+			IL_030f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_0314: stloc.s 22
+			IL_0316: ldloc.s 22
+			IL_0318: stloc.s 5
+			IL_031a: ldc.r8 1
+			IL_0323: box [System.Runtime]System.Double
+			IL_0328: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_032d: stloc.s 22
+			IL_032f: ldloc.s 22
+			IL_0331: stloc.s 6
+			IL_0333: ldloc.s 5
+			IL_0335: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_033a: stloc.s 18
+			IL_033c: ldloc.s 18
+			IL_033e: box [System.Runtime]System.Double
+			IL_0343: stloc.s 19
+			IL_0345: ldc.i4.4
+			IL_0346: newarr [System.Runtime]System.Object
+			IL_034b: dup
+			IL_034c: ldc.i4.0
+			IL_034d: ldloc.s 5
+			IL_034f: stelem.ref
+			IL_0350: dup
+			IL_0351: ldc.i4.1
+			IL_0352: ldc.r8 0.0
+			IL_035b: box [System.Runtime]System.Double
+			IL_0360: stelem.ref
+			IL_0361: dup
+			IL_0362: ldc.i4.2
+			IL_0363: ldloc.s 19
+			IL_0365: stelem.ref
+			IL_0366: dup
+			IL_0367: ldc.i4.3
+			IL_0368: ldc.r8 2
+			IL_0371: box [System.Runtime]System.Double
+			IL_0376: stelem.ref
+			IL_0377: stloc.s 23
+			IL_0379: ldloc.s 4
+			IL_037b: ldstr "read"
+			IL_0380: ldloc.s 23
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0387: stloc.s 21
+			IL_0389: ldloc.0
+			IL_038a: ldc.i4.5
+			IL_038b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0390: ldloc.0
+			IL_0391: ldloc.s 21
+			IL_0393: ldarg.0
+			IL_0394: ldc.i4.2
+			IL_0395: ldloc.0
+			IL_0396: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_039b: ldc.i4.3
+			IL_039c: ldstr "_pendingException"
+			IL_03a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03a6: ldloc.0
+			IL_03a7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03ac: dup
+			IL_03ad: ldc.i4.0
+			IL_03ae: ldloc.1
+			IL_03af: stelem.ref
+			IL_03b0: dup
+			IL_03b1: ldc.i4.1
+			IL_03b2: ldloc.2
+			IL_03b3: stelem.ref
+			IL_03b4: dup
+			IL_03b5: ldc.i4.2
+			IL_03b6: ldloc.3
+			IL_03b7: stelem.ref
+			IL_03b8: dup
+			IL_03b9: ldc.i4.3
+			IL_03ba: ldloc.s 4
+			IL_03bc: stelem.ref
+			IL_03bd: dup
+			IL_03be: ldc.i4.4
+			IL_03bf: ldloc.s 5
+			IL_03c1: stelem.ref
+			IL_03c2: dup
+			IL_03c3: ldc.i4.5
+			IL_03c4: ldloc.s 6
+			IL_03c6: stelem.ref
+			IL_03c7: dup
+			IL_03c8: ldc.i4.6
+			IL_03c9: ldloc.s 7
+			IL_03cb: stelem.ref
+			IL_03cc: dup
+			IL_03cd: ldc.i4.7
+			IL_03ce: ldloc.s 8
+			IL_03d0: stelem.ref
+			IL_03d1: dup
+			IL_03d2: ldc.i4.8
+			IL_03d3: ldloc.s 9
+			IL_03d5: stelem.ref
+			IL_03d6: dup
+			IL_03d7: ldc.i4.s 9
+			IL_03d9: ldloc.s 10
+			IL_03db: stelem.ref
+			IL_03dc: dup
+			IL_03dd: ldc.i4.s 10
+			IL_03df: ldloc.s 11
+			IL_03e1: stelem.ref
+			IL_03e2: dup
+			IL_03e3: ldc.i4.s 11
+			IL_03e5: ldloc.s 12
+			IL_03e7: stelem.ref
+			IL_03e8: dup
+			IL_03e9: ldc.i4.s 12
+			IL_03eb: ldloc.s 13
+			IL_03ed: stelem.ref
 			IL_03ee: dup
-			IL_03ef: ldc.i4.0
-			IL_03f0: ldloc.1
-			IL_03f1: stelem.ref
-			IL_03f2: dup
-			IL_03f3: ldc.i4.1
-			IL_03f4: ldloc.2
-			IL_03f5: stelem.ref
-			IL_03f6: dup
-			IL_03f7: ldc.i4.2
-			IL_03f8: ldloc.3
-			IL_03f9: stelem.ref
-			IL_03fa: dup
-			IL_03fb: ldc.i4.3
-			IL_03fc: ldloc.s 4
-			IL_03fe: stelem.ref
-			IL_03ff: dup
-			IL_0400: ldc.i4.4
-			IL_0401: ldloc.s 5
+			IL_03ef: ldc.i4.s 13
+			IL_03f1: ldloc.s 14
+			IL_03f3: box [System.Runtime]System.Boolean
+			IL_03f8: stelem.ref
+			IL_03f9: dup
+			IL_03fa: ldc.i4.s 14
+			IL_03fc: ldloc.s 15
+			IL_03fe: box [System.Runtime]System.Boolean
 			IL_0403: stelem.ref
-			IL_0404: dup
-			IL_0405: ldc.i4.5
-			IL_0406: ldloc.s 6
-			IL_0408: stelem.ref
-			IL_0409: dup
-			IL_040a: ldc.i4.6
-			IL_040b: ldloc.s 7
-			IL_040d: stelem.ref
-			IL_040e: dup
-			IL_040f: ldc.i4.7
-			IL_0410: ldloc.s 8
-			IL_0412: stelem.ref
-			IL_0413: dup
-			IL_0414: ldc.i4.8
-			IL_0415: ldloc.s 9
-			IL_0417: stelem.ref
-			IL_0418: dup
-			IL_0419: ldc.i4.s 9
-			IL_041b: ldloc.s 10
-			IL_041d: stelem.ref
-			IL_041e: dup
-			IL_041f: ldc.i4.s 10
-			IL_0421: ldloc.s 11
-			IL_0423: stelem.ref
-			IL_0424: dup
-			IL_0425: ldc.i4.s 11
-			IL_0427: ldloc.s 12
-			IL_0429: stelem.ref
-			IL_042a: dup
-			IL_042b: ldc.i4.s 12
-			IL_042d: ldloc.s 13
-			IL_042f: stelem.ref
-			IL_0430: dup
-			IL_0431: ldc.i4.s 13
-			IL_0433: ldloc.s 14
-			IL_0435: box [System.Runtime]System.Boolean
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.s 14
-			IL_043e: ldloc.s 15
-			IL_0440: box [System.Runtime]System.Boolean
-			IL_0445: stelem.ref
-			IL_0446: pop
-			IL_0447: ldloc.0
-			IL_0448: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_044d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0452: ret
+			IL_0404: pop
+			IL_0405: ldloc.0
+			IL_0406: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_040b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0410: ret
 
-			IL_0453: ldloc.0
-			IL_0454: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
-			IL_0459: stloc.s 21
-			IL_045b: ldloc.s 21
-			IL_045d: stloc.s 7
-			IL_045f: ldloc.s 6
-			IL_0461: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_0466: stloc.s 18
-			IL_0468: ldloc.s 18
-			IL_046a: box [System.Runtime]System.Double
-			IL_046f: stloc.s 19
-			IL_0471: ldc.i4.4
-			IL_0472: newarr [System.Runtime]System.Object
-			IL_0477: dup
-			IL_0478: ldc.i4.0
-			IL_0479: ldloc.s 6
-			IL_047b: stelem.ref
-			IL_047c: dup
-			IL_047d: ldc.i4.1
-			IL_047e: ldc.r8 0.0
-			IL_0487: box [System.Runtime]System.Double
-			IL_048c: stelem.ref
-			IL_048d: dup
-			IL_048e: ldc.i4.2
-			IL_048f: ldloc.s 19
+			IL_0411: ldloc.0
+			IL_0412: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
+			IL_0417: stloc.s 21
+			IL_0419: ldloc.s 21
+			IL_041b: stloc.s 7
+			IL_041d: ldloc.s 6
+			IL_041f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_0424: stloc.s 18
+			IL_0426: ldloc.s 18
+			IL_0428: box [System.Runtime]System.Double
+			IL_042d: stloc.s 19
+			IL_042f: ldc.i4.4
+			IL_0430: newarr [System.Runtime]System.Object
+			IL_0435: dup
+			IL_0436: ldc.i4.0
+			IL_0437: ldloc.s 6
+			IL_0439: stelem.ref
+			IL_043a: dup
+			IL_043b: ldc.i4.1
+			IL_043c: ldc.r8 0.0
+			IL_0445: box [System.Runtime]System.Double
+			IL_044a: stelem.ref
+			IL_044b: dup
+			IL_044c: ldc.i4.2
+			IL_044d: ldloc.s 19
+			IL_044f: stelem.ref
+			IL_0450: dup
+			IL_0451: ldc.i4.3
+			IL_0452: ldc.i4.0
+			IL_0453: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0458: stelem.ref
+			IL_0459: stloc.s 23
+			IL_045b: ldloc.s 4
+			IL_045d: ldstr "read"
+			IL_0462: ldloc.s 23
+			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0469: stloc.s 21
+			IL_046b: ldloc.0
+			IL_046c: ldc.i4.6
+			IL_046d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0472: ldloc.0
+			IL_0473: ldloc.s 21
+			IL_0475: ldarg.0
+			IL_0476: ldc.i4.3
+			IL_0477: ldloc.0
+			IL_0478: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_047d: ldc.i4.3
+			IL_047e: ldstr "_pendingException"
+			IL_0483: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0488: ldloc.0
+			IL_0489: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_048e: dup
+			IL_048f: ldc.i4.0
+			IL_0490: ldloc.1
 			IL_0491: stelem.ref
 			IL_0492: dup
-			IL_0493: ldc.i4.3
-			IL_0494: ldc.i4.0
-			IL_0495: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_049a: stelem.ref
-			IL_049b: stloc.s 23
-			IL_049d: ldloc.s 4
-			IL_049f: ldstr "read"
-			IL_04a4: ldloc.s 23
-			IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_04ab: stloc.s 21
-			IL_04ad: ldloc.0
-			IL_04ae: ldc.i4.6
-			IL_04af: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04b4: ldloc.0
-			IL_04b5: ldloc.s 21
-			IL_04b7: ldarg.0
-			IL_04b8: ldc.i4.3
-			IL_04b9: ldloc.0
-			IL_04ba: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04bf: ldc.i4.3
-			IL_04c0: ldstr "_pendingException"
-			IL_04c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04ca: ldloc.0
-			IL_04cb: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0493: ldc.i4.1
+			IL_0494: ldloc.2
+			IL_0495: stelem.ref
+			IL_0496: dup
+			IL_0497: ldc.i4.2
+			IL_0498: ldloc.3
+			IL_0499: stelem.ref
+			IL_049a: dup
+			IL_049b: ldc.i4.3
+			IL_049c: ldloc.s 4
+			IL_049e: stelem.ref
+			IL_049f: dup
+			IL_04a0: ldc.i4.4
+			IL_04a1: ldloc.s 5
+			IL_04a3: stelem.ref
+			IL_04a4: dup
+			IL_04a5: ldc.i4.5
+			IL_04a6: ldloc.s 6
+			IL_04a8: stelem.ref
+			IL_04a9: dup
+			IL_04aa: ldc.i4.6
+			IL_04ab: ldloc.s 7
+			IL_04ad: stelem.ref
+			IL_04ae: dup
+			IL_04af: ldc.i4.7
+			IL_04b0: ldloc.s 8
+			IL_04b2: stelem.ref
+			IL_04b3: dup
+			IL_04b4: ldc.i4.8
+			IL_04b5: ldloc.s 9
+			IL_04b7: stelem.ref
+			IL_04b8: dup
+			IL_04b9: ldc.i4.s 9
+			IL_04bb: ldloc.s 10
+			IL_04bd: stelem.ref
+			IL_04be: dup
+			IL_04bf: ldc.i4.s 10
+			IL_04c1: ldloc.s 11
+			IL_04c3: stelem.ref
+			IL_04c4: dup
+			IL_04c5: ldc.i4.s 11
+			IL_04c7: ldloc.s 12
+			IL_04c9: stelem.ref
+			IL_04ca: dup
+			IL_04cb: ldc.i4.s 12
+			IL_04cd: ldloc.s 13
+			IL_04cf: stelem.ref
 			IL_04d0: dup
-			IL_04d1: ldc.i4.0
-			IL_04d2: ldloc.1
-			IL_04d3: stelem.ref
-			IL_04d4: dup
-			IL_04d5: ldc.i4.1
-			IL_04d6: ldloc.2
-			IL_04d7: stelem.ref
-			IL_04d8: dup
-			IL_04d9: ldc.i4.2
-			IL_04da: ldloc.3
-			IL_04db: stelem.ref
-			IL_04dc: dup
-			IL_04dd: ldc.i4.3
-			IL_04de: ldloc.s 4
-			IL_04e0: stelem.ref
-			IL_04e1: dup
-			IL_04e2: ldc.i4.4
-			IL_04e3: ldloc.s 5
+			IL_04d1: ldc.i4.s 13
+			IL_04d3: ldloc.s 14
+			IL_04d5: box [System.Runtime]System.Boolean
+			IL_04da: stelem.ref
+			IL_04db: dup
+			IL_04dc: ldc.i4.s 14
+			IL_04de: ldloc.s 15
+			IL_04e0: box [System.Runtime]System.Boolean
 			IL_04e5: stelem.ref
-			IL_04e6: dup
-			IL_04e7: ldc.i4.5
-			IL_04e8: ldloc.s 6
-			IL_04ea: stelem.ref
-			IL_04eb: dup
-			IL_04ec: ldc.i4.6
-			IL_04ed: ldloc.s 7
-			IL_04ef: stelem.ref
-			IL_04f0: dup
-			IL_04f1: ldc.i4.7
-			IL_04f2: ldloc.s 8
-			IL_04f4: stelem.ref
-			IL_04f5: dup
-			IL_04f6: ldc.i4.8
-			IL_04f7: ldloc.s 9
-			IL_04f9: stelem.ref
-			IL_04fa: dup
-			IL_04fb: ldc.i4.s 9
-			IL_04fd: ldloc.s 10
-			IL_04ff: stelem.ref
-			IL_0500: dup
-			IL_0501: ldc.i4.s 10
-			IL_0503: ldloc.s 11
-			IL_0505: stelem.ref
-			IL_0506: dup
-			IL_0507: ldc.i4.s 11
-			IL_0509: ldloc.s 12
-			IL_050b: stelem.ref
-			IL_050c: dup
-			IL_050d: ldc.i4.s 12
-			IL_050f: ldloc.s 13
-			IL_0511: stelem.ref
-			IL_0512: dup
-			IL_0513: ldc.i4.s 13
-			IL_0515: ldloc.s 14
-			IL_0517: box [System.Runtime]System.Boolean
-			IL_051c: stelem.ref
-			IL_051d: dup
-			IL_051e: ldc.i4.s 14
-			IL_0520: ldloc.s 15
-			IL_0522: box [System.Runtime]System.Boolean
-			IL_0527: stelem.ref
-			IL_0528: pop
-			IL_0529: ldloc.0
-			IL_052a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_052f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0534: ret
+			IL_04e6: pop
+			IL_04e7: ldloc.0
+			IL_04e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04f2: ret
 
-			IL_0535: ldloc.0
-			IL_0536: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
-			IL_053b: stloc.s 21
-			IL_053d: ldloc.s 21
-			IL_053f: stloc.s 8
-			IL_0541: ldloc.s 4
-			IL_0543: ldstr "write"
-			IL_0548: ldstr "X"
-			IL_054d: ldc.r8 4
-			IL_0556: box [System.Runtime]System.Double
-			IL_055b: ldstr "utf8"
-			IL_0560: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0565: stloc.s 21
-			IL_0567: ldloc.0
-			IL_0568: ldc.i4.7
-			IL_0569: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_056e: ldloc.0
-			IL_056f: ldloc.s 21
-			IL_0571: ldarg.0
-			IL_0572: ldc.i4.4
-			IL_0573: ldloc.0
-			IL_0574: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0579: ldc.i4.3
-			IL_057a: ldstr "_pendingException"
-			IL_057f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0584: ldloc.0
-			IL_0585: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04f3: ldloc.0
+			IL_04f4: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
+			IL_04f9: stloc.s 21
+			IL_04fb: ldloc.s 21
+			IL_04fd: stloc.s 8
+			IL_04ff: ldloc.s 4
+			IL_0501: ldstr "write"
+			IL_0506: ldstr "X"
+			IL_050b: ldc.r8 4
+			IL_0514: box [System.Runtime]System.Double
+			IL_0519: ldstr "utf8"
+			IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0523: stloc.s 21
+			IL_0525: ldloc.0
+			IL_0526: ldc.i4.7
+			IL_0527: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_052c: ldloc.0
+			IL_052d: ldloc.s 21
+			IL_052f: ldarg.0
+			IL_0530: ldc.i4.4
+			IL_0531: ldloc.0
+			IL_0532: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0537: ldc.i4.3
+			IL_0538: ldstr "_pendingException"
+			IL_053d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0542: ldloc.0
+			IL_0543: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0548: dup
+			IL_0549: ldc.i4.0
+			IL_054a: ldloc.1
+			IL_054b: stelem.ref
+			IL_054c: dup
+			IL_054d: ldc.i4.1
+			IL_054e: ldloc.2
+			IL_054f: stelem.ref
+			IL_0550: dup
+			IL_0551: ldc.i4.2
+			IL_0552: ldloc.3
+			IL_0553: stelem.ref
+			IL_0554: dup
+			IL_0555: ldc.i4.3
+			IL_0556: ldloc.s 4
+			IL_0558: stelem.ref
+			IL_0559: dup
+			IL_055a: ldc.i4.4
+			IL_055b: ldloc.s 5
+			IL_055d: stelem.ref
+			IL_055e: dup
+			IL_055f: ldc.i4.5
+			IL_0560: ldloc.s 6
+			IL_0562: stelem.ref
+			IL_0563: dup
+			IL_0564: ldc.i4.6
+			IL_0565: ldloc.s 7
+			IL_0567: stelem.ref
+			IL_0568: dup
+			IL_0569: ldc.i4.7
+			IL_056a: ldloc.s 8
+			IL_056c: stelem.ref
+			IL_056d: dup
+			IL_056e: ldc.i4.8
+			IL_056f: ldloc.s 9
+			IL_0571: stelem.ref
+			IL_0572: dup
+			IL_0573: ldc.i4.s 9
+			IL_0575: ldloc.s 10
+			IL_0577: stelem.ref
+			IL_0578: dup
+			IL_0579: ldc.i4.s 10
+			IL_057b: ldloc.s 11
+			IL_057d: stelem.ref
+			IL_057e: dup
+			IL_057f: ldc.i4.s 11
+			IL_0581: ldloc.s 12
+			IL_0583: stelem.ref
+			IL_0584: dup
+			IL_0585: ldc.i4.s 12
+			IL_0587: ldloc.s 13
+			IL_0589: stelem.ref
 			IL_058a: dup
-			IL_058b: ldc.i4.0
-			IL_058c: ldloc.1
-			IL_058d: stelem.ref
-			IL_058e: dup
-			IL_058f: ldc.i4.1
-			IL_0590: ldloc.2
-			IL_0591: stelem.ref
-			IL_0592: dup
-			IL_0593: ldc.i4.2
-			IL_0594: ldloc.3
-			IL_0595: stelem.ref
-			IL_0596: dup
-			IL_0597: ldc.i4.3
-			IL_0598: ldloc.s 4
-			IL_059a: stelem.ref
-			IL_059b: dup
-			IL_059c: ldc.i4.4
-			IL_059d: ldloc.s 5
+			IL_058b: ldc.i4.s 13
+			IL_058d: ldloc.s 14
+			IL_058f: box [System.Runtime]System.Boolean
+			IL_0594: stelem.ref
+			IL_0595: dup
+			IL_0596: ldc.i4.s 14
+			IL_0598: ldloc.s 15
+			IL_059a: box [System.Runtime]System.Boolean
 			IL_059f: stelem.ref
-			IL_05a0: dup
-			IL_05a1: ldc.i4.5
-			IL_05a2: ldloc.s 6
-			IL_05a4: stelem.ref
-			IL_05a5: dup
-			IL_05a6: ldc.i4.6
-			IL_05a7: ldloc.s 7
-			IL_05a9: stelem.ref
-			IL_05aa: dup
-			IL_05ab: ldc.i4.7
-			IL_05ac: ldloc.s 8
-			IL_05ae: stelem.ref
-			IL_05af: dup
-			IL_05b0: ldc.i4.8
-			IL_05b1: ldloc.s 9
-			IL_05b3: stelem.ref
-			IL_05b4: dup
-			IL_05b5: ldc.i4.s 9
-			IL_05b7: ldloc.s 10
-			IL_05b9: stelem.ref
-			IL_05ba: dup
-			IL_05bb: ldc.i4.s 10
-			IL_05bd: ldloc.s 11
-			IL_05bf: stelem.ref
-			IL_05c0: dup
-			IL_05c1: ldc.i4.s 11
-			IL_05c3: ldloc.s 12
-			IL_05c5: stelem.ref
-			IL_05c6: dup
-			IL_05c7: ldc.i4.s 12
-			IL_05c9: ldloc.s 13
-			IL_05cb: stelem.ref
-			IL_05cc: dup
-			IL_05cd: ldc.i4.s 13
-			IL_05cf: ldloc.s 14
-			IL_05d1: box [System.Runtime]System.Boolean
-			IL_05d6: stelem.ref
-			IL_05d7: dup
-			IL_05d8: ldc.i4.s 14
-			IL_05da: ldloc.s 15
-			IL_05dc: box [System.Runtime]System.Boolean
-			IL_05e1: stelem.ref
-			IL_05e2: pop
+			IL_05a0: pop
+			IL_05a1: ldloc.0
+			IL_05a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05a7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05ac: ret
+
+			IL_05ad: ldloc.0
+			IL_05ae: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
+			IL_05b3: stloc.s 21
+			IL_05b5: ldloc.s 21
+			IL_05b7: stloc.s 9
+			IL_05b9: ldloc.s 4
+			IL_05bb: ldstr "write"
+			IL_05c0: ldstr "Y"
+			IL_05c5: ldc.i4.0
+			IL_05c6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_05cb: ldstr "utf8"
+			IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_05d5: stloc.s 21
+			IL_05d7: ldloc.0
+			IL_05d8: ldc.i4.8
+			IL_05d9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05de: ldloc.0
+			IL_05df: ldloc.s 21
+			IL_05e1: ldarg.0
+			IL_05e2: ldc.i4.5
 			IL_05e3: ldloc.0
-			IL_05e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05ee: ret
-
-			IL_05ef: ldloc.0
-			IL_05f0: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
-			IL_05f5: stloc.s 21
-			IL_05f7: ldloc.s 21
-			IL_05f9: stloc.s 9
-			IL_05fb: ldloc.s 4
-			IL_05fd: ldstr "write"
-			IL_0602: ldstr "Y"
-			IL_0607: ldc.i4.0
-			IL_0608: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_060d: ldstr "utf8"
-			IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0617: stloc.s 21
-			IL_0619: ldloc.0
-			IL_061a: ldc.i4.8
-			IL_061b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0620: ldloc.0
-			IL_0621: ldloc.s 21
-			IL_0623: ldarg.0
-			IL_0624: ldc.i4.5
-			IL_0625: ldloc.0
-			IL_0626: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_062b: ldc.i4.3
-			IL_062c: ldstr "_pendingException"
-			IL_0631: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0636: ldloc.0
-			IL_0637: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05e4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05e9: ldc.i4.3
+			IL_05ea: ldstr "_pendingException"
+			IL_05ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05f4: ldloc.0
+			IL_05f5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05fa: dup
+			IL_05fb: ldc.i4.0
+			IL_05fc: ldloc.1
+			IL_05fd: stelem.ref
+			IL_05fe: dup
+			IL_05ff: ldc.i4.1
+			IL_0600: ldloc.2
+			IL_0601: stelem.ref
+			IL_0602: dup
+			IL_0603: ldc.i4.2
+			IL_0604: ldloc.3
+			IL_0605: stelem.ref
+			IL_0606: dup
+			IL_0607: ldc.i4.3
+			IL_0608: ldloc.s 4
+			IL_060a: stelem.ref
+			IL_060b: dup
+			IL_060c: ldc.i4.4
+			IL_060d: ldloc.s 5
+			IL_060f: stelem.ref
+			IL_0610: dup
+			IL_0611: ldc.i4.5
+			IL_0612: ldloc.s 6
+			IL_0614: stelem.ref
+			IL_0615: dup
+			IL_0616: ldc.i4.6
+			IL_0617: ldloc.s 7
+			IL_0619: stelem.ref
+			IL_061a: dup
+			IL_061b: ldc.i4.7
+			IL_061c: ldloc.s 8
+			IL_061e: stelem.ref
+			IL_061f: dup
+			IL_0620: ldc.i4.8
+			IL_0621: ldloc.s 9
+			IL_0623: stelem.ref
+			IL_0624: dup
+			IL_0625: ldc.i4.s 9
+			IL_0627: ldloc.s 10
+			IL_0629: stelem.ref
+			IL_062a: dup
+			IL_062b: ldc.i4.s 10
+			IL_062d: ldloc.s 11
+			IL_062f: stelem.ref
+			IL_0630: dup
+			IL_0631: ldc.i4.s 11
+			IL_0633: ldloc.s 12
+			IL_0635: stelem.ref
+			IL_0636: dup
+			IL_0637: ldc.i4.s 12
+			IL_0639: ldloc.s 13
+			IL_063b: stelem.ref
 			IL_063c: dup
-			IL_063d: ldc.i4.0
-			IL_063e: ldloc.1
-			IL_063f: stelem.ref
-			IL_0640: dup
-			IL_0641: ldc.i4.1
-			IL_0642: ldloc.2
-			IL_0643: stelem.ref
-			IL_0644: dup
-			IL_0645: ldc.i4.2
-			IL_0646: ldloc.3
-			IL_0647: stelem.ref
-			IL_0648: dup
-			IL_0649: ldc.i4.3
-			IL_064a: ldloc.s 4
-			IL_064c: stelem.ref
-			IL_064d: dup
-			IL_064e: ldc.i4.4
-			IL_064f: ldloc.s 5
+			IL_063d: ldc.i4.s 13
+			IL_063f: ldloc.s 14
+			IL_0641: box [System.Runtime]System.Boolean
+			IL_0646: stelem.ref
+			IL_0647: dup
+			IL_0648: ldc.i4.s 14
+			IL_064a: ldloc.s 15
+			IL_064c: box [System.Runtime]System.Boolean
 			IL_0651: stelem.ref
-			IL_0652: dup
-			IL_0653: ldc.i4.5
-			IL_0654: ldloc.s 6
-			IL_0656: stelem.ref
-			IL_0657: dup
-			IL_0658: ldc.i4.6
-			IL_0659: ldloc.s 7
-			IL_065b: stelem.ref
-			IL_065c: dup
-			IL_065d: ldc.i4.7
-			IL_065e: ldloc.s 8
-			IL_0660: stelem.ref
-			IL_0661: dup
-			IL_0662: ldc.i4.8
-			IL_0663: ldloc.s 9
-			IL_0665: stelem.ref
-			IL_0666: dup
-			IL_0667: ldc.i4.s 9
-			IL_0669: ldloc.s 10
-			IL_066b: stelem.ref
-			IL_066c: dup
-			IL_066d: ldc.i4.s 10
-			IL_066f: ldloc.s 11
-			IL_0671: stelem.ref
-			IL_0672: dup
-			IL_0673: ldc.i4.s 11
-			IL_0675: ldloc.s 12
-			IL_0677: stelem.ref
-			IL_0678: dup
-			IL_0679: ldc.i4.s 12
-			IL_067b: ldloc.s 13
-			IL_067d: stelem.ref
-			IL_067e: dup
-			IL_067f: ldc.i4.s 13
-			IL_0681: ldloc.s 14
-			IL_0683: box [System.Runtime]System.Boolean
-			IL_0688: stelem.ref
-			IL_0689: dup
-			IL_068a: ldc.i4.s 14
-			IL_068c: ldloc.s 15
-			IL_068e: box [System.Runtime]System.Boolean
-			IL_0693: stelem.ref
-			IL_0694: pop
-			IL_0695: ldloc.0
-			IL_0696: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_069b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06a0: ret
+			IL_0652: pop
+			IL_0653: ldloc.0
+			IL_0654: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0659: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_065e: ret
 
-			IL_06a1: ldloc.0
-			IL_06a2: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
-			IL_06a7: stloc.s 21
-			IL_06a9: ldloc.s 21
-			IL_06ab: stloc.s 10
-			IL_06ad: ldloc.s 4
-			IL_06af: ldstr "close"
-			IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_06b9: stloc.s 21
-			IL_06bb: ldloc.0
-			IL_06bc: ldc.i4.s 9
-			IL_06be: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06c3: ldloc.0
-			IL_06c4: ldloc.s 21
-			IL_06c6: ldarg.0
-			IL_06c7: ldc.i4.6
-			IL_06c8: ldloc.0
-			IL_06c9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06ce: ldc.i4.3
-			IL_06cf: ldstr "_pendingException"
-			IL_06d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_06d9: ldloc.0
-			IL_06da: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_065f: ldloc.0
+			IL_0660: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
+			IL_0665: stloc.s 21
+			IL_0667: ldloc.s 21
+			IL_0669: stloc.s 10
+			IL_066b: ldloc.s 4
+			IL_066d: ldstr "close"
+			IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0677: stloc.s 21
+			IL_0679: ldloc.0
+			IL_067a: ldc.i4.s 9
+			IL_067c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0681: ldloc.0
+			IL_0682: ldloc.s 21
+			IL_0684: ldarg.0
+			IL_0685: ldc.i4.6
+			IL_0686: ldloc.0
+			IL_0687: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_068c: ldc.i4.3
+			IL_068d: ldstr "_pendingException"
+			IL_0692: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0697: ldloc.0
+			IL_0698: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_069d: dup
+			IL_069e: ldc.i4.0
+			IL_069f: ldloc.1
+			IL_06a0: stelem.ref
+			IL_06a1: dup
+			IL_06a2: ldc.i4.1
+			IL_06a3: ldloc.2
+			IL_06a4: stelem.ref
+			IL_06a5: dup
+			IL_06a6: ldc.i4.2
+			IL_06a7: ldloc.3
+			IL_06a8: stelem.ref
+			IL_06a9: dup
+			IL_06aa: ldc.i4.3
+			IL_06ab: ldloc.s 4
+			IL_06ad: stelem.ref
+			IL_06ae: dup
+			IL_06af: ldc.i4.4
+			IL_06b0: ldloc.s 5
+			IL_06b2: stelem.ref
+			IL_06b3: dup
+			IL_06b4: ldc.i4.5
+			IL_06b5: ldloc.s 6
+			IL_06b7: stelem.ref
+			IL_06b8: dup
+			IL_06b9: ldc.i4.6
+			IL_06ba: ldloc.s 7
+			IL_06bc: stelem.ref
+			IL_06bd: dup
+			IL_06be: ldc.i4.7
+			IL_06bf: ldloc.s 8
+			IL_06c1: stelem.ref
+			IL_06c2: dup
+			IL_06c3: ldc.i4.8
+			IL_06c4: ldloc.s 9
+			IL_06c6: stelem.ref
+			IL_06c7: dup
+			IL_06c8: ldc.i4.s 9
+			IL_06ca: ldloc.s 10
+			IL_06cc: stelem.ref
+			IL_06cd: dup
+			IL_06ce: ldc.i4.s 10
+			IL_06d0: ldloc.s 11
+			IL_06d2: stelem.ref
+			IL_06d3: dup
+			IL_06d4: ldc.i4.s 11
+			IL_06d6: ldloc.s 12
+			IL_06d8: stelem.ref
+			IL_06d9: dup
+			IL_06da: ldc.i4.s 12
+			IL_06dc: ldloc.s 13
+			IL_06de: stelem.ref
 			IL_06df: dup
-			IL_06e0: ldc.i4.0
-			IL_06e1: ldloc.1
-			IL_06e2: stelem.ref
-			IL_06e3: dup
-			IL_06e4: ldc.i4.1
-			IL_06e5: ldloc.2
-			IL_06e6: stelem.ref
-			IL_06e7: dup
-			IL_06e8: ldc.i4.2
-			IL_06e9: ldloc.3
-			IL_06ea: stelem.ref
-			IL_06eb: dup
-			IL_06ec: ldc.i4.3
-			IL_06ed: ldloc.s 4
-			IL_06ef: stelem.ref
-			IL_06f0: dup
-			IL_06f1: ldc.i4.4
-			IL_06f2: ldloc.s 5
+			IL_06e0: ldc.i4.s 13
+			IL_06e2: ldloc.s 14
+			IL_06e4: box [System.Runtime]System.Boolean
+			IL_06e9: stelem.ref
+			IL_06ea: dup
+			IL_06eb: ldc.i4.s 14
+			IL_06ed: ldloc.s 15
+			IL_06ef: box [System.Runtime]System.Boolean
 			IL_06f4: stelem.ref
-			IL_06f5: dup
-			IL_06f6: ldc.i4.5
-			IL_06f7: ldloc.s 6
-			IL_06f9: stelem.ref
-			IL_06fa: dup
-			IL_06fb: ldc.i4.6
-			IL_06fc: ldloc.s 7
-			IL_06fe: stelem.ref
-			IL_06ff: dup
-			IL_0700: ldc.i4.7
-			IL_0701: ldloc.s 8
-			IL_0703: stelem.ref
-			IL_0704: dup
-			IL_0705: ldc.i4.8
-			IL_0706: ldloc.s 9
-			IL_0708: stelem.ref
-			IL_0709: dup
-			IL_070a: ldc.i4.s 9
-			IL_070c: ldloc.s 10
-			IL_070e: stelem.ref
-			IL_070f: dup
-			IL_0710: ldc.i4.s 10
-			IL_0712: ldloc.s 11
-			IL_0714: stelem.ref
-			IL_0715: dup
-			IL_0716: ldc.i4.s 11
-			IL_0718: ldloc.s 12
-			IL_071a: stelem.ref
-			IL_071b: dup
-			IL_071c: ldc.i4.s 12
-			IL_071e: ldloc.s 13
-			IL_0720: stelem.ref
-			IL_0721: dup
-			IL_0722: ldc.i4.s 13
-			IL_0724: ldloc.s 14
-			IL_0726: box [System.Runtime]System.Boolean
-			IL_072b: stelem.ref
-			IL_072c: dup
-			IL_072d: ldc.i4.s 14
-			IL_072f: ldloc.s 15
-			IL_0731: box [System.Runtime]System.Boolean
-			IL_0736: stelem.ref
-			IL_0737: pop
-			IL_0738: ldloc.0
-			IL_0739: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_073e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0743: ret
+			IL_06f5: pop
+			IL_06f6: ldloc.0
+			IL_06f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06fc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0701: ret
 
-			IL_0744: ldloc.0
-			IL_0745: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
-			IL_074a: pop
-			IL_074b: ldloc.s 5
-			IL_074d: ldstr "toString"
-			IL_0752: ldstr "utf8"
-			IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_075c: stloc.s 21
-			IL_075e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0763: ldstr "ExplicitRead:"
-			IL_0768: ldloc.s 21
-			IL_076a: ldloc.s 7
-			IL_076c: ldstr "bytesRead"
-			IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0776: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-			IL_077b: pop
-			IL_077c: ldloc.s 6
-			IL_077e: ldstr "toString"
-			IL_0783: ldstr "utf8"
-			IL_0788: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_078d: stloc.s 21
-			IL_078f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0794: ldstr "ImplicitReadAfterExplicit:"
-			IL_0799: ldloc.s 21
-			IL_079b: ldloc.s 8
-			IL_079d: ldstr "bytesRead"
-			IL_07a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-			IL_07ac: pop
-			IL_07ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07b2: ldstr "ExplicitWriteBytes:"
-			IL_07b7: ldloc.s 9
-			IL_07b9: ldstr "bytesWritten"
-			IL_07be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_07c8: pop
-			IL_07c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07ce: ldstr "ImplicitWriteBytes:"
-			IL_07d3: ldloc.s 10
-			IL_07d5: ldstr "bytesWritten"
-			IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_07e4: pop
-			IL_07e5: ldarg.0
-			IL_07e6: ldc.i4.1
-			IL_07e7: ldelem.ref
-			IL_07e8: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_07ed: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_07f2: ldstr "Cannot access 'fs' before initialization"
-			IL_07f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_07fc: stloc.s 21
-			IL_07fe: ldloc.s 21
-			IL_0800: ldstr "readFileSync"
-			IL_0805: ldloc.2
-			IL_0806: ldstr "utf8"
-			IL_080b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0810: stloc.s 21
-			IL_0812: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0817: ldstr "FinalText:"
-			IL_081c: ldloc.s 21
-			IL_081e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0823: pop
-			IL_0824: br IL_08a6
+			IL_0702: ldloc.0
+			IL_0703: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
+			IL_0708: pop
+			IL_0709: ldloc.s 5
+			IL_070b: ldstr "toString"
+			IL_0710: ldstr "utf8"
+			IL_0715: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_071a: stloc.s 21
+			IL_071c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0721: ldstr "ExplicitRead:"
+			IL_0726: ldloc.s 21
+			IL_0728: ldloc.s 7
+			IL_072a: ldstr "bytesRead"
+			IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0734: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+			IL_0739: pop
+			IL_073a: ldloc.s 6
+			IL_073c: ldstr "toString"
+			IL_0741: ldstr "utf8"
+			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_074b: stloc.s 21
+			IL_074d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0752: ldstr "ImplicitReadAfterExplicit:"
+			IL_0757: ldloc.s 21
+			IL_0759: ldloc.s 8
+			IL_075b: ldstr "bytesRead"
+			IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0765: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+			IL_076a: pop
+			IL_076b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0770: ldstr "ExplicitWriteBytes:"
+			IL_0775: ldloc.s 9
+			IL_0777: ldstr "bytesWritten"
+			IL_077c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0781: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0786: pop
+			IL_0787: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_078c: ldstr "ImplicitWriteBytes:"
+			IL_0791: ldloc.s 10
+			IL_0793: ldstr "bytesWritten"
+			IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_079d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_07a2: pop
+			IL_07a3: ldarg.0
+			IL_07a4: ldc.i4.1
+			IL_07a5: ldelem.ref
+			IL_07a6: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_07ab: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_07b0: ldstr "readFileSync"
+			IL_07b5: ldloc.2
+			IL_07b6: ldstr "utf8"
+			IL_07bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_07c0: stloc.s 21
+			IL_07c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07c7: ldstr "FinalText:"
+			IL_07cc: ldloc.s 21
+			IL_07ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_07d3: pop
+			IL_07d4: br IL_0856
 
-			IL_0829: ldloc.0
-			IL_082a: ldc.i4.1
-			IL_082b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0830: ldloc.0
-			IL_0831: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0836: stloc.s 21
-			IL_0838: ldloc.0
-			IL_0839: ldc.i4.0
-			IL_083a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_083f: ldloc.0
-			IL_0840: ldc.i4.0
-			IL_0841: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0846: ldloc.s 21
-			IL_0848: stloc.s 11
-			IL_084a: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L30C18::.ctor()
-			IL_084f: stloc.s 12
-			IL_0851: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0856: stloc.s 24
-			IL_0858: ldloc.s 11
-			IL_085a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_085f: stloc.s 25
-			IL_0861: ldloc.s 25
-			IL_0863: brfalse IL_087b
+			IL_07d9: ldloc.0
+			IL_07da: ldc.i4.1
+			IL_07db: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07e0: ldloc.0
+			IL_07e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07e6: stloc.s 21
+			IL_07e8: ldloc.0
+			IL_07e9: ldc.i4.0
+			IL_07ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07ef: ldloc.0
+			IL_07f0: ldc.i4.0
+			IL_07f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07f6: ldloc.s 21
+			IL_07f8: stloc.s 11
+			IL_07fa: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L30C18::.ctor()
+			IL_07ff: stloc.s 12
+			IL_0801: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0806: stloc.s 24
+			IL_0808: ldloc.s 11
+			IL_080a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_080f: stloc.s 25
+			IL_0811: ldloc.s 25
+			IL_0813: brfalse IL_082b
 
-			IL_0868: ldloc.s 11
-			IL_086a: ldstr "message"
-			IL_086f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0874: stloc.s 27
-			IL_0876: br IL_087f
+			IL_0818: ldloc.s 11
+			IL_081a: ldstr "message"
+			IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0824: stloc.s 27
+			IL_0826: br IL_082f
 
-			IL_087b: ldloc.s 11
-			IL_087d: stloc.s 27
+			IL_082b: ldloc.s 11
+			IL_082d: stloc.s 27
 
-			IL_087f: ldloc.s 24
-			IL_0881: ldstr "Error:"
-			IL_0886: ldloc.s 27
-			IL_0888: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_088d: pop
-			IL_088e: br IL_08a6
+			IL_082f: ldloc.s 24
+			IL_0831: ldstr "Error:"
+			IL_0836: ldloc.s 27
+			IL_0838: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_083d: pop
+			IL_083e: br IL_0856
 
-			IL_0893: ldloc.0
-			IL_0894: ldc.i4.1
-			IL_0895: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_089a: ldloc.0
-			IL_089b: ldc.i4.0
-			IL_089c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08a1: br IL_08a6
+			IL_0843: ldloc.0
+			IL_0844: ldc.i4.1
+			IL_0845: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_084a: ldloc.0
+			IL_084b: ldc.i4.0
+			IL_084c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0851: br IL_0856
 
-			IL_08a6: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L32C14::.ctor()
-			IL_08ab: stloc.s 13
-			IL_08ad: ldarg.0
-			IL_08ae: ldc.i4.1
-			IL_08af: ldelem.ref
-			IL_08b0: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_08b5: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_08ba: ldstr "Cannot access 'fs' before initialization"
-			IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_08c4: stloc.s 21
-			IL_08c6: ldloc.s 21
-			IL_08c8: ldstr "rmSync"
-			IL_08cd: ldloc.2
-			IL_08ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0856: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L32C14::.ctor()
+			IL_085b: stloc.s 13
+			IL_085d: ldarg.0
+			IL_085e: ldc.i4.1
+			IL_085f: ldelem.ref
+			IL_0860: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0865: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_086a: stloc.s 21
+			IL_086c: ldloc.s 21
+			IL_086e: ldstr "rmSync"
+			IL_0873: ldloc.2
+			IL_0874: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0879: dup
+			IL_087a: ldstr "force"
+			IL_087f: ldc.i4.1
+			IL_0880: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0885: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_088a: pop
+			IL_088b: br IL_08a3
+
+			IL_0890: ldloc.0
+			IL_0891: ldc.i4.1
+			IL_0892: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0897: ldloc.0
+			IL_0898: ldc.i4.0
+			IL_0899: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_089e: br IL_08a3
+
+			IL_08a3: ldloc.0
+			IL_08a4: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08a9: stloc.s 14
+			IL_08ab: ldloc.s 14
+			IL_08ad: brfalse IL_08ea
+
+			IL_08b2: ldloc.0
+			IL_08b3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_08b8: stloc.s 21
+			IL_08ba: ldloc.0
+			IL_08bb: ldc.i4.m1
+			IL_08bc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08c1: ldloc.0
+			IL_08c2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_08cc: ldarg.0
+			IL_08cd: ldc.i4.1
+			IL_08ce: newarr [System.Runtime]System.Object
 			IL_08d3: dup
-			IL_08d4: ldstr "force"
-			IL_08d9: ldc.i4.1
-			IL_08da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_08e4: pop
-			IL_08e5: br IL_08fd
+			IL_08d4: ldc.i4.0
+			IL_08d5: ldloc.s 21
+			IL_08d7: stelem.ref
+			IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08dd: pop
+			IL_08de: ldloc.0
+			IL_08df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08e4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08e9: ret
 
 			IL_08ea: ldloc.0
-			IL_08eb: ldc.i4.1
-			IL_08ec: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08f1: ldloc.0
-			IL_08f2: ldc.i4.0
-			IL_08f3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08f8: br IL_08fd
+			IL_08eb: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08f0: stloc.s 15
+			IL_08f2: ldloc.s 15
+			IL_08f4: brfalse IL_0931
 
-			IL_08fd: ldloc.0
-			IL_08fe: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0903: stloc.s 14
-			IL_0905: ldloc.s 14
-			IL_0907: brfalse IL_0944
+			IL_08f9: ldloc.0
+			IL_08fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_08ff: stloc.s 21
+			IL_0901: ldloc.0
+			IL_0902: ldc.i4.m1
+			IL_0903: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0908: ldloc.0
+			IL_0909: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_090e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0913: ldarg.0
+			IL_0914: ldc.i4.1
+			IL_0915: newarr [System.Runtime]System.Object
+			IL_091a: dup
+			IL_091b: ldc.i4.0
+			IL_091c: ldloc.s 21
+			IL_091e: stelem.ref
+			IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0924: pop
+			IL_0925: ldloc.0
+			IL_0926: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_092b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0930: ret
 
-			IL_090c: ldloc.0
-			IL_090d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0912: stloc.s 21
-			IL_0914: ldloc.0
-			IL_0915: ldc.i4.m1
-			IL_0916: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_091b: ldloc.0
-			IL_091c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0921: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0926: ldarg.0
-			IL_0927: ldc.i4.1
-			IL_0928: newarr [System.Runtime]System.Object
-			IL_092d: dup
-			IL_092e: ldc.i4.0
-			IL_092f: ldloc.s 21
-			IL_0931: stelem.ref
-			IL_0932: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0937: pop
+			IL_0931: ldloc.0
+			IL_0932: ldc.i4.m1
+			IL_0933: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0938: ldloc.0
 			IL_0939: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_093e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0943: ret
-
-			IL_0944: ldloc.0
-			IL_0945: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_094a: stloc.s 15
-			IL_094c: ldloc.s 15
-			IL_094e: brfalse IL_098b
-
-			IL_0953: ldloc.0
-			IL_0954: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0959: stloc.s 21
-			IL_095b: ldloc.0
-			IL_095c: ldc.i4.m1
-			IL_095d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0962: ldloc.0
-			IL_0963: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0968: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_096d: ldarg.0
-			IL_096e: ldc.i4.1
-			IL_096f: newarr [System.Runtime]System.Object
-			IL_0974: dup
-			IL_0975: ldc.i4.0
-			IL_0976: ldloc.s 21
-			IL_0978: stelem.ref
-			IL_0979: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_097e: pop
-			IL_097f: ldloc.0
-			IL_0980: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0985: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_098a: ret
-
-			IL_098b: ldloc.0
-			IL_098c: ldc.i4.m1
-			IL_098d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0992: ldloc.0
-			IL_0993: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0998: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_099d: ldarg.0
-			IL_099e: ldc.i4.1
-			IL_099f: newarr [System.Runtime]System.Object
-			IL_09a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_09a9: pop
-			IL_09aa: ldloc.0
-			IL_09ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09b0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09b5: ret
+			IL_093e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0943: ldarg.0
+			IL_0944: ldc.i4.1
+			IL_0945: newarr [System.Runtime]System.Object
+			IL_094a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_094f: pop
+			IL_0950: ldloc.0
+			IL_0951: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0956: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_095b: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1280,24 +1256,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2aa2
+			// Method begins at RVA 0x2a48
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1382,7 +1349,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2af0
+		// Method begins at RVA 0x2a75
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x284b
+					// Method begins at RVA 0x27ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2854
+					// Method begins at RVA 0x27f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x285d
+					// Method begins at RVA 0x27fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2842
+				// Method begins at RVA 0x27e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -139,7 +139,7 @@
 			)
 			// Method begins at RVA 0x20e0
 			// Header size: 12
-			// Code size: 1836 (0x72c)
+			// Code size: 1774 (0x6ee)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope,
@@ -267,7 +267,7 @@
 
 			IL_00b7: ldloc.0
 			IL_00b8: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00bd: switch (IL_00e2, IL_0609, IL_0660, IL_059f, IL_02d5, IL_037d, IL_046e, IL_04fe)
+			IL_00bd: switch (IL_00e2, IL_05d5, IL_0622, IL_056b, IL_02a1, IL_0349, IL_043a, IL_04ca)
 
 			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_00e7: stloc.s 13
@@ -309,630 +309,614 @@
 			IL_0153: ldelem.ref
 			IL_0154: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
 			IL_0159: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::path
-			IL_015e: ldstr "Cannot access 'path' before initialization"
-			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0168: stloc.s 13
-			IL_016a: ldarg.0
-			IL_016b: ldc.i4.1
-			IL_016c: ldelem.ref
-			IL_016d: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_0172: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
-			IL_0177: ldstr "Cannot access 'os' before initialization"
-			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0181: stloc.s 18
-			IL_0183: ldloc.s 18
-			IL_0185: ldstr "tmpdir"
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_018f: stloc.s 18
-			IL_0191: ldloc.1
-			IL_0192: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0197: stloc.s 17
-			IL_0199: ldstr "js2il-fs-open-"
-			IL_019e: ldloc.s 17
-			IL_01a0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a5: stloc.s 17
-			IL_01a7: ldloc.s 17
-			IL_01a9: ldstr ".txt"
-			IL_01ae: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b3: stloc.s 17
-			IL_01b5: ldloc.s 13
-			IL_01b7: ldstr "join"
-			IL_01bc: ldloc.s 18
-			IL_01be: ldloc.s 17
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c5: stloc.s 18
-			IL_01c7: ldloc.s 18
-			IL_01c9: stloc.2
-			IL_01ca: ldloc.0
-			IL_01cb: ldc.i4.0
-			IL_01cc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01d1: ldloc.0
-			IL_01d2: ldc.i4.0
-			IL_01d3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_01d8: ldloc.0
-			IL_01d9: ldc.i4.0
-			IL_01da: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01df: ldloc.0
-			IL_01e0: ldc.i4.0
-			IL_01e1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_01e6: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
-			IL_01eb: stloc.3
-			IL_01ec: ldarg.0
-			IL_01ed: ldc.i4.1
-			IL_01ee: ldelem.ref
-			IL_01ef: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_01f4: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_01f9: ldstr "Cannot access 'fs' before initialization"
-			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0203: stloc.s 18
-			IL_0205: ldloc.s 18
-			IL_0207: ldstr "rmSync"
-			IL_020c: ldloc.2
-			IL_020d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0212: dup
-			IL_0213: ldstr "force"
-			IL_0218: ldc.i4.1
-			IL_0219: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0223: pop
-			IL_0224: ldarg.0
-			IL_0225: ldc.i4.1
-			IL_0226: ldelem.ref
-			IL_0227: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_022c: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_0231: ldstr "Cannot access 'fs' before initialization"
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_023b: stloc.s 18
-			IL_023d: ldloc.s 18
-			IL_023f: ldstr "promises"
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0249: stloc.s 18
-			IL_024b: ldloc.s 18
-			IL_024d: ldstr "open"
-			IL_0252: ldloc.2
-			IL_0253: ldstr "w+"
-			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_025d: stloc.s 18
-			IL_025f: ldloc.0
+			IL_015e: stloc.s 13
+			IL_0160: ldarg.0
+			IL_0161: ldc.i4.1
+			IL_0162: ldelem.ref
+			IL_0163: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_0168: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
+			IL_016d: ldstr "tmpdir"
+			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0177: stloc.s 18
+			IL_0179: ldloc.1
+			IL_017a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_017f: stloc.s 17
+			IL_0181: ldstr "js2il-fs-open-"
+			IL_0186: ldloc.s 17
+			IL_0188: call string [System.Runtime]System.String::Concat(string, string)
+			IL_018d: stloc.s 17
+			IL_018f: ldloc.s 17
+			IL_0191: ldstr ".txt"
+			IL_0196: call string [System.Runtime]System.String::Concat(string, string)
+			IL_019b: stloc.s 17
+			IL_019d: ldloc.s 13
+			IL_019f: ldstr "join"
+			IL_01a4: ldloc.s 18
+			IL_01a6: ldloc.s 17
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01ad: stloc.s 18
+			IL_01af: ldloc.s 18
+			IL_01b1: stloc.2
+			IL_01b2: ldloc.0
+			IL_01b3: ldc.i4.0
+			IL_01b4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_01b9: ldloc.0
+			IL_01ba: ldc.i4.0
+			IL_01bb: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_01c0: ldloc.0
+			IL_01c1: ldc.i4.0
+			IL_01c2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01c7: ldloc.0
+			IL_01c8: ldc.i4.0
+			IL_01c9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_01ce: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
+			IL_01d3: stloc.3
+			IL_01d4: ldarg.0
+			IL_01d5: ldc.i4.1
+			IL_01d6: ldelem.ref
+			IL_01d7: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_01dc: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_01e1: stloc.s 18
+			IL_01e3: ldloc.s 18
+			IL_01e5: ldstr "rmSync"
+			IL_01ea: ldloc.2
+			IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01f0: dup
+			IL_01f1: ldstr "force"
+			IL_01f6: ldc.i4.1
+			IL_01f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0201: pop
+			IL_0202: ldarg.0
+			IL_0203: ldc.i4.1
+			IL_0204: ldelem.ref
+			IL_0205: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_020a: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_020f: ldstr "promises"
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0219: ldstr "open"
+			IL_021e: ldloc.2
+			IL_021f: ldstr "w+"
+			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0229: stloc.s 18
+			IL_022b: ldloc.0
+			IL_022c: ldc.i4.4
+			IL_022d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0232: ldloc.0
+			IL_0233: ldloc.s 18
+			IL_0235: ldarg.0
+			IL_0236: ldc.i4.1
+			IL_0237: ldloc.0
+			IL_0238: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_023d: ldc.i4.3
+			IL_023e: ldstr "_pendingException"
+			IL_0243: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0248: ldloc.0
+			IL_0249: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_024e: dup
+			IL_024f: ldc.i4.0
+			IL_0250: ldloc.1
+			IL_0251: stelem.ref
+			IL_0252: dup
+			IL_0253: ldc.i4.1
+			IL_0254: ldloc.2
+			IL_0255: stelem.ref
+			IL_0256: dup
+			IL_0257: ldc.i4.2
+			IL_0258: ldloc.3
+			IL_0259: stelem.ref
+			IL_025a: dup
+			IL_025b: ldc.i4.3
+			IL_025c: ldloc.s 4
+			IL_025e: stelem.ref
+			IL_025f: dup
 			IL_0260: ldc.i4.4
-			IL_0261: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0266: ldloc.0
-			IL_0267: ldloc.s 18
-			IL_0269: ldarg.0
-			IL_026a: ldc.i4.1
-			IL_026b: ldloc.0
-			IL_026c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0271: ldc.i4.3
-			IL_0272: ldstr "_pendingException"
-			IL_0277: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_027c: ldloc.0
-			IL_027d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0282: dup
-			IL_0283: ldc.i4.0
-			IL_0284: ldloc.1
-			IL_0285: stelem.ref
-			IL_0286: dup
-			IL_0287: ldc.i4.1
-			IL_0288: ldloc.2
-			IL_0289: stelem.ref
-			IL_028a: dup
-			IL_028b: ldc.i4.2
-			IL_028c: ldloc.3
-			IL_028d: stelem.ref
-			IL_028e: dup
-			IL_028f: ldc.i4.3
-			IL_0290: ldloc.s 4
-			IL_0292: stelem.ref
-			IL_0293: dup
-			IL_0294: ldc.i4.4
-			IL_0295: ldloc.s 5
-			IL_0297: stelem.ref
-			IL_0298: dup
-			IL_0299: ldc.i4.5
-			IL_029a: ldloc.s 6
-			IL_029c: stelem.ref
-			IL_029d: dup
-			IL_029e: ldc.i4.6
-			IL_029f: ldloc.s 7
-			IL_02a1: stelem.ref
-			IL_02a2: dup
-			IL_02a3: ldc.i4.7
-			IL_02a4: ldloc.s 8
-			IL_02a6: stelem.ref
-			IL_02a7: dup
-			IL_02a8: ldc.i4.8
-			IL_02a9: ldloc.s 9
-			IL_02ab: stelem.ref
-			IL_02ac: dup
-			IL_02ad: ldc.i4.s 9
-			IL_02af: ldloc.s 10
-			IL_02b1: stelem.ref
-			IL_02b2: dup
-			IL_02b3: ldc.i4.s 10
-			IL_02b5: ldloc.s 11
-			IL_02b7: box [System.Runtime]System.Boolean
-			IL_02bc: stelem.ref
-			IL_02bd: dup
-			IL_02be: ldc.i4.s 11
-			IL_02c0: ldloc.s 12
-			IL_02c2: box [System.Runtime]System.Boolean
-			IL_02c7: stelem.ref
-			IL_02c8: pop
-			IL_02c9: ldloc.0
-			IL_02ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02cf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02d4: ret
+			IL_0261: ldloc.s 5
+			IL_0263: stelem.ref
+			IL_0264: dup
+			IL_0265: ldc.i4.5
+			IL_0266: ldloc.s 6
+			IL_0268: stelem.ref
+			IL_0269: dup
+			IL_026a: ldc.i4.6
+			IL_026b: ldloc.s 7
+			IL_026d: stelem.ref
+			IL_026e: dup
+			IL_026f: ldc.i4.7
+			IL_0270: ldloc.s 8
+			IL_0272: stelem.ref
+			IL_0273: dup
+			IL_0274: ldc.i4.8
+			IL_0275: ldloc.s 9
+			IL_0277: stelem.ref
+			IL_0278: dup
+			IL_0279: ldc.i4.s 9
+			IL_027b: ldloc.s 10
+			IL_027d: stelem.ref
+			IL_027e: dup
+			IL_027f: ldc.i4.s 10
+			IL_0281: ldloc.s 11
+			IL_0283: box [System.Runtime]System.Boolean
+			IL_0288: stelem.ref
+			IL_0289: dup
+			IL_028a: ldc.i4.s 11
+			IL_028c: ldloc.s 12
+			IL_028e: box [System.Runtime]System.Boolean
+			IL_0293: stelem.ref
+			IL_0294: pop
+			IL_0295: ldloc.0
+			IL_0296: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_029b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02a0: ret
 
-			IL_02d5: ldloc.0
-			IL_02d6: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
-			IL_02db: stloc.s 18
-			IL_02dd: ldloc.s 18
-			IL_02df: stloc.s 4
-			IL_02e1: ldloc.s 4
-			IL_02e3: ldstr "write"
-			IL_02e8: ldstr "hello"
-			IL_02ed: ldc.r8 0.0
-			IL_02f6: box [System.Runtime]System.Double
-			IL_02fb: ldstr "utf8"
-			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0305: stloc.s 18
-			IL_0307: ldloc.0
-			IL_0308: ldc.i4.5
-			IL_0309: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_030e: ldloc.0
-			IL_030f: ldloc.s 18
-			IL_0311: ldarg.0
-			IL_0312: ldc.i4.2
-			IL_0313: ldloc.0
-			IL_0314: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0319: ldc.i4.3
-			IL_031a: ldstr "_pendingException"
-			IL_031f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0324: ldloc.0
-			IL_0325: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_032a: dup
-			IL_032b: ldc.i4.0
-			IL_032c: ldloc.1
-			IL_032d: stelem.ref
-			IL_032e: dup
-			IL_032f: ldc.i4.1
-			IL_0330: ldloc.2
-			IL_0331: stelem.ref
-			IL_0332: dup
-			IL_0333: ldc.i4.2
-			IL_0334: ldloc.3
-			IL_0335: stelem.ref
-			IL_0336: dup
-			IL_0337: ldc.i4.3
-			IL_0338: ldloc.s 4
-			IL_033a: stelem.ref
-			IL_033b: dup
-			IL_033c: ldc.i4.4
-			IL_033d: ldloc.s 5
-			IL_033f: stelem.ref
-			IL_0340: dup
-			IL_0341: ldc.i4.5
-			IL_0342: ldloc.s 6
-			IL_0344: stelem.ref
-			IL_0345: dup
-			IL_0346: ldc.i4.6
-			IL_0347: ldloc.s 7
-			IL_0349: stelem.ref
-			IL_034a: dup
-			IL_034b: ldc.i4.7
-			IL_034c: ldloc.s 8
-			IL_034e: stelem.ref
-			IL_034f: dup
-			IL_0350: ldc.i4.8
-			IL_0351: ldloc.s 9
-			IL_0353: stelem.ref
-			IL_0354: dup
-			IL_0355: ldc.i4.s 9
-			IL_0357: ldloc.s 10
-			IL_0359: stelem.ref
-			IL_035a: dup
-			IL_035b: ldc.i4.s 10
-			IL_035d: ldloc.s 11
-			IL_035f: box [System.Runtime]System.Boolean
-			IL_0364: stelem.ref
-			IL_0365: dup
-			IL_0366: ldc.i4.s 11
-			IL_0368: ldloc.s 12
-			IL_036a: box [System.Runtime]System.Boolean
-			IL_036f: stelem.ref
-			IL_0370: pop
-			IL_0371: ldloc.0
-			IL_0372: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0377: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_037c: ret
+			IL_02a1: ldloc.0
+			IL_02a2: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
+			IL_02a7: stloc.s 18
+			IL_02a9: ldloc.s 18
+			IL_02ab: stloc.s 4
+			IL_02ad: ldloc.s 4
+			IL_02af: ldstr "write"
+			IL_02b4: ldstr "hello"
+			IL_02b9: ldc.r8 0.0
+			IL_02c2: box [System.Runtime]System.Double
+			IL_02c7: ldstr "utf8"
+			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_02d1: stloc.s 18
+			IL_02d3: ldloc.0
+			IL_02d4: ldc.i4.5
+			IL_02d5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02da: ldloc.0
+			IL_02db: ldloc.s 18
+			IL_02dd: ldarg.0
+			IL_02de: ldc.i4.2
+			IL_02df: ldloc.0
+			IL_02e0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02e5: ldc.i4.3
+			IL_02e6: ldstr "_pendingException"
+			IL_02eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02f0: ldloc.0
+			IL_02f1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02f6: dup
+			IL_02f7: ldc.i4.0
+			IL_02f8: ldloc.1
+			IL_02f9: stelem.ref
+			IL_02fa: dup
+			IL_02fb: ldc.i4.1
+			IL_02fc: ldloc.2
+			IL_02fd: stelem.ref
+			IL_02fe: dup
+			IL_02ff: ldc.i4.2
+			IL_0300: ldloc.3
+			IL_0301: stelem.ref
+			IL_0302: dup
+			IL_0303: ldc.i4.3
+			IL_0304: ldloc.s 4
+			IL_0306: stelem.ref
+			IL_0307: dup
+			IL_0308: ldc.i4.4
+			IL_0309: ldloc.s 5
+			IL_030b: stelem.ref
+			IL_030c: dup
+			IL_030d: ldc.i4.5
+			IL_030e: ldloc.s 6
+			IL_0310: stelem.ref
+			IL_0311: dup
+			IL_0312: ldc.i4.6
+			IL_0313: ldloc.s 7
+			IL_0315: stelem.ref
+			IL_0316: dup
+			IL_0317: ldc.i4.7
+			IL_0318: ldloc.s 8
+			IL_031a: stelem.ref
+			IL_031b: dup
+			IL_031c: ldc.i4.8
+			IL_031d: ldloc.s 9
+			IL_031f: stelem.ref
+			IL_0320: dup
+			IL_0321: ldc.i4.s 9
+			IL_0323: ldloc.s 10
+			IL_0325: stelem.ref
+			IL_0326: dup
+			IL_0327: ldc.i4.s 10
+			IL_0329: ldloc.s 11
+			IL_032b: box [System.Runtime]System.Boolean
+			IL_0330: stelem.ref
+			IL_0331: dup
+			IL_0332: ldc.i4.s 11
+			IL_0334: ldloc.s 12
+			IL_0336: box [System.Runtime]System.Boolean
+			IL_033b: stelem.ref
+			IL_033c: pop
+			IL_033d: ldloc.0
+			IL_033e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0343: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0348: ret
 
-			IL_037d: ldloc.0
-			IL_037e: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
-			IL_0383: stloc.s 18
-			IL_0385: ldloc.s 18
-			IL_0387: stloc.s 5
-			IL_0389: ldc.r8 5
-			IL_0392: box [System.Runtime]System.Double
-			IL_0397: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_039c: stloc.s 19
-			IL_039e: ldloc.s 19
-			IL_03a0: stloc.s 6
-			IL_03a2: ldloc.s 6
-			IL_03a4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_03a9: stloc.s 15
-			IL_03ab: ldloc.s 15
-			IL_03ad: box [System.Runtime]System.Double
-			IL_03b2: stloc.s 16
-			IL_03b4: ldc.i4.4
-			IL_03b5: newarr [System.Runtime]System.Object
-			IL_03ba: dup
-			IL_03bb: ldc.i4.0
-			IL_03bc: ldloc.s 6
-			IL_03be: stelem.ref
-			IL_03bf: dup
-			IL_03c0: ldc.i4.1
-			IL_03c1: ldc.r8 0.0
-			IL_03ca: box [System.Runtime]System.Double
-			IL_03cf: stelem.ref
-			IL_03d0: dup
-			IL_03d1: ldc.i4.2
-			IL_03d2: ldloc.s 16
-			IL_03d4: stelem.ref
-			IL_03d5: dup
+			IL_0349: ldloc.0
+			IL_034a: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
+			IL_034f: stloc.s 18
+			IL_0351: ldloc.s 18
+			IL_0353: stloc.s 5
+			IL_0355: ldc.r8 5
+			IL_035e: box [System.Runtime]System.Double
+			IL_0363: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_0368: stloc.s 19
+			IL_036a: ldloc.s 19
+			IL_036c: stloc.s 6
+			IL_036e: ldloc.s 6
+			IL_0370: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_0375: stloc.s 15
+			IL_0377: ldloc.s 15
+			IL_0379: box [System.Runtime]System.Double
+			IL_037e: stloc.s 16
+			IL_0380: ldc.i4.4
+			IL_0381: newarr [System.Runtime]System.Object
+			IL_0386: dup
+			IL_0387: ldc.i4.0
+			IL_0388: ldloc.s 6
+			IL_038a: stelem.ref
+			IL_038b: dup
+			IL_038c: ldc.i4.1
+			IL_038d: ldc.r8 0.0
+			IL_0396: box [System.Runtime]System.Double
+			IL_039b: stelem.ref
+			IL_039c: dup
+			IL_039d: ldc.i4.2
+			IL_039e: ldloc.s 16
+			IL_03a0: stelem.ref
+			IL_03a1: dup
+			IL_03a2: ldc.i4.3
+			IL_03a3: ldc.r8 0.0
+			IL_03ac: box [System.Runtime]System.Double
+			IL_03b1: stelem.ref
+			IL_03b2: stloc.s 20
+			IL_03b4: ldloc.s 4
+			IL_03b6: ldstr "read"
+			IL_03bb: ldloc.s 20
+			IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_03c2: stloc.s 18
+			IL_03c4: ldloc.0
+			IL_03c5: ldc.i4.6
+			IL_03c6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03cb: ldloc.0
+			IL_03cc: ldloc.s 18
+			IL_03ce: ldarg.0
+			IL_03cf: ldc.i4.3
+			IL_03d0: ldloc.0
+			IL_03d1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
 			IL_03d6: ldc.i4.3
-			IL_03d7: ldc.r8 0.0
-			IL_03e0: box [System.Runtime]System.Double
-			IL_03e5: stelem.ref
-			IL_03e6: stloc.s 20
-			IL_03e8: ldloc.s 4
-			IL_03ea: ldstr "read"
-			IL_03ef: ldloc.s 20
-			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_03f6: stloc.s 18
-			IL_03f8: ldloc.0
-			IL_03f9: ldc.i4.6
-			IL_03fa: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03ff: ldloc.0
-			IL_0400: ldloc.s 18
-			IL_0402: ldarg.0
-			IL_0403: ldc.i4.3
-			IL_0404: ldloc.0
-			IL_0405: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_040a: ldc.i4.3
-			IL_040b: ldstr "_pendingException"
-			IL_0410: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0415: ldloc.0
-			IL_0416: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_041b: dup
-			IL_041c: ldc.i4.0
-			IL_041d: ldloc.1
-			IL_041e: stelem.ref
-			IL_041f: dup
-			IL_0420: ldc.i4.1
-			IL_0421: ldloc.2
-			IL_0422: stelem.ref
-			IL_0423: dup
-			IL_0424: ldc.i4.2
-			IL_0425: ldloc.3
-			IL_0426: stelem.ref
-			IL_0427: dup
-			IL_0428: ldc.i4.3
-			IL_0429: ldloc.s 4
-			IL_042b: stelem.ref
-			IL_042c: dup
-			IL_042d: ldc.i4.4
-			IL_042e: ldloc.s 5
-			IL_0430: stelem.ref
-			IL_0431: dup
-			IL_0432: ldc.i4.5
-			IL_0433: ldloc.s 6
-			IL_0435: stelem.ref
-			IL_0436: dup
-			IL_0437: ldc.i4.6
-			IL_0438: ldloc.s 7
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.7
-			IL_043d: ldloc.s 8
-			IL_043f: stelem.ref
-			IL_0440: dup
-			IL_0441: ldc.i4.8
-			IL_0442: ldloc.s 9
-			IL_0444: stelem.ref
-			IL_0445: dup
-			IL_0446: ldc.i4.s 9
-			IL_0448: ldloc.s 10
-			IL_044a: stelem.ref
-			IL_044b: dup
-			IL_044c: ldc.i4.s 10
-			IL_044e: ldloc.s 11
-			IL_0450: box [System.Runtime]System.Boolean
-			IL_0455: stelem.ref
-			IL_0456: dup
-			IL_0457: ldc.i4.s 11
-			IL_0459: ldloc.s 12
-			IL_045b: box [System.Runtime]System.Boolean
-			IL_0460: stelem.ref
-			IL_0461: pop
-			IL_0462: ldloc.0
-			IL_0463: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0468: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_046d: ret
+			IL_03d7: ldstr "_pendingException"
+			IL_03dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03e1: ldloc.0
+			IL_03e2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03e7: dup
+			IL_03e8: ldc.i4.0
+			IL_03e9: ldloc.1
+			IL_03ea: stelem.ref
+			IL_03eb: dup
+			IL_03ec: ldc.i4.1
+			IL_03ed: ldloc.2
+			IL_03ee: stelem.ref
+			IL_03ef: dup
+			IL_03f0: ldc.i4.2
+			IL_03f1: ldloc.3
+			IL_03f2: stelem.ref
+			IL_03f3: dup
+			IL_03f4: ldc.i4.3
+			IL_03f5: ldloc.s 4
+			IL_03f7: stelem.ref
+			IL_03f8: dup
+			IL_03f9: ldc.i4.4
+			IL_03fa: ldloc.s 5
+			IL_03fc: stelem.ref
+			IL_03fd: dup
+			IL_03fe: ldc.i4.5
+			IL_03ff: ldloc.s 6
+			IL_0401: stelem.ref
+			IL_0402: dup
+			IL_0403: ldc.i4.6
+			IL_0404: ldloc.s 7
+			IL_0406: stelem.ref
+			IL_0407: dup
+			IL_0408: ldc.i4.7
+			IL_0409: ldloc.s 8
+			IL_040b: stelem.ref
+			IL_040c: dup
+			IL_040d: ldc.i4.8
+			IL_040e: ldloc.s 9
+			IL_0410: stelem.ref
+			IL_0411: dup
+			IL_0412: ldc.i4.s 9
+			IL_0414: ldloc.s 10
+			IL_0416: stelem.ref
+			IL_0417: dup
+			IL_0418: ldc.i4.s 10
+			IL_041a: ldloc.s 11
+			IL_041c: box [System.Runtime]System.Boolean
+			IL_0421: stelem.ref
+			IL_0422: dup
+			IL_0423: ldc.i4.s 11
+			IL_0425: ldloc.s 12
+			IL_0427: box [System.Runtime]System.Boolean
+			IL_042c: stelem.ref
+			IL_042d: pop
+			IL_042e: ldloc.0
+			IL_042f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0434: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0439: ret
 
-			IL_046e: ldloc.0
-			IL_046f: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
-			IL_0474: stloc.s 18
-			IL_0476: ldloc.s 18
-			IL_0478: stloc.s 7
-			IL_047a: ldloc.s 4
-			IL_047c: ldstr "close"
-			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0486: stloc.s 18
-			IL_0488: ldloc.0
-			IL_0489: ldc.i4.7
-			IL_048a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_048f: ldloc.0
-			IL_0490: ldloc.s 18
-			IL_0492: ldarg.0
-			IL_0493: ldc.i4.4
-			IL_0494: ldloc.0
-			IL_0495: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_049a: ldc.i4.3
-			IL_049b: ldstr "_pendingException"
-			IL_04a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04a5: ldloc.0
-			IL_04a6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04ab: dup
-			IL_04ac: ldc.i4.0
-			IL_04ad: ldloc.1
-			IL_04ae: stelem.ref
-			IL_04af: dup
-			IL_04b0: ldc.i4.1
-			IL_04b1: ldloc.2
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.2
-			IL_04b5: ldloc.3
-			IL_04b6: stelem.ref
-			IL_04b7: dup
-			IL_04b8: ldc.i4.3
-			IL_04b9: ldloc.s 4
-			IL_04bb: stelem.ref
-			IL_04bc: dup
-			IL_04bd: ldc.i4.4
-			IL_04be: ldloc.s 5
-			IL_04c0: stelem.ref
-			IL_04c1: dup
-			IL_04c2: ldc.i4.5
-			IL_04c3: ldloc.s 6
-			IL_04c5: stelem.ref
-			IL_04c6: dup
-			IL_04c7: ldc.i4.6
-			IL_04c8: ldloc.s 7
-			IL_04ca: stelem.ref
-			IL_04cb: dup
-			IL_04cc: ldc.i4.7
-			IL_04cd: ldloc.s 8
-			IL_04cf: stelem.ref
-			IL_04d0: dup
-			IL_04d1: ldc.i4.8
-			IL_04d2: ldloc.s 9
-			IL_04d4: stelem.ref
-			IL_04d5: dup
-			IL_04d6: ldc.i4.s 9
-			IL_04d8: ldloc.s 10
-			IL_04da: stelem.ref
-			IL_04db: dup
-			IL_04dc: ldc.i4.s 10
-			IL_04de: ldloc.s 11
-			IL_04e0: box [System.Runtime]System.Boolean
-			IL_04e5: stelem.ref
-			IL_04e6: dup
-			IL_04e7: ldc.i4.s 11
-			IL_04e9: ldloc.s 12
-			IL_04eb: box [System.Runtime]System.Boolean
-			IL_04f0: stelem.ref
-			IL_04f1: pop
-			IL_04f2: ldloc.0
-			IL_04f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04f8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04fd: ret
+			IL_043a: ldloc.0
+			IL_043b: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
+			IL_0440: stloc.s 18
+			IL_0442: ldloc.s 18
+			IL_0444: stloc.s 7
+			IL_0446: ldloc.s 4
+			IL_0448: ldstr "close"
+			IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0452: stloc.s 18
+			IL_0454: ldloc.0
+			IL_0455: ldc.i4.7
+			IL_0456: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_045b: ldloc.0
+			IL_045c: ldloc.s 18
+			IL_045e: ldarg.0
+			IL_045f: ldc.i4.4
+			IL_0460: ldloc.0
+			IL_0461: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0466: ldc.i4.3
+			IL_0467: ldstr "_pendingException"
+			IL_046c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0471: ldloc.0
+			IL_0472: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0477: dup
+			IL_0478: ldc.i4.0
+			IL_0479: ldloc.1
+			IL_047a: stelem.ref
+			IL_047b: dup
+			IL_047c: ldc.i4.1
+			IL_047d: ldloc.2
+			IL_047e: stelem.ref
+			IL_047f: dup
+			IL_0480: ldc.i4.2
+			IL_0481: ldloc.3
+			IL_0482: stelem.ref
+			IL_0483: dup
+			IL_0484: ldc.i4.3
+			IL_0485: ldloc.s 4
+			IL_0487: stelem.ref
+			IL_0488: dup
+			IL_0489: ldc.i4.4
+			IL_048a: ldloc.s 5
+			IL_048c: stelem.ref
+			IL_048d: dup
+			IL_048e: ldc.i4.5
+			IL_048f: ldloc.s 6
+			IL_0491: stelem.ref
+			IL_0492: dup
+			IL_0493: ldc.i4.6
+			IL_0494: ldloc.s 7
+			IL_0496: stelem.ref
+			IL_0497: dup
+			IL_0498: ldc.i4.7
+			IL_0499: ldloc.s 8
+			IL_049b: stelem.ref
+			IL_049c: dup
+			IL_049d: ldc.i4.8
+			IL_049e: ldloc.s 9
+			IL_04a0: stelem.ref
+			IL_04a1: dup
+			IL_04a2: ldc.i4.s 9
+			IL_04a4: ldloc.s 10
+			IL_04a6: stelem.ref
+			IL_04a7: dup
+			IL_04a8: ldc.i4.s 10
+			IL_04aa: ldloc.s 11
+			IL_04ac: box [System.Runtime]System.Boolean
+			IL_04b1: stelem.ref
+			IL_04b2: dup
+			IL_04b3: ldc.i4.s 11
+			IL_04b5: ldloc.s 12
+			IL_04b7: box [System.Runtime]System.Boolean
+			IL_04bc: stelem.ref
+			IL_04bd: pop
+			IL_04be: ldloc.0
+			IL_04bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04c4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04c9: ret
 
-			IL_04fe: ldloc.0
-			IL_04ff: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
-			IL_0504: pop
-			IL_0505: ldloc.s 4
-			IL_0507: ldstr "fd"
-			IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0511: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_0516: ldstr "number"
-			IL_051b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0520: stloc.s 21
-			IL_0522: ldloc.s 21
-			IL_0524: box [System.Runtime]System.Boolean
-			IL_0529: stloc.s 22
-			IL_052b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0530: ldstr "FDIsNumber:"
-			IL_0535: ldloc.s 22
-			IL_0537: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_053c: pop
-			IL_053d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0542: ldstr "BytesWritten:"
-			IL_0547: ldloc.s 5
-			IL_0549: ldstr "bytesWritten"
-			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0553: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0558: pop
-			IL_0559: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_055e: ldstr "BytesRead:"
-			IL_0563: ldloc.s 7
-			IL_0565: ldstr "bytesRead"
-			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_056f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0574: pop
-			IL_0575: ldloc.s 6
-			IL_0577: ldstr "toString"
-			IL_057c: ldstr "utf8"
-			IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0586: stloc.s 18
-			IL_0588: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_058d: ldstr "BufferText:"
-			IL_0592: ldloc.s 18
-			IL_0594: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0599: pop
-			IL_059a: br IL_061c
+			IL_04ca: ldloc.0
+			IL_04cb: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
+			IL_04d0: pop
+			IL_04d1: ldloc.s 4
+			IL_04d3: ldstr "fd"
+			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04dd: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_04e2: ldstr "number"
+			IL_04e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_04ec: stloc.s 21
+			IL_04ee: ldloc.s 21
+			IL_04f0: box [System.Runtime]System.Boolean
+			IL_04f5: stloc.s 22
+			IL_04f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04fc: ldstr "FDIsNumber:"
+			IL_0501: ldloc.s 22
+			IL_0503: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0508: pop
+			IL_0509: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_050e: ldstr "BytesWritten:"
+			IL_0513: ldloc.s 5
+			IL_0515: ldstr "bytesWritten"
+			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_051f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0524: pop
+			IL_0525: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_052a: ldstr "BytesRead:"
+			IL_052f: ldloc.s 7
+			IL_0531: ldstr "bytesRead"
+			IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_053b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0540: pop
+			IL_0541: ldloc.s 6
+			IL_0543: ldstr "toString"
+			IL_0548: ldstr "utf8"
+			IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0552: stloc.s 18
+			IL_0554: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0559: ldstr "BufferText:"
+			IL_055e: ldloc.s 18
+			IL_0560: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0565: pop
+			IL_0566: br IL_05e8
 
-			IL_059f: ldloc.0
-			IL_05a0: ldc.i4.1
-			IL_05a1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_05a6: ldloc.0
-			IL_05a7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_05ac: stloc.s 18
-			IL_05ae: ldloc.0
-			IL_05af: ldc.i4.0
-			IL_05b0: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_05b5: ldloc.0
-			IL_05b6: ldc.i4.0
-			IL_05b7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_05bc: ldloc.s 18
-			IL_05be: stloc.s 8
-			IL_05c0: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
-			IL_05c5: stloc.s 9
-			IL_05c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05cc: stloc.s 23
-			IL_05ce: ldloc.s 8
-			IL_05d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05d5: stloc.s 21
-			IL_05d7: ldloc.s 21
-			IL_05d9: brfalse IL_05f1
+			IL_056b: ldloc.0
+			IL_056c: ldc.i4.1
+			IL_056d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0572: ldloc.0
+			IL_0573: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0578: stloc.s 18
+			IL_057a: ldloc.0
+			IL_057b: ldc.i4.0
+			IL_057c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0581: ldloc.0
+			IL_0582: ldc.i4.0
+			IL_0583: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0588: ldloc.s 18
+			IL_058a: stloc.s 8
+			IL_058c: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
+			IL_0591: stloc.s 9
+			IL_0593: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0598: stloc.s 23
+			IL_059a: ldloc.s 8
+			IL_059c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05a1: stloc.s 21
+			IL_05a3: ldloc.s 21
+			IL_05a5: brfalse IL_05bd
 
-			IL_05de: ldloc.s 8
-			IL_05e0: ldstr "message"
-			IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ea: stloc.s 25
-			IL_05ec: br IL_05f5
+			IL_05aa: ldloc.s 8
+			IL_05ac: ldstr "message"
+			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b6: stloc.s 25
+			IL_05b8: br IL_05c1
 
-			IL_05f1: ldloc.s 8
-			IL_05f3: stloc.s 25
+			IL_05bd: ldloc.s 8
+			IL_05bf: stloc.s 25
 
-			IL_05f5: ldloc.s 23
-			IL_05f7: ldstr "Error:"
-			IL_05fc: ldloc.s 25
-			IL_05fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0603: pop
-			IL_0604: br IL_061c
+			IL_05c1: ldloc.s 23
+			IL_05c3: ldstr "Error:"
+			IL_05c8: ldloc.s 25
+			IL_05ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_05cf: pop
+			IL_05d0: br IL_05e8
 
-			IL_0609: ldloc.0
-			IL_060a: ldc.i4.1
-			IL_060b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0610: ldloc.0
-			IL_0611: ldc.i4.0
-			IL_0612: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0617: br IL_061c
+			IL_05d5: ldloc.0
+			IL_05d6: ldc.i4.1
+			IL_05d7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_05dc: ldloc.0
+			IL_05dd: ldc.i4.0
+			IL_05de: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_05e3: br IL_05e8
 
-			IL_061c: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L27C14::.ctor()
-			IL_0621: stloc.s 10
-			IL_0623: ldarg.0
-			IL_0624: ldc.i4.1
-			IL_0625: ldelem.ref
-			IL_0626: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_062b: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_0630: ldstr "Cannot access 'fs' before initialization"
-			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_063a: stloc.s 18
-			IL_063c: ldloc.s 18
-			IL_063e: ldstr "rmSync"
-			IL_0643: ldloc.2
-			IL_0644: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0649: dup
-			IL_064a: ldstr "force"
-			IL_064f: ldc.i4.1
-			IL_0650: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_065a: pop
-			IL_065b: br IL_0673
+			IL_05e8: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L27C14::.ctor()
+			IL_05ed: stloc.s 10
+			IL_05ef: ldarg.0
+			IL_05f0: ldc.i4.1
+			IL_05f1: ldelem.ref
+			IL_05f2: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_05f7: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_05fc: stloc.s 18
+			IL_05fe: ldloc.s 18
+			IL_0600: ldstr "rmSync"
+			IL_0605: ldloc.2
+			IL_0606: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_060b: dup
+			IL_060c: ldstr "force"
+			IL_0611: ldc.i4.1
+			IL_0612: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_061c: pop
+			IL_061d: br IL_0635
 
-			IL_0660: ldloc.0
-			IL_0661: ldc.i4.1
-			IL_0662: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0667: ldloc.0
-			IL_0668: ldc.i4.0
-			IL_0669: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_066e: br IL_0673
+			IL_0622: ldloc.0
+			IL_0623: ldc.i4.1
+			IL_0624: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0629: ldloc.0
+			IL_062a: ldc.i4.0
+			IL_062b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0630: br IL_0635
 
-			IL_0673: ldloc.0
-			IL_0674: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0679: stloc.s 11
-			IL_067b: ldloc.s 11
-			IL_067d: brfalse IL_06ba
+			IL_0635: ldloc.0
+			IL_0636: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_063b: stloc.s 11
+			IL_063d: ldloc.s 11
+			IL_063f: brfalse IL_067c
 
-			IL_0682: ldloc.0
-			IL_0683: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0688: stloc.s 18
-			IL_068a: ldloc.0
-			IL_068b: ldc.i4.m1
-			IL_068c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0691: ldloc.0
-			IL_0692: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0697: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_069c: ldarg.0
-			IL_069d: ldc.i4.1
-			IL_069e: newarr [System.Runtime]System.Object
-			IL_06a3: dup
-			IL_06a4: ldc.i4.0
-			IL_06a5: ldloc.s 18
-			IL_06a7: stelem.ref
-			IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06ad: pop
-			IL_06ae: ldloc.0
-			IL_06af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06b4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06b9: ret
+			IL_0644: ldloc.0
+			IL_0645: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_064a: stloc.s 18
+			IL_064c: ldloc.0
+			IL_064d: ldc.i4.m1
+			IL_064e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0653: ldloc.0
+			IL_0654: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0659: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_065e: ldarg.0
+			IL_065f: ldc.i4.1
+			IL_0660: newarr [System.Runtime]System.Object
+			IL_0665: dup
+			IL_0666: ldc.i4.0
+			IL_0667: ldloc.s 18
+			IL_0669: stelem.ref
+			IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_066f: pop
+			IL_0670: ldloc.0
+			IL_0671: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0676: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_067b: ret
 
-			IL_06ba: ldloc.0
-			IL_06bb: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_06c0: stloc.s 12
-			IL_06c2: ldloc.s 12
-			IL_06c4: brfalse IL_0701
+			IL_067c: ldloc.0
+			IL_067d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0682: stloc.s 12
+			IL_0684: ldloc.s 12
+			IL_0686: brfalse IL_06c3
 
-			IL_06c9: ldloc.0
-			IL_06ca: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_06cf: stloc.s 18
-			IL_06d1: ldloc.0
-			IL_06d2: ldc.i4.m1
-			IL_06d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06d8: ldloc.0
-			IL_06d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_06e3: ldarg.0
-			IL_06e4: ldc.i4.1
-			IL_06e5: newarr [System.Runtime]System.Object
-			IL_06ea: dup
-			IL_06eb: ldc.i4.0
-			IL_06ec: ldloc.s 18
-			IL_06ee: stelem.ref
-			IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06f4: pop
-			IL_06f5: ldloc.0
-			IL_06f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0700: ret
+			IL_068b: ldloc.0
+			IL_068c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0691: stloc.s 18
+			IL_0693: ldloc.0
+			IL_0694: ldc.i4.m1
+			IL_0695: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_069a: ldloc.0
+			IL_069b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06a5: ldarg.0
+			IL_06a6: ldc.i4.1
+			IL_06a7: newarr [System.Runtime]System.Object
+			IL_06ac: dup
+			IL_06ad: ldc.i4.0
+			IL_06ae: ldloc.s 18
+			IL_06b0: stelem.ref
+			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06b6: pop
+			IL_06b7: ldloc.0
+			IL_06b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06c2: ret
 
-			IL_0701: ldloc.0
-			IL_0702: ldc.i4.m1
-			IL_0703: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0708: ldloc.0
-			IL_0709: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_070e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0713: ldarg.0
-			IL_0714: ldc.i4.1
-			IL_0715: newarr [System.Runtime]System.Object
-			IL_071a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_071f: pop
-			IL_0720: ldloc.0
-			IL_0721: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0726: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_072b: ret
+			IL_06c3: ldloc.0
+			IL_06c4: ldc.i4.m1
+			IL_06c5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06ca: ldloc.0
+			IL_06cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06d5: ldarg.0
+			IL_06d6: ldc.i4.1
+			IL_06d7: newarr [System.Runtime]System.Object
+			IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06e1: pop
+			IL_06e2: ldloc.0
+			IL_06e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06e8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06ed: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -954,24 +938,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2818
+			// Method begins at RVA 0x27da
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FSPromises_Open_Read_Write_Close/Scope::path
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1056,7 +1031,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2866
+		// Method begins at RVA 0x2807
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Buffer.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Buffer.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2255
+				// Method begins at RVA 0x2226
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,15 +52,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x2194
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 95 (0x5f)
 			.maxstack 8
 			.locals init (
 				[0] bool,
 				[1] object,
-				[2] object,
-				[3] object
+				[2] object
 			)
 
 			IL_0000: ldarg.2
@@ -86,18 +85,14 @@
 			IL_0040: ldstr "fs"
 			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
 			IL_004a: stloc.2
-			IL_004b: ldarg.0
-			IL_004c: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-			IL_0051: ldstr "Cannot access 'testFile' before initialization"
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_005b: stloc.3
-			IL_005c: ldloc.2
-			IL_005d: ldstr "rmSync"
-			IL_0062: ldloc.3
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0068: pop
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_004b: ldloc.2
+			IL_004c: ldstr "rmSync"
+			IL_0051: ldarg.0
+			IL_0052: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_005c: pop
+			IL_005d: ldnull
+			IL_005e: ret
 		} // end of method ArrowFunction_L8C28::__js_call__
 
 	} // end of class ArrowFunction_L8C28
@@ -120,7 +115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225e
+				// Method begins at RVA 0x222f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +139,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2223
+			// Method begins at RVA 0x21ff
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -178,18 +173,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2241
+			// Method begins at RVA 0x221d
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -207,7 +199,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 333 (0x14d)
+		// Code size: 309 (0x135)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_ReadFile_Buffer/Scope,
@@ -261,77 +253,71 @@
 		IL_0079: stloc.3
 		IL_007a: ldloc.0
 		IL_007b: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-		IL_0080: ldstr "Cannot access 'testFile' before initialization"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_008a: stloc.s 4
-		IL_008c: ldloc.3
-		IL_008d: ldstr "writeFileSync"
-		IL_0092: ldloc.s 4
-		IL_0094: ldstr "Buffer test"
-		IL_0099: ldstr "utf8"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00a3: pop
-		IL_00a4: ldloc.0
-		IL_00a5: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-		IL_00aa: ldstr "Cannot access 'testFile' before initialization"
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00b4: stloc.s 4
-		IL_00b6: ldloc.1
-		IL_00b7: ldstr "readFile"
-		IL_00bc: ldloc.s 4
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c3: stloc.s 4
-		IL_00c5: ldc.i4.1
-		IL_00c6: newarr [System.Runtime]System.Object
-		IL_00cb: dup
-		IL_00cc: ldc.i4.0
-		IL_00cd: ldloc.0
-		IL_00ce: stelem.ref
-		IL_00cf: ldc.i4.0
-		IL_00d0: ldelem.ref
-		IL_00d1: castclass Modules.FSPromises_ReadFile_Buffer/Scope
-		IL_00d6: ldftn object Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L8C28::__js_call__(class Modules.FSPromises_ReadFile_Buffer/Scope, object, object)
-		IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00e1: ldc.i4.1
-		IL_00e2: newarr [System.Runtime]System.Object
-		IL_00e7: dup
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldloc.0
-		IL_00ea: stelem.ref
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00f5: ldc.i4.1
-		IL_00f6: conv.r8
-		IL_00f7: ldstr ""
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0101: stloc.3
-		IL_0102: ldloc.s 4
-		IL_0104: ldstr "then"
-		IL_0109: ldloc.3
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010f: stloc.3
-		IL_0110: ldnull
-		IL_0111: ldftn object Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10::__js_call__(object, object)
-		IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_011c: ldc.i4.1
-		IL_011d: newarr [System.Runtime]System.Object
-		IL_0122: dup
-		IL_0123: ldc.i4.0
-		IL_0124: ldloc.0
-		IL_0125: stelem.ref
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0130: ldc.i4.1
-		IL_0131: conv.r8
-		IL_0132: ldstr ""
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_013c: stloc.s 4
-		IL_013e: ldloc.3
-		IL_013f: ldstr "catch"
-		IL_0144: ldloc.s 4
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014b: pop
-		IL_014c: ret
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldstr "writeFileSync"
+		IL_0088: ldloc.s 4
+		IL_008a: ldstr "Buffer test"
+		IL_008f: ldstr "utf8"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0099: pop
+		IL_009a: ldloc.1
+		IL_009b: ldstr "readFile"
+		IL_00a0: ldloc.0
+		IL_00a1: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ab: stloc.s 4
+		IL_00ad: ldc.i4.1
+		IL_00ae: newarr [System.Runtime]System.Object
+		IL_00b3: dup
+		IL_00b4: ldc.i4.0
+		IL_00b5: ldloc.0
+		IL_00b6: stelem.ref
+		IL_00b7: ldc.i4.0
+		IL_00b8: ldelem.ref
+		IL_00b9: castclass Modules.FSPromises_ReadFile_Buffer/Scope
+		IL_00be: ldftn object Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L8C28::__js_call__(class Modules.FSPromises_ReadFile_Buffer/Scope, object, object)
+		IL_00c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.0
+		IL_00d2: stelem.ref
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00dd: ldc.i4.1
+		IL_00de: conv.r8
+		IL_00df: ldstr ""
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00e9: stloc.3
+		IL_00ea: ldloc.s 4
+		IL_00ec: ldstr "then"
+		IL_00f1: ldloc.3
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f7: stloc.3
+		IL_00f8: ldnull
+		IL_00f9: ldftn object Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10::__js_call__(object, object)
+		IL_00ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0104: ldc.i4.1
+		IL_0105: newarr [System.Runtime]System.Object
+		IL_010a: dup
+		IL_010b: ldc.i4.0
+		IL_010c: ldloc.0
+		IL_010d: stelem.ref
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0118: ldc.i4.1
+		IL_0119: conv.r8
+		IL_011a: ldstr ""
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0124: stloc.s 4
+		IL_0126: ldloc.3
+		IL_0127: ldstr "catch"
+		IL_012c: ldloc.s 4
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0133: pop
+		IL_0134: ret
 	} // end of method FSPromises_ReadFile_Buffer::__js_module_init__
 
 } // end of class Modules.FSPromises_ReadFile_Buffer
@@ -343,7 +329,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2267
+		// Method begins at RVA 0x2238
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Utf8.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Utf8.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2230
+				// Method begins at RVA 0x2205
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,13 +52,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21b0
+			// Method begins at RVA 0x219c
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -71,18 +70,14 @@
 			IL_0017: ldstr "fs"
 			IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
 			IL_0021: stloc.0
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-			IL_0028: ldstr "Cannot access 'testFile' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.1
-			IL_0033: ldloc.0
-			IL_0034: ldstr "rmSync"
-			IL_0039: ldloc.1
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003f: pop
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0022: ldloc.0
+			IL_0023: ldstr "rmSync"
+			IL_0028: ldarg.0
+			IL_0029: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0033: pop
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method ArrowFunction_L8C36::__js_call__
 
 	} // end of class ArrowFunction_L8C36
@@ -105,7 +100,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2239
+				// Method begins at RVA 0x220e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -129,7 +124,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21fe
+			// Method begins at RVA 0x21de
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -163,18 +158,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221c
+			// Method begins at RVA 0x21fc
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -192,7 +184,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 338 (0x152)
+		// Code size: 318 (0x13e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_ReadFile_Utf8/Scope,
@@ -246,78 +238,74 @@
 		IL_0079: stloc.3
 		IL_007a: ldloc.0
 		IL_007b: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-		IL_0080: ldstr "Cannot access 'testFile' before initialization"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_008a: stloc.s 4
-		IL_008c: ldloc.3
-		IL_008d: ldstr "writeFileSync"
-		IL_0092: ldloc.s 4
-		IL_0094: ldstr "Hello, fs/promises!"
-		IL_0099: ldstr "utf8"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00a3: pop
-		IL_00a4: ldloc.0
-		IL_00a5: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-		IL_00aa: ldstr "Cannot access 'testFile' before initialization"
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldstr "writeFileSync"
+		IL_0088: ldloc.s 4
+		IL_008a: ldstr "Hello, fs/promises!"
+		IL_008f: ldstr "utf8"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0099: pop
+		IL_009a: ldloc.0
+		IL_009b: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
+		IL_00a0: stloc.s 4
+		IL_00a2: ldloc.1
+		IL_00a3: ldstr "readFile"
+		IL_00a8: ldloc.s 4
+		IL_00aa: ldstr "utf8"
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_00b4: stloc.s 4
-		IL_00b6: ldloc.1
-		IL_00b7: ldstr "readFile"
-		IL_00bc: ldloc.s 4
-		IL_00be: ldstr "utf8"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00c8: stloc.s 4
-		IL_00ca: ldc.i4.1
-		IL_00cb: newarr [System.Runtime]System.Object
-		IL_00d0: dup
-		IL_00d1: ldc.i4.0
-		IL_00d2: ldloc.0
-		IL_00d3: stelem.ref
-		IL_00d4: ldc.i4.0
-		IL_00d5: ldelem.ref
-		IL_00d6: castclass Modules.FSPromises_ReadFile_Utf8/Scope
-		IL_00db: ldftn object Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L8C36::__js_call__(class Modules.FSPromises_ReadFile_Utf8/Scope, object, object)
-		IL_00e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00b6: ldc.i4.1
+		IL_00b7: newarr [System.Runtime]System.Object
+		IL_00bc: dup
+		IL_00bd: ldc.i4.0
+		IL_00be: ldloc.0
+		IL_00bf: stelem.ref
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldelem.ref
+		IL_00c2: castclass Modules.FSPromises_ReadFile_Utf8/Scope
+		IL_00c7: ldftn object Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L8C36::__js_call__(class Modules.FSPromises_ReadFile_Utf8/Scope, object, object)
+		IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00d2: ldc.i4.1
+		IL_00d3: newarr [System.Runtime]System.Object
+		IL_00d8: dup
+		IL_00d9: ldc.i4.0
+		IL_00da: ldloc.0
+		IL_00db: stelem.ref
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_00e6: ldc.i4.1
-		IL_00e7: newarr [System.Runtime]System.Object
-		IL_00ec: dup
-		IL_00ed: ldc.i4.0
-		IL_00ee: ldloc.0
-		IL_00ef: stelem.ref
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00fa: ldc.i4.1
-		IL_00fb: conv.r8
-		IL_00fc: ldstr ""
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0106: stloc.3
-		IL_0107: ldloc.s 4
-		IL_0109: ldstr "then"
-		IL_010e: ldloc.3
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0114: stloc.3
-		IL_0115: ldnull
-		IL_0116: ldftn object Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10::__js_call__(object, object)
-		IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00e7: conv.r8
+		IL_00e8: ldstr ""
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00f2: stloc.3
+		IL_00f3: ldloc.s 4
+		IL_00f5: ldstr "then"
+		IL_00fa: ldloc.3
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0100: stloc.3
+		IL_0101: ldnull
+		IL_0102: ldftn object Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10::__js_call__(object, object)
+		IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_010d: ldc.i4.1
+		IL_010e: newarr [System.Runtime]System.Object
+		IL_0113: dup
+		IL_0114: ldc.i4.0
+		IL_0115: ldloc.0
+		IL_0116: stelem.ref
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_0121: ldc.i4.1
-		IL_0122: newarr [System.Runtime]System.Object
-		IL_0127: dup
-		IL_0128: ldc.i4.0
-		IL_0129: ldloc.0
-		IL_012a: stelem.ref
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0135: ldc.i4.1
-		IL_0136: conv.r8
-		IL_0137: ldstr ""
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0141: stloc.s 4
-		IL_0143: ldloc.3
-		IL_0144: ldstr "catch"
-		IL_0149: ldloc.s 4
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0150: pop
-		IL_0151: ret
+		IL_0122: conv.r8
+		IL_0123: ldstr ""
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_012d: stloc.s 4
+		IL_012f: ldloc.3
+		IL_0130: ldstr "catch"
+		IL_0135: ldloc.s 4
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_013c: pop
+		IL_013d: ret
 	} // end of method FSPromises_ReadFile_Utf8::__js_module_init__
 
 } // end of class Modules.FSPromises_ReadFile_Utf8
@@ -329,7 +317,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2242
+		// Method begins at RVA 0x2217
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x241e
+					// Method begins at RVA 0x2394
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -52,7 +52,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23dc
+				// Method begins at RVA 0x2368
 				// Header size: 12
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -84,7 +84,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2415
+				// Method begins at RVA 0x238b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22fc
+			// Method begins at RVA 0x229c
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -170,7 +170,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2427
+				// Method begins at RVA 0x239d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -194,7 +194,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x235f
+			// Method begins at RVA 0x22ff
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -223,7 +223,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2430
+				// Method begins at RVA 0x23a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -249,9 +249,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2380
+			// Method begins at RVA 0x2320
 			// Header size: 12
-			// Code size: 78 (0x4e)
+			// Code size: 58 (0x3a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -260,30 +260,26 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-			IL_0006: ldstr "Cannot access 'syncFs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldarg.0
-			IL_0012: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-			IL_0017: ldstr "Cannot access 'dir' before initialization"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0021: stloc.1
-			IL_0022: ldloc.0
-			IL_0023: ldstr "rmSync"
-			IL_0028: ldloc.1
-			IL_0029: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002e: dup
-			IL_002f: ldstr "recursive"
-			IL_0034: ldc.i4.1
-			IL_0035: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003a: dup
-			IL_003b: ldstr "force"
-			IL_0040: ldc.i4.1
-			IL_0041: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004b: pop
-			IL_004c: ldnull
-			IL_004d: ret
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+			IL_000d: stloc.1
+			IL_000e: ldloc.0
+			IL_000f: ldstr "rmSync"
+			IL_0014: ldloc.1
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001a: dup
+			IL_001b: ldstr "recursive"
+			IL_0020: ldc.i4.1
+			IL_0021: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0026: dup
+			IL_0027: ldstr "force"
+			IL_002c: ldc.i4.1
+			IL_002d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0037: pop
+			IL_0038: ldnull
+			IL_0039: ret
 		} // end of method ArrowFunction_L21C14::__js_call__
 
 	} // end of class ArrowFunction_L21C14
@@ -304,21 +300,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23f6
+			// Method begins at RVA 0x2382
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FSPromises_Readdir_Names/Scope::dir
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -336,7 +326,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 670 (0x29e)
+		// Code size: 576 (0x240)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_Names/Scope,
@@ -396,173 +386,153 @@
 		IL_0081: stfld object Modules.FSPromises_Readdir_Names/Scope::dir
 		IL_0086: ldloc.0
 		IL_0087: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_008c: ldstr "Cannot access 'syncFs' before initialization"
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0096: stloc.s 4
-		IL_0098: ldloc.0
-		IL_0099: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_009e: ldstr "Cannot access 'dir' before initialization"
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00a8: stloc.s 5
-		IL_00aa: ldloc.s 4
-		IL_00ac: ldstr "mkdirSync"
-		IL_00b1: ldloc.s 5
-		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00b8: dup
-		IL_00b9: ldstr "recursive"
-		IL_00be: ldc.i4.1
-		IL_00bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00c9: pop
-		IL_00ca: ldloc.0
-		IL_00cb: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_00d0: ldstr "Cannot access 'syncFs' before initialization"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00da: stloc.s 5
-		IL_00dc: ldloc.0
-		IL_00dd: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_00e2: ldstr "Cannot access 'dir' before initialization"
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00ec: stloc.s 4
-		IL_00ee: ldloc.2
-		IL_00ef: ldstr "join"
-		IL_00f4: ldloc.s 4
-		IL_00f6: ldstr "alpha.txt"
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0100: stloc.s 4
-		IL_0102: ldloc.s 5
-		IL_0104: ldstr "writeFileSync"
-		IL_0109: ldloc.s 4
-		IL_010b: ldstr ""
-		IL_0110: ldstr "utf8"
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_011a: pop
-		IL_011b: ldloc.0
-		IL_011c: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_0121: ldstr "Cannot access 'syncFs' before initialization"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_012b: stloc.s 4
-		IL_012d: ldloc.0
-		IL_012e: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_0133: ldstr "Cannot access 'dir' before initialization"
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_013d: stloc.s 5
-		IL_013f: ldloc.2
-		IL_0140: ldstr "join"
-		IL_0145: ldloc.s 5
-		IL_0147: ldstr "beta.txt"
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0151: stloc.s 5
-		IL_0153: ldloc.s 4
-		IL_0155: ldstr "writeFileSync"
-		IL_015a: ldloc.s 5
-		IL_015c: ldstr ""
-		IL_0161: ldstr "utf8"
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_016b: pop
-		IL_016c: ldloc.0
-		IL_016d: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_0172: ldstr "Cannot access 'syncFs' before initialization"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_017c: stloc.s 5
-		IL_017e: ldloc.0
-		IL_017f: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_0184: ldstr "Cannot access 'dir' before initialization"
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_018e: stloc.s 4
-		IL_0190: ldloc.2
-		IL_0191: ldstr "join"
-		IL_0196: ldloc.s 4
-		IL_0198: ldstr "subdir"
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01a2: stloc.s 4
-		IL_01a4: ldloc.s 5
-		IL_01a6: ldstr "mkdirSync"
-		IL_01ab: ldloc.s 4
+		IL_008c: stloc.s 4
+		IL_008e: ldloc.0
+		IL_008f: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0094: stloc.s 5
+		IL_0096: ldloc.s 4
+		IL_0098: ldstr "mkdirSync"
+		IL_009d: ldloc.s 5
+		IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a4: dup
+		IL_00a5: ldstr "recursive"
+		IL_00aa: ldc.i4.1
+		IL_00ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00b5: pop
+		IL_00b6: ldloc.0
+		IL_00b7: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_00bc: stloc.s 5
+		IL_00be: ldloc.0
+		IL_00bf: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_00c4: stloc.s 4
+		IL_00c6: ldloc.2
+		IL_00c7: ldstr "join"
+		IL_00cc: ldloc.s 4
+		IL_00ce: ldstr "alpha.txt"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00d8: stloc.s 4
+		IL_00da: ldloc.s 5
+		IL_00dc: ldstr "writeFileSync"
+		IL_00e1: ldloc.s 4
+		IL_00e3: ldstr ""
+		IL_00e8: ldstr "utf8"
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00f2: pop
+		IL_00f3: ldloc.0
+		IL_00f4: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_00f9: stloc.s 4
+		IL_00fb: ldloc.0
+		IL_00fc: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0101: stloc.s 5
+		IL_0103: ldloc.2
+		IL_0104: ldstr "join"
+		IL_0109: ldloc.s 5
+		IL_010b: ldstr "beta.txt"
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0115: stloc.s 5
+		IL_0117: ldloc.s 4
+		IL_0119: ldstr "writeFileSync"
+		IL_011e: ldloc.s 5
+		IL_0120: ldstr ""
+		IL_0125: ldstr "utf8"
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_012f: pop
+		IL_0130: ldloc.0
+		IL_0131: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_0136: stloc.s 5
+		IL_0138: ldloc.0
+		IL_0139: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_013e: stloc.s 4
+		IL_0140: ldloc.2
+		IL_0141: ldstr "join"
+		IL_0146: ldloc.s 4
+		IL_0148: ldstr "subdir"
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0152: stloc.s 4
+		IL_0154: ldloc.s 5
+		IL_0156: ldstr "mkdirSync"
+		IL_015b: ldloc.s 4
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0162: pop
+		IL_0163: ldloc.1
+		IL_0164: ldstr "readdir"
+		IL_0169: ldloc.0
+		IL_016a: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0174: stloc.s 4
+		IL_0176: ldnull
+		IL_0177: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11::__js_call__(object, object)
+		IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0182: ldc.i4.1
+		IL_0183: newarr [System.Runtime]System.Object
+		IL_0188: dup
+		IL_0189: ldc.i4.0
+		IL_018a: ldloc.0
+		IL_018b: stelem.ref
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0196: ldc.i4.1
+		IL_0197: conv.r8
+		IL_0198: ldstr ""
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01a2: stloc.s 5
+		IL_01a4: ldloc.s 4
+		IL_01a6: ldstr "then"
+		IL_01ab: ldloc.s 5
 		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01b2: pop
-		IL_01b3: ldloc.0
-		IL_01b4: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_01b9: ldstr "Cannot access 'dir' before initialization"
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01c3: stloc.s 4
-		IL_01c5: ldloc.1
-		IL_01c6: ldstr "readdir"
-		IL_01cb: ldloc.s 4
-		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01d2: stloc.s 4
-		IL_01d4: ldnull
-		IL_01d5: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11::__js_call__(object, object)
-		IL_01db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01e0: ldc.i4.1
-		IL_01e1: newarr [System.Runtime]System.Object
-		IL_01e6: dup
-		IL_01e7: ldc.i4.0
-		IL_01e8: ldloc.0
-		IL_01e9: stelem.ref
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01f4: ldc.i4.1
-		IL_01f5: conv.r8
-		IL_01f6: ldstr ""
-		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0200: stloc.s 5
-		IL_0202: ldloc.s 4
-		IL_0204: ldstr "then"
-		IL_0209: ldloc.s 5
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0210: stloc.s 5
-		IL_0212: ldnull
-		IL_0213: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12::__js_call__(object, object)
-		IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_021e: ldc.i4.1
-		IL_021f: newarr [System.Runtime]System.Object
-		IL_0224: dup
-		IL_0225: ldc.i4.0
-		IL_0226: ldloc.0
-		IL_0227: stelem.ref
-		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0232: ldc.i4.1
-		IL_0233: conv.r8
-		IL_0234: ldstr ""
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_023e: stloc.s 4
-		IL_0240: ldloc.s 5
-		IL_0242: ldstr "catch"
-		IL_0247: ldloc.s 4
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_024e: stloc.s 4
-		IL_0250: ldc.i4.1
-		IL_0251: newarr [System.Runtime]System.Object
-		IL_0256: dup
-		IL_0257: ldc.i4.0
-		IL_0258: ldloc.0
-		IL_0259: stelem.ref
-		IL_025a: ldc.i4.0
-		IL_025b: ldelem.ref
-		IL_025c: castclass Modules.FSPromises_Readdir_Names/Scope
-		IL_0261: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14::__js_call__(class Modules.FSPromises_Readdir_Names/Scope, object)
-		IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_026c: ldc.i4.1
-		IL_026d: newarr [System.Runtime]System.Object
-		IL_0272: dup
-		IL_0273: ldc.i4.0
-		IL_0274: ldloc.0
-		IL_0275: stelem.ref
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0280: ldc.i4.0
-		IL_0281: conv.r8
-		IL_0282: ldstr ""
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_028c: stloc.s 5
-		IL_028e: ldloc.s 4
-		IL_0290: ldstr "finally"
-		IL_0295: ldloc.s 5
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_029c: pop
-		IL_029d: ret
+		IL_01b2: stloc.s 5
+		IL_01b4: ldnull
+		IL_01b5: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12::__js_call__(object, object)
+		IL_01bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01c0: ldc.i4.1
+		IL_01c1: newarr [System.Runtime]System.Object
+		IL_01c6: dup
+		IL_01c7: ldc.i4.0
+		IL_01c8: ldloc.0
+		IL_01c9: stelem.ref
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01d4: ldc.i4.1
+		IL_01d5: conv.r8
+		IL_01d6: ldstr ""
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01e0: stloc.s 4
+		IL_01e2: ldloc.s 5
+		IL_01e4: ldstr "catch"
+		IL_01e9: ldloc.s 4
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01f0: stloc.s 4
+		IL_01f2: ldc.i4.1
+		IL_01f3: newarr [System.Runtime]System.Object
+		IL_01f8: dup
+		IL_01f9: ldc.i4.0
+		IL_01fa: ldloc.0
+		IL_01fb: stelem.ref
+		IL_01fc: ldc.i4.0
+		IL_01fd: ldelem.ref
+		IL_01fe: castclass Modules.FSPromises_Readdir_Names/Scope
+		IL_0203: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14::__js_call__(class Modules.FSPromises_Readdir_Names/Scope, object)
+		IL_0209: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_020e: ldc.i4.1
+		IL_020f: newarr [System.Runtime]System.Object
+		IL_0214: dup
+		IL_0215: ldc.i4.0
+		IL_0216: ldloc.0
+		IL_0217: stelem.ref
+		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0222: ldc.i4.0
+		IL_0223: conv.r8
+		IL_0224: ldstr ""
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_022e: stloc.s 5
+		IL_0230: ldloc.s 4
+		IL_0232: ldstr "finally"
+		IL_0237: ldloc.s 5
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_023e: pop
+		IL_023f: ret
 	} // end of method FSPromises_Readdir_Names::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_Names
@@ -574,7 +544,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2439
+		// Method begins at RVA 0x23af
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x245e
+					// Method begins at RVA 0x23ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -52,7 +52,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23c4
+				// Method begins at RVA 0x2368
 				// Header size: 12
 				// Code size: 74 (0x4a)
 				.maxstack 8
@@ -113,7 +113,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2467
+					// Method begins at RVA 0x23f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -137,7 +137,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x241c
+				// Method begins at RVA 0x23c0
 				// Header size: 12
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -169,7 +169,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2455
+				// Method begins at RVA 0x23e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -193,7 +193,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22bc
+			// Method begins at RVA 0x2274
 			// Header size: 12
 			// Code size: 128 (0x80)
 			.maxstack 8
@@ -267,7 +267,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2470
+				// Method begins at RVA 0x23fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -291,7 +291,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2348
+			// Method begins at RVA 0x2300
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -320,7 +320,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2479
+				// Method begins at RVA 0x2407
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -346,9 +346,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2368
+			// Method begins at RVA 0x2320
 			// Header size: 12
-			// Code size: 78 (0x4e)
+			// Code size: 58 (0x3a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -357,30 +357,26 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-			IL_0006: ldstr "Cannot access 'syncFs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldarg.0
-			IL_0012: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-			IL_0017: ldstr "Cannot access 'dir' before initialization"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0021: stloc.1
-			IL_0022: ldloc.0
-			IL_0023: ldstr "rmSync"
-			IL_0028: ldloc.1
-			IL_0029: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002e: dup
-			IL_002f: ldstr "recursive"
-			IL_0034: ldc.i4.1
-			IL_0035: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003a: dup
-			IL_003b: ldstr "force"
-			IL_0040: ldc.i4.1
-			IL_0041: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004b: pop
-			IL_004c: ldnull
-			IL_004d: ret
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+			IL_000d: stloc.1
+			IL_000e: ldloc.0
+			IL_000f: ldstr "rmSync"
+			IL_0014: ldloc.1
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001a: dup
+			IL_001b: ldstr "recursive"
+			IL_0020: ldc.i4.1
+			IL_0021: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0026: dup
+			IL_0027: ldstr "force"
+			IL_002c: ldc.i4.1
+			IL_002d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0037: pop
+			IL_0038: ldnull
+			IL_0039: ret
 		} // end of method ArrowFunction_L21C14::__js_call__
 
 	} // end of class ArrowFunction_L21C14
@@ -401,21 +397,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2436
+			// Method begins at RVA 0x23da
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -433,7 +423,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 606 (0x25e)
+		// Code size: 536 (0x218)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_WithFileTypes/Scope,
@@ -493,155 +483,141 @@
 		IL_0081: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
 		IL_0086: ldloc.0
 		IL_0087: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_008c: ldstr "Cannot access 'syncFs' before initialization"
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0096: stloc.s 4
-		IL_0098: ldloc.0
-		IL_0099: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_009e: ldstr "Cannot access 'dir' before initialization"
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00a8: stloc.s 5
-		IL_00aa: ldloc.s 4
-		IL_00ac: ldstr "mkdirSync"
-		IL_00b1: ldloc.s 5
-		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00b8: dup
-		IL_00b9: ldstr "recursive"
-		IL_00be: ldc.i4.1
-		IL_00bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00c9: pop
-		IL_00ca: ldloc.0
-		IL_00cb: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_00d0: ldstr "Cannot access 'syncFs' before initialization"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00da: stloc.s 5
-		IL_00dc: ldloc.0
-		IL_00dd: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_00e2: ldstr "Cannot access 'dir' before initialization"
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00ec: stloc.s 4
-		IL_00ee: ldloc.2
-		IL_00ef: ldstr "join"
-		IL_00f4: ldloc.s 4
-		IL_00f6: ldstr "alpha.txt"
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0100: stloc.s 4
-		IL_0102: ldloc.s 5
-		IL_0104: ldstr "writeFileSync"
-		IL_0109: ldloc.s 4
-		IL_010b: ldstr ""
-		IL_0110: ldstr "utf8"
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_011a: pop
-		IL_011b: ldloc.0
-		IL_011c: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_0121: ldstr "Cannot access 'syncFs' before initialization"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_012b: stloc.s 4
-		IL_012d: ldloc.0
-		IL_012e: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_0133: ldstr "Cannot access 'dir' before initialization"
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_013d: stloc.s 5
-		IL_013f: ldloc.2
-		IL_0140: ldstr "join"
-		IL_0145: ldloc.s 5
-		IL_0147: ldstr "subdir"
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0151: stloc.s 5
-		IL_0153: ldloc.s 4
-		IL_0155: ldstr "mkdirSync"
-		IL_015a: ldloc.s 5
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0161: pop
+		IL_008c: stloc.s 4
+		IL_008e: ldloc.0
+		IL_008f: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_0094: stloc.s 5
+		IL_0096: ldloc.s 4
+		IL_0098: ldstr "mkdirSync"
+		IL_009d: ldloc.s 5
+		IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a4: dup
+		IL_00a5: ldstr "recursive"
+		IL_00aa: ldc.i4.1
+		IL_00ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00b5: pop
+		IL_00b6: ldloc.0
+		IL_00b7: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_00bc: stloc.s 5
+		IL_00be: ldloc.0
+		IL_00bf: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_00c4: stloc.s 4
+		IL_00c6: ldloc.2
+		IL_00c7: ldstr "join"
+		IL_00cc: ldloc.s 4
+		IL_00ce: ldstr "alpha.txt"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00d8: stloc.s 4
+		IL_00da: ldloc.s 5
+		IL_00dc: ldstr "writeFileSync"
+		IL_00e1: ldloc.s 4
+		IL_00e3: ldstr ""
+		IL_00e8: ldstr "utf8"
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00f2: pop
+		IL_00f3: ldloc.0
+		IL_00f4: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_00f9: stloc.s 4
+		IL_00fb: ldloc.0
+		IL_00fc: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_0101: stloc.s 5
+		IL_0103: ldloc.2
+		IL_0104: ldstr "join"
+		IL_0109: ldloc.s 5
+		IL_010b: ldstr "subdir"
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0115: stloc.s 5
+		IL_0117: ldloc.s 4
+		IL_0119: ldstr "mkdirSync"
+		IL_011e: ldloc.s 5
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0125: pop
+		IL_0126: ldloc.0
+		IL_0127: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_012c: stloc.s 5
+		IL_012e: ldloc.1
+		IL_012f: ldstr "readdir"
+		IL_0134: ldloc.s 5
+		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_013b: dup
+		IL_013c: ldstr "withFileTypes"
+		IL_0141: ldc.i4.1
+		IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_014c: stloc.s 5
+		IL_014e: ldnull
+		IL_014f: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11::__js_call__(object, object)
+		IL_0155: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_015a: ldc.i4.1
+		IL_015b: newarr [System.Runtime]System.Object
+		IL_0160: dup
+		IL_0161: ldc.i4.0
 		IL_0162: ldloc.0
-		IL_0163: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_0168: ldstr "Cannot access 'dir' before initialization"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0172: stloc.s 5
-		IL_0174: ldloc.1
-		IL_0175: ldstr "readdir"
-		IL_017a: ldloc.s 5
-		IL_017c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0181: dup
-		IL_0182: ldstr "withFileTypes"
-		IL_0187: ldc.i4.1
-		IL_0188: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0192: stloc.s 5
-		IL_0194: ldnull
-		IL_0195: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11::__js_call__(object, object)
-		IL_019b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01a0: ldc.i4.1
-		IL_01a1: newarr [System.Runtime]System.Object
-		IL_01a6: dup
-		IL_01a7: ldc.i4.0
-		IL_01a8: ldloc.0
-		IL_01a9: stelem.ref
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01b4: ldc.i4.1
-		IL_01b5: conv.r8
-		IL_01b6: ldstr ""
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01c0: stloc.s 4
-		IL_01c2: ldloc.s 5
-		IL_01c4: ldstr "then"
-		IL_01c9: ldloc.s 4
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01d0: stloc.s 4
-		IL_01d2: ldnull
-		IL_01d3: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12::__js_call__(object, object)
-		IL_01d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01de: ldc.i4.1
-		IL_01df: newarr [System.Runtime]System.Object
-		IL_01e4: dup
-		IL_01e5: ldc.i4.0
-		IL_01e6: ldloc.0
-		IL_01e7: stelem.ref
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01f2: ldc.i4.1
-		IL_01f3: conv.r8
-		IL_01f4: ldstr ""
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01fe: stloc.s 5
-		IL_0200: ldloc.s 4
-		IL_0202: ldstr "catch"
-		IL_0207: ldloc.s 5
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_020e: stloc.s 5
-		IL_0210: ldc.i4.1
-		IL_0211: newarr [System.Runtime]System.Object
-		IL_0216: dup
-		IL_0217: ldc.i4.0
-		IL_0218: ldloc.0
-		IL_0219: stelem.ref
-		IL_021a: ldc.i4.0
-		IL_021b: ldelem.ref
-		IL_021c: castclass Modules.FSPromises_Readdir_WithFileTypes/Scope
-		IL_0221: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14::__js_call__(class Modules.FSPromises_Readdir_WithFileTypes/Scope, object)
-		IL_0227: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_022c: ldc.i4.1
-		IL_022d: newarr [System.Runtime]System.Object
-		IL_0232: dup
-		IL_0233: ldc.i4.0
-		IL_0234: ldloc.0
-		IL_0235: stelem.ref
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0240: ldc.i4.0
-		IL_0241: conv.r8
-		IL_0242: ldstr ""
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_024c: stloc.s 4
-		IL_024e: ldloc.s 5
-		IL_0250: ldstr "finally"
-		IL_0255: ldloc.s 4
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_025c: pop
-		IL_025d: ret
+		IL_0163: stelem.ref
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_016e: ldc.i4.1
+		IL_016f: conv.r8
+		IL_0170: ldstr ""
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_017a: stloc.s 4
+		IL_017c: ldloc.s 5
+		IL_017e: ldstr "then"
+		IL_0183: ldloc.s 4
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_018a: stloc.s 4
+		IL_018c: ldnull
+		IL_018d: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12::__js_call__(object, object)
+		IL_0193: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0198: ldc.i4.1
+		IL_0199: newarr [System.Runtime]System.Object
+		IL_019e: dup
+		IL_019f: ldc.i4.0
+		IL_01a0: ldloc.0
+		IL_01a1: stelem.ref
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01ac: ldc.i4.1
+		IL_01ad: conv.r8
+		IL_01ae: ldstr ""
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01b8: stloc.s 5
+		IL_01ba: ldloc.s 4
+		IL_01bc: ldstr "catch"
+		IL_01c1: ldloc.s 5
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01c8: stloc.s 5
+		IL_01ca: ldc.i4.1
+		IL_01cb: newarr [System.Runtime]System.Object
+		IL_01d0: dup
+		IL_01d1: ldc.i4.0
+		IL_01d2: ldloc.0
+		IL_01d3: stelem.ref
+		IL_01d4: ldc.i4.0
+		IL_01d5: ldelem.ref
+		IL_01d6: castclass Modules.FSPromises_Readdir_WithFileTypes/Scope
+		IL_01db: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14::__js_call__(class Modules.FSPromises_Readdir_WithFileTypes/Scope, object)
+		IL_01e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01e6: ldc.i4.1
+		IL_01e7: newarr [System.Runtime]System.Object
+		IL_01ec: dup
+		IL_01ed: ldc.i4.0
+		IL_01ee: ldloc.0
+		IL_01ef: stelem.ref
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01fa: ldc.i4.0
+		IL_01fb: conv.r8
+		IL_01fc: ldstr ""
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0206: stloc.s 4
+		IL_0208: ldloc.s 5
+		IL_020a: ldstr "finally"
+		IL_020f: ldloc.s 4
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0216: pop
+		IL_0217: ret
 	} // end of method FSPromises_Readdir_WithFileTypes::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_WithFileTypes
@@ -653,7 +629,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2482
+		// Method begins at RVA 0x2410
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226d
+				// Method begins at RVA 0x223e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,13 +52,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x2194
 			// Header size: 12
-			// Code size: 131 (0x83)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -87,18 +86,14 @@
 			IL_0058: ldstr "fs"
 			IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
 			IL_0062: stloc.0
-			IL_0063: ldarg.0
-			IL_0064: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-			IL_0069: ldstr "Cannot access 'testFile' before initialization"
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0073: stloc.1
-			IL_0074: ldloc.0
-			IL_0075: ldstr "rmSync"
-			IL_007a: ldloc.1
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0080: pop
-			IL_0081: ldnull
-			IL_0082: ret
+			IL_0063: ldloc.0
+			IL_0064: ldstr "rmSync"
+			IL_0069: ldarg.0
+			IL_006a: ldfld object Modules.FSPromises_Realpath/Scope::testFile
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0074: pop
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method ArrowFunction_L8C28::__js_call__
 
 	} // end of class ArrowFunction_L8C28
@@ -121,7 +116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2276
+				// Method begins at RVA 0x2247
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +140,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x223b
+			// Method begins at RVA 0x2217
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -179,18 +174,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2259
+			// Method begins at RVA 0x2235
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Realpath/Scope::testFile
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -208,7 +200,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 333 (0x14d)
+		// Code size: 309 (0x135)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Realpath/Scope,
@@ -262,77 +254,71 @@
 		IL_0079: stloc.3
 		IL_007a: ldloc.0
 		IL_007b: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-		IL_0080: ldstr "Cannot access 'testFile' before initialization"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_008a: stloc.s 4
-		IL_008c: ldloc.3
-		IL_008d: ldstr "writeFileSync"
-		IL_0092: ldloc.s 4
-		IL_0094: ldstr "test"
-		IL_0099: ldstr "utf8"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00a3: pop
-		IL_00a4: ldloc.0
-		IL_00a5: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-		IL_00aa: ldstr "Cannot access 'testFile' before initialization"
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00b4: stloc.s 4
-		IL_00b6: ldloc.1
-		IL_00b7: ldstr "realpath"
-		IL_00bc: ldloc.s 4
-		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c3: stloc.s 4
-		IL_00c5: ldc.i4.1
-		IL_00c6: newarr [System.Runtime]System.Object
-		IL_00cb: dup
-		IL_00cc: ldc.i4.0
-		IL_00cd: ldloc.0
-		IL_00ce: stelem.ref
-		IL_00cf: ldc.i4.0
-		IL_00d0: ldelem.ref
-		IL_00d1: castclass Modules.FSPromises_Realpath/Scope
-		IL_00d6: ldftn object Modules.FSPromises_Realpath/ArrowFunction_L8C28::__js_call__(class Modules.FSPromises_Realpath/Scope, object, object)
-		IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00e1: ldc.i4.1
-		IL_00e2: newarr [System.Runtime]System.Object
-		IL_00e7: dup
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldloc.0
-		IL_00ea: stelem.ref
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00f5: ldc.i4.1
-		IL_00f6: conv.r8
-		IL_00f7: ldstr ""
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0101: stloc.3
-		IL_0102: ldloc.s 4
-		IL_0104: ldstr "then"
-		IL_0109: ldloc.3
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010f: stloc.3
-		IL_0110: ldnull
-		IL_0111: ldftn object Modules.FSPromises_Realpath/ArrowFunction_L12C10::__js_call__(object, object)
-		IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_011c: ldc.i4.1
-		IL_011d: newarr [System.Runtime]System.Object
-		IL_0122: dup
-		IL_0123: ldc.i4.0
-		IL_0124: ldloc.0
-		IL_0125: stelem.ref
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0130: ldc.i4.1
-		IL_0131: conv.r8
-		IL_0132: ldstr ""
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_013c: stloc.s 4
-		IL_013e: ldloc.3
-		IL_013f: ldstr "catch"
-		IL_0144: ldloc.s 4
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014b: pop
-		IL_014c: ret
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldstr "writeFileSync"
+		IL_0088: ldloc.s 4
+		IL_008a: ldstr "test"
+		IL_008f: ldstr "utf8"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0099: pop
+		IL_009a: ldloc.1
+		IL_009b: ldstr "realpath"
+		IL_00a0: ldloc.0
+		IL_00a1: ldfld object Modules.FSPromises_Realpath/Scope::testFile
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ab: stloc.s 4
+		IL_00ad: ldc.i4.1
+		IL_00ae: newarr [System.Runtime]System.Object
+		IL_00b3: dup
+		IL_00b4: ldc.i4.0
+		IL_00b5: ldloc.0
+		IL_00b6: stelem.ref
+		IL_00b7: ldc.i4.0
+		IL_00b8: ldelem.ref
+		IL_00b9: castclass Modules.FSPromises_Realpath/Scope
+		IL_00be: ldftn object Modules.FSPromises_Realpath/ArrowFunction_L8C28::__js_call__(class Modules.FSPromises_Realpath/Scope, object, object)
+		IL_00c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.0
+		IL_00d2: stelem.ref
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00dd: ldc.i4.1
+		IL_00de: conv.r8
+		IL_00df: ldstr ""
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00e9: stloc.3
+		IL_00ea: ldloc.s 4
+		IL_00ec: ldstr "then"
+		IL_00f1: ldloc.3
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f7: stloc.3
+		IL_00f8: ldnull
+		IL_00f9: ldftn object Modules.FSPromises_Realpath/ArrowFunction_L12C10::__js_call__(object, object)
+		IL_00ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0104: ldc.i4.1
+		IL_0105: newarr [System.Runtime]System.Object
+		IL_010a: dup
+		IL_010b: ldc.i4.0
+		IL_010c: ldloc.0
+		IL_010d: stelem.ref
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0118: ldc.i4.1
+		IL_0119: conv.r8
+		IL_011a: ldstr ""
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0124: stloc.s 4
+		IL_0126: ldloc.3
+		IL_0127: ldstr "catch"
+		IL_012c: ldloc.s 4
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0133: pop
+		IL_0134: ret
 	} // end of method FSPromises_Realpath::__js_module_init__
 
 } // end of class Modules.FSPromises_Realpath
@@ -344,7 +330,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x227f
+		// Method begins at RVA 0x2250
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27a9
+						// Method begins at RVA 0x26d4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27b2
+						// Method begins at RVA 0x26dd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27a0
+					// Method begins at RVA 0x26cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27bb
+					// Method begins at RVA 0x26e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2797
+				// Method begins at RVA 0x26c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			)
 			// Method begins at RVA 0x20e0
 			// Header size: 12
-			// Code size: 1665 (0x681)
+			// Code size: 1485 (0x5cd)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope,
@@ -278,7 +278,7 @@
 
 			IL_00b2: ldloc.0
 			IL_00b3: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00b8: switch (IL_00d1, IL_0552, IL_05b5, IL_0425, IL_0404)
+			IL_00b8: switch (IL_00d1, IL_04a8, IL_0501, IL_03a5, IL_0384)
 
 			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_00d6: stloc.s 13
@@ -320,487 +320,439 @@
 			IL_0142: ldelem.ref
 			IL_0143: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
 			IL_0148: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_014d: ldstr "Cannot access 'path' before initialization"
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0157: stloc.s 13
-			IL_0159: ldarg.0
-			IL_015a: ldc.i4.1
-			IL_015b: ldelem.ref
-			IL_015c: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0161: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
-			IL_0166: ldstr "Cannot access 'os' before initialization"
-			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0170: stloc.s 18
-			IL_0172: ldloc.s 18
-			IL_0174: ldstr "tmpdir"
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_017e: stloc.s 18
-			IL_0180: ldloc.1
-			IL_0181: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0186: stloc.s 17
-			IL_0188: ldstr "js2il-fs-rename-existing-dir-"
-			IL_018d: ldloc.s 17
-			IL_018f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 13
-			IL_0198: ldstr "join"
-			IL_019d: ldloc.s 18
-			IL_019f: ldloc.s 17
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a6: stloc.s 18
-			IL_01a8: ldloc.s 18
-			IL_01aa: stloc.2
-			IL_01ab: ldarg.0
-			IL_01ac: ldc.i4.1
-			IL_01ad: ldelem.ref
-			IL_01ae: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01b3: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_01b8: ldstr "Cannot access 'path' before initialization"
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01c2: stloc.s 18
-			IL_01c4: ldloc.s 18
-			IL_01c6: ldstr "join"
-			IL_01cb: ldloc.2
-			IL_01cc: ldstr "source"
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01d6: stloc.s 18
-			IL_01d8: ldloc.s 18
-			IL_01da: stloc.3
-			IL_01db: ldarg.0
-			IL_01dc: ldc.i4.1
-			IL_01dd: ldelem.ref
-			IL_01de: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01e3: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_01e8: ldstr "Cannot access 'path' before initialization"
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_01f2: stloc.s 18
-			IL_01f4: ldloc.s 18
-			IL_01f6: ldstr "join"
-			IL_01fb: ldloc.2
-			IL_01fc: ldstr "destination"
-			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0206: stloc.s 18
-			IL_0208: ldloc.s 18
-			IL_020a: stloc.s 4
-			IL_020c: ldarg.0
-			IL_020d: ldc.i4.1
-			IL_020e: ldelem.ref
-			IL_020f: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0214: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_0219: ldstr "Cannot access 'path' before initialization"
-			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0223: stloc.s 18
-			IL_0225: ldloc.s 18
-			IL_0227: ldstr "join"
-			IL_022c: ldloc.s 4
-			IL_022e: ldstr "keep.txt"
-			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0238: stloc.s 18
-			IL_023a: ldloc.s 18
-			IL_023c: stloc.s 5
-			IL_023e: ldloc.0
-			IL_023f: ldc.i4.0
-			IL_0240: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0245: ldloc.0
-			IL_0246: ldc.i4.0
-			IL_0247: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_024c: ldloc.0
-			IL_024d: ldc.i4.0
-			IL_024e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0253: ldloc.0
-			IL_0254: ldc.i4.0
-			IL_0255: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_025a: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8::.ctor()
-			IL_025f: stloc.s 6
-			IL_0261: ldarg.0
-			IL_0262: ldc.i4.1
-			IL_0263: ldelem.ref
-			IL_0264: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0269: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_026e: ldstr "Cannot access 'fs' before initialization"
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0278: stloc.s 18
-			IL_027a: ldloc.s 18
-			IL_027c: ldstr "rmSync"
-			IL_0281: ldloc.2
-			IL_0282: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0287: dup
-			IL_0288: ldstr "recursive"
-			IL_028d: ldc.i4.1
-			IL_028e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0293: dup
-			IL_0294: ldstr "force"
-			IL_0299: ldc.i4.1
-			IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02a4: pop
-			IL_02a5: ldarg.0
-			IL_02a6: ldc.i4.1
-			IL_02a7: ldelem.ref
-			IL_02a8: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_02ad: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_02b2: ldstr "Cannot access 'fs' before initialization"
-			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_02bc: stloc.s 18
-			IL_02be: ldloc.s 18
-			IL_02c0: ldstr "mkdirSync"
-			IL_02c5: ldloc.3
-			IL_02c6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02cb: dup
-			IL_02cc: ldstr "recursive"
-			IL_02d1: ldc.i4.1
-			IL_02d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02dc: pop
-			IL_02dd: ldarg.0
-			IL_02de: ldc.i4.1
-			IL_02df: ldelem.ref
-			IL_02e0: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_02e5: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_02ea: ldstr "Cannot access 'fs' before initialization"
-			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_02f4: stloc.s 18
-			IL_02f6: ldloc.s 18
-			IL_02f8: ldstr "mkdirSync"
-			IL_02fd: ldloc.s 4
-			IL_02ff: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0304: dup
-			IL_0305: ldstr "recursive"
-			IL_030a: ldc.i4.1
-			IL_030b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0315: pop
-			IL_0316: ldarg.0
-			IL_0317: ldc.i4.1
-			IL_0318: ldelem.ref
-			IL_0319: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_031e: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0323: ldstr "Cannot access 'fs' before initialization"
-			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_032d: stloc.s 18
-			IL_032f: ldloc.s 18
-			IL_0331: ldstr "writeFileSync"
-			IL_0336: ldloc.s 5
-			IL_0338: ldstr "keep"
-			IL_033d: ldstr "utf8"
-			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0347: pop
-			IL_0348: ldloc.0
-			IL_0349: ldc.i4.0
-			IL_034a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_034f: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L20C12::.ctor()
-			IL_0354: stloc.s 7
-			IL_0356: ldarg.0
-			IL_0357: ldc.i4.1
-			IL_0358: ldelem.ref
-			IL_0359: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_035e: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0363: ldstr "Cannot access 'fs' before initialization"
-			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_036d: stloc.s 18
-			IL_036f: ldloc.s 18
-			IL_0371: ldstr "promises"
-			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_037b: stloc.s 18
-			IL_037d: ldloc.s 18
-			IL_037f: ldstr "rename"
-			IL_0384: ldloc.3
-			IL_0385: ldloc.s 4
-			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_038c: stloc.s 18
-			IL_038e: ldloc.0
-			IL_038f: ldc.i4.4
-			IL_0390: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0395: ldloc.0
-			IL_0396: ldloc.s 18
-			IL_0398: ldarg.0
-			IL_0399: ldc.i4.1
-			IL_039a: ldloc.0
-			IL_039b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03a0: ldc.i4.3
-			IL_03a1: ldstr "_pendingException"
-			IL_03a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03ab: ldloc.0
-			IL_03ac: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03b1: dup
-			IL_03b2: ldc.i4.0
-			IL_03b3: ldloc.1
-			IL_03b4: stelem.ref
-			IL_03b5: dup
-			IL_03b6: ldc.i4.1
-			IL_03b7: ldloc.2
-			IL_03b8: stelem.ref
-			IL_03b9: dup
-			IL_03ba: ldc.i4.2
-			IL_03bb: ldloc.3
-			IL_03bc: stelem.ref
-			IL_03bd: dup
-			IL_03be: ldc.i4.3
-			IL_03bf: ldloc.s 4
-			IL_03c1: stelem.ref
-			IL_03c2: dup
-			IL_03c3: ldc.i4.4
-			IL_03c4: ldloc.s 5
-			IL_03c6: stelem.ref
-			IL_03c7: dup
-			IL_03c8: ldc.i4.5
-			IL_03c9: ldloc.s 6
-			IL_03cb: stelem.ref
-			IL_03cc: dup
-			IL_03cd: ldc.i4.6
-			IL_03ce: ldloc.s 7
-			IL_03d0: stelem.ref
-			IL_03d1: dup
-			IL_03d2: ldc.i4.7
-			IL_03d3: ldloc.s 8
-			IL_03d5: stelem.ref
-			IL_03d6: dup
-			IL_03d7: ldc.i4.8
-			IL_03d8: ldloc.s 9
-			IL_03da: stelem.ref
-			IL_03db: dup
-			IL_03dc: ldc.i4.s 9
-			IL_03de: ldloc.s 10
-			IL_03e0: stelem.ref
-			IL_03e1: dup
-			IL_03e2: ldc.i4.s 10
-			IL_03e4: ldloc.s 11
-			IL_03e6: box [System.Runtime]System.Boolean
-			IL_03eb: stelem.ref
-			IL_03ec: dup
-			IL_03ed: ldc.i4.s 11
-			IL_03ef: ldloc.s 12
-			IL_03f1: box [System.Runtime]System.Boolean
-			IL_03f6: stelem.ref
-			IL_03f7: pop
-			IL_03f8: ldloc.0
-			IL_03f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03fe: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0403: ret
+			IL_014d: stloc.s 13
+			IL_014f: ldarg.0
+			IL_0150: ldc.i4.1
+			IL_0151: ldelem.ref
+			IL_0152: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0157: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
+			IL_015c: ldstr "tmpdir"
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0166: stloc.s 18
+			IL_0168: ldloc.1
+			IL_0169: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_016e: stloc.s 17
+			IL_0170: ldstr "js2il-fs-rename-existing-dir-"
+			IL_0175: ldloc.s 17
+			IL_0177: call string [System.Runtime]System.String::Concat(string, string)
+			IL_017c: stloc.s 17
+			IL_017e: ldloc.s 13
+			IL_0180: ldstr "join"
+			IL_0185: ldloc.s 18
+			IL_0187: ldloc.s 17
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_018e: stloc.s 18
+			IL_0190: ldloc.s 18
+			IL_0192: stloc.2
+			IL_0193: ldarg.0
+			IL_0194: ldc.i4.1
+			IL_0195: ldelem.ref
+			IL_0196: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_019b: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_01a0: ldstr "join"
+			IL_01a5: ldloc.2
+			IL_01a6: ldstr "source"
+			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01b0: stloc.s 18
+			IL_01b2: ldloc.s 18
+			IL_01b4: stloc.3
+			IL_01b5: ldarg.0
+			IL_01b6: ldc.i4.1
+			IL_01b7: ldelem.ref
+			IL_01b8: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_01bd: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_01c2: ldstr "join"
+			IL_01c7: ldloc.2
+			IL_01c8: ldstr "destination"
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01d2: stloc.s 18
+			IL_01d4: ldloc.s 18
+			IL_01d6: stloc.s 4
+			IL_01d8: ldarg.0
+			IL_01d9: ldc.i4.1
+			IL_01da: ldelem.ref
+			IL_01db: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_01e0: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_01e5: ldstr "join"
+			IL_01ea: ldloc.s 4
+			IL_01ec: ldstr "keep.txt"
+			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01f6: stloc.s 18
+			IL_01f8: ldloc.s 18
+			IL_01fa: stloc.s 5
+			IL_01fc: ldloc.0
+			IL_01fd: ldc.i4.0
+			IL_01fe: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0203: ldloc.0
+			IL_0204: ldc.i4.0
+			IL_0205: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_020a: ldloc.0
+			IL_020b: ldc.i4.0
+			IL_020c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0211: ldloc.0
+			IL_0212: ldc.i4.0
+			IL_0213: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0218: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8::.ctor()
+			IL_021d: stloc.s 6
+			IL_021f: ldarg.0
+			IL_0220: ldc.i4.1
+			IL_0221: ldelem.ref
+			IL_0222: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0227: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_022c: stloc.s 18
+			IL_022e: ldloc.s 18
+			IL_0230: ldstr "rmSync"
+			IL_0235: ldloc.2
+			IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_023b: dup
+			IL_023c: ldstr "recursive"
+			IL_0241: ldc.i4.1
+			IL_0242: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0247: dup
+			IL_0248: ldstr "force"
+			IL_024d: ldc.i4.1
+			IL_024e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0258: pop
+			IL_0259: ldarg.0
+			IL_025a: ldc.i4.1
+			IL_025b: ldelem.ref
+			IL_025c: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0261: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0266: stloc.s 18
+			IL_0268: ldloc.s 18
+			IL_026a: ldstr "mkdirSync"
+			IL_026f: ldloc.3
+			IL_0270: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0275: dup
+			IL_0276: ldstr "recursive"
+			IL_027b: ldc.i4.1
+			IL_027c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0286: pop
+			IL_0287: ldarg.0
+			IL_0288: ldc.i4.1
+			IL_0289: ldelem.ref
+			IL_028a: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_028f: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0294: stloc.s 18
+			IL_0296: ldloc.s 18
+			IL_0298: ldstr "mkdirSync"
+			IL_029d: ldloc.s 4
+			IL_029f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02a4: dup
+			IL_02a5: ldstr "recursive"
+			IL_02aa: ldc.i4.1
+			IL_02ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02b5: pop
+			IL_02b6: ldarg.0
+			IL_02b7: ldc.i4.1
+			IL_02b8: ldelem.ref
+			IL_02b9: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_02be: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_02c3: ldstr "writeFileSync"
+			IL_02c8: ldloc.s 5
+			IL_02ca: ldstr "keep"
+			IL_02cf: ldstr "utf8"
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_02d9: pop
+			IL_02da: ldloc.0
+			IL_02db: ldc.i4.0
+			IL_02dc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_02e1: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L20C12::.ctor()
+			IL_02e6: stloc.s 7
+			IL_02e8: ldarg.0
+			IL_02e9: ldc.i4.1
+			IL_02ea: ldelem.ref
+			IL_02eb: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_02f0: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_02f5: ldstr "promises"
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ff: ldstr "rename"
+			IL_0304: ldloc.3
+			IL_0305: ldloc.s 4
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_030c: stloc.s 18
+			IL_030e: ldloc.0
+			IL_030f: ldc.i4.4
+			IL_0310: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0315: ldloc.0
+			IL_0316: ldloc.s 18
+			IL_0318: ldarg.0
+			IL_0319: ldc.i4.1
+			IL_031a: ldloc.0
+			IL_031b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0320: ldc.i4.3
+			IL_0321: ldstr "_pendingException"
+			IL_0326: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_032b: ldloc.0
+			IL_032c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0331: dup
+			IL_0332: ldc.i4.0
+			IL_0333: ldloc.1
+			IL_0334: stelem.ref
+			IL_0335: dup
+			IL_0336: ldc.i4.1
+			IL_0337: ldloc.2
+			IL_0338: stelem.ref
+			IL_0339: dup
+			IL_033a: ldc.i4.2
+			IL_033b: ldloc.3
+			IL_033c: stelem.ref
+			IL_033d: dup
+			IL_033e: ldc.i4.3
+			IL_033f: ldloc.s 4
+			IL_0341: stelem.ref
+			IL_0342: dup
+			IL_0343: ldc.i4.4
+			IL_0344: ldloc.s 5
+			IL_0346: stelem.ref
+			IL_0347: dup
+			IL_0348: ldc.i4.5
+			IL_0349: ldloc.s 6
+			IL_034b: stelem.ref
+			IL_034c: dup
+			IL_034d: ldc.i4.6
+			IL_034e: ldloc.s 7
+			IL_0350: stelem.ref
+			IL_0351: dup
+			IL_0352: ldc.i4.7
+			IL_0353: ldloc.s 8
+			IL_0355: stelem.ref
+			IL_0356: dup
+			IL_0357: ldc.i4.8
+			IL_0358: ldloc.s 9
+			IL_035a: stelem.ref
+			IL_035b: dup
+			IL_035c: ldc.i4.s 9
+			IL_035e: ldloc.s 10
+			IL_0360: stelem.ref
+			IL_0361: dup
+			IL_0362: ldc.i4.s 10
+			IL_0364: ldloc.s 11
+			IL_0366: box [System.Runtime]System.Boolean
+			IL_036b: stelem.ref
+			IL_036c: dup
+			IL_036d: ldc.i4.s 11
+			IL_036f: ldloc.s 12
+			IL_0371: box [System.Runtime]System.Boolean
+			IL_0376: stelem.ref
+			IL_0377: pop
+			IL_0378: ldloc.0
+			IL_0379: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_037e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0383: ret
 
-			IL_0404: ldloc.0
-			IL_0405: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
-			IL_040a: pop
-			IL_040b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0410: ldstr "RenameResult:"
-			IL_0415: ldstr "success"
-			IL_041a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_041f: pop
-			IL_0420: br IL_049d
+			IL_0384: ldloc.0
+			IL_0385: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
+			IL_038a: pop
+			IL_038b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0390: ldstr "RenameResult:"
+			IL_0395: ldstr "success"
+			IL_039a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_039f: pop
+			IL_03a0: br IL_041d
 
-			IL_0425: ldloc.0
-			IL_0426: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_042b: stloc.s 18
-			IL_042d: ldloc.0
-			IL_042e: ldc.i4.0
-			IL_042f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0434: ldloc.s 18
-			IL_0436: stloc.s 8
-			IL_0438: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L23C22::.ctor()
-			IL_043d: stloc.s 9
-			IL_043f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0444: stloc.s 19
-			IL_0446: ldstr "^EPERM: "
-			IL_044b: ldstr ""
-			IL_0450: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0455: stloc.s 20
-			IL_0457: ldloc.s 8
-			IL_0459: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_045e: stloc.s 21
-			IL_0460: ldloc.s 21
-			IL_0462: brfalse IL_047a
+			IL_03a5: ldloc.0
+			IL_03a6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_03ab: stloc.s 18
+			IL_03ad: ldloc.0
+			IL_03ae: ldc.i4.0
+			IL_03af: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_03b4: ldloc.s 18
+			IL_03b6: stloc.s 8
+			IL_03b8: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L23C22::.ctor()
+			IL_03bd: stloc.s 9
+			IL_03bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03c4: stloc.s 19
+			IL_03c6: ldstr "^EPERM: "
+			IL_03cb: ldstr ""
+			IL_03d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_03d5: stloc.s 20
+			IL_03d7: ldloc.s 8
+			IL_03d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03de: stloc.s 21
+			IL_03e0: ldloc.s 21
+			IL_03e2: brfalse IL_03fa
 
-			IL_0467: ldloc.s 8
-			IL_0469: ldstr "message"
-			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0473: stloc.s 23
-			IL_0475: br IL_047e
+			IL_03e7: ldloc.s 8
+			IL_03e9: ldstr "message"
+			IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03f3: stloc.s 23
+			IL_03f5: br IL_03fe
 
-			IL_047a: ldloc.s 8
-			IL_047c: stloc.s 23
+			IL_03fa: ldloc.s 8
+			IL_03fc: stloc.s 23
 
-			IL_047e: ldloc.s 20
-			IL_0480: ldloc.s 23
-			IL_0482: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0487: stloc.s 18
-			IL_0489: ldloc.s 19
-			IL_048b: ldstr "RenameStartsWithEPERM:"
-			IL_0490: ldloc.s 18
-			IL_0492: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0497: pop
-			IL_0498: br IL_049d
+			IL_03fe: ldloc.s 20
+			IL_0400: ldloc.s 23
+			IL_0402: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0407: stloc.s 18
+			IL_0409: ldloc.s 19
+			IL_040b: ldstr "RenameStartsWithEPERM:"
+			IL_0410: ldloc.s 18
+			IL_0412: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0417: pop
+			IL_0418: br IL_041d
 
-			IL_049d: ldarg.0
-			IL_049e: ldc.i4.1
-			IL_049f: ldelem.ref
-			IL_04a0: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_04a5: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_04aa: ldstr "Cannot access 'fs' before initialization"
-			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_04b4: stloc.s 18
-			IL_04b6: ldloc.s 18
-			IL_04b8: ldstr "existsSync"
-			IL_04bd: ldloc.3
-			IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04c3: stloc.s 18
-			IL_04c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04ca: ldstr "SourceExists:"
-			IL_04cf: ldloc.s 18
-			IL_04d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_04d6: pop
-			IL_04d7: ldarg.0
-			IL_04d8: ldc.i4.1
-			IL_04d9: ldelem.ref
-			IL_04da: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_04df: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_04e4: ldstr "Cannot access 'fs' before initialization"
-			IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_04ee: stloc.s 18
-			IL_04f0: ldloc.s 18
-			IL_04f2: ldstr "existsSync"
-			IL_04f7: ldloc.s 4
-			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04fe: stloc.s 18
-			IL_0500: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0505: ldstr "DestinationExists:"
-			IL_050a: ldloc.s 18
-			IL_050c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0511: pop
-			IL_0512: ldarg.0
-			IL_0513: ldc.i4.1
-			IL_0514: ldelem.ref
-			IL_0515: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_051a: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_051f: ldstr "Cannot access 'fs' before initialization"
-			IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_041d: ldarg.0
+			IL_041e: ldc.i4.1
+			IL_041f: ldelem.ref
+			IL_0420: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0425: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_042a: ldstr "existsSync"
+			IL_042f: ldloc.3
+			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0435: stloc.s 18
+			IL_0437: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_043c: ldstr "SourceExists:"
+			IL_0441: ldloc.s 18
+			IL_0443: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0448: pop
+			IL_0449: ldarg.0
+			IL_044a: ldc.i4.1
+			IL_044b: ldelem.ref
+			IL_044c: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0451: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0456: ldstr "existsSync"
+			IL_045b: ldloc.s 4
+			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0462: stloc.s 18
+			IL_0464: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0469: ldstr "DestinationExists:"
+			IL_046e: ldloc.s 18
+			IL_0470: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0475: pop
+			IL_0476: ldarg.0
+			IL_0477: ldc.i4.1
+			IL_0478: ldelem.ref
+			IL_0479: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_047e: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0483: ldstr "existsSync"
+			IL_0488: ldloc.s 5
+			IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_048f: stloc.s 18
+			IL_0491: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0496: ldstr "SentinelExists:"
+			IL_049b: ldloc.s 18
+			IL_049d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_04a2: pop
+			IL_04a3: br IL_04bb
+
+			IL_04a8: ldloc.0
+			IL_04a9: ldc.i4.1
+			IL_04aa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_04af: ldloc.0
+			IL_04b0: ldc.i4.0
+			IL_04b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_04b6: br IL_04bb
+
+			IL_04bb: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L30C14::.ctor()
+			IL_04c0: stloc.s 10
+			IL_04c2: ldarg.0
+			IL_04c3: ldc.i4.1
+			IL_04c4: ldelem.ref
+			IL_04c5: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_04ca: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_04cf: stloc.s 18
+			IL_04d1: ldloc.s 18
+			IL_04d3: ldstr "rmSync"
+			IL_04d8: ldloc.2
+			IL_04d9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04de: dup
+			IL_04df: ldstr "recursive"
+			IL_04e4: ldc.i4.1
+			IL_04e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04ea: dup
+			IL_04eb: ldstr "force"
+			IL_04f0: ldc.i4.1
+			IL_04f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04fb: pop
+			IL_04fc: br IL_0514
+
+			IL_0501: ldloc.0
+			IL_0502: ldc.i4.1
+			IL_0503: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0508: ldloc.0
+			IL_0509: ldc.i4.0
+			IL_050a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_050f: br IL_0514
+
+			IL_0514: ldloc.0
+			IL_0515: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_051a: stloc.s 11
+			IL_051c: ldloc.s 11
+			IL_051e: brfalse IL_055b
+
+			IL_0523: ldloc.0
+			IL_0524: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
 			IL_0529: stloc.s 18
-			IL_052b: ldloc.s 18
-			IL_052d: ldstr "existsSync"
-			IL_0532: ldloc.s 5
-			IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0539: stloc.s 18
-			IL_053b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0540: ldstr "SentinelExists:"
-			IL_0545: ldloc.s 18
-			IL_0547: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_054c: pop
-			IL_054d: br IL_0565
+			IL_052b: ldloc.0
+			IL_052c: ldc.i4.m1
+			IL_052d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0532: ldloc.0
+			IL_0533: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0538: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_053d: ldarg.0
+			IL_053e: ldc.i4.1
+			IL_053f: newarr [System.Runtime]System.Object
+			IL_0544: dup
+			IL_0545: ldc.i4.0
+			IL_0546: ldloc.s 18
+			IL_0548: stelem.ref
+			IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_054e: pop
+			IL_054f: ldloc.0
+			IL_0550: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0555: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_055a: ret
 
-			IL_0552: ldloc.0
-			IL_0553: ldc.i4.1
-			IL_0554: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0559: ldloc.0
-			IL_055a: ldc.i4.0
-			IL_055b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0560: br IL_0565
+			IL_055b: ldloc.0
+			IL_055c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0561: stloc.s 12
+			IL_0563: ldloc.s 12
+			IL_0565: brfalse IL_05a2
 
-			IL_0565: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L30C14::.ctor()
-			IL_056a: stloc.s 10
-			IL_056c: ldarg.0
-			IL_056d: ldc.i4.1
-			IL_056e: ldelem.ref
-			IL_056f: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0574: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0579: ldstr "Cannot access 'fs' before initialization"
-			IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0583: stloc.s 18
-			IL_0585: ldloc.s 18
-			IL_0587: ldstr "rmSync"
-			IL_058c: ldloc.2
-			IL_058d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0592: dup
-			IL_0593: ldstr "recursive"
-			IL_0598: ldc.i4.1
-			IL_0599: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_059e: dup
-			IL_059f: ldstr "force"
-			IL_05a4: ldc.i4.1
-			IL_05a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_05af: pop
-			IL_05b0: br IL_05c8
+			IL_056a: ldloc.0
+			IL_056b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0570: stloc.s 18
+			IL_0572: ldloc.0
+			IL_0573: ldc.i4.m1
+			IL_0574: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0579: ldloc.0
+			IL_057a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_057f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0584: ldarg.0
+			IL_0585: ldc.i4.1
+			IL_0586: newarr [System.Runtime]System.Object
+			IL_058b: dup
+			IL_058c: ldc.i4.0
+			IL_058d: ldloc.s 18
+			IL_058f: stelem.ref
+			IL_0590: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0595: pop
+			IL_0596: ldloc.0
+			IL_0597: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_059c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05a1: ret
 
-			IL_05b5: ldloc.0
-			IL_05b6: ldc.i4.1
-			IL_05b7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_05bc: ldloc.0
-			IL_05bd: ldc.i4.0
-			IL_05be: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_05c3: br IL_05c8
-
-			IL_05c8: ldloc.0
-			IL_05c9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_05ce: stloc.s 11
-			IL_05d0: ldloc.s 11
-			IL_05d2: brfalse IL_060f
-
-			IL_05d7: ldloc.0
-			IL_05d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_05dd: stloc.s 18
-			IL_05df: ldloc.0
-			IL_05e0: ldc.i4.m1
-			IL_05e1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05e6: ldloc.0
-			IL_05e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05f1: ldarg.0
-			IL_05f2: ldc.i4.1
-			IL_05f3: newarr [System.Runtime]System.Object
-			IL_05f8: dup
-			IL_05f9: ldc.i4.0
-			IL_05fa: ldloc.s 18
-			IL_05fc: stelem.ref
-			IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0602: pop
-			IL_0603: ldloc.0
-			IL_0604: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0609: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_060e: ret
-
-			IL_060f: ldloc.0
-			IL_0610: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0615: stloc.s 12
-			IL_0617: ldloc.s 12
-			IL_0619: brfalse IL_0656
-
-			IL_061e: ldloc.0
-			IL_061f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0624: stloc.s 18
-			IL_0626: ldloc.0
-			IL_0627: ldc.i4.m1
-			IL_0628: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_062d: ldloc.0
-			IL_062e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0633: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0638: ldarg.0
-			IL_0639: ldc.i4.1
-			IL_063a: newarr [System.Runtime]System.Object
-			IL_063f: dup
-			IL_0640: ldc.i4.0
-			IL_0641: ldloc.s 18
-			IL_0643: stelem.ref
-			IL_0644: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0649: pop
-			IL_064a: ldloc.0
-			IL_064b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0650: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0655: ret
-
-			IL_0656: ldloc.0
-			IL_0657: ldc.i4.m1
-			IL_0658: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_065d: ldloc.0
-			IL_065e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0663: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0668: ldarg.0
-			IL_0669: ldc.i4.1
-			IL_066a: newarr [System.Runtime]System.Object
-			IL_066f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0674: pop
-			IL_0675: ldloc.0
-			IL_0676: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_067b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0680: ret
+			IL_05a2: ldloc.0
+			IL_05a3: ldc.i4.m1
+			IL_05a4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05a9: ldloc.0
+			IL_05aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_05b4: ldarg.0
+			IL_05b5: ldc.i4.1
+			IL_05b6: newarr [System.Runtime]System.Object
+			IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05c0: pop
+			IL_05c1: ldloc.0
+			IL_05c2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05c7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05cc: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -822,24 +774,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x276d
+			// Method begins at RVA 0x26b9
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -924,7 +867,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27c4
+		// Method begins at RVA 0x26ef
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_FileSize.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_FileSize.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2246
+				// Method begins at RVA 0x2217
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,13 +52,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21bc
+			// Method begins at RVA 0x21a4
 			// Header size: 12
-			// Code size: 76 (0x4c)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -73,18 +72,14 @@
 			IL_0021: ldstr "fs"
 			IL_0026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
 			IL_002b: stloc.0
-			IL_002c: ldarg.0
-			IL_002d: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-			IL_0032: ldstr "Cannot access 'testFile' before initialization"
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_003c: stloc.1
-			IL_003d: ldloc.0
-			IL_003e: ldstr "rmSync"
-			IL_0043: ldloc.1
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0049: pop
-			IL_004a: ldnull
-			IL_004b: ret
+			IL_002c: ldloc.0
+			IL_002d: ldstr "rmSync"
+			IL_0032: ldarg.0
+			IL_0033: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
+			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_003d: pop
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method ArrowFunction_L9C24::__js_call__
 
 	} // end of class ArrowFunction_L9C24
@@ -107,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224f
+				// Method begins at RVA 0x2220
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +126,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2214
+			// Method begins at RVA 0x21f0
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -165,18 +160,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2232
+			// Method begins at RVA 0x220e
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -194,7 +186,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 351 (0x15f)
+		// Code size: 327 (0x147)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Stat_FileSize/Scope,
@@ -251,77 +243,71 @@
 		IL_0089: stloc.s 4
 		IL_008b: ldloc.0
 		IL_008c: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-		IL_0091: ldstr "Cannot access 'testFile' before initialization"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_009b: stloc.s 5
-		IL_009d: ldloc.s 4
-		IL_009f: ldstr "writeFileSync"
-		IL_00a4: ldloc.s 5
-		IL_00a6: ldloc.3
-		IL_00a7: ldstr "utf8"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00b1: pop
-		IL_00b2: ldloc.0
-		IL_00b3: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-		IL_00b8: ldstr "Cannot access 'testFile' before initialization"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00c2: stloc.s 5
-		IL_00c4: ldloc.1
-		IL_00c5: ldstr "stat"
-		IL_00ca: ldloc.s 5
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d1: stloc.s 5
-		IL_00d3: ldc.i4.1
-		IL_00d4: newarr [System.Runtime]System.Object
-		IL_00d9: dup
-		IL_00da: ldc.i4.0
-		IL_00db: ldloc.0
-		IL_00dc: stelem.ref
-		IL_00dd: ldc.i4.0
-		IL_00de: ldelem.ref
-		IL_00df: castclass Modules.FSPromises_Stat_FileSize/Scope
-		IL_00e4: ldftn object Modules.FSPromises_Stat_FileSize/ArrowFunction_L9C24::__js_call__(class Modules.FSPromises_Stat_FileSize/Scope, object, object)
-		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00ef: ldc.i4.1
-		IL_00f0: newarr [System.Runtime]System.Object
-		IL_00f5: dup
-		IL_00f6: ldc.i4.0
-		IL_00f7: ldloc.0
-		IL_00f8: stelem.ref
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0103: ldc.i4.1
-		IL_0104: conv.r8
-		IL_0105: ldstr ""
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_010f: stloc.s 4
-		IL_0111: ldloc.s 5
-		IL_0113: ldstr "then"
-		IL_0118: ldloc.s 4
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011f: stloc.s 4
-		IL_0121: ldnull
-		IL_0122: ldftn object Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10::__js_call__(object, object)
-		IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_012d: ldc.i4.1
-		IL_012e: newarr [System.Runtime]System.Object
-		IL_0133: dup
-		IL_0134: ldc.i4.0
-		IL_0135: ldloc.0
-		IL_0136: stelem.ref
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0141: ldc.i4.1
-		IL_0142: conv.r8
-		IL_0143: ldstr ""
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_014d: stloc.s 5
-		IL_014f: ldloc.s 4
-		IL_0151: ldstr "catch"
-		IL_0156: ldloc.s 5
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_015d: pop
-		IL_015e: ret
+		IL_0091: stloc.s 5
+		IL_0093: ldloc.s 4
+		IL_0095: ldstr "writeFileSync"
+		IL_009a: ldloc.s 5
+		IL_009c: ldloc.3
+		IL_009d: ldstr "utf8"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00a7: pop
+		IL_00a8: ldloc.1
+		IL_00a9: ldstr "stat"
+		IL_00ae: ldloc.0
+		IL_00af: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b9: stloc.s 5
+		IL_00bb: ldc.i4.1
+		IL_00bc: newarr [System.Runtime]System.Object
+		IL_00c1: dup
+		IL_00c2: ldc.i4.0
+		IL_00c3: ldloc.0
+		IL_00c4: stelem.ref
+		IL_00c5: ldc.i4.0
+		IL_00c6: ldelem.ref
+		IL_00c7: castclass Modules.FSPromises_Stat_FileSize/Scope
+		IL_00cc: ldftn object Modules.FSPromises_Stat_FileSize/ArrowFunction_L9C24::__js_call__(class Modules.FSPromises_Stat_FileSize/Scope, object, object)
+		IL_00d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00d7: ldc.i4.1
+		IL_00d8: newarr [System.Runtime]System.Object
+		IL_00dd: dup
+		IL_00de: ldc.i4.0
+		IL_00df: ldloc.0
+		IL_00e0: stelem.ref
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00eb: ldc.i4.1
+		IL_00ec: conv.r8
+		IL_00ed: ldstr ""
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00f7: stloc.s 4
+		IL_00f9: ldloc.s 5
+		IL_00fb: ldstr "then"
+		IL_0100: ldloc.s 4
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0107: stloc.s 4
+		IL_0109: ldnull
+		IL_010a: ldftn object Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10::__js_call__(object, object)
+		IL_0110: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0115: ldc.i4.1
+		IL_0116: newarr [System.Runtime]System.Object
+		IL_011b: dup
+		IL_011c: ldc.i4.0
+		IL_011d: ldloc.0
+		IL_011e: stelem.ref
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0129: ldc.i4.1
+		IL_012a: conv.r8
+		IL_012b: ldstr ""
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0135: stloc.s 5
+		IL_0137: ldloc.s 4
+		IL_0139: ldstr "catch"
+		IL_013e: ldloc.s 5
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0145: pop
+		IL_0146: ret
 	} // end of method FSPromises_Stat_FileSize::__js_module_init__
 
 } // end of class Modules.FSPromises_Stat_FileSize
@@ -333,7 +319,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2258
+		// Method begins at RVA 0x2229
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_RichMetadata.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_RichMetadata.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2812
+				// Method begins at RVA 0x270e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,13 +52,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x23dc
+			// Method begins at RVA 0x236c
 			// Header size: 12
-			// Code size: 56 (0x38)
+			// Code size: 32 (0x20)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
@@ -66,21 +65,13 @@
 			IL_0002: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_0007: ldarg.0
 			IL_0008: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fs
-			IL_000d: ldstr "Cannot access 'fs' before initialization"
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0017: stloc.0
-			IL_0018: ldarg.0
-			IL_0019: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_001e: ldstr "Cannot access 'dir' before initialization"
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0028: stloc.1
-			IL_0029: ldloc.0
-			IL_002a: ldstr "stat"
-			IL_002f: ldloc.1
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0035: stloc.1
-			IL_0036: ldloc.1
-			IL_0037: ret
+			IL_000d: ldstr "stat"
+			IL_0012: ldarg.0
+			IL_0013: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001d: stloc.0
+			IL_001e: ldloc.0
+			IL_001f: ret
 		} // end of method ArrowFunction_L18C20::__js_call__
 
 	} // end of class ArrowFunction_L18C20
@@ -103,7 +94,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x281b
+				// Method begins at RVA 0x2717
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -130,9 +121,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2420
+			// Method begins at RVA 0x2398
 			// Header size: 12
-			// Code size: 731 (0x2db)
+			// Code size: 691 (0x2b3)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -329,50 +320,42 @@
 			IL_0248: pop
 			IL_0249: ldarg.0
 			IL_024a: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_024f: ldstr "Cannot access 'syncFs' before initialization"
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0259: stloc.3
-			IL_025a: ldarg.0
-			IL_025b: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-			IL_0260: ldstr "Cannot access 'file' before initialization"
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_026a: stloc.s 8
-			IL_026c: ldloc.3
-			IL_026d: ldstr "rmSync"
-			IL_0272: ldloc.s 8
-			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0279: dup
-			IL_027a: ldstr "force"
-			IL_027f: ldc.i4.1
-			IL_0280: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_028a: pop
-			IL_028b: ldarg.0
-			IL_028c: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_0291: ldstr "Cannot access 'syncFs' before initialization"
-			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_029b: stloc.s 8
-			IL_029d: ldarg.0
-			IL_029e: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_02a3: ldstr "Cannot access 'dir' before initialization"
-			IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_02ad: stloc.3
-			IL_02ae: ldloc.s 8
-			IL_02b0: ldstr "rmSync"
-			IL_02b5: ldloc.3
-			IL_02b6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02bb: dup
-			IL_02bc: ldstr "force"
-			IL_02c1: ldc.i4.1
-			IL_02c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02c7: dup
-			IL_02c8: ldstr "recursive"
-			IL_02cd: ldc.i4.1
-			IL_02ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02d8: pop
-			IL_02d9: ldnull
-			IL_02da: ret
+			IL_024f: stloc.3
+			IL_0250: ldarg.0
+			IL_0251: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+			IL_0256: stloc.s 8
+			IL_0258: ldloc.3
+			IL_0259: ldstr "rmSync"
+			IL_025e: ldloc.s 8
+			IL_0260: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0265: dup
+			IL_0266: ldstr "force"
+			IL_026b: ldc.i4.1
+			IL_026c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0276: pop
+			IL_0277: ldarg.0
+			IL_0278: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+			IL_027d: stloc.s 8
+			IL_027f: ldarg.0
+			IL_0280: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_0285: stloc.3
+			IL_0286: ldloc.s 8
+			IL_0288: ldstr "rmSync"
+			IL_028d: ldloc.3
+			IL_028e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0293: dup
+			IL_0294: ldstr "force"
+			IL_0299: ldc.i4.1
+			IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_029f: dup
+			IL_02a0: ldstr "recursive"
+			IL_02a5: ldc.i4.1
+			IL_02a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02b0: pop
+			IL_02b1: ldnull
+			IL_02b2: ret
 		} // end of method ArrowFunction_L21C9::__js_call__
 
 	} // end of class ArrowFunction_L21C9
@@ -395,7 +378,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2824
+				// Method begins at RVA 0x2720
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -422,9 +405,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2708
+			// Method begins at RVA 0x2658
 			// Header size: 12
-			// Code size: 201 (0xc9)
+			// Code size: 161 (0xa1)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -459,50 +442,42 @@
 			IL_0032: pop
 			IL_0033: ldarg.0
 			IL_0034: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_0039: ldstr "Cannot access 'syncFs' before initialization"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0043: stloc.s 4
-			IL_0045: ldarg.0
-			IL_0046: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-			IL_004b: ldstr "Cannot access 'file' before initialization"
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0055: stloc.s 5
-			IL_0057: ldloc.s 4
-			IL_0059: ldstr "rmSync"
-			IL_005e: ldloc.s 5
-			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0065: dup
-			IL_0066: ldstr "force"
-			IL_006b: ldc.i4.1
-			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0076: pop
-			IL_0077: ldarg.0
-			IL_0078: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_007d: ldstr "Cannot access 'syncFs' before initialization"
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0087: stloc.s 5
-			IL_0089: ldarg.0
-			IL_008a: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_008f: ldstr "Cannot access 'dir' before initialization"
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0099: stloc.s 4
-			IL_009b: ldloc.s 5
-			IL_009d: ldstr "rmSync"
-			IL_00a2: ldloc.s 4
-			IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00a9: dup
-			IL_00aa: ldstr "force"
-			IL_00af: ldc.i4.1
-			IL_00b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00b5: dup
-			IL_00b6: ldstr "recursive"
-			IL_00bb: ldc.i4.1
-			IL_00bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00c6: pop
-			IL_00c7: ldnull
-			IL_00c8: ret
+			IL_0039: stloc.s 4
+			IL_003b: ldarg.0
+			IL_003c: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+			IL_0041: stloc.s 5
+			IL_0043: ldloc.s 4
+			IL_0045: ldstr "rmSync"
+			IL_004a: ldloc.s 5
+			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0051: dup
+			IL_0052: ldstr "force"
+			IL_0057: ldc.i4.1
+			IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0062: pop
+			IL_0063: ldarg.0
+			IL_0064: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+			IL_0069: stloc.s 5
+			IL_006b: ldarg.0
+			IL_006c: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_0071: stloc.s 4
+			IL_0073: ldloc.s 5
+			IL_0075: ldstr "rmSync"
+			IL_007a: ldloc.s 4
+			IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0081: dup
+			IL_0082: ldstr "force"
+			IL_0087: ldc.i4.1
+			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_008d: dup
+			IL_008e: ldstr "recursive"
+			IL_0093: ldc.i4.1
+			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_009e: pop
+			IL_009f: ldnull
+			IL_00a0: ret
 		} // end of method ArrowFunction_L36C10::__js_call__
 
 	} // end of class ArrowFunction_L36C10
@@ -529,27 +504,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27dd
+			// Method begins at RVA 0x2705
 			// Header size: 1
-			// Code size: 52 (0x34)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_0032: nop
-			IL_0033: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -567,7 +530,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 895 (0x37f)
+		// Code size: 783 (0x30f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Stat_RichMetadata/Scope,
@@ -691,191 +654,165 @@
 		IL_0140: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
 		IL_0145: ldloc.0
 		IL_0146: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-		IL_014b: ldstr "Cannot access 'syncFs' before initialization"
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0155: stloc.s 4
-		IL_0157: ldloc.0
-		IL_0158: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-		IL_015d: ldstr "Cannot access 'file' before initialization"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0167: stloc.s 9
-		IL_0169: ldloc.s 4
-		IL_016b: ldstr "rmSync"
-		IL_0170: ldloc.s 9
-		IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0177: dup
-		IL_0178: ldstr "force"
-		IL_017d: ldc.i4.1
-		IL_017e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0188: pop
-		IL_0189: ldloc.0
-		IL_018a: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-		IL_018f: ldstr "Cannot access 'syncFs' before initialization"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0199: stloc.s 9
-		IL_019b: ldloc.0
-		IL_019c: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-		IL_01a1: ldstr "Cannot access 'dir' before initialization"
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01ab: stloc.s 4
-		IL_01ad: ldloc.s 9
-		IL_01af: ldstr "rmSync"
-		IL_01b4: ldloc.s 4
-		IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01bb: dup
-		IL_01bc: ldstr "force"
-		IL_01c1: ldc.i4.1
-		IL_01c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_01c7: dup
-		IL_01c8: ldstr "recursive"
-		IL_01cd: ldc.i4.1
-		IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01d8: pop
-		IL_01d9: ldloc.0
-		IL_01da: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-		IL_01df: ldstr "Cannot access 'syncFs' before initialization"
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01e9: stloc.s 4
-		IL_01eb: ldloc.0
-		IL_01ec: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-		IL_01f1: ldstr "Cannot access 'file' before initialization"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01fb: stloc.s 9
-		IL_01fd: ldloc.s 4
-		IL_01ff: ldstr "writeFileSync"
-		IL_0204: ldloc.s 9
-		IL_0206: ldstr "hello"
-		IL_020b: ldstr "utf8"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0215: pop
-		IL_0216: ldloc.0
-		IL_0217: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-		IL_021c: ldstr "Cannot access 'syncFs' before initialization"
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0226: stloc.s 9
-		IL_0228: ldloc.0
-		IL_0229: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-		IL_022e: ldstr "Cannot access 'dir' before initialization"
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0238: stloc.s 4
-		IL_023a: ldloc.s 9
-		IL_023c: ldstr "mkdirSync"
-		IL_0241: ldloc.s 4
-		IL_0243: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0248: dup
-		IL_0249: ldstr "recursive"
-		IL_024e: ldc.i4.1
-		IL_024f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0259: pop
-		IL_025a: ldloc.0
-		IL_025b: ldnull
-		IL_025c: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-		IL_0261: ldloc.0
-		IL_0262: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fs
-		IL_0267: ldstr "Cannot access 'fs' before initialization"
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_014b: stloc.s 4
+		IL_014d: ldloc.0
+		IL_014e: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+		IL_0153: stloc.s 9
+		IL_0155: ldloc.s 4
+		IL_0157: ldstr "rmSync"
+		IL_015c: ldloc.s 9
+		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0163: dup
+		IL_0164: ldstr "force"
+		IL_0169: ldc.i4.1
+		IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0174: pop
+		IL_0175: ldloc.0
+		IL_0176: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+		IL_017b: stloc.s 9
+		IL_017d: ldloc.0
+		IL_017e: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+		IL_0183: stloc.s 4
+		IL_0185: ldloc.s 9
+		IL_0187: ldstr "rmSync"
+		IL_018c: ldloc.s 4
+		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0193: dup
+		IL_0194: ldstr "force"
+		IL_0199: ldc.i4.1
+		IL_019a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_019f: dup
+		IL_01a0: ldstr "recursive"
+		IL_01a5: ldc.i4.1
+		IL_01a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01b0: pop
+		IL_01b1: ldloc.0
+		IL_01b2: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+		IL_01b7: stloc.s 4
+		IL_01b9: ldloc.0
+		IL_01ba: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+		IL_01bf: ldstr "writeFileSync"
+		IL_01c4: ldloc.s 4
+		IL_01c6: ldstr "hello"
+		IL_01cb: ldstr "utf8"
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_01d5: pop
+		IL_01d6: ldloc.0
+		IL_01d7: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+		IL_01dc: stloc.s 4
+		IL_01de: ldloc.0
+		IL_01df: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+		IL_01e4: stloc.s 9
+		IL_01e6: ldloc.s 4
+		IL_01e8: ldstr "mkdirSync"
+		IL_01ed: ldloc.s 9
+		IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01f4: dup
+		IL_01f5: ldstr "recursive"
+		IL_01fa: ldc.i4.1
+		IL_01fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0205: pop
+		IL_0206: ldloc.0
+		IL_0207: ldnull
+		IL_0208: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+		IL_020d: ldloc.0
+		IL_020e: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fs
+		IL_0213: ldstr "stat"
+		IL_0218: ldloc.0
+		IL_0219: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0223: stloc.s 9
+		IL_0225: ldc.i4.1
+		IL_0226: newarr [System.Runtime]System.Object
+		IL_022b: dup
+		IL_022c: ldc.i4.0
+		IL_022d: ldloc.0
+		IL_022e: stelem.ref
+		IL_022f: ldc.i4.0
+		IL_0230: ldelem.ref
+		IL_0231: castclass Modules.FSPromises_Stat_RichMetadata/Scope
+		IL_0236: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L18C20::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
+		IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0241: ldc.i4.1
+		IL_0242: newarr [System.Runtime]System.Object
+		IL_0247: dup
+		IL_0248: ldc.i4.0
+		IL_0249: ldloc.0
+		IL_024a: stelem.ref
+		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0255: ldc.i4.1
+		IL_0256: conv.r8
+		IL_0257: ldstr ""
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0261: stloc.s 4
+		IL_0263: ldloc.s 9
+		IL_0265: ldstr "then"
+		IL_026a: ldloc.s 4
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0271: stloc.s 4
-		IL_0273: ldloc.0
-		IL_0274: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-		IL_0279: ldstr "Cannot access 'file' before initialization"
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0283: stloc.s 9
-		IL_0285: ldloc.s 4
-		IL_0287: ldstr "stat"
-		IL_028c: ldloc.s 9
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0293: stloc.s 9
-		IL_0295: ldc.i4.1
-		IL_0296: newarr [System.Runtime]System.Object
-		IL_029b: dup
-		IL_029c: ldc.i4.0
-		IL_029d: ldloc.0
-		IL_029e: stelem.ref
-		IL_029f: ldc.i4.0
-		IL_02a0: ldelem.ref
-		IL_02a1: castclass Modules.FSPromises_Stat_RichMetadata/Scope
-		IL_02a6: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L18C20::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
-		IL_02ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02b1: ldc.i4.1
-		IL_02b2: newarr [System.Runtime]System.Object
-		IL_02b7: dup
-		IL_02b8: ldc.i4.0
-		IL_02b9: ldloc.0
-		IL_02ba: stelem.ref
-		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02c5: ldc.i4.1
-		IL_02c6: conv.r8
-		IL_02c7: ldstr ""
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02d1: stloc.s 4
-		IL_02d3: ldloc.s 9
-		IL_02d5: ldstr "then"
-		IL_02da: ldloc.s 4
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02e1: stloc.s 4
-		IL_02e3: ldc.i4.1
-		IL_02e4: newarr [System.Runtime]System.Object
-		IL_02e9: dup
-		IL_02ea: ldc.i4.0
-		IL_02eb: ldloc.0
-		IL_02ec: stelem.ref
-		IL_02ed: ldc.i4.0
-		IL_02ee: ldelem.ref
-		IL_02ef: castclass Modules.FSPromises_Stat_RichMetadata/Scope
-		IL_02f4: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
-		IL_02fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02ff: ldc.i4.1
-		IL_0300: newarr [System.Runtime]System.Object
-		IL_0305: dup
-		IL_0306: ldc.i4.0
-		IL_0307: ldloc.0
-		IL_0308: stelem.ref
-		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0313: ldc.i4.1
-		IL_0314: conv.r8
-		IL_0315: ldstr ""
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_031f: stloc.s 9
-		IL_0321: ldloc.s 4
-		IL_0323: ldstr "then"
-		IL_0328: ldloc.s 9
-		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_032f: stloc.s 9
-		IL_0331: ldc.i4.1
-		IL_0332: newarr [System.Runtime]System.Object
-		IL_0337: dup
-		IL_0338: ldc.i4.0
-		IL_0339: ldloc.0
-		IL_033a: stelem.ref
-		IL_033b: ldc.i4.0
-		IL_033c: ldelem.ref
-		IL_033d: castclass Modules.FSPromises_Stat_RichMetadata/Scope
-		IL_0342: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
-		IL_0348: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_034d: ldc.i4.1
-		IL_034e: newarr [System.Runtime]System.Object
-		IL_0353: dup
-		IL_0354: ldc.i4.0
-		IL_0355: ldloc.0
-		IL_0356: stelem.ref
-		IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0361: ldc.i4.1
-		IL_0362: conv.r8
-		IL_0363: ldstr ""
-		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_036d: stloc.s 4
-		IL_036f: ldloc.s 9
-		IL_0371: ldstr "catch"
-		IL_0376: ldloc.s 4
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_037d: pop
-		IL_037e: ret
+		IL_0273: ldc.i4.1
+		IL_0274: newarr [System.Runtime]System.Object
+		IL_0279: dup
+		IL_027a: ldc.i4.0
+		IL_027b: ldloc.0
+		IL_027c: stelem.ref
+		IL_027d: ldc.i4.0
+		IL_027e: ldelem.ref
+		IL_027f: castclass Modules.FSPromises_Stat_RichMetadata/Scope
+		IL_0284: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
+		IL_028a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_028f: ldc.i4.1
+		IL_0290: newarr [System.Runtime]System.Object
+		IL_0295: dup
+		IL_0296: ldc.i4.0
+		IL_0297: ldloc.0
+		IL_0298: stelem.ref
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02a3: ldc.i4.1
+		IL_02a4: conv.r8
+		IL_02a5: ldstr ""
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_02af: stloc.s 9
+		IL_02b1: ldloc.s 4
+		IL_02b3: ldstr "then"
+		IL_02b8: ldloc.s 9
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02bf: stloc.s 9
+		IL_02c1: ldc.i4.1
+		IL_02c2: newarr [System.Runtime]System.Object
+		IL_02c7: dup
+		IL_02c8: ldc.i4.0
+		IL_02c9: ldloc.0
+		IL_02ca: stelem.ref
+		IL_02cb: ldc.i4.0
+		IL_02cc: ldelem.ref
+		IL_02cd: castclass Modules.FSPromises_Stat_RichMetadata/Scope
+		IL_02d2: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
+		IL_02d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02dd: ldc.i4.1
+		IL_02de: newarr [System.Runtime]System.Object
+		IL_02e3: dup
+		IL_02e4: ldc.i4.0
+		IL_02e5: ldloc.0
+		IL_02e6: stelem.ref
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02f1: ldc.i4.1
+		IL_02f2: conv.r8
+		IL_02f3: ldstr ""
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_02fd: stloc.s 4
+		IL_02ff: ldloc.s 9
+		IL_0301: ldstr "catch"
+		IL_0306: ldloc.s 4
+		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_030d: pop
+		IL_030e: ret
 	} // end of method FSPromises_Stat_RichMetadata::__js_module_init__
 
 } // end of class Modules.FSPromises_Stat_RichMetadata
@@ -887,7 +824,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x282d
+		// Method begins at RVA 0x2729
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_WriteFile_Utf8.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_WriteFile_Utf8.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x2201
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,9 +44,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x216c
 			// Header size: 12
-			// Code size: 120 (0x78)
+			// Code size: 98 (0x62)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -61,39 +61,33 @@
 			IL_0010: stloc.1
 			IL_0011: ldarg.0
 			IL_0012: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-			IL_0017: ldstr "Cannot access 'testFile' before initialization"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0021: stloc.2
-			IL_0022: ldloc.1
-			IL_0023: ldstr "readFileSync"
-			IL_0028: ldloc.2
-			IL_0029: ldstr "utf8"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0033: stloc.2
-			IL_0034: ldloc.2
-			IL_0035: stloc.0
-			IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_003b: ldstr "Written content:"
-			IL_0040: ldloc.0
-			IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0046: pop
-			IL_0047: ldarg.0
-			IL_0048: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
-			IL_004d: ldstr "fs"
-			IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-			IL_0057: stloc.2
-			IL_0058: ldarg.0
-			IL_0059: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-			IL_005e: ldstr "Cannot access 'testFile' before initialization"
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0068: stloc.1
-			IL_0069: ldloc.2
-			IL_006a: ldstr "rmSync"
-			IL_006f: ldloc.1
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0075: pop
-			IL_0076: ldnull
-			IL_0077: ret
+			IL_0017: stloc.2
+			IL_0018: ldloc.1
+			IL_0019: ldstr "readFileSync"
+			IL_001e: ldloc.2
+			IL_001f: ldstr "utf8"
+			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0029: stloc.2
+			IL_002a: ldloc.2
+			IL_002b: stloc.0
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0031: ldstr "Written content:"
+			IL_0036: ldloc.0
+			IL_0037: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_003c: pop
+			IL_003d: ldarg.0
+			IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
+			IL_0043: ldstr "fs"
+			IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_004d: stloc.2
+			IL_004e: ldloc.2
+			IL_004f: ldstr "rmSync"
+			IL_0054: ldarg.0
+			IL_0055: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_005f: pop
+			IL_0060: ldnull
+			IL_0061: ret
 		} // end of method ArrowFunction_L7C63::__js_call__
 
 	} // end of class ArrowFunction_L7C63
@@ -116,7 +110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2237
+				// Method begins at RVA 0x220a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +134,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21fc
+			// Method begins at RVA 0x21da
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -174,18 +168,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221a
+			// Method begins at RVA 0x21f8
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -203,7 +194,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 282 (0x11a)
+		// Code size: 272 (0x110)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_WriteFile_Utf8/Scope,
@@ -252,67 +243,65 @@
 		IL_0064: stfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
 		IL_0069: ldloc.0
 		IL_006a: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-		IL_006f: ldstr "Cannot access 'testFile' before initialization"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0079: stloc.3
-		IL_007a: ldloc.1
-		IL_007b: ldstr "writeFile"
-		IL_0080: ldloc.3
-		IL_0081: ldstr "Written by fs/promises"
-		IL_0086: ldstr "utf8"
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0090: stloc.3
-		IL_0091: ldc.i4.1
-		IL_0092: newarr [System.Runtime]System.Object
-		IL_0097: dup
-		IL_0098: ldc.i4.0
-		IL_0099: ldloc.0
-		IL_009a: stelem.ref
-		IL_009b: ldc.i4.0
-		IL_009c: ldelem.ref
-		IL_009d: castclass Modules.FSPromises_WriteFile_Utf8/Scope
-		IL_00a2: ldftn object Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L7C63::__js_call__(class Modules.FSPromises_WriteFile_Utf8/Scope, object)
-		IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ad: ldc.i4.1
-		IL_00ae: newarr [System.Runtime]System.Object
-		IL_00b3: dup
-		IL_00b4: ldc.i4.0
-		IL_00b5: ldloc.0
-		IL_00b6: stelem.ref
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00c1: ldc.i4.0
-		IL_00c2: conv.r8
-		IL_00c3: ldstr ""
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00cd: stloc.s 4
-		IL_00cf: ldloc.3
-		IL_00d0: ldstr "then"
-		IL_00d5: ldloc.s 4
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00dc: stloc.s 4
-		IL_00de: ldnull
-		IL_00df: ldftn object Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10::__js_call__(object, object)
-		IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00ea: ldc.i4.1
-		IL_00eb: newarr [System.Runtime]System.Object
-		IL_00f0: dup
-		IL_00f1: ldc.i4.0
-		IL_00f2: ldloc.0
-		IL_00f3: stelem.ref
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00fe: ldc.i4.1
-		IL_00ff: conv.r8
-		IL_0100: ldstr ""
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_010a: stloc.3
-		IL_010b: ldloc.s 4
-		IL_010d: ldstr "catch"
-		IL_0112: ldloc.3
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0118: pop
-		IL_0119: ret
+		IL_006f: stloc.3
+		IL_0070: ldloc.1
+		IL_0071: ldstr "writeFile"
+		IL_0076: ldloc.3
+		IL_0077: ldstr "Written by fs/promises"
+		IL_007c: ldstr "utf8"
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0086: stloc.3
+		IL_0087: ldc.i4.1
+		IL_0088: newarr [System.Runtime]System.Object
+		IL_008d: dup
+		IL_008e: ldc.i4.0
+		IL_008f: ldloc.0
+		IL_0090: stelem.ref
+		IL_0091: ldc.i4.0
+		IL_0092: ldelem.ref
+		IL_0093: castclass Modules.FSPromises_WriteFile_Utf8/Scope
+		IL_0098: ldftn object Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L7C63::__js_call__(class Modules.FSPromises_WriteFile_Utf8/Scope, object)
+		IL_009e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a3: ldc.i4.1
+		IL_00a4: newarr [System.Runtime]System.Object
+		IL_00a9: dup
+		IL_00aa: ldc.i4.0
+		IL_00ab: ldloc.0
+		IL_00ac: stelem.ref
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00b7: ldc.i4.0
+		IL_00b8: conv.r8
+		IL_00b9: ldstr ""
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00c3: stloc.s 4
+		IL_00c5: ldloc.3
+		IL_00c6: ldstr "then"
+		IL_00cb: ldloc.s 4
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00d2: stloc.s 4
+		IL_00d4: ldnull
+		IL_00d5: ldftn object Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10::__js_call__(object, object)
+		IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00e0: ldc.i4.1
+		IL_00e1: newarr [System.Runtime]System.Object
+		IL_00e6: dup
+		IL_00e7: ldc.i4.0
+		IL_00e8: ldloc.0
+		IL_00e9: stelem.ref
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00f4: ldc.i4.1
+		IL_00f5: conv.r8
+		IL_00f6: ldstr ""
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0100: stloc.3
+		IL_0101: ldloc.s 4
+		IL_0103: ldstr "catch"
+		IL_0108: ldloc.3
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_010e: pop
+		IL_010f: ret
 	} // end of method FSPromises_WriteFile_Utf8::__js_module_init__
 
 } // end of class Modules.FSPromises_WriteFile_Utf8
@@ -324,7 +313,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2240
+		// Method begins at RVA 0x2213
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_Append_Rename_Unlink_Callback.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_Append_Rename_Unlink_Callback.verified.txt
@@ -34,7 +34,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2625
+							// Method begins at RVA 0x2511
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -55,7 +55,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x261c
+						// Method begins at RVA 0x2508
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -80,15 +80,14 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24c0
+					// Method begins at RVA 0x2414
 					// Header size: 12
-					// Code size: 247 (0xf7)
+					// Code size: 187 (0xbb)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/ArrowFunction_L28C28/Scope/Block_L29C27,
 						[1] bool,
-						[2] object,
-						[3] object
+						[2] object
 					)
 
 					IL_0000: ldarg.2
@@ -109,73 +108,53 @@
 					IL_002e: ldnull
 					IL_002f: ret
 
-					IL_0030: ldarg.0
-					IL_0031: ldc.i4.2
-					IL_0032: ldelem.ref
-					IL_0033: castclass Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope
-					IL_0038: ldfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
-					IL_003d: ldstr "Cannot access 'text' before initialization"
-					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0047: stloc.2
-					IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-					IL_004d: ldstr "RenamedText:"
-					IL_0052: ldloc.2
-					IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-					IL_0058: pop
-					IL_0059: ldarg.0
-					IL_005a: ldc.i4.0
-					IL_005b: ldelem.ref
-					IL_005c: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_0061: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-					IL_0066: ldstr "Cannot access 'fs' before initialization"
-					IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0070: stloc.2
-					IL_0071: ldarg.0
-					IL_0072: ldc.i4.0
-					IL_0073: ldelem.ref
-					IL_0074: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_0079: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-					IL_007e: ldstr "Cannot access 'source' before initialization"
-					IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0088: stloc.3
-					IL_0089: ldloc.2
-					IL_008a: ldstr "existsSync"
-					IL_008f: ldloc.3
-					IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0095: stloc.3
-					IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-					IL_009b: ldstr "SourceExists:"
-					IL_00a0: ldloc.3
-					IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-					IL_00a6: pop
-					IL_00a7: ldarg.0
-					IL_00a8: ldc.i4.0
-					IL_00a9: ldelem.ref
-					IL_00aa: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_00af: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-					IL_00b4: ldstr "Cannot access 'fs' before initialization"
-					IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_00be: stloc.3
-					IL_00bf: ldarg.0
-					IL_00c0: ldc.i4.0
-					IL_00c1: ldelem.ref
-					IL_00c2: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_00c7: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-					IL_00cc: ldstr "Cannot access 'renamed' before initialization"
-					IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_00d6: stloc.2
-					IL_00d7: ldloc.3
-					IL_00d8: ldstr "existsSync"
-					IL_00dd: ldloc.2
-					IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00e3: stloc.2
-					IL_00e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-					IL_00e9: ldstr "RenamedExists:"
-					IL_00ee: ldloc.2
-					IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-					IL_00f4: pop
-					IL_00f5: ldnull
-					IL_00f6: ret
+					IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+					IL_0035: ldstr "RenamedText:"
+					IL_003a: ldarg.0
+					IL_003b: ldc.i4.2
+					IL_003c: ldelem.ref
+					IL_003d: castclass Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope
+					IL_0042: ldfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
+					IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+					IL_004c: pop
+					IL_004d: ldarg.0
+					IL_004e: ldc.i4.0
+					IL_004f: ldelem.ref
+					IL_0050: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_0055: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+					IL_005a: ldstr "existsSync"
+					IL_005f: ldarg.0
+					IL_0060: ldc.i4.0
+					IL_0061: ldelem.ref
+					IL_0062: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_0067: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0071: stloc.2
+					IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+					IL_0077: ldstr "SourceExists:"
+					IL_007c: ldloc.2
+					IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+					IL_0082: pop
+					IL_0083: ldarg.0
+					IL_0084: ldc.i4.0
+					IL_0085: ldelem.ref
+					IL_0086: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_008b: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+					IL_0090: ldstr "existsSync"
+					IL_0095: ldarg.0
+					IL_0096: ldc.i4.0
+					IL_0097: ldelem.ref
+					IL_0098: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_009d: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+					IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00a7: stloc.2
+					IL_00a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+					IL_00ad: ldstr "RenamedExists:"
+					IL_00b2: ldloc.2
+					IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+					IL_00b8: pop
+					IL_00b9: ldnull
+					IL_00ba: ret
 				} // end of method ArrowFunction_L28C28::__js_call__
 
 			} // end of class ArrowFunction_L28C28
@@ -196,7 +175,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2613
+						// Method begins at RVA 0x24ff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -218,18 +197,15 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ff
+					// Method begins at RVA 0x24f6
 					// Header size: 1
-					// Code size: 19 (0x13)
+					// Code size: 8 (0x8)
 					.maxstack 8
 
 					IL_0000: ldarg.0
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-					IL_000c: stfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
-					IL_0011: nop
-					IL_0012: ret
+					IL_0006: nop
+					IL_0007: ret
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
@@ -246,17 +222,16 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23b4
+				// Method begins at RVA 0x2338
 				// Header size: 12
-				// Code size: 256 (0x100)
+				// Code size: 206 (0xce)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope,
 					[1] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope/Block_L22C23,
 					[2] bool,
 					[3] object,
-					[4] object,
-					[5] object
+					[4] object
 				)
 
 				IL_0000: newobj instance void Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::.ctor()
@@ -283,79 +258,67 @@
 				IL_0037: ldc.i4.0
 				IL_0038: ldelem.ref
 				IL_0039: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_003e: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-				IL_0043: ldstr "Cannot access 'fs' before initialization"
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_004d: stloc.3
-				IL_004e: ldarg.0
-				IL_004f: ldc.i4.0
-				IL_0050: ldelem.ref
-				IL_0051: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_0056: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-				IL_005b: ldstr "Cannot access 'renamed' before initialization"
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0065: stloc.s 4
-				IL_0067: ldloc.3
-				IL_0068: ldstr "readFileSync"
-				IL_006d: ldloc.s 4
-				IL_006f: ldstr "utf8"
-				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0079: stloc.s 4
-				IL_007b: ldloc.0
-				IL_007c: ldloc.s 4
-				IL_007e: stfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
-				IL_0083: ldarg.0
-				IL_0084: ldc.i4.0
-				IL_0085: ldelem.ref
-				IL_0086: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_008b: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-				IL_0090: ldstr "Cannot access 'fs' before initialization"
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_009a: stloc.s 4
-				IL_009c: ldarg.0
-				IL_009d: ldc.i4.0
-				IL_009e: ldelem.ref
-				IL_009f: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_00a4: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-				IL_00a9: ldstr "Cannot access 'renamed' before initialization"
-				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00b3: stloc.3
-				IL_00b4: ldnull
-				IL_00b5: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/ArrowFunction_L28C28::__js_call__(object[], object, object)
-				IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_00c0: ldc.i4.3
-				IL_00c1: newarr [System.Runtime]System.Object
-				IL_00c6: dup
-				IL_00c7: ldc.i4.0
-				IL_00c8: ldarg.0
-				IL_00c9: ldc.i4.0
-				IL_00ca: ldelem.ref
-				IL_00cb: stelem.ref
-				IL_00cc: dup
-				IL_00cd: ldc.i4.1
-				IL_00ce: ldarg.0
-				IL_00cf: ldc.i4.1
-				IL_00d0: ldelem.ref
-				IL_00d1: stelem.ref
-				IL_00d2: dup
-				IL_00d3: ldc.i4.2
-				IL_00d4: ldloc.0
-				IL_00d5: stelem.ref
-				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_00e0: ldc.i4.1
-				IL_00e1: conv.r8
-				IL_00e2: ldstr ""
-				IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_00ec: stloc.s 5
-				IL_00ee: ldloc.s 4
-				IL_00f0: ldstr "unlink"
-				IL_00f5: ldloc.3
-				IL_00f6: ldloc.s 5
-				IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00fd: pop
-				IL_00fe: ldnull
-				IL_00ff: ret
+				IL_003e: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+				IL_0043: stloc.3
+				IL_0044: ldarg.0
+				IL_0045: ldc.i4.0
+				IL_0046: ldelem.ref
+				IL_0047: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_004c: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+				IL_0051: ldstr "readFileSync"
+				IL_0056: ldloc.3
+				IL_0057: ldstr "utf8"
+				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0061: stloc.3
+				IL_0062: ldloc.0
+				IL_0063: ldloc.3
+				IL_0064: stfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
+				IL_0069: ldarg.0
+				IL_006a: ldc.i4.0
+				IL_006b: ldelem.ref
+				IL_006c: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_0071: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+				IL_0076: stloc.3
+				IL_0077: ldnull
+				IL_0078: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/ArrowFunction_L28C28::__js_call__(object[], object, object)
+				IL_007e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0083: ldc.i4.3
+				IL_0084: newarr [System.Runtime]System.Object
+				IL_0089: dup
+				IL_008a: ldc.i4.0
+				IL_008b: ldarg.0
+				IL_008c: ldc.i4.0
+				IL_008d: ldelem.ref
+				IL_008e: stelem.ref
+				IL_008f: dup
+				IL_0090: ldc.i4.1
+				IL_0091: ldarg.0
+				IL_0092: ldc.i4.1
+				IL_0093: ldelem.ref
+				IL_0094: stelem.ref
+				IL_0095: dup
+				IL_0096: ldc.i4.2
+				IL_0097: ldloc.0
+				IL_0098: stelem.ref
+				IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_00a3: ldc.i4.1
+				IL_00a4: conv.r8
+				IL_00a5: ldstr ""
+				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_00af: stloc.s 4
+				IL_00b1: ldarg.0
+				IL_00b2: ldc.i4.0
+				IL_00b3: ldelem.ref
+				IL_00b4: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_00b9: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+				IL_00be: ldstr "unlink"
+				IL_00c3: ldloc.3
+				IL_00c4: ldloc.s 4
+				IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00cb: pop
+				IL_00cc: ldnull
+				IL_00cd: ret
 			} // end of method ArrowFunction_L21C32::__js_call__
 
 		} // end of class ArrowFunction_L21C32
@@ -375,7 +338,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25f6
+					// Method begins at RVA 0x24ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -396,7 +359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ed
+				// Method begins at RVA 0x24e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -423,9 +386,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22f4
+			// Method begins at RVA 0x229c
 			// Header size: 12
-			// Code size: 177 (0xb1)
+			// Code size: 143 (0x8f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/Scope,
@@ -433,8 +396,7 @@
 				[2] bool,
 				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/Scope::.ctor()
@@ -458,49 +420,41 @@
 			IL_0035: ret
 
 			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-			IL_003c: ldstr "Cannot access 'fs' before initialization"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0046: stloc.3
-			IL_0047: ldarg.0
-			IL_0048: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-			IL_004d: ldstr "Cannot access 'source' before initialization"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0057: stloc.s 4
+			IL_0037: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+			IL_003c: stloc.3
+			IL_003d: ldarg.0
+			IL_003e: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+			IL_0043: stloc.s 4
+			IL_0045: ldnull
+			IL_0046: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32::__js_call__(object[], object, object)
+			IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0051: ldc.i4.2
+			IL_0052: newarr [System.Runtime]System.Object
+			IL_0057: dup
+			IL_0058: ldc.i4.0
 			IL_0059: ldarg.0
-			IL_005a: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-			IL_005f: ldstr "Cannot access 'renamed' before initialization"
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0069: stloc.s 5
-			IL_006b: ldnull
-			IL_006c: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32::__js_call__(object[], object, object)
-			IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0077: ldc.i4.2
-			IL_0078: newarr [System.Runtime]System.Object
-			IL_007d: dup
-			IL_007e: ldc.i4.0
-			IL_007f: ldarg.0
-			IL_0080: stelem.ref
-			IL_0081: dup
-			IL_0082: ldc.i4.1
-			IL_0083: ldloc.0
-			IL_0084: stelem.ref
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_008f: ldc.i4.1
-			IL_0090: conv.r8
-			IL_0091: ldstr ""
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_009b: stloc.s 6
-			IL_009d: ldloc.3
-			IL_009e: ldstr "rename"
-			IL_00a3: ldloc.s 4
-			IL_00a5: ldloc.s 5
-			IL_00a7: ldloc.s 6
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_00ae: pop
-			IL_00af: ldnull
-			IL_00b0: ret
+			IL_005a: stelem.ref
+			IL_005b: dup
+			IL_005c: ldc.i4.1
+			IL_005d: ldloc.0
+			IL_005e: stelem.ref
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0069: ldc.i4.1
+			IL_006a: conv.r8
+			IL_006b: ldstr ""
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0075: stloc.s 5
+			IL_0077: ldarg.0
+			IL_0078: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+			IL_007d: ldstr "rename"
+			IL_0082: ldloc.3
+			IL_0083: ldloc.s 4
+			IL_0085: ldloc.s 5
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_008c: pop
+			IL_008d: ldnull
+			IL_008e: ret
 		} // end of method ArrowFunction_L15C36::__js_call__
 
 	} // end of class ArrowFunction_L15C36
@@ -523,24 +477,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25c3
+			// Method begins at RVA 0x24db
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -558,7 +503,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 663 (0x297)
+		// Code size: 575 (0x23f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_Append_Rename_Unlink_Callback/Scope,
@@ -571,8 +516,7 @@
 			[7] object,
 			[8] string,
 			[9] object,
-			[10] object,
-			[11] object[]
+			[10] object[]
 		)
 
 		IL_0000: newobj instance void Modules.FS_Append_Rename_Unlink_Callback/Scope::.ctor()
@@ -681,120 +625,100 @@
 		IL_0139: stfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
 		IL_013e: ldloc.0
 		IL_013f: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-		IL_0144: ldstr "Cannot access 'fs' before initialization"
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_014e: stloc.s 4
-		IL_0150: ldloc.0
-		IL_0151: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-		IL_0156: ldstr "Cannot access 'source' before initialization"
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0160: stloc.s 9
-		IL_0162: ldloc.s 4
-		IL_0164: ldstr "rmSync"
-		IL_0169: ldloc.s 9
-		IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0170: dup
-		IL_0171: ldstr "force"
-		IL_0176: ldc.i4.1
-		IL_0177: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0181: pop
-		IL_0182: ldloc.0
-		IL_0183: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-		IL_0188: ldstr "Cannot access 'fs' before initialization"
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0192: stloc.s 9
-		IL_0194: ldloc.0
-		IL_0195: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-		IL_019a: ldstr "Cannot access 'renamed' before initialization"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0144: stloc.s 4
+		IL_0146: ldloc.0
+		IL_0147: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+		IL_014c: stloc.s 9
+		IL_014e: ldloc.s 4
+		IL_0150: ldstr "rmSync"
+		IL_0155: ldloc.s 9
+		IL_0157: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_015c: dup
+		IL_015d: ldstr "force"
+		IL_0162: ldc.i4.1
+		IL_0163: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_016d: pop
+		IL_016e: ldloc.0
+		IL_016f: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+		IL_0174: stloc.s 9
+		IL_0176: ldloc.0
+		IL_0177: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+		IL_017c: stloc.s 4
+		IL_017e: ldloc.s 9
+		IL_0180: ldstr "rmSync"
+		IL_0185: ldloc.s 4
+		IL_0187: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_018c: dup
+		IL_018d: ldstr "force"
+		IL_0192: ldc.i4.1
+		IL_0193: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_019d: pop
+		IL_019e: ldloc.0
+		IL_019f: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
 		IL_01a4: stloc.s 4
-		IL_01a6: ldloc.s 9
-		IL_01a8: ldstr "rmSync"
-		IL_01ad: ldloc.s 4
-		IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01b4: dup
-		IL_01b5: ldstr "force"
-		IL_01ba: ldc.i4.1
-		IL_01bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01c5: pop
-		IL_01c6: ldloc.0
-		IL_01c7: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-		IL_01cc: ldstr "Cannot access 'fs' before initialization"
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01d6: stloc.s 4
-		IL_01d8: ldloc.0
-		IL_01d9: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-		IL_01de: ldstr "Cannot access 'source' before initialization"
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01e8: stloc.s 9
-		IL_01ea: ldloc.s 4
-		IL_01ec: ldstr "writeFileSync"
-		IL_01f1: ldloc.s 9
-		IL_01f3: ldstr "a"
-		IL_01f8: ldstr "utf8"
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0202: pop
-		IL_0203: ldloc.0
-		IL_0204: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-		IL_0209: ldstr "Cannot access 'fs' before initialization"
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0213: stloc.s 9
-		IL_0215: ldloc.0
-		IL_0216: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-		IL_021b: ldstr "Cannot access 'source' before initialization"
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0225: stloc.s 4
-		IL_0227: ldc.i4.1
-		IL_0228: newarr [System.Runtime]System.Object
-		IL_022d: dup
-		IL_022e: ldc.i4.0
-		IL_022f: ldloc.0
-		IL_0230: stelem.ref
-		IL_0231: ldc.i4.0
-		IL_0232: ldelem.ref
-		IL_0233: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-		IL_0238: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36::__js_call__(class Modules.FS_Append_Rename_Unlink_Callback/Scope, object, object)
-		IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0243: ldc.i4.1
-		IL_0244: newarr [System.Runtime]System.Object
-		IL_0249: dup
-		IL_024a: ldc.i4.0
-		IL_024b: ldloc.0
-		IL_024c: stelem.ref
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0257: ldc.i4.1
-		IL_0258: conv.r8
-		IL_0259: ldstr ""
-		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0263: stloc.s 10
-		IL_0265: ldc.i4.4
-		IL_0266: newarr [System.Runtime]System.Object
-		IL_026b: dup
-		IL_026c: ldc.i4.0
-		IL_026d: ldloc.s 4
-		IL_026f: stelem.ref
-		IL_0270: dup
-		IL_0271: ldc.i4.1
-		IL_0272: ldstr "b"
-		IL_0277: stelem.ref
-		IL_0278: dup
-		IL_0279: ldc.i4.2
-		IL_027a: ldstr "utf8"
-		IL_027f: stelem.ref
-		IL_0280: dup
-		IL_0281: ldc.i4.3
-		IL_0282: ldloc.s 10
-		IL_0284: stelem.ref
-		IL_0285: stloc.s 11
-		IL_0287: ldloc.s 9
-		IL_0289: ldstr "appendFile"
-		IL_028e: ldloc.s 11
-		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_0295: pop
-		IL_0296: ret
+		IL_01a6: ldloc.0
+		IL_01a7: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+		IL_01ac: ldstr "writeFileSync"
+		IL_01b1: ldloc.s 4
+		IL_01b3: ldstr "a"
+		IL_01b8: ldstr "utf8"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_01c2: pop
+		IL_01c3: ldloc.0
+		IL_01c4: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+		IL_01c9: stloc.s 4
+		IL_01cb: ldc.i4.1
+		IL_01cc: newarr [System.Runtime]System.Object
+		IL_01d1: dup
+		IL_01d2: ldc.i4.0
+		IL_01d3: ldloc.0
+		IL_01d4: stelem.ref
+		IL_01d5: ldc.i4.0
+		IL_01d6: ldelem.ref
+		IL_01d7: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+		IL_01dc: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36::__js_call__(class Modules.FS_Append_Rename_Unlink_Callback/Scope, object, object)
+		IL_01e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01e7: ldc.i4.1
+		IL_01e8: newarr [System.Runtime]System.Object
+		IL_01ed: dup
+		IL_01ee: ldc.i4.0
+		IL_01ef: ldloc.0
+		IL_01f0: stelem.ref
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01fb: ldc.i4.1
+		IL_01fc: conv.r8
+		IL_01fd: ldstr ""
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0207: stloc.s 9
+		IL_0209: ldc.i4.4
+		IL_020a: newarr [System.Runtime]System.Object
+		IL_020f: dup
+		IL_0210: ldc.i4.0
+		IL_0211: ldloc.0
+		IL_0212: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+		IL_0217: stelem.ref
+		IL_0218: dup
+		IL_0219: ldc.i4.1
+		IL_021a: ldstr "b"
+		IL_021f: stelem.ref
+		IL_0220: dup
+		IL_0221: ldc.i4.2
+		IL_0222: ldstr "utf8"
+		IL_0227: stelem.ref
+		IL_0228: dup
+		IL_0229: ldc.i4.3
+		IL_022a: ldloc.s 9
+		IL_022c: stelem.ref
+		IL_022d: stloc.s 10
+		IL_022f: ldloc.s 4
+		IL_0231: ldstr "appendFile"
+		IL_0236: ldloc.s 10
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_023d: pop
+		IL_023e: ret
 	} // end of method FS_Append_Rename_Unlink_Callback::__js_module_init__
 
 } // end of class Modules.FS_Append_Rename_Unlink_Callback
@@ -806,7 +730,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x262e
+		// Method begins at RVA 0x251a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ab
+				// Method begins at RVA 0x23fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,13 +52,10 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2338
-			// Header size: 12
-			// Code size: 49 (0x31)
+			// Method begins at RVA 0x22f5
+			// Header size: 1
+			// Code size: 32 (0x20)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: ldstr "Chunk:"
@@ -66,17 +63,12 @@
 			IL_000b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_0010: pop
 			IL_0011: ldarg.0
-			IL_0012: ldfld object Modules.FS_CreateReadStream_Basic/Scope::chunks
-			IL_0017: ldstr "Cannot access 'chunks' before initialization"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ldstr "push"
-			IL_0028: ldarg.2
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002e: pop
-			IL_002f: ldnull
-			IL_0030: ret
+			IL_0012: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FS_CreateReadStream_Basic/Scope::chunks
+			IL_0017: ldarg.2
+			IL_0018: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_001d: pop
+			IL_001e: ldnull
+			IL_001f: ret
 		} // end of method ArrowFunction_L15C19::__js_call__
 
 	} // end of class ArrowFunction_L15C19
@@ -92,7 +84,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b4
+				// Method begins at RVA 0x2403
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,52 +110,49 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2378
+			// Method begins at RVA 0x2318
 			// Header size: 12
-			// Code size: 117 (0x75)
+			// Code size: 89 (0x59)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] string,
+				[1] object,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FS_CreateReadStream_Basic/Scope::chunks
-			IL_0006: ldstr "Cannot access 'chunks' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "join"
-			IL_0017: ldstr "|"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0027: ldstr "Combined:"
-			IL_002c: ldloc.0
-			IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0032: pop
-			IL_0033: ldarg.0
-			IL_0034: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-			IL_0039: ldstr "Cannot access 'fs' before initialization"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0043: stloc.0
-			IL_0044: ldarg.0
-			IL_0045: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-			IL_004a: ldstr "Cannot access 'file' before initialization"
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0054: stloc.1
-			IL_0055: ldloc.0
-			IL_0056: ldstr "rmSync"
-			IL_005b: ldloc.1
-			IL_005c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0061: dup
-			IL_0062: ldstr "force"
-			IL_0067: ldc.i4.1
-			IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0072: pop
-			IL_0073: ldnull
-			IL_0074: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FS_CreateReadStream_Basic/Scope::chunks
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldstr "|"
+			IL_0013: stelem.ref
+			IL_0014: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0019: stloc.0
+			IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_001f: ldstr "Combined:"
+			IL_0024: ldloc.0
+			IL_0025: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_002a: pop
+			IL_002b: ldarg.0
+			IL_002c: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+			IL_0038: stloc.2
+			IL_0039: ldloc.1
+			IL_003a: ldstr "rmSync"
+			IL_003f: ldloc.2
+			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0045: dup
+			IL_0046: ldstr "force"
+			IL_004b: ldc.i4.1
+			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0056: pop
+			IL_0057: ldnull
+			IL_0058: ret
 		} // end of method ArrowFunction_L20C18::__js_call__
 
 	} // end of class ArrowFunction_L20C18
@@ -186,7 +175,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24bd
+				// Method begins at RVA 0x240c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -213,9 +202,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x23fc
+			// Method begins at RVA 0x2380
 			// Header size: 12
-			// Code size: 121 (0x79)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -250,26 +239,22 @@
 			IL_0032: pop
 			IL_0033: ldarg.0
 			IL_0034: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-			IL_0039: ldstr "Cannot access 'fs' before initialization"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0043: stloc.s 4
-			IL_0045: ldarg.0
-			IL_0046: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-			IL_004b: ldstr "Cannot access 'file' before initialization"
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0055: stloc.s 5
-			IL_0057: ldloc.s 4
-			IL_0059: ldstr "rmSync"
-			IL_005e: ldloc.s 5
-			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0065: dup
-			IL_0066: ldstr "force"
-			IL_006b: ldc.i4.1
-			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0076: pop
-			IL_0077: ldnull
-			IL_0078: ret
+			IL_0039: stloc.s 4
+			IL_003b: ldarg.0
+			IL_003c: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+			IL_0041: stloc.s 5
+			IL_0043: ldloc.s 4
+			IL_0045: ldstr "rmSync"
+			IL_004a: ldloc.s 5
+			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0051: dup
+			IL_0052: ldstr "force"
+			IL_0057: ldc.i4.1
+			IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0062: pop
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method ArrowFunction_L25C20::__js_call__
 
 	} // end of class ArrowFunction_L25C20
@@ -285,30 +270,21 @@
 		// Fields
 		.field public object fs
 		.field public object file
-		.field public object chunks
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array chunks
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2481
+			// Method begins at RVA 0x23f1
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FS_CreateReadStream_Basic/Scope::file
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.FS_CreateReadStream_Basic/Scope::chunks
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -326,7 +302,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 729 (0x2d9)
+		// Code size: 665 (0x299)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_CreateReadStream_Basic/Scope,
@@ -424,162 +400,148 @@
 		IL_00ef: stfld object Modules.FS_CreateReadStream_Basic/Scope::file
 		IL_00f4: ldloc.0
 		IL_00f5: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-		IL_00fa: ldstr "Cannot access 'fs' before initialization"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0104: stloc.s 5
-		IL_0106: ldloc.0
-		IL_0107: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-		IL_010c: ldstr "Cannot access 'file' before initialization"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0116: stloc.s 10
-		IL_0118: ldloc.s 5
-		IL_011a: ldstr "rmSync"
-		IL_011f: ldloc.s 10
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0126: dup
-		IL_0127: ldstr "force"
-		IL_012c: ldc.i4.1
-		IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0137: pop
-		IL_0138: ldloc.0
-		IL_0139: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-		IL_013e: ldstr "Cannot access 'fs' before initialization"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0148: stloc.s 10
-		IL_014a: ldloc.0
-		IL_014b: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-		IL_0150: ldstr "Cannot access 'file' before initialization"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_015a: stloc.s 5
-		IL_015c: ldloc.s 10
-		IL_015e: ldstr "writeFileSync"
-		IL_0163: ldloc.s 5
-		IL_0165: ldstr "hello world"
-		IL_016a: ldstr "utf8"
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0174: pop
-		IL_0175: ldloc.0
-		IL_0176: ldc.i4.0
-		IL_0177: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_017c: stfld object Modules.FS_CreateReadStream_Basic/Scope::chunks
-		IL_0181: ldloc.0
-		IL_0182: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-		IL_0187: ldstr "Cannot access 'fs' before initialization"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0191: stloc.s 5
-		IL_0193: ldloc.0
-		IL_0194: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-		IL_0199: ldstr "Cannot access 'file' before initialization"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01a3: stloc.s 10
-		IL_01a5: ldloc.s 5
-		IL_01a7: ldstr "createReadStream"
-		IL_01ac: ldloc.s 10
-		IL_01ae: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01b3: dup
-		IL_01b4: ldstr "encoding"
-		IL_01b9: ldstr "utf8"
-		IL_01be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_01c3: dup
-		IL_01c4: ldstr "highWaterMark"
-		IL_01c9: ldc.r8 5
-		IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01dc: stloc.s 10
-		IL_01de: ldloc.s 10
-		IL_01e0: stloc.s 4
-		IL_01e2: ldc.i4.1
-		IL_01e3: newarr [System.Runtime]System.Object
-		IL_01e8: dup
-		IL_01e9: ldc.i4.0
-		IL_01ea: ldloc.0
-		IL_01eb: stelem.ref
-		IL_01ec: ldc.i4.0
-		IL_01ed: ldelem.ref
-		IL_01ee: castclass Modules.FS_CreateReadStream_Basic/Scope
-		IL_01f3: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L15C19::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object, object)
-		IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01fe: ldc.i4.1
-		IL_01ff: newarr [System.Runtime]System.Object
-		IL_0204: dup
-		IL_0205: ldc.i4.0
-		IL_0206: ldloc.0
-		IL_0207: stelem.ref
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0212: ldc.i4.1
-		IL_0213: conv.r8
-		IL_0214: ldstr ""
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_021e: stloc.s 10
-		IL_0220: ldloc.s 4
-		IL_0222: ldstr "on"
-		IL_0227: ldstr "data"
-		IL_022c: ldloc.s 10
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0233: pop
-		IL_0234: ldc.i4.1
-		IL_0235: newarr [System.Runtime]System.Object
-		IL_023a: dup
-		IL_023b: ldc.i4.0
-		IL_023c: ldloc.0
-		IL_023d: stelem.ref
-		IL_023e: ldc.i4.0
-		IL_023f: ldelem.ref
-		IL_0240: castclass Modules.FS_CreateReadStream_Basic/Scope
-		IL_0245: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L20C18::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object)
-		IL_024b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0250: ldc.i4.1
-		IL_0251: newarr [System.Runtime]System.Object
-		IL_0256: dup
-		IL_0257: ldc.i4.0
-		IL_0258: ldloc.0
-		IL_0259: stelem.ref
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0264: ldc.i4.0
-		IL_0265: conv.r8
-		IL_0266: ldstr ""
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0270: stloc.s 10
-		IL_0272: ldloc.s 4
-		IL_0274: ldstr "on"
-		IL_0279: ldstr "end"
-		IL_027e: ldloc.s 10
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0285: pop
-		IL_0286: ldc.i4.1
-		IL_0287: newarr [System.Runtime]System.Object
-		IL_028c: dup
-		IL_028d: ldc.i4.0
-		IL_028e: ldloc.0
-		IL_028f: stelem.ref
-		IL_0290: ldc.i4.0
-		IL_0291: ldelem.ref
-		IL_0292: castclass Modules.FS_CreateReadStream_Basic/Scope
-		IL_0297: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L25C20::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object, object)
-		IL_029d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02a2: ldc.i4.1
-		IL_02a3: newarr [System.Runtime]System.Object
-		IL_02a8: dup
-		IL_02a9: ldc.i4.0
-		IL_02aa: ldloc.0
-		IL_02ab: stelem.ref
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02b6: ldc.i4.1
-		IL_02b7: conv.r8
-		IL_02b8: ldstr ""
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02c2: stloc.s 10
-		IL_02c4: ldloc.s 4
-		IL_02c6: ldstr "on"
-		IL_02cb: ldstr "error"
-		IL_02d0: ldloc.s 10
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_02d7: pop
-		IL_02d8: ret
+		IL_00fa: stloc.s 5
+		IL_00fc: ldloc.0
+		IL_00fd: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+		IL_0102: stloc.s 10
+		IL_0104: ldloc.s 5
+		IL_0106: ldstr "rmSync"
+		IL_010b: ldloc.s 10
+		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0112: dup
+		IL_0113: ldstr "force"
+		IL_0118: ldc.i4.1
+		IL_0119: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0123: pop
+		IL_0124: ldloc.0
+		IL_0125: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+		IL_012a: stloc.s 10
+		IL_012c: ldloc.0
+		IL_012d: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
+		IL_0132: ldstr "writeFileSync"
+		IL_0137: ldloc.s 10
+		IL_0139: ldstr "hello world"
+		IL_013e: ldstr "utf8"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0148: pop
+		IL_0149: ldloc.0
+		IL_014a: ldc.i4.0
+		IL_014b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0150: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FS_CreateReadStream_Basic/Scope::chunks
+		IL_0155: ldloc.0
+		IL_0156: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
+		IL_015b: stloc.s 10
+		IL_015d: ldloc.0
+		IL_015e: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+		IL_0163: stloc.s 5
+		IL_0165: ldloc.s 10
+		IL_0167: ldstr "createReadStream"
+		IL_016c: ldloc.s 5
+		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0173: dup
+		IL_0174: ldstr "encoding"
+		IL_0179: ldstr "utf8"
+		IL_017e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0183: dup
+		IL_0184: ldstr "highWaterMark"
+		IL_0189: ldc.r8 5
+		IL_0192: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_019c: stloc.s 5
+		IL_019e: ldloc.s 5
+		IL_01a0: stloc.s 4
+		IL_01a2: ldc.i4.1
+		IL_01a3: newarr [System.Runtime]System.Object
+		IL_01a8: dup
+		IL_01a9: ldc.i4.0
+		IL_01aa: ldloc.0
+		IL_01ab: stelem.ref
+		IL_01ac: ldc.i4.0
+		IL_01ad: ldelem.ref
+		IL_01ae: castclass Modules.FS_CreateReadStream_Basic/Scope
+		IL_01b3: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L15C19::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object, object)
+		IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01be: ldc.i4.1
+		IL_01bf: newarr [System.Runtime]System.Object
+		IL_01c4: dup
+		IL_01c5: ldc.i4.0
+		IL_01c6: ldloc.0
+		IL_01c7: stelem.ref
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01d2: ldc.i4.1
+		IL_01d3: conv.r8
+		IL_01d4: ldstr ""
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01de: stloc.s 5
+		IL_01e0: ldloc.s 4
+		IL_01e2: ldstr "on"
+		IL_01e7: ldstr "data"
+		IL_01ec: ldloc.s 5
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01f3: pop
+		IL_01f4: ldc.i4.1
+		IL_01f5: newarr [System.Runtime]System.Object
+		IL_01fa: dup
+		IL_01fb: ldc.i4.0
+		IL_01fc: ldloc.0
+		IL_01fd: stelem.ref
+		IL_01fe: ldc.i4.0
+		IL_01ff: ldelem.ref
+		IL_0200: castclass Modules.FS_CreateReadStream_Basic/Scope
+		IL_0205: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L20C18::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object)
+		IL_020b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0210: ldc.i4.1
+		IL_0211: newarr [System.Runtime]System.Object
+		IL_0216: dup
+		IL_0217: ldc.i4.0
+		IL_0218: ldloc.0
+		IL_0219: stelem.ref
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0224: ldc.i4.0
+		IL_0225: conv.r8
+		IL_0226: ldstr ""
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0230: stloc.s 5
+		IL_0232: ldloc.s 4
+		IL_0234: ldstr "on"
+		IL_0239: ldstr "end"
+		IL_023e: ldloc.s 5
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0245: pop
+		IL_0246: ldc.i4.1
+		IL_0247: newarr [System.Runtime]System.Object
+		IL_024c: dup
+		IL_024d: ldc.i4.0
+		IL_024e: ldloc.0
+		IL_024f: stelem.ref
+		IL_0250: ldc.i4.0
+		IL_0251: ldelem.ref
+		IL_0252: castclass Modules.FS_CreateReadStream_Basic/Scope
+		IL_0257: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L25C20::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object, object)
+		IL_025d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0262: ldc.i4.1
+		IL_0263: newarr [System.Runtime]System.Object
+		IL_0268: dup
+		IL_0269: ldc.i4.0
+		IL_026a: ldloc.0
+		IL_026b: stelem.ref
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0276: ldc.i4.1
+		IL_0277: conv.r8
+		IL_0278: ldstr ""
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0282: stloc.s 5
+		IL_0284: ldloc.s 4
+		IL_0286: ldstr "on"
+		IL_028b: ldstr "error"
+		IL_0290: ldloc.s 5
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0297: pop
+		IL_0298: ret
 	} // end of method FS_CreateReadStream_Basic::__js_module_init__
 
 } // end of class Modules.FS_CreateReadStream_Basic
@@ -591,7 +553,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24c6
+		// Method begins at RVA 0x2415
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243c
+				// Method begins at RVA 0x23c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,9 +44,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22ec
+			// Method begins at RVA 0x22c4
 			// Header size: 12
-			// Code size: 135 (0x87)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -54,48 +54,38 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_0006: ldstr "Cannot access 'fs' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldarg.0
-			IL_0012: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_0017: ldstr "Cannot access 'file' before initialization"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0021: stloc.1
-			IL_0022: ldloc.0
-			IL_0023: ldstr "readFileSync"
-			IL_0028: ldloc.1
-			IL_0029: ldstr "utf8"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0033: stloc.1
-			IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0039: ldstr "FileText:"
-			IL_003e: ldloc.1
-			IL_003f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0044: pop
-			IL_0045: ldarg.0
-			IL_0046: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_004b: ldstr "Cannot access 'fs' before initialization"
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0055: stloc.1
-			IL_0056: ldarg.0
-			IL_0057: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_005c: ldstr "Cannot access 'file' before initialization"
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0066: stloc.0
-			IL_0067: ldloc.1
-			IL_0068: ldstr "rmSync"
-			IL_006d: ldloc.0
-			IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0073: dup
-			IL_0074: ldstr "force"
-			IL_0079: ldc.i4.1
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0084: pop
-			IL_0085: ldnull
-			IL_0086: ret
+			IL_0001: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
+			IL_000d: ldstr "readFileSync"
+			IL_0012: ldloc.0
+			IL_0013: ldstr "utf8"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_001d: stloc.0
+			IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0023: ldstr "FileText:"
+			IL_0028: ldloc.0
+			IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_002e: pop
+			IL_002f: ldarg.0
+			IL_0030: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
+			IL_0035: stloc.0
+			IL_0036: ldarg.0
+			IL_0037: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_003c: stloc.1
+			IL_003d: ldloc.0
+			IL_003e: ldstr "rmSync"
+			IL_0043: ldloc.1
+			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0049: dup
+			IL_004a: ldstr "force"
+			IL_004f: ldc.i4.1
+			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method ArrowFunction_L13C21::__js_call__
 
 	} // end of class ArrowFunction_L13C21
@@ -111,7 +101,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2445
+				// Method begins at RVA 0x23cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -134,7 +124,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x237f
+			// Method begins at RVA 0x232d
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -169,7 +159,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244e
+				// Method begins at RVA 0x23d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,9 +186,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2398
+			// Method begins at RVA 0x2348
 			// Header size: 12
-			// Code size: 121 (0x79)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -233,26 +223,22 @@
 			IL_0032: pop
 			IL_0033: ldarg.0
 			IL_0034: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_0039: ldstr "Cannot access 'fs' before initialization"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0043: stloc.s 4
-			IL_0045: ldarg.0
-			IL_0046: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_004b: ldstr "Cannot access 'file' before initialization"
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0055: stloc.s 5
-			IL_0057: ldloc.s 4
-			IL_0059: ldstr "rmSync"
-			IL_005e: ldloc.s 5
-			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0065: dup
-			IL_0066: ldstr "force"
-			IL_006b: ldc.i4.1
-			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0076: pop
-			IL_0077: ldnull
-			IL_0078: ret
+			IL_0039: stloc.s 4
+			IL_003b: ldarg.0
+			IL_003c: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_0041: stloc.s 5
+			IL_0043: ldloc.s 4
+			IL_0045: ldstr "rmSync"
+			IL_004a: ldloc.s 5
+			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0051: dup
+			IL_0052: ldstr "force"
+			IL_0057: ldc.i4.1
+			IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0062: pop
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method ArrowFunction_L22C20::__js_call__
 
 	} // end of class ArrowFunction_L22C20
@@ -272,21 +258,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x241d
+			// Method begins at RVA 0x23b9
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -304,7 +284,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 656 (0x290)
+		// Code size: 616 (0x268)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_CreateWriteStream_Basic/Scope,
@@ -402,139 +382,131 @@
 		IL_00ef: stfld object Modules.FS_CreateWriteStream_Basic/Scope::file
 		IL_00f4: ldloc.0
 		IL_00f5: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-		IL_00fa: ldstr "Cannot access 'fs' before initialization"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0104: stloc.s 5
-		IL_0106: ldloc.0
-		IL_0107: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-		IL_010c: ldstr "Cannot access 'file' before initialization"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0116: stloc.s 10
-		IL_0118: ldloc.s 5
-		IL_011a: ldstr "rmSync"
-		IL_011f: ldloc.s 10
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0126: dup
-		IL_0127: ldstr "force"
-		IL_012c: ldc.i4.1
-		IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0137: pop
-		IL_0138: ldloc.0
-		IL_0139: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-		IL_013e: ldstr "Cannot access 'fs' before initialization"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0148: stloc.s 10
-		IL_014a: ldloc.0
-		IL_014b: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-		IL_0150: ldstr "Cannot access 'file' before initialization"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_015a: stloc.s 5
-		IL_015c: ldloc.s 10
-		IL_015e: ldstr "createWriteStream"
-		IL_0163: ldloc.s 5
-		IL_0165: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_016a: dup
-		IL_016b: ldstr "encoding"
-		IL_0170: ldstr "utf8"
-		IL_0175: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_017f: stloc.s 5
-		IL_0181: ldloc.s 5
-		IL_0183: stloc.s 4
-		IL_0185: ldc.i4.1
-		IL_0186: newarr [System.Runtime]System.Object
-		IL_018b: dup
-		IL_018c: ldc.i4.0
-		IL_018d: ldloc.0
-		IL_018e: stelem.ref
-		IL_018f: ldc.i4.0
-		IL_0190: ldelem.ref
-		IL_0191: castclass Modules.FS_CreateWriteStream_Basic/Scope
-		IL_0196: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L13C21::__js_call__(class Modules.FS_CreateWriteStream_Basic/Scope, object)
-		IL_019c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01a1: ldc.i4.1
-		IL_01a2: newarr [System.Runtime]System.Object
-		IL_01a7: dup
-		IL_01a8: ldc.i4.0
-		IL_01a9: ldloc.0
-		IL_01aa: stelem.ref
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01b5: ldc.i4.0
-		IL_01b6: conv.r8
-		IL_01b7: ldstr ""
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01c1: stloc.s 5
-		IL_01c3: ldloc.s 4
-		IL_01c5: ldstr "on"
-		IL_01ca: ldstr "finish"
-		IL_01cf: ldloc.s 5
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01d6: pop
-		IL_01d7: ldnull
-		IL_01d8: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L18C20::__js_call__(object)
-		IL_01de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01e3: ldc.i4.1
-		IL_01e4: newarr [System.Runtime]System.Object
-		IL_01e9: dup
-		IL_01ea: ldc.i4.0
-		IL_01eb: ldloc.0
-		IL_01ec: stelem.ref
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01f7: ldc.i4.0
-		IL_01f8: conv.r8
-		IL_01f9: ldstr ""
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0203: stloc.s 5
-		IL_0205: ldloc.s 4
-		IL_0207: ldstr "on"
-		IL_020c: ldstr "close"
-		IL_0211: ldloc.s 5
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0218: pop
-		IL_0219: ldc.i4.1
-		IL_021a: newarr [System.Runtime]System.Object
-		IL_021f: dup
-		IL_0220: ldc.i4.0
-		IL_0221: ldloc.0
-		IL_0222: stelem.ref
-		IL_0223: ldc.i4.0
-		IL_0224: ldelem.ref
-		IL_0225: castclass Modules.FS_CreateWriteStream_Basic/Scope
-		IL_022a: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L22C20::__js_call__(class Modules.FS_CreateWriteStream_Basic/Scope, object, object)
-		IL_0230: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0235: ldc.i4.1
-		IL_0236: newarr [System.Runtime]System.Object
-		IL_023b: dup
-		IL_023c: ldc.i4.0
-		IL_023d: ldloc.0
-		IL_023e: stelem.ref
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0249: ldc.i4.1
-		IL_024a: conv.r8
-		IL_024b: ldstr ""
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0255: stloc.s 5
-		IL_0257: ldloc.s 4
-		IL_0259: ldstr "on"
-		IL_025e: ldstr "error"
-		IL_0263: ldloc.s 5
-		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_026a: pop
-		IL_026b: ldloc.s 4
-		IL_026d: ldstr "write"
-		IL_0272: ldstr "hello "
-		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_027c: pop
-		IL_027d: ldloc.s 4
-		IL_027f: ldstr "end"
-		IL_0284: ldstr "world"
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_028e: pop
-		IL_028f: ret
+		IL_00fa: stloc.s 5
+		IL_00fc: ldloc.0
+		IL_00fd: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+		IL_0102: stloc.s 10
+		IL_0104: ldloc.s 5
+		IL_0106: ldstr "rmSync"
+		IL_010b: ldloc.s 10
+		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0112: dup
+		IL_0113: ldstr "force"
+		IL_0118: ldc.i4.1
+		IL_0119: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0123: pop
+		IL_0124: ldloc.0
+		IL_0125: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
+		IL_012a: stloc.s 10
+		IL_012c: ldloc.0
+		IL_012d: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+		IL_0132: stloc.s 5
+		IL_0134: ldloc.s 10
+		IL_0136: ldstr "createWriteStream"
+		IL_013b: ldloc.s 5
+		IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0142: dup
+		IL_0143: ldstr "encoding"
+		IL_0148: ldstr "utf8"
+		IL_014d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0157: stloc.s 5
+		IL_0159: ldloc.s 5
+		IL_015b: stloc.s 4
+		IL_015d: ldc.i4.1
+		IL_015e: newarr [System.Runtime]System.Object
+		IL_0163: dup
+		IL_0164: ldc.i4.0
+		IL_0165: ldloc.0
+		IL_0166: stelem.ref
+		IL_0167: ldc.i4.0
+		IL_0168: ldelem.ref
+		IL_0169: castclass Modules.FS_CreateWriteStream_Basic/Scope
+		IL_016e: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L13C21::__js_call__(class Modules.FS_CreateWriteStream_Basic/Scope, object)
+		IL_0174: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0179: ldc.i4.1
+		IL_017a: newarr [System.Runtime]System.Object
+		IL_017f: dup
+		IL_0180: ldc.i4.0
+		IL_0181: ldloc.0
+		IL_0182: stelem.ref
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_018d: ldc.i4.0
+		IL_018e: conv.r8
+		IL_018f: ldstr ""
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0199: stloc.s 5
+		IL_019b: ldloc.s 4
+		IL_019d: ldstr "on"
+		IL_01a2: ldstr "finish"
+		IL_01a7: ldloc.s 5
+		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01ae: pop
+		IL_01af: ldnull
+		IL_01b0: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L18C20::__js_call__(object)
+		IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01bb: ldc.i4.1
+		IL_01bc: newarr [System.Runtime]System.Object
+		IL_01c1: dup
+		IL_01c2: ldc.i4.0
+		IL_01c3: ldloc.0
+		IL_01c4: stelem.ref
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01cf: ldc.i4.0
+		IL_01d0: conv.r8
+		IL_01d1: ldstr ""
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01db: stloc.s 5
+		IL_01dd: ldloc.s 4
+		IL_01df: ldstr "on"
+		IL_01e4: ldstr "close"
+		IL_01e9: ldloc.s 5
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01f0: pop
+		IL_01f1: ldc.i4.1
+		IL_01f2: newarr [System.Runtime]System.Object
+		IL_01f7: dup
+		IL_01f8: ldc.i4.0
+		IL_01f9: ldloc.0
+		IL_01fa: stelem.ref
+		IL_01fb: ldc.i4.0
+		IL_01fc: ldelem.ref
+		IL_01fd: castclass Modules.FS_CreateWriteStream_Basic/Scope
+		IL_0202: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L22C20::__js_call__(class Modules.FS_CreateWriteStream_Basic/Scope, object, object)
+		IL_0208: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_020d: ldc.i4.1
+		IL_020e: newarr [System.Runtime]System.Object
+		IL_0213: dup
+		IL_0214: ldc.i4.0
+		IL_0215: ldloc.0
+		IL_0216: stelem.ref
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0221: ldc.i4.1
+		IL_0222: conv.r8
+		IL_0223: ldstr ""
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_022d: stloc.s 5
+		IL_022f: ldloc.s 4
+		IL_0231: ldstr "on"
+		IL_0236: ldstr "error"
+		IL_023b: ldloc.s 5
+		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0242: pop
+		IL_0243: ldloc.s 4
+		IL_0245: ldstr "write"
+		IL_024a: ldstr "hello "
+		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0254: pop
+		IL_0255: ldloc.s 4
+		IL_0257: ldstr "end"
+		IL_025c: ldstr "world"
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0266: pop
+		IL_0267: ret
 	} // end of method FS_CreateWriteStream_Basic::__js_module_init__
 
 } // end of class Modules.FS_CreateWriteStream_Basic
@@ -546,7 +518,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2457
+		// Method begins at RVA 0x23dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_Open_Callback_FileHandle.verified.txt
+++ b/tests/Js2IL.Tests/Node/FS/Snapshots/GeneratorTests.FS_Open_Callback_FileHandle.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2554
+					// Method begins at RVA 0x24c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23b8
+				// Method begins at RVA 0x2378
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x255d
+					// Method begins at RVA 0x24cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -103,9 +103,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23e0
+				// Method begins at RVA 0x23a0
 				// Header size: 12
-				// Code size: 163 (0xa3)
+				// Code size: 121 (0x79)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -116,57 +116,47 @@
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_0008: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_000d: ldstr "Cannot access 'fs' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.0
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_0020: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_0025: ldstr "Cannot access 'file' before initialization"
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_002f: stloc.1
-				IL_0030: ldloc.0
-				IL_0031: ldstr "readFileSync"
-				IL_0036: ldloc.1
-				IL_0037: ldstr "utf8"
-				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0041: stloc.1
-				IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0047: ldstr "FileText:"
-				IL_004c: ldloc.1
-				IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0052: pop
-				IL_0053: ldarg.0
-				IL_0054: ldc.i4.0
-				IL_0055: ldelem.ref
-				IL_0056: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_005b: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_0060: ldstr "Cannot access 'fs' before initialization"
-				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_006a: stloc.1
-				IL_006b: ldarg.0
-				IL_006c: ldc.i4.0
-				IL_006d: ldelem.ref
-				IL_006e: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_0073: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_0078: ldstr "Cannot access 'file' before initialization"
-				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0082: stloc.0
-				IL_0083: ldloc.1
-				IL_0084: ldstr "rmSync"
-				IL_0089: ldloc.0
-				IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_008f: dup
-				IL_0090: ldstr "force"
-				IL_0095: ldc.i4.1
-				IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00a0: pop
-				IL_00a1: ldnull
-				IL_00a2: ret
+				IL_0008: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_000d: stloc.0
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.0
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_0016: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
+				IL_001b: ldstr "readFileSync"
+				IL_0020: ldloc.0
+				IL_0021: ldstr "utf8"
+				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_002b: stloc.0
+				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0031: ldstr "FileText:"
+				IL_0036: ldloc.0
+				IL_0037: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_003c: pop
+				IL_003d: ldarg.0
+				IL_003e: ldc.i4.0
+				IL_003f: ldelem.ref
+				IL_0040: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_0045: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
+				IL_004a: stloc.0
+				IL_004b: ldarg.0
+				IL_004c: ldc.i4.0
+				IL_004d: ldelem.ref
+				IL_004e: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_0053: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_0058: stloc.1
+				IL_0059: ldloc.0
+				IL_005a: ldstr "rmSync"
+				IL_005f: ldloc.1
+				IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0065: dup
+				IL_0066: ldstr "force"
+				IL_006b: ldc.i4.1
+				IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0076: pop
+				IL_0077: ldnull
+				IL_0078: ret
 			} // end of method ArrowFunction_L20C67::__js_call__
 
 		} // end of class ArrowFunction_L20C67
@@ -189,7 +179,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2566
+					// Method begins at RVA 0x24d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,9 +204,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2490
+				// Method begins at RVA 0x2428
 				// Header size: 12
-				// Code size: 135 (0x87)
+				// Code size: 115 (0x73)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -254,29 +244,25 @@
 				IL_0035: ldelem.ref
 				IL_0036: castclass Modules.FS_Open_Callback_FileHandle/Scope
 				IL_003b: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_0040: ldstr "Cannot access 'fs' before initialization"
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_004a: stloc.s 4
-				IL_004c: ldarg.0
-				IL_004d: ldc.i4.0
-				IL_004e: ldelem.ref
-				IL_004f: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_0054: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_0059: ldstr "Cannot access 'file' before initialization"
-				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0063: stloc.s 5
-				IL_0065: ldloc.s 4
-				IL_0067: ldstr "rmSync"
-				IL_006c: ldloc.s 5
-				IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0073: dup
-				IL_0074: ldstr "force"
-				IL_0079: ldc.i4.1
-				IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0084: pop
-				IL_0085: ldnull
-				IL_0086: ret
+				IL_0040: stloc.s 4
+				IL_0042: ldarg.0
+				IL_0043: ldc.i4.0
+				IL_0044: ldelem.ref
+				IL_0045: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_004a: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_004f: stloc.s 5
+				IL_0051: ldloc.s 4
+				IL_0053: ldstr "rmSync"
+				IL_0058: ldloc.s 5
+				IL_005a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_005f: dup
+				IL_0060: ldstr "force"
+				IL_0065: ldc.i4.1
+				IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0070: pop
+				IL_0071: ldnull
+				IL_0072: ret
 			} // end of method ArrowFunction_L23C8::__js_call__
 
 		} // end of class ArrowFunction_L23C8
@@ -297,7 +283,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x254b
+					// Method begins at RVA 0x24b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -319,7 +305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2542
+				// Method begins at RVA 0x24b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -347,9 +333,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2210
+			// Method begins at RVA 0x21e4
 			// Header size: 12
-			// Code size: 412 (0x19c)
+			// Code size: 392 (0x188)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope,
@@ -370,7 +356,7 @@
 			IL_000e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0013: stloc.2
 			IL_0014: ldloc.2
-			IL_0015: brfalse IL_007f
+			IL_0015: brfalse IL_006b
 
 			IL_001a: newobj instance void Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope/Block_L12C13::.ctor()
 			IL_001f: stloc.1
@@ -383,127 +369,123 @@
 			IL_003a: pop
 			IL_003b: ldarg.0
 			IL_003c: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-			IL_0041: ldstr "Cannot access 'fs' before initialization"
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004b: stloc.3
-			IL_004c: ldarg.0
-			IL_004d: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-			IL_0052: ldstr "Cannot access 'file' before initialization"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_005c: stloc.s 4
-			IL_005e: ldloc.3
-			IL_005f: ldstr "rmSync"
-			IL_0064: ldloc.s 4
-			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_006b: dup
-			IL_006c: ldstr "force"
-			IL_0071: ldc.i4.1
-			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_007c: pop
-			IL_007d: ldnull
-			IL_007e: ret
+			IL_0041: stloc.3
+			IL_0042: ldarg.0
+			IL_0043: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+			IL_0048: stloc.s 4
+			IL_004a: ldloc.3
+			IL_004b: ldstr "rmSync"
+			IL_0050: ldloc.s 4
+			IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0057: dup
+			IL_0058: ldstr "force"
+			IL_005d: ldc.i4.1
+			IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0068: pop
+			IL_0069: ldnull
+			IL_006a: ret
 
-			IL_007f: ldloc.0
-			IL_0080: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
-			IL_0085: ldstr "fd"
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_0094: ldstr "number"
-			IL_0099: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_009e: stloc.2
-			IL_009f: ldloc.2
-			IL_00a0: box [System.Runtime]System.Boolean
-			IL_00a5: stloc.s 5
-			IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00ac: ldstr "FDIsNumber:"
-			IL_00b1: ldloc.s 5
-			IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00b8: pop
-			IL_00b9: ldloc.0
-			IL_00ba: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
-			IL_00bf: stloc.s 4
-			IL_00c1: ldloc.s 4
-			IL_00c3: ldstr "write"
-			IL_00c8: ldstr "ok"
-			IL_00cd: ldc.r8 0.0
-			IL_00d6: box [System.Runtime]System.Double
-			IL_00db: ldstr "utf8"
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_00e5: stloc.s 4
-			IL_00e7: ldnull
-			IL_00e8: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C40::__js_call__(object[], object)
-			IL_00ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00f3: ldc.i4.2
-			IL_00f4: newarr [System.Runtime]System.Object
-			IL_00f9: dup
-			IL_00fa: ldc.i4.0
-			IL_00fb: ldarg.0
-			IL_00fc: stelem.ref
-			IL_00fd: dup
-			IL_00fe: ldc.i4.1
-			IL_00ff: ldloc.0
-			IL_0100: stelem.ref
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_010b: ldc.i4.0
-			IL_010c: conv.r8
-			IL_010d: ldstr ""
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0117: stloc.3
-			IL_0118: ldloc.s 4
-			IL_011a: ldstr "then"
-			IL_011f: ldloc.3
-			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0125: stloc.3
-			IL_0126: ldnull
-			IL_0127: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67::__js_call__(object[], object)
-			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0132: ldc.i4.2
-			IL_0133: newarr [System.Runtime]System.Object
-			IL_0138: dup
-			IL_0139: ldc.i4.0
-			IL_013a: ldarg.0
-			IL_013b: stelem.ref
-			IL_013c: dup
-			IL_013d: ldc.i4.1
-			IL_013e: ldloc.0
-			IL_013f: stelem.ref
-			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_014a: ldc.i4.0
-			IL_014b: conv.r8
-			IL_014c: ldstr ""
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0156: stloc.s 4
-			IL_0158: ldnull
-			IL_0159: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8::__js_call__(object[], object, object)
-			IL_015f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0164: ldc.i4.2
-			IL_0165: newarr [System.Runtime]System.Object
-			IL_016a: dup
-			IL_016b: ldc.i4.0
-			IL_016c: ldarg.0
-			IL_016d: stelem.ref
-			IL_016e: dup
-			IL_016f: ldc.i4.1
-			IL_0170: ldloc.0
-			IL_0171: stelem.ref
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_017c: ldc.i4.1
-			IL_017d: conv.r8
-			IL_017e: ldstr ""
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0188: stloc.s 6
-			IL_018a: ldloc.3
-			IL_018b: ldstr "then"
-			IL_0190: ldloc.s 4
-			IL_0192: ldloc.s 6
-			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0199: pop
-			IL_019a: ldnull
-			IL_019b: ret
+			IL_006b: ldloc.0
+			IL_006c: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
+			IL_0071: ldstr "fd"
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0080: ldstr "number"
+			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_008a: stloc.2
+			IL_008b: ldloc.2
+			IL_008c: box [System.Runtime]System.Boolean
+			IL_0091: stloc.s 5
+			IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0098: ldstr "FDIsNumber:"
+			IL_009d: ldloc.s 5
+			IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00a4: pop
+			IL_00a5: ldloc.0
+			IL_00a6: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
+			IL_00ab: stloc.s 4
+			IL_00ad: ldloc.s 4
+			IL_00af: ldstr "write"
+			IL_00b4: ldstr "ok"
+			IL_00b9: ldc.r8 0.0
+			IL_00c2: box [System.Runtime]System.Double
+			IL_00c7: ldstr "utf8"
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00d1: stloc.s 4
+			IL_00d3: ldnull
+			IL_00d4: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C40::__js_call__(object[], object)
+			IL_00da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00df: ldc.i4.2
+			IL_00e0: newarr [System.Runtime]System.Object
+			IL_00e5: dup
+			IL_00e6: ldc.i4.0
+			IL_00e7: ldarg.0
+			IL_00e8: stelem.ref
+			IL_00e9: dup
+			IL_00ea: ldc.i4.1
+			IL_00eb: ldloc.0
+			IL_00ec: stelem.ref
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00f7: ldc.i4.0
+			IL_00f8: conv.r8
+			IL_00f9: ldstr ""
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0103: stloc.3
+			IL_0104: ldloc.s 4
+			IL_0106: ldstr "then"
+			IL_010b: ldloc.3
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0111: stloc.3
+			IL_0112: ldnull
+			IL_0113: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67::__js_call__(object[], object)
+			IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_011e: ldc.i4.2
+			IL_011f: newarr [System.Runtime]System.Object
+			IL_0124: dup
+			IL_0125: ldc.i4.0
+			IL_0126: ldarg.0
+			IL_0127: stelem.ref
+			IL_0128: dup
+			IL_0129: ldc.i4.1
+			IL_012a: ldloc.0
+			IL_012b: stelem.ref
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0136: ldc.i4.0
+			IL_0137: conv.r8
+			IL_0138: ldstr ""
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0142: stloc.s 4
+			IL_0144: ldnull
+			IL_0145: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8::__js_call__(object[], object, object)
+			IL_014b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0150: ldc.i4.2
+			IL_0151: newarr [System.Runtime]System.Object
+			IL_0156: dup
+			IL_0157: ldc.i4.0
+			IL_0158: ldarg.0
+			IL_0159: stelem.ref
+			IL_015a: dup
+			IL_015b: ldc.i4.1
+			IL_015c: ldloc.0
+			IL_015d: stelem.ref
+			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0168: ldc.i4.1
+			IL_0169: conv.r8
+			IL_016a: ldstr ""
+			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0174: stloc.s 6
+			IL_0176: ldloc.3
+			IL_0177: ldstr "then"
+			IL_017c: ldloc.s 4
+			IL_017e: ldloc.s 6
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0185: pop
+			IL_0186: ldnull
+			IL_0187: ret
 		} // end of method ArrowFunction_L11C21::__js_call__
 
 	} // end of class ArrowFunction_L11C21
@@ -523,21 +505,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2523
+			// Method begins at RVA 0x24a7
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -555,7 +531,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 433 (0x1b1)
+		// Code size: 389 (0x185)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_Open_Callback_FileHandle/Scope,
@@ -567,8 +543,7 @@
 			[6] float64,
 			[7] object,
 			[8] string,
-			[9] object,
-			[10] object
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.FS_Open_Callback_FileHandle/Scope::.ctor()
@@ -653,66 +628,56 @@
 		IL_00ef: stfld object Modules.FS_Open_Callback_FileHandle/Scope::file
 		IL_00f4: ldloc.0
 		IL_00f5: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-		IL_00fa: ldstr "Cannot access 'fs' before initialization"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0104: stloc.s 4
-		IL_0106: ldloc.0
-		IL_0107: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-		IL_010c: ldstr "Cannot access 'file' before initialization"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0116: stloc.s 9
-		IL_0118: ldloc.s 4
-		IL_011a: ldstr "rmSync"
-		IL_011f: ldloc.s 9
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0126: dup
-		IL_0127: ldstr "force"
+		IL_00fa: stloc.s 4
+		IL_00fc: ldloc.0
+		IL_00fd: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+		IL_0102: stloc.s 9
+		IL_0104: ldloc.s 4
+		IL_0106: ldstr "rmSync"
+		IL_010b: ldloc.s 9
+		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0112: dup
+		IL_0113: ldstr "force"
+		IL_0118: ldc.i4.1
+		IL_0119: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0123: pop
+		IL_0124: ldloc.0
+		IL_0125: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+		IL_012a: stloc.s 9
 		IL_012c: ldc.i4.1
-		IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0137: pop
-		IL_0138: ldloc.0
-		IL_0139: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-		IL_013e: ldstr "Cannot access 'fs' before initialization"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0148: stloc.s 9
-		IL_014a: ldloc.0
-		IL_014b: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-		IL_0150: ldstr "Cannot access 'file' before initialization"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_015a: stloc.s 4
-		IL_015c: ldc.i4.1
-		IL_015d: newarr [System.Runtime]System.Object
-		IL_0162: dup
-		IL_0163: ldc.i4.0
-		IL_0164: ldloc.0
-		IL_0165: stelem.ref
-		IL_0166: ldc.i4.0
-		IL_0167: ldelem.ref
-		IL_0168: castclass Modules.FS_Open_Callback_FileHandle/Scope
-		IL_016d: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21::__js_call__(class Modules.FS_Open_Callback_FileHandle/Scope, object, object, object)
-		IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0178: ldc.i4.1
-		IL_0179: newarr [System.Runtime]System.Object
-		IL_017e: dup
-		IL_017f: ldc.i4.0
-		IL_0180: ldloc.0
-		IL_0181: stelem.ref
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_018c: ldc.i4.2
-		IL_018d: conv.r8
-		IL_018e: ldstr ""
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0198: stloc.s 10
-		IL_019a: ldloc.s 9
-		IL_019c: ldstr "open"
-		IL_01a1: ldloc.s 4
-		IL_01a3: ldstr "w+"
-		IL_01a8: ldloc.s 10
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_01af: pop
-		IL_01b0: ret
+		IL_012d: newarr [System.Runtime]System.Object
+		IL_0132: dup
+		IL_0133: ldc.i4.0
+		IL_0134: ldloc.0
+		IL_0135: stelem.ref
+		IL_0136: ldc.i4.0
+		IL_0137: ldelem.ref
+		IL_0138: castclass Modules.FS_Open_Callback_FileHandle/Scope
+		IL_013d: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21::__js_call__(class Modules.FS_Open_Callback_FileHandle/Scope, object, object, object)
+		IL_0143: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0148: ldc.i4.1
+		IL_0149: newarr [System.Runtime]System.Object
+		IL_014e: dup
+		IL_014f: ldc.i4.0
+		IL_0150: ldloc.0
+		IL_0151: stelem.ref
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_015c: ldc.i4.2
+		IL_015d: conv.r8
+		IL_015e: ldstr ""
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0168: stloc.s 4
+		IL_016a: ldloc.0
+		IL_016b: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
+		IL_0170: ldstr "open"
+		IL_0175: ldloc.s 9
+		IL_0177: ldstr "w+"
+		IL_017c: ldloc.s 4
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0183: pop
+		IL_0184: ret
 	} // end of method FS_Open_Callback_FileHandle::__js_module_init__
 
 } // end of class Modules.FS_Open_Callback_FileHandle
@@ -724,7 +689,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x256f
+		// Method begins at RVA 0x24dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
+++ b/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27cf
+				// Method begins at RVA 0x26fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21ac
 			// Header size: 12
 			// Code size: 82 (0x52)
 			.maxstack 8
@@ -95,7 +95,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d8
+				// Method begins at RVA 0x2703
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +121,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2238
+			// Method begins at RVA 0x220c
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -162,7 +162,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27fe
+						// Method begins at RVA 0x271e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -187,7 +187,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2448
+					// Method begins at RVA 0x23e0
 					// Header size: 12
 					// Code size: 36 (0x24)
 					.maxstack 8
@@ -234,7 +234,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x2819
+								// Method begins at RVA 0x2739
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -259,7 +259,7 @@
 							.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 								01 00 02 00 00 00 00 00
 							)
-							// Method begins at RVA 0x26a4
+							// Method begins at RVA 0x2608
 							// Header size: 12
 							// Code size: 36 (0x24)
 							.maxstack 8
@@ -302,7 +302,7 @@
 								.method public hidebysig specialname rtspecialname 
 									instance void .ctor () cil managed 
 								{
-									// Method begins at RVA 0x282b
+									// Method begins at RVA 0x274b
 									// Header size: 1
 									// Code size: 8 (0x8)
 									.maxstack 8
@@ -325,7 +325,7 @@
 								.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 									01 00 00 00 00 00 00 00
 								)
-								// Method begins at RVA 0x2792
+								// Method begins at RVA 0x26de
 								// Header size: 1
 								// Code size: 18 (0x12)
 								.maxstack 8
@@ -347,7 +347,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x2822
+								// Method begins at RVA 0x2742
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -371,15 +371,14 @@
 							.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 								01 00 02 00 00 00 00 00
 							)
-							// Method begins at RVA 0x26d4
+							// Method begins at RVA 0x2638
 							// Header size: 12
-							// Code size: 178 (0xb2)
+							// Code size: 154 (0x9a)
 							.maxstack 8
 							.locals init (
 								[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/Scope,
 								[1] object,
-								[2] object,
-								[3] object
+								[2] object
 							)
 
 							IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/Scope::.ctor()
@@ -413,36 +412,28 @@
 							IL_0050: ldelem.ref
 							IL_0051: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
 							IL_0056: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-							IL_005b: ldstr "Cannot access 'agent' before initialization"
-							IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-							IL_0065: stloc.2
-							IL_0066: ldloc.2
-							IL_0067: ldstr "destroy"
-							IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-							IL_0071: pop
-							IL_0072: ldarg.0
-							IL_0073: ldc.i4.0
-							IL_0074: ldelem.ref
-							IL_0075: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-							IL_007a: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-							IL_007f: ldstr "Cannot access 'server' before initialization"
-							IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-							IL_0089: stloc.2
-							IL_008a: ldnull
-							IL_008b: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
-							IL_0091: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-							IL_0096: ldc.i4.0
-							IL_0097: conv.r8
-							IL_0098: ldstr ""
-							IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-							IL_00a2: stloc.3
-							IL_00a3: ldloc.2
-							IL_00a4: ldstr "close"
-							IL_00a9: ldloc.3
-							IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-							IL_00af: pop
-							IL_00b0: ldnull
-							IL_00b1: ret
+							IL_005b: ldstr "destroy"
+							IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+							IL_0065: pop
+							IL_0066: ldnull
+							IL_0067: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
+							IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+							IL_0072: ldc.i4.0
+							IL_0073: conv.r8
+							IL_0074: ldstr ""
+							IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+							IL_007e: stloc.2
+							IL_007f: ldarg.0
+							IL_0080: ldc.i4.0
+							IL_0081: ldelem.ref
+							IL_0082: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+							IL_0087: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
+							IL_008c: ldstr "close"
+							IL_0091: ldloc.2
+							IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+							IL_0097: pop
+							IL_0098: ldnull
+							IL_0099: ret
 						} // end of method FunctionExpression_L57C30::__js_call__
 
 					} // end of class FunctionExpression_L57C30
@@ -461,7 +452,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2810
+							// Method begins at RVA 0x2730
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -486,7 +477,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x25b0
+						// Method begins at RVA 0x2514
 						// Header size: 12
 						// Code size: 232 (0xe8)
 						.maxstack 8
@@ -617,7 +608,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2807
+						// Method begins at RVA 0x2727
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -641,9 +632,9 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2478
+					// Method begins at RVA 0x2410
 					// Header size: 12
-					// Code size: 298 (0x12a)
+					// Code size: 248 (0xf8)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/Scope,
@@ -651,8 +642,7 @@
 						[2] object,
 						[3] object,
 						[4] object,
-						[5] object,
-						[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+						[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 					)
 
 					IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/Scope::.ctor()
@@ -674,98 +664,84 @@
 					IL_002c: ldelem.ref
 					IL_002d: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
 					IL_0032: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-					IL_0037: ldstr "Cannot access 'http' before initialization"
-					IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0041: stloc.2
-					IL_0042: ldarg.0
-					IL_0043: ldc.i4.1
-					IL_0044: ldelem.ref
-					IL_0045: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-					IL_004a: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-					IL_004f: ldstr "Cannot access 'info' before initialization"
-					IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0059: stloc.3
-					IL_005a: ldloc.3
-					IL_005b: ldstr "address"
-					IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0065: stloc.3
-					IL_0066: ldarg.0
-					IL_0067: ldc.i4.1
-					IL_0068: ldelem.ref
-					IL_0069: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-					IL_006e: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-					IL_0073: ldstr "Cannot access 'info' before initialization"
-					IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_007d: stloc.s 4
-					IL_007f: ldloc.s 4
-					IL_0081: ldstr "port"
-					IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_008b: stloc.s 4
-					IL_008d: ldarg.0
-					IL_008e: ldc.i4.0
-					IL_008f: ldelem.ref
-					IL_0090: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-					IL_0095: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-					IL_009a: ldstr "Cannot access 'agent' before initialization"
-					IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_00a4: stloc.s 5
-					IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_00ab: dup
-					IL_00ac: ldstr "host"
-					IL_00b1: ldloc.3
-					IL_00b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_0037: stloc.2
+					IL_0038: ldarg.0
+					IL_0039: ldc.i4.1
+					IL_003a: ldelem.ref
+					IL_003b: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+					IL_0040: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+					IL_0045: ldstr "address"
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_004f: stloc.3
+					IL_0050: ldarg.0
+					IL_0051: ldc.i4.1
+					IL_0052: ldelem.ref
+					IL_0053: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+					IL_0058: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+					IL_005d: ldstr "port"
+					IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0067: stloc.s 4
+					IL_0069: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_006e: dup
+					IL_006f: ldstr "host"
+					IL_0074: ldloc.3
+					IL_0075: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_007a: dup
+					IL_007b: ldstr "port"
+					IL_0080: ldloc.s 4
+					IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_0087: dup
+					IL_0088: ldstr "path"
+					IL_008d: ldstr "/two"
+					IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_0097: dup
+					IL_0098: ldstr "agent"
+					IL_009d: ldarg.0
+					IL_009e: ldc.i4.0
+					IL_009f: ldelem.ref
+					IL_00a0: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+					IL_00a5: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+					IL_00aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_00af: stloc.s 5
+					IL_00b1: ldc.i4.4
+					IL_00b2: newarr [System.Runtime]System.Object
 					IL_00b7: dup
-					IL_00b8: ldstr "port"
-					IL_00bd: ldloc.s 4
-					IL_00bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00c4: dup
-					IL_00c5: ldstr "path"
-					IL_00ca: ldstr "/two"
-					IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00d4: dup
-					IL_00d5: ldstr "agent"
-					IL_00da: ldloc.s 5
-					IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00e1: stloc.s 6
-					IL_00e3: ldc.i4.4
-					IL_00e4: newarr [System.Runtime]System.Object
-					IL_00e9: dup
-					IL_00ea: ldc.i4.0
-					IL_00eb: ldarg.0
-					IL_00ec: ldc.i4.0
-					IL_00ed: ldelem.ref
-					IL_00ee: stelem.ref
-					IL_00ef: dup
-					IL_00f0: ldc.i4.1
-					IL_00f1: ldarg.0
-					IL_00f2: ldc.i4.1
-					IL_00f3: ldelem.ref
-					IL_00f4: stelem.ref
-					IL_00f5: dup
-					IL_00f6: ldc.i4.2
-					IL_00f7: ldarg.0
-					IL_00f8: ldc.i4.2
-					IL_00f9: ldelem.ref
-					IL_00fa: stelem.ref
-					IL_00fb: dup
-					IL_00fc: ldc.i4.3
-					IL_00fd: ldloc.0
-					IL_00fe: stelem.ref
-					IL_00ff: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
-					IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_010a: ldc.i4.1
-					IL_010b: conv.r8
-					IL_010c: ldstr ""
-					IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_0116: stloc.s 5
-					IL_0118: ldloc.2
-					IL_0119: ldstr "get"
-					IL_011e: ldloc.s 6
-					IL_0120: ldloc.s 5
-					IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0127: pop
-					IL_0128: ldnull
-					IL_0129: ret
+					IL_00b8: ldc.i4.0
+					IL_00b9: ldarg.0
+					IL_00ba: ldc.i4.0
+					IL_00bb: ldelem.ref
+					IL_00bc: stelem.ref
+					IL_00bd: dup
+					IL_00be: ldc.i4.1
+					IL_00bf: ldarg.0
+					IL_00c0: ldc.i4.1
+					IL_00c1: ldelem.ref
+					IL_00c2: stelem.ref
+					IL_00c3: dup
+					IL_00c4: ldc.i4.2
+					IL_00c5: ldarg.0
+					IL_00c6: ldc.i4.2
+					IL_00c7: ldelem.ref
+					IL_00c8: stelem.ref
+					IL_00c9: dup
+					IL_00ca: ldc.i4.3
+					IL_00cb: ldloc.0
+					IL_00cc: stelem.ref
+					IL_00cd: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
+					IL_00d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_00d8: ldc.i4.1
+					IL_00d9: conv.r8
+					IL_00da: ldstr ""
+					IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_00e4: stloc.s 4
+					IL_00e6: ldloc.2
+					IL_00e7: ldstr "get"
+					IL_00ec: ldloc.s 5
+					IL_00ee: ldloc.s 4
+					IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_00f5: pop
+					IL_00f6: ldnull
+					IL_00f7: ret
 				} // end of method FunctionExpression_L38C20::__js_call__
 
 			} // end of class FunctionExpression_L38C20
@@ -784,7 +760,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27f5
+					// Method begins at RVA 0x2715
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -809,7 +785,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x236c
+				// Method begins at RVA 0x2304
 				// Header size: 12
 				// Code size: 208 (0xd0)
 				.maxstack 8
@@ -923,18 +899,15 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27e1
+				// Method begins at RVA 0x270c
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -952,104 +925,85 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2264
+			// Method begins at RVA 0x2238
 			// Header size: 12
-			// Code size: 252 (0xfc)
+			// Code size: 190 (0xbe)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] object,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.1
-			IL_0017: ldloc.1
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.1
-			IL_0023: ldloc.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-			IL_002a: ldarg.0
-			IL_002b: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-			IL_0030: ldstr "Cannot access 'http' before initialization"
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_003a: stloc.1
-			IL_003b: ldloc.0
-			IL_003c: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-			IL_0041: ldstr "Cannot access 'info' before initialization"
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004b: stloc.2
-			IL_004c: ldloc.2
-			IL_004d: ldstr "address"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0057: stloc.2
-			IL_0058: ldloc.0
-			IL_0059: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-			IL_005e: ldstr "Cannot access 'info' before initialization"
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0068: stloc.3
-			IL_0069: ldloc.3
-			IL_006a: ldstr "port"
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0074: stloc.3
-			IL_0075: ldarg.0
-			IL_0076: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-			IL_007b: ldstr "Cannot access 'agent' before initialization"
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0017: ldloc.0
+			IL_0018: ldloc.1
+			IL_0019: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+			IL_001e: ldarg.0
+			IL_001f: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+			IL_0024: stloc.1
+			IL_0025: ldloc.0
+			IL_0026: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+			IL_002b: ldstr "address"
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0035: stloc.2
+			IL_0036: ldloc.0
+			IL_0037: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+			IL_003c: ldstr "port"
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0046: stloc.3
+			IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004c: dup
+			IL_004d: ldstr "host"
+			IL_0052: ldloc.2
+			IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0058: dup
+			IL_0059: ldstr "port"
+			IL_005e: ldloc.3
+			IL_005f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0064: dup
+			IL_0065: ldstr "path"
+			IL_006a: ldstr "/one"
+			IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0074: dup
+			IL_0075: ldstr "agent"
+			IL_007a: ldarg.0
+			IL_007b: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+			IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0085: stloc.s 4
-			IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_008c: dup
-			IL_008d: ldstr "host"
-			IL_0092: ldloc.2
-			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0098: dup
-			IL_0099: ldstr "port"
-			IL_009e: ldloc.3
-			IL_009f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a4: dup
-			IL_00a5: ldstr "path"
-			IL_00aa: ldstr "/one"
-			IL_00af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00b4: dup
-			IL_00b5: ldstr "agent"
-			IL_00ba: ldloc.s 4
-			IL_00bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00c1: stloc.s 5
-			IL_00c3: ldc.i4.2
-			IL_00c4: newarr [System.Runtime]System.Object
-			IL_00c9: dup
-			IL_00ca: ldc.i4.0
-			IL_00cb: ldarg.0
-			IL_00cc: stelem.ref
-			IL_00cd: dup
-			IL_00ce: ldc.i4.1
-			IL_00cf: ldloc.0
-			IL_00d0: stelem.ref
-			IL_00d1: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
-			IL_00d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00dc: ldc.i4.1
-			IL_00dd: conv.r8
-			IL_00de: ldstr ""
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00e8: stloc.s 4
-			IL_00ea: ldloc.1
-			IL_00eb: ldstr "get"
-			IL_00f0: ldloc.s 5
-			IL_00f2: ldloc.s 4
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f9: pop
-			IL_00fa: ldnull
-			IL_00fb: ret
+			IL_0087: ldc.i4.2
+			IL_0088: newarr [System.Runtime]System.Object
+			IL_008d: dup
+			IL_008e: ldc.i4.0
+			IL_008f: ldarg.0
+			IL_0090: stelem.ref
+			IL_0091: dup
+			IL_0092: ldc.i4.1
+			IL_0093: ldloc.0
+			IL_0094: stelem.ref
+			IL_0095: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
+			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00a0: ldc.i4.1
+			IL_00a1: conv.r8
+			IL_00a2: ldstr ""
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00ac: stloc.3
+			IL_00ad: ldloc.1
+			IL_00ae: ldstr "get"
+			IL_00b3: ldloc.s 4
+			IL_00b5: ldloc.3
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00bb: pop
+			IL_00bc: ldnull
+			IL_00bd: ret
 		} // end of method FunctionExpression_L19C30::__js_call__
 
 	} // end of class FunctionExpression_L19C30
@@ -1077,24 +1031,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27a5
+			// Method begins at RVA 0x26f1
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1112,7 +1057,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 379 (0x17b)
+		// Code size: 333 (0x14d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope,
@@ -1131,123 +1076,109 @@
 		IL_0014: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
 		IL_0019: ldloc.0
 		IL_001a: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-		IL_001f: ldstr "Cannot access 'http' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_001f: ldstr "Agent"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0029: stloc.1
 		IL_002a: ldloc.1
-		IL_002b: ldstr "Agent"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0035: stloc.1
-		IL_0036: ldloc.1
-		IL_0037: ldc.i4.1
-		IL_0038: newarr [System.Runtime]System.Object
-		IL_003d: dup
-		IL_003e: ldc.i4.0
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0044: dup
-		IL_0045: ldstr "keepAlive"
-		IL_004a: ldc.i4.1
-		IL_004b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0050: stelem.ref
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0056: stloc.1
-		IL_0057: ldloc.0
-		IL_0058: ldloc.1
-		IL_0059: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-		IL_005e: ldloc.0
-		IL_005f: ldc.r8 0.0
-		IL_0068: box [System.Runtime]System.Double
-		IL_006d: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
-		IL_0072: ldloc.0
-		IL_0073: ldc.r8 0.0
-		IL_007c: box [System.Runtime]System.Double
-		IL_0081: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
-		IL_0086: ldloc.0
-		IL_0087: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-		IL_008c: ldstr "Cannot access 'http' before initialization"
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0096: stloc.1
-		IL_0097: ldc.i4.1
-		IL_0098: newarr [System.Runtime]System.Object
-		IL_009d: dup
-		IL_009e: ldc.i4.0
-		IL_009f: ldloc.0
-		IL_00a0: stelem.ref
-		IL_00a1: ldc.i4.0
-		IL_00a2: ldelem.ref
-		IL_00a3: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_00a8: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
-		IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00b3: ldc.i4.2
-		IL_00b4: conv.r8
-		IL_00b5: ldstr ""
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00bf: stloc.2
-		IL_00c0: ldloc.1
-		IL_00c1: ldstr "createServer"
-		IL_00c6: ldloc.2
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00cc: stloc.2
-		IL_00cd: ldloc.0
-		IL_00ce: ldloc.2
-		IL_00cf: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-		IL_00d4: ldloc.0
-		IL_00d5: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-		IL_00da: ldstr "Cannot access 'server' before initialization"
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00e4: stloc.2
-		IL_00e5: ldc.i4.1
-		IL_00e6: newarr [System.Runtime]System.Object
-		IL_00eb: dup
-		IL_00ec: ldc.i4.0
-		IL_00ed: ldloc.0
-		IL_00ee: stelem.ref
-		IL_00ef: ldc.i4.0
-		IL_00f0: ldelem.ref
-		IL_00f1: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_00f6: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
-		IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0101: ldc.i4.0
-		IL_0102: conv.r8
-		IL_0103: ldstr ""
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_010d: stloc.1
-		IL_010e: ldloc.2
-		IL_010f: ldstr "on"
-		IL_0114: ldstr "connection"
-		IL_0119: ldloc.1
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_011f: pop
-		IL_0120: ldloc.0
-		IL_0121: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-		IL_0126: ldstr "Cannot access 'server' before initialization"
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0130: stloc.1
-		IL_0131: ldc.i4.1
-		IL_0132: newarr [System.Runtime]System.Object
-		IL_0137: dup
-		IL_0138: ldc.i4.0
-		IL_0139: ldloc.0
-		IL_013a: stelem.ref
-		IL_013b: ldc.i4.0
-		IL_013c: ldelem.ref
-		IL_013d: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_0142: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
-		IL_0148: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_014d: ldc.i4.0
-		IL_014e: conv.r8
-		IL_014f: ldstr ""
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0159: stloc.2
-		IL_015a: ldloc.1
-		IL_015b: ldstr "listen"
-		IL_0160: ldc.r8 0.0
-		IL_0169: box [System.Runtime]System.Double
-		IL_016e: ldstr "127.0.0.1"
-		IL_0173: ldloc.2
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0179: pop
-		IL_017a: ret
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0038: dup
+		IL_0039: ldstr "keepAlive"
+		IL_003e: ldc.i4.1
+		IL_003f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0044: stelem.ref
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_004a: stloc.1
+		IL_004b: ldloc.0
+		IL_004c: ldloc.1
+		IL_004d: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+		IL_0052: ldloc.0
+		IL_0053: ldc.r8 0.0
+		IL_005c: box [System.Runtime]System.Double
+		IL_0061: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
+		IL_0066: ldloc.0
+		IL_0067: ldc.r8 0.0
+		IL_0070: box [System.Runtime]System.Double
+		IL_0075: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
+		IL_007a: ldc.i4.1
+		IL_007b: newarr [System.Runtime]System.Object
+		IL_0080: dup
+		IL_0081: ldc.i4.0
+		IL_0082: ldloc.0
+		IL_0083: stelem.ref
+		IL_0084: ldc.i4.0
+		IL_0085: ldelem.ref
+		IL_0086: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+		IL_008b: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
+		IL_0091: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0096: ldc.i4.2
+		IL_0097: conv.r8
+		IL_0098: ldstr ""
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00a2: stloc.1
+		IL_00a3: ldloc.0
+		IL_00a4: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+		IL_00a9: ldstr "createServer"
+		IL_00ae: ldloc.1
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b4: stloc.1
+		IL_00b5: ldloc.0
+		IL_00b6: ldloc.1
+		IL_00b7: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
+		IL_00bc: ldc.i4.1
+		IL_00bd: newarr [System.Runtime]System.Object
+		IL_00c2: dup
+		IL_00c3: ldc.i4.0
+		IL_00c4: ldloc.0
+		IL_00c5: stelem.ref
+		IL_00c6: ldc.i4.0
+		IL_00c7: ldelem.ref
+		IL_00c8: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+		IL_00cd: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
+		IL_00d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00d8: ldc.i4.0
+		IL_00d9: conv.r8
+		IL_00da: ldstr ""
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00e4: stloc.1
+		IL_00e5: ldloc.0
+		IL_00e6: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
+		IL_00eb: ldstr "on"
+		IL_00f0: ldstr "connection"
+		IL_00f5: ldloc.1
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00fb: pop
+		IL_00fc: ldloc.0
+		IL_00fd: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
+		IL_0102: stloc.1
+		IL_0103: ldc.i4.1
+		IL_0104: newarr [System.Runtime]System.Object
+		IL_0109: dup
+		IL_010a: ldc.i4.0
+		IL_010b: ldloc.0
+		IL_010c: stelem.ref
+		IL_010d: ldc.i4.0
+		IL_010e: ldelem.ref
+		IL_010f: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+		IL_0114: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
+		IL_011a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_011f: ldc.i4.0
+		IL_0120: conv.r8
+		IL_0121: ldstr ""
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_012b: stloc.2
+		IL_012c: ldloc.1
+		IL_012d: ldstr "listen"
+		IL_0132: ldc.r8 0.0
+		IL_013b: box [System.Runtime]System.Double
+		IL_0140: ldstr "127.0.0.1"
+		IL_0145: ldloc.2
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_014b: pop
+		IL_014c: ret
 	} // end of method Http_Agent_KeepAlive_Reuses_Connection::__js_module_init__
 
 } // end of class Modules.Http_Agent_KeepAlive_Reuses_Connection
@@ -1259,7 +1190,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2834
+		// Method begins at RVA 0x2754
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
+++ b/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f4
+				// Method begins at RVA 0x24a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x20f8
 			// Header size: 12
 			// Code size: 238 (0xee)
 			.maxstack 8
@@ -147,7 +147,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x250f
+						// Method begins at RVA 0x24c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -172,7 +172,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x241c
+					// Method begins at RVA 0x23f0
 					// Header size: 12
 					// Code size: 36 (0x24)
 					.maxstack 8
@@ -215,7 +215,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2521
+							// Method begins at RVA 0x24d3
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -238,7 +238,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x24c2
+						// Method begins at RVA 0x248a
 						// Header size: 1
 						// Code size: 18 (0x12)
 						.maxstack 8
@@ -260,7 +260,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2518
+						// Method begins at RVA 0x24ca
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -284,15 +284,14 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x244c
+					// Method begins at RVA 0x2420
 					// Header size: 12
-					// Code size: 106 (0x6a)
+					// Code size: 94 (0x5e)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C77/FunctionExpression_L29C18/Scope,
 						[1] object,
-						[2] object,
-						[3] object
+						[2] object
 					)
 
 					IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C77/FunctionExpression_L29C18/Scope::.ctor()
@@ -309,29 +308,25 @@
 					IL_0023: ldloc.1
 					IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 					IL_0029: pop
-					IL_002a: ldarg.0
-					IL_002b: ldc.i4.0
-					IL_002c: ldelem.ref
-					IL_002d: castclass Modules.Http_CreateServer_Get_Loopback/Scope
-					IL_0032: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-					IL_0037: ldstr "Cannot access 'server' before initialization"
-					IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0041: stloc.2
-					IL_0042: ldnull
-					IL_0043: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C77/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
-					IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_004e: ldc.i4.0
-					IL_004f: conv.r8
-					IL_0050: ldstr ""
-					IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_005a: stloc.3
-					IL_005b: ldloc.2
-					IL_005c: ldstr "close"
-					IL_0061: ldloc.3
-					IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0067: pop
-					IL_0068: ldnull
-					IL_0069: ret
+					IL_002a: ldnull
+					IL_002b: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C77/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
+					IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0036: ldc.i4.0
+					IL_0037: conv.r8
+					IL_0038: ldstr ""
+					IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0042: stloc.2
+					IL_0043: ldarg.0
+					IL_0044: ldc.i4.0
+					IL_0045: ldelem.ref
+					IL_0046: castclass Modules.Http_CreateServer_Get_Loopback/Scope
+					IL_004b: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
+					IL_0050: ldstr "close"
+					IL_0055: ldloc.2
+					IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_005b: pop
+					IL_005c: ldnull
+					IL_005d: ret
 				} // end of method FunctionExpression_L29C18::__js_call__
 
 			} // end of class FunctionExpression_L29C18
@@ -350,7 +345,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2506
+					// Method begins at RVA 0x24b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -375,7 +370,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x231c
+				// Method begins at RVA 0x22f0
 				// Header size: 12
 				// Code size: 242 (0xf2)
 				.maxstack 8
@@ -492,7 +487,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24fd
+				// Method begins at RVA 0x24af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -518,9 +513,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x220c
+			// Method begins at RVA 0x21f4
 			// Header size: 12
-			// Code size: 259 (0x103)
+			// Code size: 237 (0xed)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/Scope,
@@ -534,89 +529,83 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldstr "server ready:"
-			IL_002a: ldloc.1
-			IL_002b: ldstr "address"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0018: stloc.1
+			IL_0019: ldstr "server ready:"
+			IL_001e: ldloc.1
+			IL_001f: ldstr "address"
+			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_002e: stloc.3
+			IL_002f: ldloc.3
+			IL_0030: ldstr ":"
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_003a: stloc.3
 			IL_003b: ldloc.3
-			IL_003c: ldstr ":"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0046: stloc.3
-			IL_0047: ldloc.3
-			IL_0048: ldloc.1
-			IL_0049: ldstr "port"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0058: ldc.r8 0.0
-			IL_0061: cgt
-			IL_0063: box [System.Runtime]System.Boolean
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006d: stloc.3
-			IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0073: ldloc.3
-			IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0079: pop
-			IL_007a: ldarg.0
-			IL_007b: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
-			IL_0080: ldstr "Cannot access 'http' before initialization"
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_008a: stloc.2
-			IL_008b: ldstr "http://"
-			IL_0090: ldloc.1
-			IL_0091: ldstr "address"
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a0: stloc.3
-			IL_00a1: ldloc.3
-			IL_00a2: ldstr ":"
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00ac: stloc.3
-			IL_00ad: ldloc.3
-			IL_00ae: ldloc.1
-			IL_00af: ldstr "port"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00be: stloc.3
-			IL_00bf: ldloc.3
-			IL_00c0: ldstr "/hello?name=js2il"
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00ca: stloc.3
-			IL_00cb: ldc.i4.2
-			IL_00cc: newarr [System.Runtime]System.Object
-			IL_00d1: dup
-			IL_00d2: ldc.i4.0
-			IL_00d3: ldarg.0
-			IL_00d4: stelem.ref
-			IL_00d5: dup
-			IL_00d6: ldc.i4.1
-			IL_00d7: ldloc.0
-			IL_00d8: stelem.ref
-			IL_00d9: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C77::__js_call__(object[], object, object)
-			IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00e4: ldc.i4.1
-			IL_00e5: conv.r8
-			IL_00e6: ldstr ""
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00f0: stloc.s 4
-			IL_00f2: ldloc.2
-			IL_00f3: ldstr "get"
-			IL_00f8: ldloc.3
-			IL_00f9: ldloc.s 4
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0100: pop
-			IL_0101: ldnull
-			IL_0102: ret
+			IL_003c: ldloc.1
+			IL_003d: ldstr "port"
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0047: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_004c: ldc.r8 0.0
+			IL_0055: cgt
+			IL_0057: box [System.Runtime]System.Boolean
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0061: stloc.3
+			IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0067: ldloc.3
+			IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_006d: pop
+			IL_006e: ldarg.0
+			IL_006f: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
+			IL_0074: stloc.2
+			IL_0075: ldstr "http://"
+			IL_007a: ldloc.1
+			IL_007b: ldstr "address"
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_008a: stloc.3
+			IL_008b: ldloc.3
+			IL_008c: ldstr ":"
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0096: stloc.3
+			IL_0097: ldloc.3
+			IL_0098: ldloc.1
+			IL_0099: ldstr "port"
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00a8: stloc.3
+			IL_00a9: ldloc.3
+			IL_00aa: ldstr "/hello?name=js2il"
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00b4: stloc.3
+			IL_00b5: ldc.i4.2
+			IL_00b6: newarr [System.Runtime]System.Object
+			IL_00bb: dup
+			IL_00bc: ldc.i4.0
+			IL_00bd: ldarg.0
+			IL_00be: stelem.ref
+			IL_00bf: dup
+			IL_00c0: ldc.i4.1
+			IL_00c1: ldloc.0
+			IL_00c2: stelem.ref
+			IL_00c3: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C77::__js_call__(object[], object, object)
+			IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00ce: ldc.i4.1
+			IL_00cf: conv.r8
+			IL_00d0: ldstr ""
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00da: stloc.s 4
+			IL_00dc: ldloc.2
+			IL_00dd: ldstr "get"
+			IL_00e2: ldloc.3
+			IL_00e3: ldloc.s 4
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ea: pop
+			IL_00eb: ldnull
+			IL_00ec: ret
 		} // end of method FunctionExpression_L15C30::__js_call__
 
 	} // end of class FunctionExpression_L15C30
@@ -637,21 +626,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24d5
+			// Method begins at RVA 0x249d
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -669,7 +652,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 178 (0xb2)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_CreateServer_Get_Loopback/Scope,
@@ -686,57 +669,51 @@
 		IL_0012: ldloc.0
 		IL_0013: ldloc.1
 		IL_0014: stfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
-		IL_001f: ldstr "Cannot access 'http' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldnull
-		IL_002b: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
-		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0036: ldc.i4.2
-		IL_0037: conv.r8
-		IL_0038: ldstr ""
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0042: stloc.2
-		IL_0043: ldloc.1
-		IL_0044: ldstr "createServer"
-		IL_0049: ldloc.2
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_004f: stloc.2
-		IL_0050: ldloc.0
-		IL_0051: ldloc.2
-		IL_0052: stfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-		IL_0057: ldloc.0
-		IL_0058: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-		IL_005d: ldstr "Cannot access 'server' before initialization"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0067: stloc.2
-		IL_0068: ldc.i4.1
-		IL_0069: newarr [System.Runtime]System.Object
-		IL_006e: dup
-		IL_006f: ldc.i4.0
-		IL_0070: ldloc.0
-		IL_0071: stelem.ref
-		IL_0072: ldc.i4.0
-		IL_0073: ldelem.ref
-		IL_0074: castclass Modules.Http_CreateServer_Get_Loopback/Scope
-		IL_0079: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
-		IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0084: ldc.i4.0
-		IL_0085: conv.r8
-		IL_0086: ldstr ""
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0090: stloc.1
-		IL_0091: ldloc.2
-		IL_0092: ldstr "listen"
-		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: ldstr "127.0.0.1"
-		IL_00aa: ldloc.1
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00b0: pop
-		IL_00b1: ret
+		IL_0019: ldnull
+		IL_001a: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
+		IL_0020: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0025: ldc.i4.2
+		IL_0026: conv.r8
+		IL_0027: ldstr ""
+		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0031: stloc.1
+		IL_0032: ldloc.0
+		IL_0033: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
+		IL_0038: ldstr "createServer"
+		IL_003d: ldloc.1
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0043: stloc.1
+		IL_0044: ldloc.0
+		IL_0045: ldloc.1
+		IL_0046: stfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
+		IL_004b: ldloc.0
+		IL_004c: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
+		IL_0051: stloc.1
+		IL_0052: ldc.i4.1
+		IL_0053: newarr [System.Runtime]System.Object
+		IL_0058: dup
+		IL_0059: ldc.i4.0
+		IL_005a: ldloc.0
+		IL_005b: stelem.ref
+		IL_005c: ldc.i4.0
+		IL_005d: ldelem.ref
+		IL_005e: castclass Modules.Http_CreateServer_Get_Loopback/Scope
+		IL_0063: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
+		IL_0069: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_006e: ldc.i4.0
+		IL_006f: conv.r8
+		IL_0070: ldstr ""
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_007a: stloc.2
+		IL_007b: ldloc.1
+		IL_007c: ldstr "listen"
+		IL_0081: ldc.r8 0.0
+		IL_008a: box [System.Runtime]System.Double
+		IL_008f: ldstr "127.0.0.1"
+		IL_0094: ldloc.2
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Http_CreateServer_Get_Loopback::__js_module_init__
 
 } // end of class Modules.Http_CreateServer_Get_Loopback
@@ -748,7 +725,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x252a
+		// Method begins at RVA 0x24dc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b9
+					// Method begins at RVA 0x266b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22fc
+				// Method begins at RVA 0x22d0
 				// Header size: 12
 				// Code size: 36 (0x24)
 				.maxstack 8
@@ -86,7 +86,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26c2
+					// Method begins at RVA 0x2674
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -110,7 +110,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x232c
+				// Method begins at RVA 0x2300
 				// Header size: 12
 				// Code size: 372 (0x174)
 				.maxstack 8
@@ -261,7 +261,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b0
+				// Method begins at RVA 0x2662
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -289,7 +289,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 177 (0xb1)
 			.maxstack 8
@@ -388,7 +388,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26dd
+						// Method begins at RVA 0x268f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -413,7 +413,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25d8
+					// Method begins at RVA 0x25ac
 					// Header size: 12
 					// Code size: 36 (0x24)
 					.maxstack 8
@@ -456,7 +456,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x26ef
+							// Method begins at RVA 0x26a1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -479,7 +479,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x267e
+						// Method begins at RVA 0x2646
 						// Header size: 1
 						// Code size: 18 (0x12)
 						.maxstack 8
@@ -501,7 +501,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26e6
+						// Method begins at RVA 0x2698
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -525,15 +525,14 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2608
+					// Method begins at RVA 0x25dc
 					// Header size: 12
-					// Code size: 106 (0x6a)
+					// Code size: 94 (0x5e)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/Scope,
 						[1] object,
-						[2] object,
-						[3] object
+						[2] object
 					)
 
 					IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/Scope::.ctor()
@@ -550,29 +549,25 @@
 					IL_0023: ldloc.1
 					IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 					IL_0029: pop
-					IL_002a: ldarg.0
-					IL_002b: ldc.i4.0
-					IL_002c: ldelem.ref
-					IL_002d: castclass Modules.Http_Request_Post_Basic/Scope
-					IL_0032: ldfld object Modules.Http_Request_Post_Basic/Scope::server
-					IL_0037: ldstr "Cannot access 'server' before initialization"
-					IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0041: stloc.2
-					IL_0042: ldnull
-					IL_0043: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
-					IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_004e: ldc.i4.0
-					IL_004f: conv.r8
-					IL_0050: ldstr ""
-					IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_005a: stloc.3
-					IL_005b: ldloc.2
-					IL_005c: ldstr "close"
-					IL_0061: ldloc.3
-					IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0067: pop
-					IL_0068: ldnull
-					IL_0069: ret
+					IL_002a: ldnull
+					IL_002b: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
+					IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0036: ldc.i4.0
+					IL_0037: conv.r8
+					IL_0038: ldstr ""
+					IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0042: stloc.2
+					IL_0043: ldarg.0
+					IL_0044: ldc.i4.0
+					IL_0045: ldelem.ref
+					IL_0046: castclass Modules.Http_Request_Post_Basic/Scope
+					IL_004b: ldfld object Modules.Http_Request_Post_Basic/Scope::server
+					IL_0050: ldstr "close"
+					IL_0055: ldloc.2
+					IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_005b: pop
+					IL_005c: ldnull
+					IL_005d: ret
 				} // end of method FunctionExpression_req_L51C20::__js_call__
 
 			} // end of class FunctionExpression_req_L51C20
@@ -592,7 +587,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26d4
+					// Method begins at RVA 0x2686
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -617,7 +612,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24ac
+				// Method begins at RVA 0x2480
 				// Header size: 12
 				// Code size: 286 (0x11e)
 				.maxstack 8
@@ -746,7 +741,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26cb
+				// Method begins at RVA 0x267d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -772,9 +767,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x21e0
+			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 272 (0x110)
+			// Code size: 250 (0xfa)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/Scope,
@@ -790,91 +785,85 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_Request_Post_Basic/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.3
 			IL_0017: ldloc.3
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.3
-			IL_0023: ldloc.3
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Http_Request_Post_Basic/Scope::http
-			IL_002b: ldstr "Cannot access 'http' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.3
-			IL_0036: ldloc.1
-			IL_0037: ldstr "address"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.s 4
-			IL_0043: ldloc.1
-			IL_0044: ldstr "port"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004e: stloc.s 5
-			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0055: dup
-			IL_0056: ldstr "host"
-			IL_005b: ldloc.s 4
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: dup
-			IL_0063: ldstr "port"
-			IL_0068: ldloc.s 5
-			IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006f: dup
-			IL_0070: ldstr "path"
-			IL_0075: ldstr "/submit"
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_007f: dup
-			IL_0080: ldstr "method"
-			IL_0085: ldstr "POST"
-			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_008f: dup
-			IL_0090: ldstr "headers"
-			IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_009a: dup
-			IL_009b: ldstr "Content-Type"
-			IL_00a0: ldstr "text/plain"
-			IL_00a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00af: stloc.s 6
-			IL_00b1: ldc.i4.2
-			IL_00b2: newarr [System.Runtime]System.Object
-			IL_00b7: dup
-			IL_00b8: ldc.i4.0
-			IL_00b9: ldarg.0
-			IL_00ba: stelem.ref
-			IL_00bb: dup
-			IL_00bc: ldc.i4.1
-			IL_00bd: ldloc.0
-			IL_00be: stelem.ref
-			IL_00bf: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
-			IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ca: ldc.i4.1
-			IL_00cb: conv.r8
-			IL_00cc: ldstr ""
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00d6: stloc.s 5
-			IL_00d8: ldloc.3
-			IL_00d9: ldstr "request"
-			IL_00de: ldloc.s 6
-			IL_00e0: ldloc.s 5
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00e7: stloc.s 5
-			IL_00e9: ldloc.s 5
-			IL_00eb: stloc.2
-			IL_00ec: ldloc.2
-			IL_00ed: ldstr "write"
-			IL_00f2: ldstr "node "
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00fc: pop
-			IL_00fd: ldloc.2
-			IL_00fe: ldstr "end"
-			IL_0103: ldstr "baseline"
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_010d: pop
-			IL_010e: ldnull
-			IL_010f: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Http_Request_Post_Basic/Scope::http
+			IL_001f: stloc.3
+			IL_0020: ldloc.1
+			IL_0021: ldstr "address"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.s 4
+			IL_002d: ldloc.1
+			IL_002e: ldstr "port"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0038: stloc.s 5
+			IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003f: dup
+			IL_0040: ldstr "host"
+			IL_0045: ldloc.s 4
+			IL_0047: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004c: dup
+			IL_004d: ldstr "port"
+			IL_0052: ldloc.s 5
+			IL_0054: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0059: dup
+			IL_005a: ldstr "path"
+			IL_005f: ldstr "/submit"
+			IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0069: dup
+			IL_006a: ldstr "method"
+			IL_006f: ldstr "POST"
+			IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0079: dup
+			IL_007a: ldstr "headers"
+			IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0084: dup
+			IL_0085: ldstr "Content-Type"
+			IL_008a: ldstr "text/plain"
+			IL_008f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0099: stloc.s 6
+			IL_009b: ldc.i4.2
+			IL_009c: newarr [System.Runtime]System.Object
+			IL_00a1: dup
+			IL_00a2: ldc.i4.0
+			IL_00a3: ldarg.0
+			IL_00a4: stelem.ref
+			IL_00a5: dup
+			IL_00a6: ldc.i4.1
+			IL_00a7: ldloc.0
+			IL_00a8: stelem.ref
+			IL_00a9: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
+			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00b4: ldc.i4.1
+			IL_00b5: conv.r8
+			IL_00b6: ldstr ""
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00c0: stloc.s 5
+			IL_00c2: ldloc.3
+			IL_00c3: ldstr "request"
+			IL_00c8: ldloc.s 6
+			IL_00ca: ldloc.s 5
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d1: stloc.s 5
+			IL_00d3: ldloc.s 5
+			IL_00d5: stloc.2
+			IL_00d6: ldloc.2
+			IL_00d7: ldstr "write"
+			IL_00dc: ldstr "node "
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e6: pop
+			IL_00e7: ldloc.2
+			IL_00e8: ldstr "end"
+			IL_00ed: ldstr "baseline"
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f7: pop
+			IL_00f8: ldnull
+			IL_00f9: ret
 		} // end of method FunctionExpression_L28C30::__js_call__
 
 	} // end of class FunctionExpression_L28C30
@@ -895,21 +884,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2691
+			// Method begins at RVA 0x2659
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Http_Request_Post_Basic/Scope::http
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Http_Request_Post_Basic/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -927,7 +910,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Request_Post_Basic/Scope,
@@ -944,65 +927,59 @@
 		IL_0012: ldloc.0
 		IL_0013: ldloc.1
 		IL_0014: stfld object Modules.Http_Request_Post_Basic/Scope::http
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.Http_Request_Post_Basic/Scope::http
-		IL_001f: ldstr "Cannot access 'http' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
-		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.i4.0
-		IL_0035: ldelem.ref
-		IL_0036: castclass Modules.Http_Request_Post_Basic/Scope
-		IL_003b: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0046: ldc.i4.2
-		IL_0047: conv.r8
-		IL_0048: ldstr ""
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldstr "createServer"
-		IL_0059: ldloc.2
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_005f: stloc.2
-		IL_0060: ldloc.0
-		IL_0061: ldloc.2
-		IL_0062: stfld object Modules.Http_Request_Post_Basic/Scope::server
-		IL_0067: ldloc.0
-		IL_0068: ldfld object Modules.Http_Request_Post_Basic/Scope::server
-		IL_006d: ldstr "Cannot access 'server' before initialization"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0077: stloc.2
-		IL_0078: ldc.i4.1
-		IL_0079: newarr [System.Runtime]System.Object
-		IL_007e: dup
-		IL_007f: ldc.i4.0
-		IL_0080: ldloc.0
-		IL_0081: stelem.ref
-		IL_0082: ldc.i4.0
-		IL_0083: ldelem.ref
-		IL_0084: castclass Modules.Http_Request_Post_Basic/Scope
-		IL_0089: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
-		IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0094: ldc.i4.0
-		IL_0095: conv.r8
-		IL_0096: ldstr ""
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00a0: stloc.1
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "listen"
-		IL_00a7: ldc.r8 0.0
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: ldstr "127.0.0.1"
-		IL_00ba: ldloc.1
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: ldc.i4.0
+		IL_0024: ldelem.ref
+		IL_0025: castclass Modules.Http_Request_Post_Basic/Scope
+		IL_002a: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0035: ldc.i4.2
+		IL_0036: conv.r8
+		IL_0037: ldstr ""
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0041: stloc.1
+		IL_0042: ldloc.0
+		IL_0043: ldfld object Modules.Http_Request_Post_Basic/Scope::http
+		IL_0048: ldstr "createServer"
+		IL_004d: ldloc.1
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0053: stloc.1
+		IL_0054: ldloc.0
+		IL_0055: ldloc.1
+		IL_0056: stfld object Modules.Http_Request_Post_Basic/Scope::server
+		IL_005b: ldloc.0
+		IL_005c: ldfld object Modules.Http_Request_Post_Basic/Scope::server
+		IL_0061: stloc.1
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.0
+		IL_006b: stelem.ref
+		IL_006c: ldc.i4.0
+		IL_006d: ldelem.ref
+		IL_006e: castclass Modules.Http_Request_Post_Basic/Scope
+		IL_0073: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
+		IL_0079: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_007e: ldc.i4.0
+		IL_007f: conv.r8
+		IL_0080: ldstr ""
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_008a: stloc.2
+		IL_008b: ldloc.1
+		IL_008c: ldstr "listen"
+		IL_0091: ldc.r8 0.0
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: ldstr "127.0.0.1"
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method Http_Request_Post_Basic::__js_module_init__
 
 } // end of class Modules.Http_Request_Post_Basic
@@ -1014,7 +991,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26f8
+		// Method begins at RVA 0x26aa
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
+++ b/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25bd
+					// Method begins at RVA 0x256f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2324
+				// Method begins at RVA 0x22f8
 				// Header size: 12
 				// Code size: 134 (0x86)
 				.maxstack 8
@@ -120,7 +120,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25c6
+					// Method begins at RVA 0x2578
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -144,7 +144,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23b8
+				// Method begins at RVA 0x238c
 				// Header size: 12
 				// Code size: 103 (0x67)
 				.maxstack 8
@@ -209,7 +209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b4
+				// Method begins at RVA 0x2566
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -237,7 +237,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 219 (0xdb)
 			.maxstack 8
@@ -347,7 +347,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25e1
+						// Method begins at RVA 0x2593
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -372,7 +372,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24dc
+					// Method begins at RVA 0x24b0
 					// Header size: 12
 					// Code size: 36 (0x24)
 					.maxstack 8
@@ -415,7 +415,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x25f3
+							// Method begins at RVA 0x25a5
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -438,7 +438,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2582
+						// Method begins at RVA 0x254a
 						// Header size: 1
 						// Code size: 18 (0x12)
 						.maxstack 8
@@ -460,7 +460,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25ea
+						// Method begins at RVA 0x259c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -484,15 +484,14 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x250c
+					// Method begins at RVA 0x24e0
 					// Header size: 12
-					// Code size: 106 (0x6a)
+					// Code size: 94 (0x5e)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/Scope,
 						[1] object,
-						[2] object,
-						[3] object
+						[2] object
 					)
 
 					IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/Scope::.ctor()
@@ -509,29 +508,25 @@
 					IL_0023: ldloc.1
 					IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 					IL_0029: pop
-					IL_002a: ldarg.0
-					IL_002b: ldc.i4.0
-					IL_002c: ldelem.ref
-					IL_002d: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-					IL_0032: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-					IL_0037: ldstr "Cannot access 'server' before initialization"
-					IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0041: stloc.2
-					IL_0042: ldnull
-					IL_0043: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
-					IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_004e: ldc.i4.0
-					IL_004f: conv.r8
-					IL_0050: ldstr ""
-					IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_005a: stloc.3
-					IL_005b: ldloc.2
-					IL_005c: ldstr "close"
-					IL_0061: ldloc.3
-					IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0067: pop
-					IL_0068: ldnull
-					IL_0069: ret
+					IL_002a: ldnull
+					IL_002b: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
+					IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0036: ldc.i4.0
+					IL_0037: conv.r8
+					IL_0038: ldstr ""
+					IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0042: stloc.2
+					IL_0043: ldarg.0
+					IL_0044: ldc.i4.0
+					IL_0045: ldelem.ref
+					IL_0046: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+					IL_004b: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
+					IL_0050: ldstr "close"
+					IL_0055: ldloc.2
+					IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_005b: pop
+					IL_005c: ldnull
+					IL_005d: ret
 				} // end of method FunctionExpression_req_L46C20::__js_call__
 
 			} // end of class FunctionExpression_req_L46C20
@@ -551,7 +546,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25d8
+					// Method begins at RVA 0x258a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -576,7 +571,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x2400
 				// Header size: 12
 				// Code size: 164 (0xa4)
 				.maxstack 8
@@ -670,7 +665,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25cf
+				// Method begins at RVA 0x2581
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -696,9 +691,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x21f0
 			// Header size: 12
-			// Code size: 272 (0x110)
+			// Code size: 250 (0xfa)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/Scope,
@@ -714,91 +709,85 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.3
 			IL_0017: ldloc.3
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.3
-			IL_0023: ldloc.3
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
-			IL_002b: ldstr "Cannot access 'http' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.3
-			IL_0036: ldloc.1
-			IL_0037: ldstr "address"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.s 4
-			IL_0043: ldloc.1
-			IL_0044: ldstr "port"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004e: stloc.s 5
-			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0055: dup
-			IL_0056: ldstr "host"
-			IL_005b: ldloc.s 4
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: dup
-			IL_0063: ldstr "port"
-			IL_0068: ldloc.s 5
-			IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006f: dup
-			IL_0070: ldstr "path"
-			IL_0075: ldstr "/stream"
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_007f: dup
-			IL_0080: ldstr "method"
-			IL_0085: ldstr "POST"
-			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_008f: dup
-			IL_0090: ldstr "headers"
-			IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_009a: dup
-			IL_009b: ldstr "Content-Type"
-			IL_00a0: ldstr "text/plain"
-			IL_00a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00af: stloc.s 6
-			IL_00b1: ldc.i4.2
-			IL_00b2: newarr [System.Runtime]System.Object
-			IL_00b7: dup
-			IL_00b8: ldc.i4.0
-			IL_00b9: ldarg.0
-			IL_00ba: stelem.ref
-			IL_00bb: dup
-			IL_00bc: ldc.i4.1
-			IL_00bd: ldloc.0
-			IL_00be: stelem.ref
-			IL_00bf: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
-			IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ca: ldc.i4.1
-			IL_00cb: conv.r8
-			IL_00cc: ldstr ""
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00d6: stloc.s 5
-			IL_00d8: ldloc.3
-			IL_00d9: ldstr "request"
-			IL_00de: ldloc.s 6
-			IL_00e0: ldloc.s 5
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00e7: stloc.s 5
-			IL_00e9: ldloc.s 5
-			IL_00eb: stloc.2
-			IL_00ec: ldloc.2
-			IL_00ed: ldstr "write"
-			IL_00f2: ldstr "alpha"
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00fc: pop
-			IL_00fd: ldloc.2
-			IL_00fe: ldstr "end"
-			IL_0103: ldstr "beta"
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_010d: pop
-			IL_010e: ldnull
-			IL_010f: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
+			IL_001f: stloc.3
+			IL_0020: ldloc.1
+			IL_0021: ldstr "address"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.s 4
+			IL_002d: ldloc.1
+			IL_002e: ldstr "port"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0038: stloc.s 5
+			IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003f: dup
+			IL_0040: ldstr "host"
+			IL_0045: ldloc.s 4
+			IL_0047: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004c: dup
+			IL_004d: ldstr "port"
+			IL_0052: ldloc.s 5
+			IL_0054: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0059: dup
+			IL_005a: ldstr "path"
+			IL_005f: ldstr "/stream"
+			IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0069: dup
+			IL_006a: ldstr "method"
+			IL_006f: ldstr "POST"
+			IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0079: dup
+			IL_007a: ldstr "headers"
+			IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0084: dup
+			IL_0085: ldstr "Content-Type"
+			IL_008a: ldstr "text/plain"
+			IL_008f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0099: stloc.s 6
+			IL_009b: ldc.i4.2
+			IL_009c: newarr [System.Runtime]System.Object
+			IL_00a1: dup
+			IL_00a2: ldc.i4.0
+			IL_00a3: ldarg.0
+			IL_00a4: stelem.ref
+			IL_00a5: dup
+			IL_00a6: ldc.i4.1
+			IL_00a7: ldloc.0
+			IL_00a8: stelem.ref
+			IL_00a9: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
+			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00b4: ldc.i4.1
+			IL_00b5: conv.r8
+			IL_00b6: ldstr ""
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00c0: stloc.s 5
+			IL_00c2: ldloc.3
+			IL_00c3: ldstr "request"
+			IL_00c8: ldloc.s 6
+			IL_00ca: ldloc.s 5
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d1: stloc.s 5
+			IL_00d3: ldloc.s 5
+			IL_00d5: stloc.2
+			IL_00d6: ldloc.2
+			IL_00d7: ldstr "write"
+			IL_00dc: ldstr "alpha"
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e6: pop
+			IL_00e7: ldloc.2
+			IL_00e8: ldstr "end"
+			IL_00ed: ldstr "beta"
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f7: pop
+			IL_00f8: ldnull
+			IL_00f9: ret
 		} // end of method FunctionExpression_L26C30::__js_call__
 
 	} // end of class FunctionExpression_L26C30
@@ -819,21 +808,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2595
+			// Method begins at RVA 0x255d
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -851,7 +834,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope,
@@ -868,65 +851,59 @@
 		IL_0012: ldloc.0
 		IL_0013: ldloc.1
 		IL_0014: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
-		IL_001f: ldstr "Cannot access 'http' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
-		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.i4.0
-		IL_0035: ldelem.ref
-		IL_0036: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-		IL_003b: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0046: ldc.i4.2
-		IL_0047: conv.r8
-		IL_0048: ldstr ""
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldstr "createServer"
-		IL_0059: ldloc.2
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_005f: stloc.2
-		IL_0060: ldloc.0
-		IL_0061: ldloc.2
-		IL_0062: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-		IL_0067: ldloc.0
-		IL_0068: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-		IL_006d: ldstr "Cannot access 'server' before initialization"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0077: stloc.2
-		IL_0078: ldc.i4.1
-		IL_0079: newarr [System.Runtime]System.Object
-		IL_007e: dup
-		IL_007f: ldc.i4.0
-		IL_0080: ldloc.0
-		IL_0081: stelem.ref
-		IL_0082: ldc.i4.0
-		IL_0083: ldelem.ref
-		IL_0084: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-		IL_0089: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
-		IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0094: ldc.i4.0
-		IL_0095: conv.r8
-		IL_0096: ldstr ""
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00a0: stloc.1
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "listen"
-		IL_00a7: ldc.r8 0.0
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: ldstr "127.0.0.1"
-		IL_00ba: ldloc.1
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: ldc.i4.0
+		IL_0024: ldelem.ref
+		IL_0025: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+		IL_002a: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0035: ldc.i4.2
+		IL_0036: conv.r8
+		IL_0037: ldstr ""
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0041: stloc.1
+		IL_0042: ldloc.0
+		IL_0043: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
+		IL_0048: ldstr "createServer"
+		IL_004d: ldloc.1
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0053: stloc.1
+		IL_0054: ldloc.0
+		IL_0055: ldloc.1
+		IL_0056: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
+		IL_005b: ldloc.0
+		IL_005c: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
+		IL_0061: stloc.1
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.0
+		IL_006b: stelem.ref
+		IL_006c: ldc.i4.0
+		IL_006d: ldelem.ref
+		IL_006e: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+		IL_0073: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
+		IL_0079: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_007e: ldc.i4.0
+		IL_007f: conv.r8
+		IL_0080: ldstr ""
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_008a: stloc.2
+		IL_008b: ldloc.1
+		IL_008c: ldstr "listen"
+		IL_0091: ldc.r8 0.0
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: ldstr "127.0.0.1"
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method Http_Request_Streaming_Chunked_RequestBody::__js_module_init__
 
 } // end of class Modules.Http_Request_Streaming_Chunked_RequestBody
@@ -938,7 +915,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25fc
+		// Method begins at RVA 0x25ae
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
+++ b/tests/Js2IL.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2460
+				// Method begins at RVA 0x2412
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x210e
+			// Method begins at RVA 0x20f8
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -89,7 +89,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x247b
+						// Method begins at RVA 0x242d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -114,7 +114,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2300
+					// Method begins at RVA 0x22d4
 					// Header size: 12
 					// Code size: 134 (0x86)
 					.maxstack 8
@@ -191,7 +191,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x248d
+							// Method begins at RVA 0x243f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x242e
+						// Method begins at RVA 0x23f6
 						// Header size: 1
 						// Code size: 18 (0x12)
 						.maxstack 8
@@ -236,7 +236,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2484
+						// Method begins at RVA 0x2436
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -260,15 +260,14 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2394
+					// Method begins at RVA 0x2368
 					// Header size: 12
-					// Code size: 142 (0x8e)
+					// Code size: 130 (0x82)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/Scope,
 						[1] object,
-						[2] object,
-						[3] object
+						[2] object
 					)
 
 					IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/Scope::.ctor()
@@ -297,29 +296,25 @@
 					IL_0047: ldloc.1
 					IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 					IL_004d: pop
-					IL_004e: ldarg.0
-					IL_004f: ldc.i4.0
-					IL_0050: ldelem.ref
-					IL_0051: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
-					IL_0056: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-					IL_005b: ldstr "Cannot access 'server' before initialization"
-					IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0065: stloc.2
-					IL_0066: ldnull
-					IL_0067: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
-					IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_0072: ldc.i4.0
-					IL_0073: conv.r8
-					IL_0074: ldstr ""
-					IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_007e: stloc.3
-					IL_007f: ldloc.2
-					IL_0080: ldstr "close"
-					IL_0085: ldloc.3
-					IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_008b: pop
-					IL_008c: ldnull
-					IL_008d: ret
+					IL_004e: ldnull
+					IL_004f: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
+					IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_005a: ldc.i4.0
+					IL_005b: conv.r8
+					IL_005c: ldstr ""
+					IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0066: stloc.2
+					IL_0067: ldarg.0
+					IL_0068: ldc.i4.0
+					IL_0069: ldelem.ref
+					IL_006a: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
+					IL_006f: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
+					IL_0074: ldstr "close"
+					IL_0079: ldloc.2
+					IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_007f: pop
+					IL_0080: ldnull
+					IL_0081: ret
 				} // end of method FunctionExpression_L32C20::__js_call__
 
 			} // end of class FunctionExpression_L32C20
@@ -340,7 +335,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2472
+					// Method begins at RVA 0x2424
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -365,7 +360,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2210
+				// Method begins at RVA 0x21e4
 				// Header size: 12
 				// Code size: 228 (0xe4)
 				.maxstack 8
@@ -476,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2469
+				// Method begins at RVA 0x241b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -502,9 +497,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x214c
+			// Method begins at RVA 0x2134
 			// Header size: 12
-			// Code size: 184 (0xb8)
+			// Code size: 162 (0xa2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/Scope,
@@ -519,67 +514,61 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
-			IL_002b: ldstr "Cannot access 'http' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.2
-			IL_0036: ldloc.1
-			IL_0037: ldstr "address"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.3
-			IL_0042: ldloc.1
-			IL_0043: ldstr "port"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 4
-			IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0054: dup
-			IL_0055: ldstr "host"
-			IL_005a: ldloc.3
-			IL_005b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0060: dup
-			IL_0061: ldstr "port"
-			IL_0066: ldloc.s 4
-			IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006d: dup
-			IL_006e: ldstr "path"
-			IL_0073: ldstr "/stream"
-			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_007d: stloc.s 5
-			IL_007f: ldc.i4.2
-			IL_0080: newarr [System.Runtime]System.Object
-			IL_0085: dup
-			IL_0086: ldc.i4.0
-			IL_0087: ldarg.0
-			IL_0088: stelem.ref
-			IL_0089: dup
-			IL_008a: ldc.i4.1
-			IL_008b: ldloc.0
-			IL_008c: stelem.ref
-			IL_008d: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
-			IL_0093: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0098: ldc.i4.1
-			IL_0099: conv.r8
-			IL_009a: ldstr ""
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00a4: stloc.s 4
-			IL_00a6: ldloc.2
-			IL_00a7: ldstr "get"
-			IL_00ac: ldloc.s 5
-			IL_00ae: ldloc.s 4
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00b5: pop
-			IL_00b6: ldnull
-			IL_00b7: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
+			IL_001f: stloc.2
+			IL_0020: ldloc.1
+			IL_0021: ldstr "address"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.3
+			IL_002c: ldloc.1
+			IL_002d: ldstr "port"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003e: dup
+			IL_003f: ldstr "host"
+			IL_0044: ldloc.3
+			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004a: dup
+			IL_004b: ldstr "port"
+			IL_0050: ldloc.s 4
+			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0057: dup
+			IL_0058: ldstr "path"
+			IL_005d: ldstr "/stream"
+			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0067: stloc.s 5
+			IL_0069: ldc.i4.2
+			IL_006a: newarr [System.Runtime]System.Object
+			IL_006f: dup
+			IL_0070: ldc.i4.0
+			IL_0071: ldarg.0
+			IL_0072: stelem.ref
+			IL_0073: dup
+			IL_0074: ldc.i4.1
+			IL_0075: ldloc.0
+			IL_0076: stelem.ref
+			IL_0077: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
+			IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0082: ldc.i4.1
+			IL_0083: conv.r8
+			IL_0084: ldstr ""
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_008e: stloc.s 4
+			IL_0090: ldloc.2
+			IL_0091: ldstr "get"
+			IL_0096: ldloc.s 5
+			IL_0098: ldloc.s 4
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_009f: pop
+			IL_00a0: ldnull
+			IL_00a1: ret
 		} // end of method FunctionExpression_L11C30::__js_call__
 
 	} // end of class FunctionExpression_L11C30
@@ -600,21 +589,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2441
+			// Method begins at RVA 0x2409
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -632,7 +615,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 178 (0xb2)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope,
@@ -649,57 +632,51 @@
 		IL_0012: ldloc.0
 		IL_0013: ldloc.1
 		IL_0014: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
-		IL_001f: ldstr "Cannot access 'http' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldnull
-		IL_002b: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
-		IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0036: ldc.i4.2
-		IL_0037: conv.r8
-		IL_0038: ldstr ""
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0042: stloc.2
-		IL_0043: ldloc.1
-		IL_0044: ldstr "createServer"
-		IL_0049: ldloc.2
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_004f: stloc.2
-		IL_0050: ldloc.0
-		IL_0051: ldloc.2
-		IL_0052: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-		IL_0057: ldloc.0
-		IL_0058: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-		IL_005d: ldstr "Cannot access 'server' before initialization"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0067: stloc.2
-		IL_0068: ldc.i4.1
-		IL_0069: newarr [System.Runtime]System.Object
-		IL_006e: dup
-		IL_006f: ldc.i4.0
-		IL_0070: ldloc.0
-		IL_0071: stelem.ref
-		IL_0072: ldc.i4.0
-		IL_0073: ldelem.ref
-		IL_0074: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
-		IL_0079: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
-		IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0084: ldc.i4.0
-		IL_0085: conv.r8
-		IL_0086: ldstr ""
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0090: stloc.1
-		IL_0091: ldloc.2
-		IL_0092: ldstr "listen"
-		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: ldstr "127.0.0.1"
-		IL_00aa: ldloc.1
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00b0: pop
-		IL_00b1: ret
+		IL_0019: ldnull
+		IL_001a: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
+		IL_0020: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0025: ldc.i4.2
+		IL_0026: conv.r8
+		IL_0027: ldstr ""
+		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0031: stloc.1
+		IL_0032: ldloc.0
+		IL_0033: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
+		IL_0038: ldstr "createServer"
+		IL_003d: ldloc.1
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0043: stloc.1
+		IL_0044: ldloc.0
+		IL_0045: ldloc.1
+		IL_0046: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
+		IL_004b: ldloc.0
+		IL_004c: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
+		IL_0051: stloc.1
+		IL_0052: ldc.i4.1
+		IL_0053: newarr [System.Runtime]System.Object
+		IL_0058: dup
+		IL_0059: ldc.i4.0
+		IL_005a: ldloc.0
+		IL_005b: stelem.ref
+		IL_005c: ldc.i4.0
+		IL_005d: ldelem.ref
+		IL_005e: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
+		IL_0063: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
+		IL_0069: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_006e: ldc.i4.0
+		IL_006f: conv.r8
+		IL_0070: ldstr ""
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_007a: stloc.2
+		IL_007b: ldloc.1
+		IL_007c: ldstr "listen"
+		IL_0081: ldc.r8 0.0
+		IL_008a: box [System.Runtime]System.Double
+		IL_008f: ldstr "127.0.0.1"
+		IL_0094: ldloc.2
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Http_Response_Streaming_Chunked_ResponseBody::__js_module_init__
 
 } // end of class Modules.Http_Response_Streaming_Chunked_ResponseBody
@@ -711,7 +688,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2496
+		// Method begins at RVA 0x2448
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
+++ b/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x253a
+				// Method begins at RVA 0x24ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ec
+			// Method begins at RVA 0x21d8
 			// Header size: 12
 			// Code size: 127 (0x7f)
 			.maxstack 8
@@ -128,7 +128,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2555
+						// Method begins at RVA 0x2507
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -153,7 +153,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x244c
+					// Method begins at RVA 0x2420
 					// Header size: 12
 					// Code size: 36 (0x24)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2567
+							// Method begins at RVA 0x2519
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -219,7 +219,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2508
+						// Method begins at RVA 0x24d0
 						// Header size: 1
 						// Code size: 18 (0x12)
 						.maxstack 8
@@ -241,7 +241,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x255e
+						// Method begins at RVA 0x2510
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -265,15 +265,14 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x247c
+					// Method begins at RVA 0x2450
 					// Header size: 12
-					// Code size: 128 (0x80)
+					// Code size: 116 (0x74)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/Scope,
 						[1] object,
-						[2] object,
-						[3] object
+						[2] object
 					)
 
 					IL_0000: newobj instance void Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/Scope::.ctor()
@@ -290,39 +289,35 @@
 					IL_0023: ldloc.1
 					IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 					IL_0029: pop
-					IL_002a: ldarg.0
-					IL_002b: ldc.i4.0
-					IL_002c: ldelem.ref
-					IL_002d: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
-					IL_0032: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-					IL_0037: ldstr "Cannot access 'server' before initialization"
-					IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0041: stloc.2
-					IL_0042: ldnull
-					IL_0043: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/ArrowFunction_L30C22::__js_call__(object)
-					IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_004e: ldc.i4.1
-					IL_004f: newarr [System.Runtime]System.Object
-					IL_0054: dup
-					IL_0055: ldc.i4.0
-					IL_0056: ldarg.0
-					IL_0057: ldc.i4.0
-					IL_0058: ldelem.ref
-					IL_0059: stelem.ref
-					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0064: ldc.i4.0
-					IL_0065: conv.r8
-					IL_0066: ldstr ""
-					IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_0070: stloc.3
-					IL_0071: ldloc.2
-					IL_0072: ldstr "close"
-					IL_0077: ldloc.3
-					IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_007d: pop
-					IL_007e: ldnull
-					IL_007f: ret
+					IL_002a: ldnull
+					IL_002b: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/ArrowFunction_L30C22::__js_call__(object)
+					IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0036: ldc.i4.1
+					IL_0037: newarr [System.Runtime]System.Object
+					IL_003c: dup
+					IL_003d: ldc.i4.0
+					IL_003e: ldarg.0
+					IL_003f: ldc.i4.0
+					IL_0040: ldelem.ref
+					IL_0041: stelem.ref
+					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_004c: ldc.i4.0
+					IL_004d: conv.r8
+					IL_004e: ldstr ""
+					IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0058: stloc.2
+					IL_0059: ldarg.0
+					IL_005a: ldc.i4.0
+					IL_005b: ldelem.ref
+					IL_005c: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
+					IL_0061: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
+					IL_0066: ldstr "close"
+					IL_006b: ldloc.2
+					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0071: pop
+					IL_0072: ldnull
+					IL_0073: ret
 				} // end of method ArrowFunction_L28C21::__js_call__
 
 			} // end of class ArrowFunction_L28C21
@@ -342,7 +337,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x254c
+					// Method begins at RVA 0x24fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -367,7 +362,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2364
+				// Method begins at RVA 0x2338
 				// Header size: 12
 				// Code size: 220 (0xdc)
 				.maxstack 8
@@ -478,7 +473,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2543
+				// Method begins at RVA 0x24f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -504,9 +499,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2278
+			// Method begins at RVA 0x2264
 			// Header size: 12
-			// Code size: 222 (0xde)
+			// Code size: 200 (0xc8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/Scope,
@@ -521,79 +516,73 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldstr "listening:"
-			IL_002a: ldloc.1
-			IL_002b: ldstr "address"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0018: stloc.1
+			IL_0019: ldstr "listening:"
+			IL_001e: ldloc.1
+			IL_001f: ldstr "address"
+			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_002e: stloc.3
+			IL_002f: ldloc.3
+			IL_0030: ldstr ":ready"
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_003a: stloc.3
-			IL_003b: ldloc.3
-			IL_003c: ldstr ":ready"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0046: stloc.3
-			IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_004c: ldloc.3
-			IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0052: pop
-			IL_0053: ldarg.0
-			IL_0054: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
-			IL_0059: ldstr "Cannot access 'https' before initialization"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0063: stloc.2
-			IL_0064: ldstr "https://127.0.0.1:"
-			IL_0069: ldloc.1
-			IL_006a: ldstr "port"
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0079: stloc.3
-			IL_007a: ldloc.3
-			IL_007b: ldstr "/hello?x=1"
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0085: stloc.3
-			IL_0086: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_008b: dup
-			IL_008c: ldstr "rejectUnauthorized"
-			IL_0091: ldc.i4.0
-			IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0097: stloc.s 4
-			IL_0099: ldnull
-			IL_009a: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5::__js_call__(object[], object, object)
-			IL_00a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00a5: ldc.i4.2
-			IL_00a6: newarr [System.Runtime]System.Object
-			IL_00ab: dup
-			IL_00ac: ldc.i4.0
-			IL_00ad: ldarg.0
-			IL_00ae: stelem.ref
-			IL_00af: dup
-			IL_00b0: ldc.i4.1
-			IL_00b1: ldloc.0
-			IL_00b2: stelem.ref
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00bd: ldc.i4.1
-			IL_00be: conv.r8
-			IL_00bf: ldstr ""
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00c9: stloc.s 5
-			IL_00cb: ldloc.2
-			IL_00cc: ldstr "get"
-			IL_00d1: ldloc.3
-			IL_00d2: ldloc.s 4
-			IL_00d4: ldloc.s 5
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_00db: pop
-			IL_00dc: ldnull
-			IL_00dd: ret
+			IL_003b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0040: ldloc.3
+			IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0046: pop
+			IL_0047: ldarg.0
+			IL_0048: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
+			IL_004d: stloc.2
+			IL_004e: ldstr "https://127.0.0.1:"
+			IL_0053: ldloc.1
+			IL_0054: ldstr "port"
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0063: stloc.3
+			IL_0064: ldloc.3
+			IL_0065: ldstr "/hello?x=1"
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_006f: stloc.3
+			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0075: dup
+			IL_0076: ldstr "rejectUnauthorized"
+			IL_007b: ldc.i4.0
+			IL_007c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0081: stloc.s 4
+			IL_0083: ldnull
+			IL_0084: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5::__js_call__(object[], object, object)
+			IL_008a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_008f: ldc.i4.2
+			IL_0090: newarr [System.Runtime]System.Object
+			IL_0095: dup
+			IL_0096: ldc.i4.0
+			IL_0097: ldarg.0
+			IL_0098: stelem.ref
+			IL_0099: dup
+			IL_009a: ldc.i4.1
+			IL_009b: ldloc.0
+			IL_009c: stelem.ref
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00a7: ldc.i4.1
+			IL_00a8: conv.r8
+			IL_00a9: ldstr ""
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00b3: stloc.s 5
+			IL_00b5: ldloc.2
+			IL_00b6: ldstr "get"
+			IL_00bb: ldloc.3
+			IL_00bc: ldloc.s 4
+			IL_00be: ldloc.s 5
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00c5: pop
+			IL_00c6: ldnull
+			IL_00c7: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -614,21 +603,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x251b
+			// Method begins at RVA 0x24e3
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -646,7 +629,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 326 (0x146)
+		// Code size: 306 (0x132)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Https_Get_Loopback_SelfSigned/Scope,
@@ -692,82 +675,78 @@
 		IL_005d: stloc.2
 		IL_005e: ldloc.0
 		IL_005f: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
-		IL_0064: ldstr "Cannot access 'https' before initialization"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_006e: stloc.3
-		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0074: dup
-		IL_0075: ldstr "key"
-		IL_007a: ldloc.2
-		IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0080: dup
-		IL_0081: ldstr "cert"
-		IL_0086: ldloc.1
-		IL_0087: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_008c: stloc.s 4
-		IL_008e: ldnull
-		IL_008f: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L6C67::__js_call__(object, object, object)
-		IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_009a: ldc.i4.1
-		IL_009b: newarr [System.Runtime]System.Object
-		IL_00a0: dup
-		IL_00a1: ldc.i4.0
-		IL_00a2: ldloc.0
-		IL_00a3: stelem.ref
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00ae: ldc.i4.2
-		IL_00af: conv.r8
-		IL_00b0: ldstr ""
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00ba: stloc.s 5
-		IL_00bc: ldloc.3
-		IL_00bd: ldstr "createServer"
-		IL_00c2: ldloc.s 4
+		IL_0064: stloc.3
+		IL_0065: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_006a: dup
+		IL_006b: ldstr "key"
+		IL_0070: ldloc.2
+		IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0076: dup
+		IL_0077: ldstr "cert"
+		IL_007c: ldloc.1
+		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0082: stloc.s 4
+		IL_0084: ldnull
+		IL_0085: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L6C67::__js_call__(object, object, object)
+		IL_008b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0090: ldc.i4.1
+		IL_0091: newarr [System.Runtime]System.Object
+		IL_0096: dup
+		IL_0097: ldc.i4.0
+		IL_0098: ldloc.0
+		IL_0099: stelem.ref
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00a4: ldc.i4.2
+		IL_00a5: conv.r8
+		IL_00a6: ldstr ""
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00b0: stloc.s 5
+		IL_00b2: ldloc.3
+		IL_00b3: ldstr "createServer"
+		IL_00b8: ldloc.s 4
+		IL_00ba: ldloc.s 5
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00c1: stloc.s 5
+		IL_00c3: ldloc.0
 		IL_00c4: ldloc.s 5
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.0
-		IL_00ce: ldloc.s 5
-		IL_00d0: stfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-		IL_00d5: ldloc.0
-		IL_00d6: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-		IL_00db: ldstr "Cannot access 'server' before initialization"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00e5: stloc.s 5
-		IL_00e7: ldc.i4.1
-		IL_00e8: newarr [System.Runtime]System.Object
-		IL_00ed: dup
-		IL_00ee: ldc.i4.0
-		IL_00ef: ldloc.0
-		IL_00f0: stelem.ref
-		IL_00f1: ldc.i4.0
-		IL_00f2: ldelem.ref
-		IL_00f3: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
-		IL_00f8: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31::__js_call__(class Modules.Https_Get_Loopback_SelfSigned/Scope, object)
-		IL_00fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0103: ldc.i4.1
-		IL_0104: newarr [System.Runtime]System.Object
-		IL_0109: dup
-		IL_010a: ldc.i4.0
-		IL_010b: ldloc.0
-		IL_010c: stelem.ref
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0117: ldc.i4.0
-		IL_0118: conv.r8
-		IL_0119: ldstr ""
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0123: stloc.3
-		IL_0124: ldloc.s 5
-		IL_0126: ldstr "listen"
-		IL_012b: ldc.r8 0.0
-		IL_0134: box [System.Runtime]System.Double
-		IL_0139: ldstr "127.0.0.1"
-		IL_013e: ldloc.3
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0144: pop
-		IL_0145: ret
+		IL_00c6: stfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
+		IL_00cb: ldloc.0
+		IL_00cc: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
+		IL_00d1: stloc.s 5
+		IL_00d3: ldc.i4.1
+		IL_00d4: newarr [System.Runtime]System.Object
+		IL_00d9: dup
+		IL_00da: ldc.i4.0
+		IL_00db: ldloc.0
+		IL_00dc: stelem.ref
+		IL_00dd: ldc.i4.0
+		IL_00de: ldelem.ref
+		IL_00df: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
+		IL_00e4: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31::__js_call__(class Modules.Https_Get_Loopback_SelfSigned/Scope, object)
+		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ef: ldc.i4.1
+		IL_00f0: newarr [System.Runtime]System.Object
+		IL_00f5: dup
+		IL_00f6: ldc.i4.0
+		IL_00f7: ldloc.0
+		IL_00f8: stelem.ref
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0103: ldc.i4.0
+		IL_0104: conv.r8
+		IL_0105: ldstr ""
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_010f: stloc.3
+		IL_0110: ldloc.s 5
+		IL_0112: ldstr "listen"
+		IL_0117: ldc.r8 0.0
+		IL_0120: box [System.Runtime]System.Double
+		IL_0125: ldstr "127.0.0.1"
+		IL_012a: ldloc.3
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0130: pop
+		IL_0131: ret
 	} // end of method Https_Get_Loopback_SelfSigned::__js_module_init__
 
 } // end of class Modules.Https_Get_Loopback_SelfSigned
@@ -783,7 +762,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2570
+			// Method begins at RVA 0x2522
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -807,7 +786,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21a4
+		// Method begins at RVA 0x2190
 		// Header size: 12
 		// Code size: 59 (0x3b)
 		.maxstack 8
@@ -846,7 +825,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2579
+		// Method begins at RVA 0x252b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b3
+					// Method begins at RVA 0x2669
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23c8
+				// Method begins at RVA 0x23a0
 				// Header size: 12
 				// Code size: 36 (0x24)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26bc
+					// Method begins at RVA 0x2672
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -117,7 +117,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23f8
+				// Method begins at RVA 0x23d0
 				// Header size: 12
 				// Code size: 207 (0xcf)
 				.maxstack 8
@@ -219,7 +219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26aa
+				// Method begins at RVA 0x2660
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -247,7 +247,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x21fc
+			// Method begins at RVA 0x21e8
 			// Header size: 12
 			// Code size: 199 (0xc7)
 			.maxstack 8
@@ -359,7 +359,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26d7
+						// Method begins at RVA 0x268d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -384,7 +384,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25bc
+					// Method begins at RVA 0x2594
 					// Header size: 12
 					// Code size: 36 (0x24)
 					.maxstack 8
@@ -427,7 +427,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x26e9
+							// Method begins at RVA 0x269f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -450,7 +450,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2678
+						// Method begins at RVA 0x2644
 						// Header size: 1
 						// Code size: 18 (0x12)
 						.maxstack 8
@@ -472,7 +472,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26e0
+						// Method begins at RVA 0x2696
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -496,15 +496,14 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25ec
+					// Method begins at RVA 0x25c4
 					// Header size: 12
-					// Code size: 128 (0x80)
+					// Code size: 116 (0x74)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/Scope,
 						[1] object,
-						[2] object,
-						[3] object
+						[2] object
 					)
 
 					IL_0000: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/Scope::.ctor()
@@ -521,39 +520,35 @@
 					IL_0023: ldloc.1
 					IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 					IL_0029: pop
-					IL_002a: ldarg.0
-					IL_002b: ldc.i4.0
-					IL_002c: ldelem.ref
-					IL_002d: castclass Modules.Https_Request_Post_Basic/Scope
-					IL_0032: ldfld object Modules.Https_Request_Post_Basic/Scope::server
-					IL_0037: ldstr "Cannot access 'server' before initialization"
-					IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0041: stloc.2
-					IL_0042: ldnull
-					IL_0043: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/ArrowFunction_L41C22::__js_call__(object)
-					IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_004e: ldc.i4.1
-					IL_004f: newarr [System.Runtime]System.Object
-					IL_0054: dup
-					IL_0055: ldc.i4.0
-					IL_0056: ldarg.0
-					IL_0057: ldc.i4.0
-					IL_0058: ldelem.ref
-					IL_0059: stelem.ref
-					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0064: ldc.i4.0
-					IL_0065: conv.r8
-					IL_0066: ldstr ""
-					IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_0070: stloc.3
-					IL_0071: ldloc.2
-					IL_0072: ldstr "close"
-					IL_0077: ldloc.3
-					IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_007d: pop
-					IL_007e: ldnull
-					IL_007f: ret
+					IL_002a: ldnull
+					IL_002b: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/ArrowFunction_L41C22::__js_call__(object)
+					IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0036: ldc.i4.1
+					IL_0037: newarr [System.Runtime]System.Object
+					IL_003c: dup
+					IL_003d: ldc.i4.0
+					IL_003e: ldarg.0
+					IL_003f: ldc.i4.0
+					IL_0040: ldelem.ref
+					IL_0041: stelem.ref
+					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_004c: ldc.i4.0
+					IL_004d: conv.r8
+					IL_004e: ldstr ""
+					IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0058: stloc.2
+					IL_0059: ldarg.0
+					IL_005a: ldc.i4.0
+					IL_005b: ldelem.ref
+					IL_005c: castclass Modules.Https_Request_Post_Basic/Scope
+					IL_0061: ldfld object Modules.Https_Request_Post_Basic/Scope::server
+					IL_0066: ldstr "close"
+					IL_006b: ldloc.2
+					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0071: pop
+					IL_0072: ldnull
+					IL_0073: ret
 				} // end of method ArrowFunction_L39C21::__js_call__
 
 			} // end of class ArrowFunction_L39C21
@@ -573,7 +568,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26ce
+					// Method begins at RVA 0x2684
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -598,7 +593,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24d4
+				// Method begins at RVA 0x24ac
 				// Header size: 12
 				// Code size: 220 (0xdc)
 				.maxstack 8
@@ -709,7 +704,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c5
+				// Method begins at RVA 0x267b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -735,9 +730,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22bc
 			// Header size: 12
-			// Code size: 236 (0xec)
+			// Code size: 214 (0xd6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/Scope,
@@ -752,81 +747,75 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Https_Request_Post_Basic/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.3
 			IL_0017: ldloc.3
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.3
-			IL_0023: ldloc.3
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Https_Request_Post_Basic/Scope::https
-			IL_002b: ldstr "Cannot access 'https' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.3
-			IL_0036: ldloc.1
-			IL_0037: ldstr "port"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.s 4
-			IL_0043: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0048: dup
-			IL_0049: ldstr "host"
-			IL_004e: ldstr "127.0.0.1"
-			IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0058: dup
-			IL_0059: ldstr "port"
-			IL_005e: ldloc.s 4
-			IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0065: dup
-			IL_0066: ldstr "method"
-			IL_006b: ldstr "POST"
-			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0075: dup
-			IL_0076: ldstr "path"
-			IL_007b: ldstr "/submit"
-			IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0085: dup
-			IL_0086: ldstr "rejectUnauthorized"
-			IL_008b: ldc.i4.0
-			IL_008c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0091: stloc.s 5
-			IL_0093: ldnull
-			IL_0094: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5::__js_call__(object[], object, object)
-			IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_009f: ldc.i4.2
-			IL_00a0: newarr [System.Runtime]System.Object
-			IL_00a5: dup
-			IL_00a6: ldc.i4.0
-			IL_00a7: ldarg.0
-			IL_00a8: stelem.ref
-			IL_00a9: dup
-			IL_00aa: ldc.i4.1
-			IL_00ab: ldloc.0
-			IL_00ac: stelem.ref
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00b7: ldc.i4.1
-			IL_00b8: conv.r8
-			IL_00b9: ldstr ""
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00c3: stloc.s 4
-			IL_00c5: ldloc.3
-			IL_00c6: ldstr "request"
-			IL_00cb: ldloc.s 5
-			IL_00cd: ldloc.s 4
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00d4: stloc.s 4
-			IL_00d6: ldloc.s 4
-			IL_00d8: stloc.2
-			IL_00d9: ldloc.2
-			IL_00da: ldstr "end"
-			IL_00df: ldstr "hello tls"
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00e9: pop
-			IL_00ea: ldnull
-			IL_00eb: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Https_Request_Post_Basic/Scope::https
+			IL_001f: stloc.3
+			IL_0020: ldloc.1
+			IL_0021: ldstr "port"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.s 4
+			IL_002d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0032: dup
+			IL_0033: ldstr "host"
+			IL_0038: ldstr "127.0.0.1"
+			IL_003d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0042: dup
+			IL_0043: ldstr "port"
+			IL_0048: ldloc.s 4
+			IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004f: dup
+			IL_0050: ldstr "method"
+			IL_0055: ldstr "POST"
+			IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005f: dup
+			IL_0060: ldstr "path"
+			IL_0065: ldstr "/submit"
+			IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_006f: dup
+			IL_0070: ldstr "rejectUnauthorized"
+			IL_0075: ldc.i4.0
+			IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_007b: stloc.s 5
+			IL_007d: ldnull
+			IL_007e: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5::__js_call__(object[], object, object)
+			IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0089: ldc.i4.2
+			IL_008a: newarr [System.Runtime]System.Object
+			IL_008f: dup
+			IL_0090: ldc.i4.0
+			IL_0091: ldarg.0
+			IL_0092: stelem.ref
+			IL_0093: dup
+			IL_0094: ldc.i4.1
+			IL_0095: ldloc.0
+			IL_0096: stelem.ref
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00a1: ldc.i4.1
+			IL_00a2: conv.r8
+			IL_00a3: ldstr ""
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00ad: stloc.s 4
+			IL_00af: ldloc.3
+			IL_00b0: ldstr "request"
+			IL_00b5: ldloc.s 5
+			IL_00b7: ldloc.s 4
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00be: stloc.s 4
+			IL_00c0: ldloc.s 4
+			IL_00c2: stloc.2
+			IL_00c3: ldloc.2
+			IL_00c4: ldstr "end"
+			IL_00c9: ldstr "hello tls"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d3: pop
+			IL_00d4: ldnull
+			IL_00d5: ret
 		} // end of method ArrowFunction_L21C31::__js_call__
 
 	} // end of class ArrowFunction_L21C31
@@ -847,21 +836,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x268b
+			// Method begins at RVA 0x2657
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Https_Request_Post_Basic/Scope::https
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Https_Request_Post_Basic/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -879,7 +862,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 342 (0x156)
+		// Code size: 322 (0x142)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Https_Request_Post_Basic/Scope,
@@ -925,90 +908,86 @@
 		IL_005d: stloc.2
 		IL_005e: ldloc.0
 		IL_005f: ldfld object Modules.Https_Request_Post_Basic/Scope::https
-		IL_0064: ldstr "Cannot access 'https' before initialization"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_006e: stloc.3
-		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0074: dup
-		IL_0075: ldstr "key"
-		IL_007a: ldloc.2
-		IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0080: dup
-		IL_0081: ldstr "cert"
-		IL_0086: ldloc.1
-		IL_0087: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_008c: stloc.s 4
-		IL_008e: ldc.i4.1
-		IL_008f: newarr [System.Runtime]System.Object
-		IL_0094: dup
-		IL_0095: ldc.i4.0
-		IL_0096: ldloc.0
-		IL_0097: stelem.ref
-		IL_0098: ldc.i4.0
-		IL_0099: ldelem.ref
-		IL_009a: castclass Modules.Https_Request_Post_Basic/Scope
-		IL_009f: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67::__js_call__(class Modules.Https_Request_Post_Basic/Scope, object, object, object)
-		IL_00a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00aa: ldc.i4.1
-		IL_00ab: newarr [System.Runtime]System.Object
-		IL_00b0: dup
-		IL_00b1: ldc.i4.0
-		IL_00b2: ldloc.0
-		IL_00b3: stelem.ref
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00be: ldc.i4.2
-		IL_00bf: conv.r8
-		IL_00c0: ldstr ""
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00ca: stloc.s 5
-		IL_00cc: ldloc.3
-		IL_00cd: ldstr "createServer"
-		IL_00d2: ldloc.s 4
+		IL_0064: stloc.3
+		IL_0065: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_006a: dup
+		IL_006b: ldstr "key"
+		IL_0070: ldloc.2
+		IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0076: dup
+		IL_0077: ldstr "cert"
+		IL_007c: ldloc.1
+		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0082: stloc.s 4
+		IL_0084: ldc.i4.1
+		IL_0085: newarr [System.Runtime]System.Object
+		IL_008a: dup
+		IL_008b: ldc.i4.0
+		IL_008c: ldloc.0
+		IL_008d: stelem.ref
+		IL_008e: ldc.i4.0
+		IL_008f: ldelem.ref
+		IL_0090: castclass Modules.Https_Request_Post_Basic/Scope
+		IL_0095: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67::__js_call__(class Modules.Https_Request_Post_Basic/Scope, object, object, object)
+		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00a0: ldc.i4.1
+		IL_00a1: newarr [System.Runtime]System.Object
+		IL_00a6: dup
+		IL_00a7: ldc.i4.0
+		IL_00a8: ldloc.0
+		IL_00a9: stelem.ref
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00b4: ldc.i4.2
+		IL_00b5: conv.r8
+		IL_00b6: ldstr ""
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00c0: stloc.s 5
+		IL_00c2: ldloc.3
+		IL_00c3: ldstr "createServer"
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldloc.s 5
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00d1: stloc.s 5
+		IL_00d3: ldloc.0
 		IL_00d4: ldloc.s 5
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00db: stloc.s 5
-		IL_00dd: ldloc.0
-		IL_00de: ldloc.s 5
-		IL_00e0: stfld object Modules.Https_Request_Post_Basic/Scope::server
-		IL_00e5: ldloc.0
-		IL_00e6: ldfld object Modules.Https_Request_Post_Basic/Scope::server
-		IL_00eb: ldstr "Cannot access 'server' before initialization"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00f5: stloc.s 5
-		IL_00f7: ldc.i4.1
-		IL_00f8: newarr [System.Runtime]System.Object
-		IL_00fd: dup
-		IL_00fe: ldc.i4.0
-		IL_00ff: ldloc.0
-		IL_0100: stelem.ref
-		IL_0101: ldc.i4.0
-		IL_0102: ldelem.ref
-		IL_0103: castclass Modules.Https_Request_Post_Basic/Scope
-		IL_0108: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31::__js_call__(class Modules.Https_Request_Post_Basic/Scope, object)
-		IL_010e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0113: ldc.i4.1
-		IL_0114: newarr [System.Runtime]System.Object
-		IL_0119: dup
-		IL_011a: ldc.i4.0
-		IL_011b: ldloc.0
-		IL_011c: stelem.ref
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0127: ldc.i4.0
-		IL_0128: conv.r8
-		IL_0129: ldstr ""
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0133: stloc.3
-		IL_0134: ldloc.s 5
-		IL_0136: ldstr "listen"
-		IL_013b: ldc.r8 0.0
-		IL_0144: box [System.Runtime]System.Double
-		IL_0149: ldstr "127.0.0.1"
-		IL_014e: ldloc.3
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0154: pop
-		IL_0155: ret
+		IL_00d6: stfld object Modules.Https_Request_Post_Basic/Scope::server
+		IL_00db: ldloc.0
+		IL_00dc: ldfld object Modules.Https_Request_Post_Basic/Scope::server
+		IL_00e1: stloc.s 5
+		IL_00e3: ldc.i4.1
+		IL_00e4: newarr [System.Runtime]System.Object
+		IL_00e9: dup
+		IL_00ea: ldc.i4.0
+		IL_00eb: ldloc.0
+		IL_00ec: stelem.ref
+		IL_00ed: ldc.i4.0
+		IL_00ee: ldelem.ref
+		IL_00ef: castclass Modules.Https_Request_Post_Basic/Scope
+		IL_00f4: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31::__js_call__(class Modules.Https_Request_Post_Basic/Scope, object)
+		IL_00fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ff: ldc.i4.1
+		IL_0100: newarr [System.Runtime]System.Object
+		IL_0105: dup
+		IL_0106: ldc.i4.0
+		IL_0107: ldloc.0
+		IL_0108: stelem.ref
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0113: ldc.i4.0
+		IL_0114: conv.r8
+		IL_0115: ldstr ""
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_011f: stloc.3
+		IL_0120: ldloc.s 5
+		IL_0122: ldstr "listen"
+		IL_0127: ldc.r8 0.0
+		IL_0130: box [System.Runtime]System.Double
+		IL_0135: ldstr "127.0.0.1"
+		IL_013a: ldloc.3
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0140: pop
+		IL_0141: ret
 	} // end of method Https_Request_Post_Basic::__js_module_init__
 
 } // end of class Modules.Https_Request_Post_Basic
@@ -1024,7 +1003,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26f2
+			// Method begins at RVA 0x26a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1048,7 +1027,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21b4
+		// Method begins at RVA 0x21a0
 		// Header size: 12
 		// Code size: 59 (0x3b)
 		.maxstack 8
@@ -1087,7 +1066,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26fb
+		// Method begins at RVA 0x26b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
+++ b/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e5
+				// Method begins at RVA 0x2580
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x2218
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -134,7 +134,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2600
+						// Method begins at RVA 0x259b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -159,7 +159,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24ec
+					// Method begins at RVA 0x24b4
 					// Header size: 12
 					// Code size: 36 (0x24)
 					.maxstack 8
@@ -202,7 +202,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2612
+							// Method begins at RVA 0x25ad
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -225,7 +225,7 @@
 						.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x25a8
+						// Method begins at RVA 0x2564
 						// Header size: 1
 						// Code size: 18 (0x12)
 						.maxstack 8
@@ -247,7 +247,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2609
+						// Method begins at RVA 0x25a4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -271,15 +271,14 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x251c
+					// Method begins at RVA 0x24e4
 					// Header size: 12
-					// Code size: 128 (0x80)
+					// Code size: 116 (0x74)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/Scope,
 						[1] object,
-						[2] object,
-						[3] object
+						[2] object
 					)
 
 					IL_0000: newobj instance void Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/Scope::.ctor()
@@ -296,39 +295,35 @@
 					IL_0023: ldloc.1
 					IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 					IL_0029: pop
-					IL_002a: ldarg.0
-					IL_002b: ldc.i4.0
-					IL_002c: ldelem.ref
-					IL_002d: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
-					IL_0032: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-					IL_0037: ldstr "Cannot access 'server' before initialization"
-					IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0041: stloc.2
-					IL_0042: ldnull
-					IL_0043: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/ArrowFunction_L35C22::__js_call__(object)
-					IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_004e: ldc.i4.1
-					IL_004f: newarr [System.Runtime]System.Object
-					IL_0054: dup
-					IL_0055: ldc.i4.0
-					IL_0056: ldarg.0
-					IL_0057: ldc.i4.0
-					IL_0058: ldelem.ref
-					IL_0059: stelem.ref
-					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0064: ldc.i4.0
-					IL_0065: conv.r8
-					IL_0066: ldstr ""
-					IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-					IL_0070: stloc.3
-					IL_0071: ldloc.2
-					IL_0072: ldstr "close"
-					IL_0077: ldloc.3
-					IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_007d: pop
-					IL_007e: ldnull
-					IL_007f: ret
+					IL_002a: ldnull
+					IL_002b: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/ArrowFunction_L35C22::__js_call__(object)
+					IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0036: ldc.i4.1
+					IL_0037: newarr [System.Runtime]System.Object
+					IL_003c: dup
+					IL_003d: ldc.i4.0
+					IL_003e: ldarg.0
+					IL_003f: ldc.i4.0
+					IL_0040: ldelem.ref
+					IL_0041: stelem.ref
+					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_004c: ldc.i4.0
+					IL_004d: conv.r8
+					IL_004e: ldstr ""
+					IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+					IL_0058: stloc.2
+					IL_0059: ldarg.0
+					IL_005a: ldc.i4.0
+					IL_005b: ldelem.ref
+					IL_005c: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
+					IL_0061: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+					IL_0066: ldstr "close"
+					IL_006b: ldloc.2
+					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0071: pop
+					IL_0072: ldnull
+					IL_0073: ret
 				} // end of method ArrowFunction_L33C21::__js_call__
 
 			} // end of class ArrowFunction_L33C21
@@ -348,7 +343,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25f7
+					// Method begins at RVA 0x2592
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -373,7 +368,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2404
+				// Method begins at RVA 0x23cc
 				// Header size: 12
 				// Code size: 220 (0xdc)
 				.maxstack 8
@@ -484,7 +479,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ee
+				// Method begins at RVA 0x2589
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -510,9 +505,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x22cc
+			// Method begins at RVA 0x22b8
 			// Header size: 12
-			// Code size: 298 (0x12a)
+			// Code size: 264 (0x108)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/Scope,
@@ -530,103 +525,95 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.s 4
 			IL_0018: ldloc.s 4
-			IL_001a: ldstr "address"
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0024: stloc.s 4
-			IL_0026: ldloc.s 4
-			IL_0028: stloc.1
-			IL_0029: ldarg.0
-			IL_002a: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::NodeUrl
-			IL_002f: ldstr "Cannot access 'NodeUrl' before initialization"
-			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0039: stloc.s 4
-			IL_003b: ldstr "https://127.0.0.1:"
-			IL_0040: ldloc.1
-			IL_0041: ldstr "port"
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0050: stloc.s 5
-			IL_0052: ldloc.s 5
-			IL_0054: ldstr "/spec?section=27.3"
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_005e: stloc.s 5
-			IL_0060: ldc.i4.1
-			IL_0061: newarr [System.Runtime]System.Object
-			IL_0066: dup
-			IL_0067: ldc.i4.0
-			IL_0068: ldloc.s 5
-			IL_006a: stelem.ref
-			IL_006b: stloc.s 6
-			IL_006d: ldloc.s 4
-			IL_006f: ldloc.s 6
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0076: stloc.s 4
-			IL_0078: ldloc.s 4
-			IL_007a: stloc.2
-			IL_007b: ldarg.0
-			IL_007c: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
-			IL_0081: ldstr "Cannot access 'https' before initialization"
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_008b: stloc.s 4
-			IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0092: dup
-			IL_0093: ldstr "Accept-Encoding"
-			IL_0098: ldstr "identity"
-			IL_009d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a2: stloc.s 7
-			IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00a9: dup
-			IL_00aa: ldstr "method"
-			IL_00af: ldstr "GET"
-			IL_00b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00b9: dup
-			IL_00ba: ldstr "headers"
-			IL_00bf: ldloc.s 7
-			IL_00c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00c6: dup
-			IL_00c7: ldstr "rejectUnauthorized"
-			IL_00cc: ldc.i4.0
-			IL_00cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00d2: stloc.s 7
-			IL_00d4: ldnull
-			IL_00d5: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5::__js_call__(object[], object, object)
-			IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00e0: ldc.i4.2
-			IL_00e1: newarr [System.Runtime]System.Object
-			IL_00e6: dup
-			IL_00e7: ldc.i4.0
-			IL_00e8: ldarg.0
-			IL_00e9: stelem.ref
-			IL_00ea: dup
-			IL_00eb: ldc.i4.1
-			IL_00ec: ldloc.0
-			IL_00ed: stelem.ref
-			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00f8: ldc.i4.1
-			IL_00f9: conv.r8
-			IL_00fa: ldstr ""
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0104: stloc.s 8
-			IL_0106: ldloc.s 4
-			IL_0108: ldstr "request"
-			IL_010d: ldloc.2
-			IL_010e: ldloc.s 7
-			IL_0110: ldloc.s 8
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0117: stloc.s 8
-			IL_0119: ldloc.s 8
-			IL_011b: stloc.3
-			IL_011c: ldloc.3
-			IL_011d: ldstr "end"
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0127: pop
-			IL_0128: ldnull
-			IL_0129: ret
+			IL_001a: stloc.1
+			IL_001b: ldarg.0
+			IL_001c: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::NodeUrl
+			IL_0021: stloc.s 4
+			IL_0023: ldstr "https://127.0.0.1:"
+			IL_0028: ldloc.1
+			IL_0029: ldstr "port"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0038: stloc.s 5
+			IL_003a: ldloc.s 5
+			IL_003c: ldstr "/spec?section=27.3"
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0046: stloc.s 5
+			IL_0048: ldc.i4.1
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: dup
+			IL_004f: ldc.i4.0
+			IL_0050: ldloc.s 5
+			IL_0052: stelem.ref
+			IL_0053: stloc.s 6
+			IL_0055: ldloc.s 4
+			IL_0057: ldloc.s 6
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_005e: stloc.s 4
+			IL_0060: ldloc.s 4
+			IL_0062: stloc.2
+			IL_0063: ldarg.0
+			IL_0064: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
+			IL_0069: stloc.s 4
+			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0070: dup
+			IL_0071: ldstr "Accept-Encoding"
+			IL_0076: ldstr "identity"
+			IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0080: stloc.s 7
+			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0087: dup
+			IL_0088: ldstr "method"
+			IL_008d: ldstr "GET"
+			IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0097: dup
+			IL_0098: ldstr "headers"
+			IL_009d: ldloc.s 7
+			IL_009f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a4: dup
+			IL_00a5: ldstr "rejectUnauthorized"
+			IL_00aa: ldc.i4.0
+			IL_00ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00b0: stloc.s 7
+			IL_00b2: ldnull
+			IL_00b3: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5::__js_call__(object[], object, object)
+			IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00be: ldc.i4.2
+			IL_00bf: newarr [System.Runtime]System.Object
+			IL_00c4: dup
+			IL_00c5: ldc.i4.0
+			IL_00c6: ldarg.0
+			IL_00c7: stelem.ref
+			IL_00c8: dup
+			IL_00c9: ldc.i4.1
+			IL_00ca: ldloc.0
+			IL_00cb: stelem.ref
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00d6: ldc.i4.1
+			IL_00d7: conv.r8
+			IL_00d8: ldstr ""
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 4
+			IL_00e6: ldstr "request"
+			IL_00eb: ldloc.2
+			IL_00ec: ldloc.s 7
+			IL_00ee: ldloc.s 8
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00f5: stloc.s 8
+			IL_00f7: ldloc.s 8
+			IL_00f9: stloc.3
+			IL_00fa: ldloc.3
+			IL_00fb: ldstr "end"
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0105: pop
+			IL_0106: ldnull
+			IL_0107: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -649,24 +636,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25bb
+			// Method begins at RVA 0x2577
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::NodeUrl
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -684,7 +662,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 390 (0x186)
+		// Code size: 370 (0x172)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Https_Request_UrlObject_WithOptions/Scope,
@@ -753,82 +731,78 @@
 		IL_009d: stloc.2
 		IL_009e: ldloc.0
 		IL_009f: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
-		IL_00a4: ldstr "Cannot access 'https' before initialization"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00ae: stloc.3
-		IL_00af: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00b4: dup
-		IL_00b5: ldstr "key"
-		IL_00ba: ldloc.2
-		IL_00bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00c0: dup
-		IL_00c1: ldstr "cert"
-		IL_00c6: ldloc.1
-		IL_00c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00cc: stloc.s 4
-		IL_00ce: ldnull
-		IL_00cf: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L7C67::__js_call__(object, object, object)
-		IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00da: ldc.i4.1
-		IL_00db: newarr [System.Runtime]System.Object
-		IL_00e0: dup
-		IL_00e1: ldc.i4.0
-		IL_00e2: ldloc.0
-		IL_00e3: stelem.ref
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00ee: ldc.i4.2
-		IL_00ef: conv.r8
-		IL_00f0: ldstr ""
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.3
-		IL_00fd: ldstr "createServer"
-		IL_0102: ldloc.s 4
+		IL_00a4: stloc.3
+		IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00aa: dup
+		IL_00ab: ldstr "key"
+		IL_00b0: ldloc.2
+		IL_00b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00b6: dup
+		IL_00b7: ldstr "cert"
+		IL_00bc: ldloc.1
+		IL_00bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00c2: stloc.s 4
+		IL_00c4: ldnull
+		IL_00c5: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L7C67::__js_call__(object, object, object)
+		IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00d0: ldc.i4.1
+		IL_00d1: newarr [System.Runtime]System.Object
+		IL_00d6: dup
+		IL_00d7: ldc.i4.0
+		IL_00d8: ldloc.0
+		IL_00d9: stelem.ref
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00e4: ldc.i4.2
+		IL_00e5: conv.r8
+		IL_00e6: ldstr ""
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00f0: stloc.s 5
+		IL_00f2: ldloc.3
+		IL_00f3: ldstr "createServer"
+		IL_00f8: ldloc.s 4
+		IL_00fa: ldloc.s 5
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0101: stloc.s 5
+		IL_0103: ldloc.0
 		IL_0104: ldloc.s 5
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_010b: stloc.s 5
-		IL_010d: ldloc.0
-		IL_010e: ldloc.s 5
-		IL_0110: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-		IL_0115: ldloc.0
-		IL_0116: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-		IL_011b: ldstr "Cannot access 'server' before initialization"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0125: stloc.s 5
-		IL_0127: ldc.i4.1
-		IL_0128: newarr [System.Runtime]System.Object
-		IL_012d: dup
-		IL_012e: ldc.i4.0
-		IL_012f: ldloc.0
-		IL_0130: stelem.ref
-		IL_0131: ldc.i4.0
-		IL_0132: ldelem.ref
-		IL_0133: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
-		IL_0138: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31::__js_call__(class Modules.Https_Request_UrlObject_WithOptions/Scope, object)
-		IL_013e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0143: ldc.i4.1
-		IL_0144: newarr [System.Runtime]System.Object
-		IL_0149: dup
-		IL_014a: ldc.i4.0
-		IL_014b: ldloc.0
-		IL_014c: stelem.ref
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0157: ldc.i4.0
-		IL_0158: conv.r8
-		IL_0159: ldstr ""
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0163: stloc.3
-		IL_0164: ldloc.s 5
-		IL_0166: ldstr "listen"
-		IL_016b: ldc.r8 0.0
-		IL_0174: box [System.Runtime]System.Double
-		IL_0179: ldstr "127.0.0.1"
-		IL_017e: ldloc.3
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0184: pop
-		IL_0185: ret
+		IL_0106: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+		IL_010b: ldloc.0
+		IL_010c: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+		IL_0111: stloc.s 5
+		IL_0113: ldc.i4.1
+		IL_0114: newarr [System.Runtime]System.Object
+		IL_0119: dup
+		IL_011a: ldc.i4.0
+		IL_011b: ldloc.0
+		IL_011c: stelem.ref
+		IL_011d: ldc.i4.0
+		IL_011e: ldelem.ref
+		IL_011f: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
+		IL_0124: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31::__js_call__(class Modules.Https_Request_UrlObject_WithOptions/Scope, object)
+		IL_012a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_012f: ldc.i4.1
+		IL_0130: newarr [System.Runtime]System.Object
+		IL_0135: dup
+		IL_0136: ldc.i4.0
+		IL_0137: ldloc.0
+		IL_0138: stelem.ref
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0143: ldc.i4.0
+		IL_0144: conv.r8
+		IL_0145: ldstr ""
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_014f: stloc.3
+		IL_0150: ldloc.s 5
+		IL_0152: ldstr "listen"
+		IL_0157: ldc.r8 0.0
+		IL_0160: box [System.Runtime]System.Double
+		IL_0165: ldstr "127.0.0.1"
+		IL_016a: ldloc.3
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0170: pop
+		IL_0171: ret
 	} // end of method Https_Request_UrlObject_WithOptions::__js_module_init__
 
 } // end of class Modules.Https_Request_UrlObject_WithOptions
@@ -844,7 +818,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x261b
+			// Method begins at RVA 0x25b6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -868,7 +842,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21e4
+		// Method begins at RVA 0x21d0
 		// Header size: 12
 		// Code size: 59 (0x3b)
 		.maxstack 8
@@ -907,7 +881,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2624
+		// Method begins at RVA 0x25bf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
+++ b/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e2
+				// Method begins at RVA 0x248c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2263
+			// Method begins at RVA 0x2247
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -80,7 +80,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24ff
+					// Method begins at RVA 0x24a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -104,7 +104,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23e8
+				// Method begins at RVA 0x23b4
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -149,7 +149,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2508
+					// Method begins at RVA 0x24b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2420
+				// Method begins at RVA 0x23ec
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -210,7 +210,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x251a
+						// Method begins at RVA 0x24c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -233,7 +233,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24b0
+					// Method begins at RVA 0x2470
 					// Header size: 1
 					// Code size: 18 (0x12)
 					.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2511
+					// Method begins at RVA 0x24bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -279,51 +279,46 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2448
+				// Method begins at RVA 0x2414
 				// Header size: 12
-				// Code size: 92 (0x5c)
+				// Code size: 80 (0x50)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/Scope,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: newobj instance void Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/Scope::.ctor()
 				IL_0005: stloc.0
-				IL_0006: ldarg.0
-				IL_0007: ldc.i4.0
-				IL_0008: ldelem.ref
-				IL_0009: castclass Modules.Tls_CreateSecureContext_Server_Handshake/Scope
-				IL_000e: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-				IL_0013: ldstr "Cannot access 'server' before initialization"
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001d: stloc.1
-				IL_001e: ldnull
-				IL_001f: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/ArrowFunction_L27C18::__js_call__(object)
-				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_002a: ldc.i4.1
-				IL_002b: newarr [System.Runtime]System.Object
-				IL_0030: dup
-				IL_0031: ldc.i4.0
-				IL_0032: ldarg.0
-				IL_0033: ldc.i4.0
-				IL_0034: ldelem.ref
-				IL_0035: stelem.ref
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_0040: ldc.i4.0
-				IL_0041: conv.r8
-				IL_0042: ldstr ""
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_004c: stloc.2
-				IL_004d: ldloc.1
-				IL_004e: ldstr "close"
-				IL_0053: ldloc.2
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0059: pop
-				IL_005a: ldnull
-				IL_005b: ret
+				IL_0006: ldnull
+				IL_0007: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/ArrowFunction_L27C18::__js_call__(object)
+				IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0012: ldc.i4.1
+				IL_0013: newarr [System.Runtime]System.Object
+				IL_0018: dup
+				IL_0019: ldc.i4.0
+				IL_001a: ldarg.0
+				IL_001b: ldc.i4.0
+				IL_001c: ldelem.ref
+				IL_001d: stelem.ref
+				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0028: ldc.i4.0
+				IL_0029: conv.r8
+				IL_002a: ldstr ""
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_0034: stloc.1
+				IL_0035: ldarg.0
+				IL_0036: ldc.i4.0
+				IL_0037: ldelem.ref
+				IL_0038: castclass Modules.Tls_CreateSecureContext_Server_Handshake/Scope
+				IL_003d: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
+				IL_0042: ldstr "close"
+				IL_0047: ldloc.1
+				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004d: pop
+				IL_004e: ldnull
+				IL_004f: ret
 			} // end of method ArrowFunction_L26C22::__js_call__
 
 		} // end of class ArrowFunction_L26C22
@@ -342,7 +337,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24eb
+				// Method begins at RVA 0x2495
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -371,9 +366,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2278
+			// Method begins at RVA 0x225c
 			// Header size: 12
-			// Code size: 354 (0x162)
+			// Code size: 332 (0x14c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope,
@@ -387,125 +382,119 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
-			IL_002b: ldstr "Cannot access 'tls' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.2
-			IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
+			IL_001f: stloc.2
+			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0025: dup
+			IL_0026: ldstr "port"
+			IL_002b: ldloc.1
+			IL_002c: ldstr "port"
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_003b: dup
-			IL_003c: ldstr "port"
-			IL_0041: ldloc.1
-			IL_0042: ldstr "port"
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0051: dup
-			IL_0052: ldstr "host"
-			IL_0057: ldstr "127.0.0.1"
-			IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0061: dup
-			IL_0062: ldstr "rejectUnauthorized"
-			IL_0067: ldc.i4.0
-			IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_006d: stloc.3
-			IL_006e: ldnull
-			IL_006f: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L17C5::__js_call__(object[], object)
-			IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_007a: ldc.i4.2
-			IL_007b: newarr [System.Runtime]System.Object
-			IL_0080: dup
-			IL_0081: ldc.i4.0
-			IL_0082: ldarg.0
-			IL_0083: stelem.ref
-			IL_0084: dup
-			IL_0085: ldc.i4.1
-			IL_0086: ldloc.0
-			IL_0087: stelem.ref
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0092: ldc.i4.0
-			IL_0093: conv.r8
-			IL_0094: ldstr ""
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_009e: stloc.s 4
-			IL_00a0: ldloc.2
-			IL_00a1: ldstr "connect"
-			IL_00a6: ldloc.3
-			IL_00a7: ldloc.s 4
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00ae: stloc.s 4
-			IL_00b0: ldloc.0
-			IL_00b1: ldloc.s 4
-			IL_00b3: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_00b8: ldloc.0
-			IL_00b9: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_00be: ldstr "Cannot access 'client' before initialization"
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c8: stloc.s 4
-			IL_00ca: ldnull
-			IL_00cb: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L22C21::__js_call__(object, object)
-			IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00d6: ldc.i4.1
-			IL_00d7: newarr [System.Runtime]System.Object
-			IL_00dc: dup
-			IL_00dd: ldc.i4.0
-			IL_00de: ldarg.0
-			IL_00df: stelem.ref
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00ea: ldc.i4.1
-			IL_00eb: conv.r8
-			IL_00ec: ldstr ""
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00f6: stloc.2
-			IL_00f7: ldloc.s 4
-			IL_00f9: ldstr "on"
-			IL_00fe: ldstr "data"
-			IL_0103: ldloc.2
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0109: pop
-			IL_010a: ldloc.0
-			IL_010b: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_0110: ldstr "Cannot access 'client' before initialization"
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_011a: stloc.2
-			IL_011b: ldnull
-			IL_011c: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22::__js_call__(object[], object)
-			IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0127: ldc.i4.2
-			IL_0128: newarr [System.Runtime]System.Object
-			IL_012d: dup
-			IL_012e: ldc.i4.0
-			IL_012f: ldarg.0
-			IL_0130: stelem.ref
-			IL_0131: dup
-			IL_0132: ldc.i4.1
-			IL_0133: ldloc.0
-			IL_0134: stelem.ref
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_013f: ldc.i4.0
-			IL_0140: conv.r8
-			IL_0141: ldstr ""
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_014b: stloc.s 4
-			IL_014d: ldloc.2
-			IL_014e: ldstr "on"
-			IL_0153: ldstr "close"
-			IL_0158: ldloc.s 4
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_015f: pop
-			IL_0160: ldnull
-			IL_0161: ret
+			IL_003c: ldstr "host"
+			IL_0041: ldstr "127.0.0.1"
+			IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004b: dup
+			IL_004c: ldstr "rejectUnauthorized"
+			IL_0051: ldc.i4.0
+			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0057: stloc.3
+			IL_0058: ldnull
+			IL_0059: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L17C5::__js_call__(object[], object)
+			IL_005f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0064: ldc.i4.2
+			IL_0065: newarr [System.Runtime]System.Object
+			IL_006a: dup
+			IL_006b: ldc.i4.0
+			IL_006c: ldarg.0
+			IL_006d: stelem.ref
+			IL_006e: dup
+			IL_006f: ldc.i4.1
+			IL_0070: ldloc.0
+			IL_0071: stelem.ref
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_007c: ldc.i4.0
+			IL_007d: conv.r8
+			IL_007e: ldstr ""
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0088: stloc.s 4
+			IL_008a: ldloc.2
+			IL_008b: ldstr "connect"
+			IL_0090: ldloc.3
+			IL_0091: ldloc.s 4
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0098: stloc.s 4
+			IL_009a: ldloc.0
+			IL_009b: ldloc.s 4
+			IL_009d: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_00a2: ldloc.0
+			IL_00a3: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_00a8: ldstr "Cannot access 'client' before initialization"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00b2: stloc.s 4
+			IL_00b4: ldnull
+			IL_00b5: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L22C21::__js_call__(object, object)
+			IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00c0: ldc.i4.1
+			IL_00c1: newarr [System.Runtime]System.Object
+			IL_00c6: dup
+			IL_00c7: ldc.i4.0
+			IL_00c8: ldarg.0
+			IL_00c9: stelem.ref
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00d4: ldc.i4.1
+			IL_00d5: conv.r8
+			IL_00d6: ldstr ""
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00e0: stloc.2
+			IL_00e1: ldloc.s 4
+			IL_00e3: ldstr "on"
+			IL_00e8: ldstr "data"
+			IL_00ed: ldloc.2
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f3: pop
+			IL_00f4: ldloc.0
+			IL_00f5: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_00fa: ldstr "Cannot access 'client' before initialization"
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0104: stloc.2
+			IL_0105: ldnull
+			IL_0106: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22::__js_call__(object[], object)
+			IL_010c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0111: ldc.i4.2
+			IL_0112: newarr [System.Runtime]System.Object
+			IL_0117: dup
+			IL_0118: ldc.i4.0
+			IL_0119: ldarg.0
+			IL_011a: stelem.ref
+			IL_011b: dup
+			IL_011c: ldc.i4.1
+			IL_011d: ldloc.0
+			IL_011e: stelem.ref
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0129: ldc.i4.0
+			IL_012a: conv.r8
+			IL_012b: ldstr ""
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0135: stloc.s 4
+			IL_0137: ldloc.2
+			IL_0138: ldstr "on"
+			IL_013d: ldstr "close"
+			IL_0142: ldloc.s 4
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0149: pop
+			IL_014a: ldnull
+			IL_014b: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -526,21 +515,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24c3
+			// Method begins at RVA 0x2483
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -558,7 +541,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 448 (0x1c0)
+		// Code size: 418 (0x1a2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Tls_CreateSecureContext_Server_Handshake/Scope,
@@ -608,120 +591,114 @@
 		IL_0065: stloc.2
 		IL_0066: ldloc.0
 		IL_0067: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
-		IL_006c: ldstr "Cannot access 'tls' before initialization"
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0076: stloc.s 4
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_007d: dup
-		IL_007e: ldstr "key"
-		IL_0083: ldloc.2
-		IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0089: dup
-		IL_008a: ldstr "cert"
-		IL_008f: ldloc.1
-		IL_0090: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0095: stloc.s 5
-		IL_0097: ldloc.s 4
-		IL_0099: ldstr "createSecureContext"
-		IL_009e: ldloc.s 5
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a5: stloc.s 4
-		IL_00a7: ldloc.s 4
-		IL_00a9: stloc.3
-		IL_00aa: ldloc.3
-		IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_00b0: ldc.i4.0
-		IL_00b1: ceq
-		IL_00b3: stloc.s 6
-		IL_00b5: ldloc.s 6
-		IL_00b7: ldc.i4.0
-		IL_00b8: ceq
-		IL_00ba: stloc.s 6
-		IL_00bc: ldloc.s 6
-		IL_00be: box [System.Runtime]System.Boolean
-		IL_00c3: stloc.s 7
-		IL_00c5: ldstr "secureContext:"
-		IL_00ca: ldloc.s 7
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00d1: stloc.s 8
-		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d8: ldloc.s 8
-		IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00df: pop
-		IL_00e0: ldloc.0
-		IL_00e1: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
-		IL_00e6: ldstr "Cannot access 'tls' before initialization"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00f0: stloc.s 4
-		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00f7: dup
-		IL_00f8: ldstr "secureContext"
-		IL_00fd: ldloc.3
-		IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0103: stloc.s 5
-		IL_0105: ldnull
-		IL_0106: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L9C52::__js_call__(object, object)
-		IL_010c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_006c: stloc.s 4
+		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0073: dup
+		IL_0074: ldstr "key"
+		IL_0079: ldloc.2
+		IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_007f: dup
+		IL_0080: ldstr "cert"
+		IL_0085: ldloc.1
+		IL_0086: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_008b: stloc.s 5
+		IL_008d: ldloc.s 4
+		IL_008f: ldstr "createSecureContext"
+		IL_0094: ldloc.s 5
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_009b: stloc.s 4
+		IL_009d: ldloc.s 4
+		IL_009f: stloc.3
+		IL_00a0: ldloc.3
+		IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_00a6: ldc.i4.0
+		IL_00a7: ceq
+		IL_00a9: stloc.s 6
+		IL_00ab: ldloc.s 6
+		IL_00ad: ldc.i4.0
+		IL_00ae: ceq
+		IL_00b0: stloc.s 6
+		IL_00b2: ldloc.s 6
+		IL_00b4: box [System.Runtime]System.Boolean
+		IL_00b9: stloc.s 7
+		IL_00bb: ldstr "secureContext:"
+		IL_00c0: ldloc.s 7
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00c7: stloc.s 8
+		IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ce: ldloc.s 8
+		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d5: pop
+		IL_00d6: ldloc.0
+		IL_00d7: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
+		IL_00dc: stloc.s 4
+		IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e3: dup
+		IL_00e4: ldstr "secureContext"
+		IL_00e9: ldloc.3
+		IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00ef: stloc.s 5
+		IL_00f1: ldnull
+		IL_00f2: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L9C52::__js_call__(object, object)
+		IL_00f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00fd: ldc.i4.1
+		IL_00fe: newarr [System.Runtime]System.Object
+		IL_0103: dup
+		IL_0104: ldc.i4.0
+		IL_0105: ldloc.0
+		IL_0106: stelem.ref
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_0111: ldc.i4.1
-		IL_0112: newarr [System.Runtime]System.Object
-		IL_0117: dup
-		IL_0118: ldc.i4.0
-		IL_0119: ldloc.0
-		IL_011a: stelem.ref
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0125: ldc.i4.1
-		IL_0126: conv.r8
-		IL_0127: ldstr ""
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0131: stloc.s 9
-		IL_0133: ldloc.s 4
-		IL_0135: ldstr "createServer"
-		IL_013a: ldloc.s 5
-		IL_013c: ldloc.s 9
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0143: stloc.s 9
-		IL_0145: ldloc.0
-		IL_0146: ldloc.s 9
-		IL_0148: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-		IL_014d: ldloc.0
-		IL_014e: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-		IL_0153: ldstr "Cannot access 'server' before initialization"
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_015d: stloc.s 9
-		IL_015f: ldc.i4.1
-		IL_0160: newarr [System.Runtime]System.Object
-		IL_0165: dup
-		IL_0166: ldc.i4.0
-		IL_0167: ldloc.0
-		IL_0168: stelem.ref
-		IL_0169: ldc.i4.0
-		IL_016a: ldelem.ref
-		IL_016b: castclass Modules.Tls_CreateSecureContext_Server_Handshake/Scope
-		IL_0170: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31::__js_call__(class Modules.Tls_CreateSecureContext_Server_Handshake/Scope, object)
-		IL_0176: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_017b: ldc.i4.1
-		IL_017c: newarr [System.Runtime]System.Object
-		IL_0181: dup
-		IL_0182: ldc.i4.0
-		IL_0183: ldloc.0
-		IL_0184: stelem.ref
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_018f: ldc.i4.0
-		IL_0190: conv.r8
-		IL_0191: ldstr ""
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_019b: stloc.s 4
-		IL_019d: ldloc.s 9
-		IL_019f: ldstr "listen"
-		IL_01a4: ldc.r8 0.0
-		IL_01ad: box [System.Runtime]System.Double
-		IL_01b2: ldstr "127.0.0.1"
-		IL_01b7: ldloc.s 4
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_01be: pop
-		IL_01bf: ret
+		IL_0112: conv.r8
+		IL_0113: ldstr ""
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_011d: stloc.s 9
+		IL_011f: ldloc.s 4
+		IL_0121: ldstr "createServer"
+		IL_0126: ldloc.s 5
+		IL_0128: ldloc.s 9
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_012f: stloc.s 9
+		IL_0131: ldloc.0
+		IL_0132: ldloc.s 9
+		IL_0134: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
+		IL_0139: ldloc.0
+		IL_013a: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
+		IL_013f: stloc.s 9
+		IL_0141: ldc.i4.1
+		IL_0142: newarr [System.Runtime]System.Object
+		IL_0147: dup
+		IL_0148: ldc.i4.0
+		IL_0149: ldloc.0
+		IL_014a: stelem.ref
+		IL_014b: ldc.i4.0
+		IL_014c: ldelem.ref
+		IL_014d: castclass Modules.Tls_CreateSecureContext_Server_Handshake/Scope
+		IL_0152: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31::__js_call__(class Modules.Tls_CreateSecureContext_Server_Handshake/Scope, object)
+		IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_015d: ldc.i4.1
+		IL_015e: newarr [System.Runtime]System.Object
+		IL_0163: dup
+		IL_0164: ldc.i4.0
+		IL_0165: ldloc.0
+		IL_0166: stelem.ref
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0171: ldc.i4.0
+		IL_0172: conv.r8
+		IL_0173: ldstr ""
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_017d: stloc.s 4
+		IL_017f: ldloc.s 9
+		IL_0181: ldstr "listen"
+		IL_0186: ldc.r8 0.0
+		IL_018f: box [System.Runtime]System.Double
+		IL_0194: ldstr "127.0.0.1"
+		IL_0199: ldloc.s 4
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_01a0: pop
+		IL_01a1: ret
 	} // end of method Tls_CreateSecureContext_Server_Handshake::__js_module_init__
 
 } // end of class Modules.Tls_CreateSecureContext_Server_Handshake
@@ -737,7 +714,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2523
+			// Method begins at RVA 0x24cd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -761,7 +738,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x221c
+		// Method begins at RVA 0x2200
 		// Header size: 12
 		// Code size: 59 (0x3b)
 		.maxstack 8
@@ -800,7 +777,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x252c
+		// Method begins at RVA 0x24d6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2596
+				// Method begins at RVA 0x2548
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21eb
+			// Method begins at RVA 0x21d7
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -85,7 +85,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25b3
+					// Method begins at RVA 0x2565
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -109,7 +109,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23b0
+				// Method begins at RVA 0x2384
 				// Header size: 12
 				// Code size: 278 (0x116)
 				.maxstack 8
@@ -242,7 +242,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25bc
+					// Method begins at RVA 0x256e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -266,7 +266,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24d4
+				// Method begins at RVA 0x24a8
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -303,7 +303,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25ce
+						// Method begins at RVA 0x2580
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -326,7 +326,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2564
+					// Method begins at RVA 0x252c
 					// Header size: 1
 					// Code size: 18 (0x12)
 					.maxstack 8
@@ -348,7 +348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25c5
+					// Method begins at RVA 0x2577
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -372,51 +372,46 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24fc
+				// Method begins at RVA 0x24d0
 				// Header size: 12
-				// Code size: 92 (0x5c)
+				// Code size: 80 (0x50)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/Scope,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: newobj instance void Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/Scope::.ctor()
 				IL_0005: stloc.0
-				IL_0006: ldarg.0
-				IL_0007: ldc.i4.0
-				IL_0008: ldelem.ref
-				IL_0009: castclass Modules.Tls_CreateServer_Connect_Basic/Scope
-				IL_000e: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-				IL_0013: ldstr "Cannot access 'server' before initialization"
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001d: stloc.1
-				IL_001e: ldnull
-				IL_001f: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/ArrowFunction_L29C18::__js_call__(object)
-				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_002a: ldc.i4.1
-				IL_002b: newarr [System.Runtime]System.Object
-				IL_0030: dup
-				IL_0031: ldc.i4.0
-				IL_0032: ldarg.0
-				IL_0033: ldc.i4.0
-				IL_0034: ldelem.ref
-				IL_0035: stelem.ref
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_0040: ldc.i4.0
-				IL_0041: conv.r8
-				IL_0042: ldstr ""
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_004c: stloc.2
-				IL_004d: ldloc.1
-				IL_004e: ldstr "close"
-				IL_0053: ldloc.2
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0059: pop
-				IL_005a: ldnull
-				IL_005b: ret
+				IL_0006: ldnull
+				IL_0007: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/ArrowFunction_L29C18::__js_call__(object)
+				IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0012: ldc.i4.1
+				IL_0013: newarr [System.Runtime]System.Object
+				IL_0018: dup
+				IL_0019: ldc.i4.0
+				IL_001a: ldarg.0
+				IL_001b: ldc.i4.0
+				IL_001c: ldelem.ref
+				IL_001d: stelem.ref
+				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0028: ldc.i4.0
+				IL_0029: conv.r8
+				IL_002a: ldstr ""
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_0034: stloc.1
+				IL_0035: ldarg.0
+				IL_0036: ldc.i4.0
+				IL_0037: ldelem.ref
+				IL_0038: castclass Modules.Tls_CreateServer_Connect_Basic/Scope
+				IL_003d: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
+				IL_0042: ldstr "close"
+				IL_0047: ldloc.1
+				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004d: pop
+				IL_004e: ldnull
+				IL_004f: ret
 			} // end of method ArrowFunction_L28C22::__js_call__
 
 		} // end of class ArrowFunction_L28C22
@@ -435,7 +430,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x259f
+				// Method begins at RVA 0x2551
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -464,9 +459,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2210
+			// Method begins at RVA 0x21fc
 			// Header size: 12
-			// Code size: 402 (0x192)
+			// Code size: 380 (0x17c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope,
@@ -481,139 +476,133 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldstr "listening:"
-			IL_002a: ldloc.1
-			IL_002b: ldstr "address"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0018: stloc.1
+			IL_0019: ldstr "listening:"
+			IL_001e: ldloc.1
+			IL_001f: ldstr "address"
+			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_002e: stloc.3
+			IL_002f: ldloc.3
+			IL_0030: ldstr ":ready"
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_003a: stloc.3
-			IL_003b: ldloc.3
-			IL_003c: ldstr ":ready"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0046: stloc.3
-			IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_004c: ldloc.3
-			IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0052: pop
-			IL_0053: ldarg.0
-			IL_0054: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
-			IL_0059: ldstr "Cannot access 'tls' before initialization"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0063: stloc.2
-			IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0040: ldloc.3
+			IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0046: pop
+			IL_0047: ldarg.0
+			IL_0048: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
+			IL_004d: stloc.2
+			IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: dup
+			IL_0054: ldstr "port"
+			IL_0059: ldloc.1
+			IL_005a: ldstr "port"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0069: dup
-			IL_006a: ldstr "port"
-			IL_006f: ldloc.1
-			IL_0070: ldstr "port"
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_007f: dup
-			IL_0080: ldstr "host"
-			IL_0085: ldstr "127.0.0.1"
-			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_008f: dup
-			IL_0090: ldstr "rejectUnauthorized"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: stloc.s 4
-			IL_009d: ldnull
-			IL_009e: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L17C5::__js_call__(object[], object)
-			IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00a9: ldc.i4.2
-			IL_00aa: newarr [System.Runtime]System.Object
-			IL_00af: dup
-			IL_00b0: ldc.i4.0
-			IL_00b1: ldarg.0
-			IL_00b2: stelem.ref
-			IL_00b3: dup
-			IL_00b4: ldc.i4.1
-			IL_00b5: ldloc.0
-			IL_00b6: stelem.ref
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00c1: ldc.i4.0
-			IL_00c2: conv.r8
-			IL_00c3: ldstr ""
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00cd: stloc.s 5
-			IL_00cf: ldloc.2
-			IL_00d0: ldstr "connect"
-			IL_00d5: ldloc.s 4
-			IL_00d7: ldloc.s 5
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00de: stloc.s 5
-			IL_00e0: ldloc.0
-			IL_00e1: ldloc.s 5
-			IL_00e3: stfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_00e8: ldloc.0
-			IL_00e9: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_00ee: ldstr "Cannot access 'client' before initialization"
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00f8: stloc.s 5
-			IL_00fa: ldnull
-			IL_00fb: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L24C21::__js_call__(object, object)
-			IL_0101: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0106: ldc.i4.1
-			IL_0107: newarr [System.Runtime]System.Object
-			IL_010c: dup
-			IL_010d: ldc.i4.0
-			IL_010e: ldarg.0
-			IL_010f: stelem.ref
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_011a: ldc.i4.1
-			IL_011b: conv.r8
-			IL_011c: ldstr ""
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0126: stloc.2
-			IL_0127: ldloc.s 5
-			IL_0129: ldstr "on"
-			IL_012e: ldstr "data"
-			IL_0133: ldloc.2
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0139: pop
-			IL_013a: ldloc.0
-			IL_013b: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_0140: ldstr "Cannot access 'client' before initialization"
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_014a: stloc.2
-			IL_014b: ldnull
-			IL_014c: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22::__js_call__(object[], object)
-			IL_0152: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0157: ldc.i4.2
-			IL_0158: newarr [System.Runtime]System.Object
-			IL_015d: dup
-			IL_015e: ldc.i4.0
-			IL_015f: ldarg.0
-			IL_0160: stelem.ref
-			IL_0161: dup
-			IL_0162: ldc.i4.1
-			IL_0163: ldloc.0
-			IL_0164: stelem.ref
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_016f: ldc.i4.0
-			IL_0170: conv.r8
-			IL_0171: ldstr ""
-			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_017b: stloc.s 5
-			IL_017d: ldloc.2
-			IL_017e: ldstr "on"
-			IL_0183: ldstr "close"
-			IL_0188: ldloc.s 5
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_018f: pop
-			IL_0190: ldnull
-			IL_0191: ret
+			IL_006a: ldstr "host"
+			IL_006f: ldstr "127.0.0.1"
+			IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0079: dup
+			IL_007a: ldstr "rejectUnauthorized"
+			IL_007f: ldc.i4.0
+			IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0085: stloc.s 4
+			IL_0087: ldnull
+			IL_0088: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L17C5::__js_call__(object[], object)
+			IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0093: ldc.i4.2
+			IL_0094: newarr [System.Runtime]System.Object
+			IL_0099: dup
+			IL_009a: ldc.i4.0
+			IL_009b: ldarg.0
+			IL_009c: stelem.ref
+			IL_009d: dup
+			IL_009e: ldc.i4.1
+			IL_009f: ldloc.0
+			IL_00a0: stelem.ref
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00ab: ldc.i4.0
+			IL_00ac: conv.r8
+			IL_00ad: ldstr ""
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00b7: stloc.s 5
+			IL_00b9: ldloc.2
+			IL_00ba: ldstr "connect"
+			IL_00bf: ldloc.s 4
+			IL_00c1: ldloc.s 5
+			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00c8: stloc.s 5
+			IL_00ca: ldloc.0
+			IL_00cb: ldloc.s 5
+			IL_00cd: stfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_00d2: ldloc.0
+			IL_00d3: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_00d8: ldstr "Cannot access 'client' before initialization"
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00e2: stloc.s 5
+			IL_00e4: ldnull
+			IL_00e5: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L24C21::__js_call__(object, object)
+			IL_00eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00f0: ldc.i4.1
+			IL_00f1: newarr [System.Runtime]System.Object
+			IL_00f6: dup
+			IL_00f7: ldc.i4.0
+			IL_00f8: ldarg.0
+			IL_00f9: stelem.ref
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0104: ldc.i4.1
+			IL_0105: conv.r8
+			IL_0106: ldstr ""
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0110: stloc.2
+			IL_0111: ldloc.s 5
+			IL_0113: ldstr "on"
+			IL_0118: ldstr "data"
+			IL_011d: ldloc.2
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0123: pop
+			IL_0124: ldloc.0
+			IL_0125: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_012a: ldstr "Cannot access 'client' before initialization"
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0134: stloc.2
+			IL_0135: ldnull
+			IL_0136: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22::__js_call__(object[], object)
+			IL_013c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0141: ldc.i4.2
+			IL_0142: newarr [System.Runtime]System.Object
+			IL_0147: dup
+			IL_0148: ldc.i4.0
+			IL_0149: ldarg.0
+			IL_014a: stelem.ref
+			IL_014b: dup
+			IL_014c: ldc.i4.1
+			IL_014d: ldloc.0
+			IL_014e: stelem.ref
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0159: ldc.i4.0
+			IL_015a: conv.r8
+			IL_015b: ldstr ""
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0165: stloc.s 5
+			IL_0167: ldloc.2
+			IL_0168: ldstr "on"
+			IL_016d: ldstr "close"
+			IL_0172: ldloc.s 5
+			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0179: pop
+			IL_017a: ldnull
+			IL_017b: ret
 		} // end of method ArrowFunction_L11C31::__js_call__
 
 	} // end of class ArrowFunction_L11C31
@@ -634,21 +623,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2577
+			// Method begins at RVA 0x253f
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -666,7 +649,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 326 (0x146)
+		// Code size: 306 (0x132)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Tls_CreateServer_Connect_Basic/Scope,
@@ -712,82 +695,78 @@
 		IL_005d: stloc.2
 		IL_005e: ldloc.0
 		IL_005f: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
-		IL_0064: ldstr "Cannot access 'tls' before initialization"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_006e: stloc.3
-		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0074: dup
-		IL_0075: ldstr "key"
-		IL_007a: ldloc.2
-		IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0080: dup
-		IL_0081: ldstr "cert"
-		IL_0086: ldloc.1
-		IL_0087: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_008c: stloc.s 4
-		IL_008e: ldnull
-		IL_008f: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L6C65::__js_call__(object, object)
-		IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_009a: ldc.i4.1
-		IL_009b: newarr [System.Runtime]System.Object
-		IL_00a0: dup
-		IL_00a1: ldc.i4.0
-		IL_00a2: ldloc.0
-		IL_00a3: stelem.ref
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00ae: ldc.i4.1
-		IL_00af: conv.r8
-		IL_00b0: ldstr ""
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00ba: stloc.s 5
-		IL_00bc: ldloc.3
-		IL_00bd: ldstr "createServer"
-		IL_00c2: ldloc.s 4
+		IL_0064: stloc.3
+		IL_0065: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_006a: dup
+		IL_006b: ldstr "key"
+		IL_0070: ldloc.2
+		IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0076: dup
+		IL_0077: ldstr "cert"
+		IL_007c: ldloc.1
+		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0082: stloc.s 4
+		IL_0084: ldnull
+		IL_0085: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L6C65::__js_call__(object, object)
+		IL_008b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0090: ldc.i4.1
+		IL_0091: newarr [System.Runtime]System.Object
+		IL_0096: dup
+		IL_0097: ldc.i4.0
+		IL_0098: ldloc.0
+		IL_0099: stelem.ref
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00a4: ldc.i4.1
+		IL_00a5: conv.r8
+		IL_00a6: ldstr ""
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00b0: stloc.s 5
+		IL_00b2: ldloc.3
+		IL_00b3: ldstr "createServer"
+		IL_00b8: ldloc.s 4
+		IL_00ba: ldloc.s 5
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00c1: stloc.s 5
+		IL_00c3: ldloc.0
 		IL_00c4: ldloc.s 5
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.0
-		IL_00ce: ldloc.s 5
-		IL_00d0: stfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-		IL_00d5: ldloc.0
-		IL_00d6: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-		IL_00db: ldstr "Cannot access 'server' before initialization"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00e5: stloc.s 5
-		IL_00e7: ldc.i4.1
-		IL_00e8: newarr [System.Runtime]System.Object
-		IL_00ed: dup
-		IL_00ee: ldc.i4.0
-		IL_00ef: ldloc.0
-		IL_00f0: stelem.ref
-		IL_00f1: ldc.i4.0
-		IL_00f2: ldelem.ref
-		IL_00f3: castclass Modules.Tls_CreateServer_Connect_Basic/Scope
-		IL_00f8: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31::__js_call__(class Modules.Tls_CreateServer_Connect_Basic/Scope, object)
-		IL_00fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0103: ldc.i4.1
-		IL_0104: newarr [System.Runtime]System.Object
-		IL_0109: dup
-		IL_010a: ldc.i4.0
-		IL_010b: ldloc.0
-		IL_010c: stelem.ref
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0117: ldc.i4.0
-		IL_0118: conv.r8
-		IL_0119: ldstr ""
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0123: stloc.3
-		IL_0124: ldloc.s 5
-		IL_0126: ldstr "listen"
-		IL_012b: ldc.r8 0.0
-		IL_0134: box [System.Runtime]System.Double
-		IL_0139: ldstr "127.0.0.1"
-		IL_013e: ldloc.3
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0144: pop
-		IL_0145: ret
+		IL_00c6: stfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
+		IL_00cb: ldloc.0
+		IL_00cc: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
+		IL_00d1: stloc.s 5
+		IL_00d3: ldc.i4.1
+		IL_00d4: newarr [System.Runtime]System.Object
+		IL_00d9: dup
+		IL_00da: ldc.i4.0
+		IL_00db: ldloc.0
+		IL_00dc: stelem.ref
+		IL_00dd: ldc.i4.0
+		IL_00de: ldelem.ref
+		IL_00df: castclass Modules.Tls_CreateServer_Connect_Basic/Scope
+		IL_00e4: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31::__js_call__(class Modules.Tls_CreateServer_Connect_Basic/Scope, object)
+		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ef: ldc.i4.1
+		IL_00f0: newarr [System.Runtime]System.Object
+		IL_00f5: dup
+		IL_00f6: ldc.i4.0
+		IL_00f7: ldloc.0
+		IL_00f8: stelem.ref
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0103: ldc.i4.0
+		IL_0104: conv.r8
+		IL_0105: ldstr ""
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_010f: stloc.3
+		IL_0110: ldloc.s 5
+		IL_0112: ldstr "listen"
+		IL_0117: ldc.r8 0.0
+		IL_0120: box [System.Runtime]System.Double
+		IL_0125: ldstr "127.0.0.1"
+		IL_012a: ldloc.3
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0130: pop
+		IL_0131: ret
 	} // end of method Tls_CreateServer_Connect_Basic::__js_module_init__
 
 } // end of class Modules.Tls_CreateServer_Connect_Basic
@@ -803,7 +782,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25d7
+			// Method begins at RVA 0x2589
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -827,7 +806,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21a4
+		// Method begins at RVA 0x2190
 		// Header size: 12
 		// Code size: 59 (0x3b)
 		.maxstack 8
@@ -866,7 +845,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25e0
+		// Method begins at RVA 0x2592
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
+++ b/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25c2
+					// Method begins at RVA 0x2578
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2364
+				// Method begins at RVA 0x233c
 				// Header size: 12
 				// Code size: 55 (0x37)
 				.maxstack 8
@@ -99,7 +99,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25d4
+						// Method begins at RVA 0x258a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -123,7 +123,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x250c
+					// Method begins at RVA 0x24d8
 					// Header size: 12
 					// Code size: 111 (0x6f)
 					.maxstack 8
@@ -183,7 +183,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25cb
+					// Method begins at RVA 0x2581
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -207,7 +207,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23a8
+				// Method begins at RVA 0x2380
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -285,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b9
+				// Method begins at RVA 0x256f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x2120
 			// Header size: 12
 			// Code size: 187 (0xbb)
 			.maxstack 8
@@ -410,7 +410,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25f1
+					// Method begins at RVA 0x25a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -434,7 +434,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x2404
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -472,7 +472,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25fa
+					// Method begins at RVA 0x25b0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -497,7 +497,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2464
+				// Method begins at RVA 0x243c
 				// Header size: 12
 				// Code size: 36 (0x24)
 				.maxstack 8
@@ -540,7 +540,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x260c
+						// Method begins at RVA 0x25c2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -563,7 +563,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2587
+					// Method begins at RVA 0x2553
 					// Header size: 1
 					// Code size: 18 (0x12)
 					.maxstack 8
@@ -585,7 +585,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2603
+					// Method begins at RVA 0x25b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -609,15 +609,14 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2494
+				// Method begins at RVA 0x246c
 				// Header size: 12
-				// Code size: 106 (0x6a)
+				// Code size: 94 (0x5e)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/Scope,
 					[1] object,
-					[2] object,
-					[3] object
+					[2] object
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/Scope::.ctor()
@@ -634,29 +633,25 @@
 				IL_0023: ldloc.1
 				IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 				IL_0029: pop
-				IL_002a: ldarg.0
-				IL_002b: ldc.i4.0
-				IL_002c: ldelem.ref
-				IL_002d: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-				IL_0032: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-				IL_0037: ldstr "Cannot access 'server' before initialization"
-				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0041: stloc.2
-				IL_0042: ldnull
-				IL_0043: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
-				IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004e: ldc.i4.0
-				IL_004f: conv.r8
-				IL_0050: ldstr ""
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_005a: stloc.3
-				IL_005b: ldloc.2
-				IL_005c: ldstr "close"
-				IL_0061: ldloc.3
-				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0067: pop
-				IL_0068: ldnull
-				IL_0069: ret
+				IL_002a: ldnull
+				IL_002b: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
+				IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0036: ldc.i4.0
+				IL_0037: conv.r8
+				IL_0038: ldstr ""
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_0042: stloc.2
+				IL_0043: ldarg.0
+				IL_0044: ldc.i4.0
+				IL_0045: ldelem.ref
+				IL_0046: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
+				IL_004b: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
+				IL_0050: ldstr "close"
+				IL_0055: ldloc.2
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005b: pop
+				IL_005c: ldnull
+				IL_005d: ret
 			} // end of method FunctionExpression_L34C19::__js_call__
 
 		} // end of class FunctionExpression_L34C19
@@ -677,7 +672,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25dd
+				// Method begins at RVA 0x2593
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -706,9 +701,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x21fc
+			// Method begins at RVA 0x21e8
 			// Header size: 12
-			// Code size: 347 (0x15b)
+			// Code size: 325 (0x145)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope,
@@ -723,126 +718,120 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
-			IL_002b: ldstr "Cannot access 'net' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.2
-			IL_0036: ldloc.1
-			IL_0037: ldstr "port"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.3
-			IL_0042: ldloc.1
-			IL_0043: ldstr "address"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 4
-			IL_004f: ldc.i4.2
-			IL_0050: newarr [System.Runtime]System.Object
-			IL_0055: dup
-			IL_0056: ldc.i4.0
-			IL_0057: ldarg.0
-			IL_0058: stelem.ref
-			IL_0059: dup
-			IL_005a: ldc.i4.1
-			IL_005b: ldloc.0
-			IL_005c: stelem.ref
-			IL_005d: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0068: ldc.i4.0
-			IL_0069: conv.r8
-			IL_006a: ldstr ""
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0074: stloc.s 5
-			IL_0076: ldloc.2
-			IL_0077: ldstr "connect"
-			IL_007c: ldloc.3
-			IL_007d: ldloc.s 4
-			IL_007f: ldloc.s 5
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0086: stloc.s 5
-			IL_0088: ldloc.0
-			IL_0089: ldloc.s 5
-			IL_008b: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_0090: ldloc.0
-			IL_0091: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_0096: ldstr "Cannot access 'client' before initialization"
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a0: stloc.s 5
-			IL_00a2: ldloc.s 5
-			IL_00a4: ldstr "setEncoding"
-			IL_00a9: ldstr "utf8"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b3: pop
-			IL_00b4: ldloc.0
-			IL_00b5: ldstr ""
-			IL_00ba: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
-			IL_00bf: ldloc.0
-			IL_00c0: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_00c5: ldstr "Cannot access 'client' before initialization"
-			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00cf: stloc.s 5
-			IL_00d1: ldc.i4.2
-			IL_00d2: newarr [System.Runtime]System.Object
-			IL_00d7: dup
-			IL_00d8: ldc.i4.0
-			IL_00d9: ldarg.0
-			IL_00da: stelem.ref
-			IL_00db: dup
-			IL_00dc: ldc.i4.1
-			IL_00dd: ldloc.0
-			IL_00de: stelem.ref
-			IL_00df: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ea: ldc.i4.1
-			IL_00eb: conv.r8
-			IL_00ec: ldstr ""
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00f6: stloc.s 4
-			IL_00f8: ldloc.s 5
-			IL_00fa: ldstr "on"
-			IL_00ff: ldstr "data"
-			IL_0104: ldloc.s 4
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_010b: pop
-			IL_010c: ldloc.0
-			IL_010d: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_0112: ldstr "Cannot access 'client' before initialization"
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_011c: stloc.s 4
-			IL_011e: ldc.i4.2
-			IL_011f: newarr [System.Runtime]System.Object
-			IL_0124: dup
-			IL_0125: ldc.i4.0
-			IL_0126: ldarg.0
-			IL_0127: stelem.ref
-			IL_0128: dup
-			IL_0129: ldc.i4.1
-			IL_012a: ldloc.0
-			IL_012b: stelem.ref
-			IL_012c: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
-			IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0137: ldc.i4.0
-			IL_0138: conv.r8
-			IL_0139: ldstr ""
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0143: stloc.s 5
-			IL_0145: ldloc.s 4
-			IL_0147: ldstr "on"
-			IL_014c: ldstr "end"
-			IL_0151: ldloc.s 5
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0158: pop
-			IL_0159: ldnull
-			IL_015a: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
+			IL_001f: stloc.2
+			IL_0020: ldloc.1
+			IL_0021: ldstr "port"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.3
+			IL_002c: ldloc.1
+			IL_002d: ldstr "address"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: ldc.i4.2
+			IL_003a: newarr [System.Runtime]System.Object
+			IL_003f: dup
+			IL_0040: ldc.i4.0
+			IL_0041: ldarg.0
+			IL_0042: stelem.ref
+			IL_0043: dup
+			IL_0044: ldc.i4.1
+			IL_0045: ldloc.0
+			IL_0046: stelem.ref
+			IL_0047: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0052: ldc.i4.0
+			IL_0053: conv.r8
+			IL_0054: ldstr ""
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_005e: stloc.s 5
+			IL_0060: ldloc.2
+			IL_0061: ldstr "connect"
+			IL_0066: ldloc.3
+			IL_0067: ldloc.s 4
+			IL_0069: ldloc.s 5
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0070: stloc.s 5
+			IL_0072: ldloc.0
+			IL_0073: ldloc.s 5
+			IL_0075: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_007a: ldloc.0
+			IL_007b: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_0080: ldstr "Cannot access 'client' before initialization"
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_008a: stloc.s 5
+			IL_008c: ldloc.s 5
+			IL_008e: ldstr "setEncoding"
+			IL_0093: ldstr "utf8"
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_009d: pop
+			IL_009e: ldloc.0
+			IL_009f: ldstr ""
+			IL_00a4: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
+			IL_00a9: ldloc.0
+			IL_00aa: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_00af: ldstr "Cannot access 'client' before initialization"
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00b9: stloc.s 5
+			IL_00bb: ldc.i4.2
+			IL_00bc: newarr [System.Runtime]System.Object
+			IL_00c1: dup
+			IL_00c2: ldc.i4.0
+			IL_00c3: ldarg.0
+			IL_00c4: stelem.ref
+			IL_00c5: dup
+			IL_00c6: ldc.i4.1
+			IL_00c7: ldloc.0
+			IL_00c8: stelem.ref
+			IL_00c9: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00d4: ldc.i4.1
+			IL_00d5: conv.r8
+			IL_00d6: ldstr ""
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00e0: stloc.s 4
+			IL_00e2: ldloc.s 5
+			IL_00e4: ldstr "on"
+			IL_00e9: ldstr "data"
+			IL_00ee: ldloc.s 4
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f5: pop
+			IL_00f6: ldloc.0
+			IL_00f7: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_00fc: ldstr "Cannot access 'client' before initialization"
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0106: stloc.s 4
+			IL_0108: ldc.i4.2
+			IL_0109: newarr [System.Runtime]System.Object
+			IL_010e: dup
+			IL_010f: ldc.i4.0
+			IL_0110: ldarg.0
+			IL_0111: stelem.ref
+			IL_0112: dup
+			IL_0113: ldc.i4.1
+			IL_0114: ldloc.0
+			IL_0115: stelem.ref
+			IL_0116: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
+			IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0121: ldc.i4.0
+			IL_0122: conv.r8
+			IL_0123: ldstr ""
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_012d: stloc.s 5
+			IL_012f: ldloc.s 4
+			IL_0131: ldstr "on"
+			IL_0136: ldstr "end"
+			IL_013b: ldloc.s 5
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0142: pop
+			IL_0143: ldnull
+			IL_0144: ret
 		} // end of method FunctionExpression_L22C30::__js_call__
 
 	} // end of class FunctionExpression_L22C30
@@ -863,21 +852,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x259a
+			// Method begins at RVA 0x2566
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -895,7 +878,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 193 (0xc1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope,
@@ -915,70 +898,66 @@
 		IL_0014: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
 		IL_0019: ldloc.0
 		IL_001a: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
-		IL_001f: ldstr "Cannot access 'net' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_002f: dup
-		IL_0030: ldstr "allowHalfOpen"
-		IL_0035: ldc.i4.1
-		IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_003b: stloc.2
-		IL_003c: ldc.i4.1
-		IL_003d: newarr [System.Runtime]System.Object
-		IL_0042: dup
-		IL_0043: ldc.i4.0
-		IL_0044: ldloc.0
-		IL_0045: stelem.ref
-		IL_0046: ldc.i4.0
-		IL_0047: ldelem.ref
-		IL_0048: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-		IL_004d: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
-		IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0058: ldc.i4.1
-		IL_0059: conv.r8
-		IL_005a: ldstr ""
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0064: stloc.3
-		IL_0065: ldloc.1
-		IL_0066: ldstr "createServer"
-		IL_006b: ldloc.2
-		IL_006c: ldloc.3
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0072: stloc.3
-		IL_0073: ldloc.0
-		IL_0074: ldloc.3
-		IL_0075: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-		IL_007a: ldloc.0
-		IL_007b: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-		IL_0080: ldstr "Cannot access 'server' before initialization"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_008a: stloc.3
-		IL_008b: ldc.i4.1
-		IL_008c: newarr [System.Runtime]System.Object
-		IL_0091: dup
-		IL_0092: ldc.i4.0
-		IL_0093: ldloc.0
-		IL_0094: stelem.ref
-		IL_0095: ldc.i4.0
-		IL_0096: ldelem.ref
-		IL_0097: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-		IL_009c: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
-		IL_00a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00a7: ldc.i4.0
-		IL_00a8: conv.r8
-		IL_00a9: ldstr ""
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00b3: stloc.1
-		IL_00b4: ldloc.3
-		IL_00b5: ldstr "listen"
-		IL_00ba: ldc.r8 0.0
-		IL_00c3: box [System.Runtime]System.Double
-		IL_00c8: ldstr "127.0.0.1"
-		IL_00cd: ldloc.1
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_001f: stloc.1
+		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0025: dup
+		IL_0026: ldstr "allowHalfOpen"
+		IL_002b: ldc.i4.1
+		IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0031: stloc.2
+		IL_0032: ldc.i4.1
+		IL_0033: newarr [System.Runtime]System.Object
+		IL_0038: dup
+		IL_0039: ldc.i4.0
+		IL_003a: ldloc.0
+		IL_003b: stelem.ref
+		IL_003c: ldc.i4.0
+		IL_003d: ldelem.ref
+		IL_003e: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
+		IL_0043: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
+		IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_004e: ldc.i4.1
+		IL_004f: conv.r8
+		IL_0050: ldstr ""
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_005a: stloc.3
+		IL_005b: ldloc.1
+		IL_005c: ldstr "createServer"
+		IL_0061: ldloc.2
+		IL_0062: ldloc.3
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0068: stloc.3
+		IL_0069: ldloc.0
+		IL_006a: ldloc.3
+		IL_006b: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
+		IL_0070: ldloc.0
+		IL_0071: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
+		IL_0076: stloc.3
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: ldc.i4.0
+		IL_0082: ldelem.ref
+		IL_0083: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
+		IL_0088: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
+		IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0093: ldc.i4.0
+		IL_0094: conv.r8
+		IL_0095: ldstr ""
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_009f: stloc.1
+		IL_00a0: ldloc.3
+		IL_00a1: ldstr "listen"
+		IL_00a6: ldc.r8 0.0
+		IL_00af: box [System.Runtime]System.Double
+		IL_00b4: ldstr "127.0.0.1"
+		IL_00b9: ldloc.1
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00bf: pop
+		IL_00c0: ret
 	} // end of method Net_CreateServer_AllowHalfOpen_Delayed_Response::__js_module_init__
 
 } // end of class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response
@@ -990,7 +969,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2615
+		// Method begins at RVA 0x25cb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2575
+					// Method begins at RVA 0x2527
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2378
+				// Method begins at RVA 0x234c
 				// Header size: 12
 				// Code size: 55 (0x37)
 				.maxstack 8
@@ -95,7 +95,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x257e
+					// Method begins at RVA 0x2530
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -119,7 +119,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23bc
+				// Method begins at RVA 0x2390
 				// Header size: 12
 				// Code size: 125 (0x7d)
 				.maxstack 8
@@ -194,7 +194,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x256c
+				// Method begins at RVA 0x251e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -221,7 +221,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 148 (0x94)
 			.maxstack 8
@@ -307,7 +307,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x259b
+					// Method begins at RVA 0x254d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -331,7 +331,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2448
+				// Method begins at RVA 0x241c
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -369,7 +369,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25a4
+					// Method begins at RVA 0x2556
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -394,7 +394,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2480
+				// Method begins at RVA 0x2454
 				// Header size: 12
 				// Code size: 55 (0x37)
 				.maxstack 8
@@ -446,7 +446,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25b6
+						// Method begins at RVA 0x2568
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -469,7 +469,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x253a
+					// Method begins at RVA 0x2502
 					// Header size: 1
 					// Code size: 18 (0x12)
 					.maxstack 8
@@ -491,7 +491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ad
+					// Method begins at RVA 0x255f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -515,15 +515,14 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24c4
+				// Method begins at RVA 0x2498
 				// Header size: 12
-				// Code size: 106 (0x6a)
+				// Code size: 94 (0x5e)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/Scope,
 					[1] object,
-					[2] object,
-					[3] object
+					[2] object
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/Scope::.ctor()
@@ -540,29 +539,25 @@
 				IL_0023: ldloc.1
 				IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 				IL_0029: pop
-				IL_002a: ldarg.0
-				IL_002b: ldc.i4.0
-				IL_002c: ldelem.ref
-				IL_002d: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-				IL_0032: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-				IL_0037: ldstr "Cannot access 'server' before initialization"
-				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0041: stloc.2
-				IL_0042: ldnull
-				IL_0043: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
-				IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004e: ldc.i4.0
-				IL_004f: conv.r8
-				IL_0050: ldstr ""
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_005a: stloc.3
-				IL_005b: ldloc.2
-				IL_005c: ldstr "close"
-				IL_0061: ldloc.3
-				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0067: pop
-				IL_0068: ldnull
-				IL_0069: ret
+				IL_002a: ldnull
+				IL_002b: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
+				IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0036: ldc.i4.0
+				IL_0037: conv.r8
+				IL_0038: ldstr ""
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_0042: stloc.2
+				IL_0043: ldarg.0
+				IL_0044: ldc.i4.0
+				IL_0045: ldelem.ref
+				IL_0046: castclass Modules.Net_CreateServer_Connect_Basic/Scope
+				IL_004b: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
+				IL_0050: ldstr "close"
+				IL_0055: ldloc.2
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005b: pop
+				IL_005c: ldnull
+				IL_005d: ret
 			} // end of method FunctionExpression_L32C19::__js_call__
 
 		} // end of class FunctionExpression_L32C19
@@ -583,7 +578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2587
+				// Method begins at RVA 0x2539
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -612,9 +607,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x21c0
+			// Method begins at RVA 0x21a8
 			// Header size: 12
-			// Code size: 428 (0x1ac)
+			// Code size: 406 (0x196)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope,
@@ -630,150 +625,144 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldstr "listening:"
-			IL_002a: ldloc.1
-			IL_002b: ldstr "family"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0018: stloc.1
+			IL_0019: ldstr "listening:"
+			IL_001e: ldloc.1
+			IL_001f: ldstr "family"
+			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_002e: stloc.3
+			IL_002f: ldloc.3
+			IL_0030: ldstr ":"
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_003a: stloc.3
 			IL_003b: ldloc.3
-			IL_003c: ldstr ":"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0046: stloc.3
-			IL_0047: ldloc.3
-			IL_0048: ldloc.1
-			IL_0049: ldstr "address"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003c: ldloc.1
+			IL_003d: ldstr "address"
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: ldstr ":"
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0058: stloc.3
 			IL_0059: ldloc.3
-			IL_005a: ldstr ":"
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0064: stloc.3
-			IL_0065: ldloc.3
-			IL_0066: ldloc.1
-			IL_0067: ldstr "port"
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0071: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0076: ldc.r8 0.0
-			IL_007f: cgt
-			IL_0081: box [System.Runtime]System.Boolean
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_008b: stloc.3
-			IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0091: ldloc.3
-			IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0097: pop
-			IL_0098: ldarg.0
-			IL_0099: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
-			IL_009e: ldstr "Cannot access 'net' before initialization"
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a8: stloc.2
-			IL_00a9: ldloc.1
-			IL_00aa: ldstr "port"
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b4: stloc.s 4
-			IL_00b6: ldloc.1
-			IL_00b7: ldstr "address"
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c1: stloc.s 5
-			IL_00c3: ldc.i4.2
-			IL_00c4: newarr [System.Runtime]System.Object
-			IL_00c9: dup
-			IL_00ca: ldc.i4.0
-			IL_00cb: ldarg.0
-			IL_00cc: stelem.ref
-			IL_00cd: dup
-			IL_00ce: ldc.i4.1
-			IL_00cf: ldloc.0
-			IL_00d0: stelem.ref
-			IL_00d1: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_00d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00dc: ldc.i4.0
-			IL_00dd: conv.r8
-			IL_00de: ldstr ""
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00e8: stloc.s 6
-			IL_00ea: ldloc.2
-			IL_00eb: ldstr "connect"
-			IL_00f0: ldloc.s 4
-			IL_00f2: ldloc.s 5
-			IL_00f4: ldloc.s 6
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_00fb: stloc.s 6
-			IL_00fd: ldloc.0
-			IL_00fe: ldloc.s 6
-			IL_0100: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_0105: ldloc.0
-			IL_0106: ldstr ""
-			IL_010b: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
-			IL_0110: ldloc.0
-			IL_0111: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_0116: ldstr "Cannot access 'client' before initialization"
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0120: stloc.s 6
-			IL_0122: ldc.i4.2
-			IL_0123: newarr [System.Runtime]System.Object
-			IL_0128: dup
-			IL_0129: ldc.i4.0
-			IL_012a: ldarg.0
-			IL_012b: stelem.ref
-			IL_012c: dup
-			IL_012d: ldc.i4.1
-			IL_012e: ldloc.0
-			IL_012f: stelem.ref
-			IL_0130: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
-			IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_013b: ldc.i4.1
-			IL_013c: conv.r8
-			IL_013d: ldstr ""
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0147: stloc.s 5
-			IL_0149: ldloc.s 6
-			IL_014b: ldstr "on"
-			IL_0150: ldstr "data"
-			IL_0155: ldloc.s 5
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_015c: pop
-			IL_015d: ldloc.0
-			IL_015e: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_0163: ldstr "Cannot access 'client' before initialization"
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_016d: stloc.s 5
-			IL_016f: ldc.i4.2
-			IL_0170: newarr [System.Runtime]System.Object
-			IL_0175: dup
-			IL_0176: ldc.i4.0
-			IL_0177: ldarg.0
-			IL_0178: stelem.ref
-			IL_0179: dup
-			IL_017a: ldc.i4.1
-			IL_017b: ldloc.0
-			IL_017c: stelem.ref
-			IL_017d: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
-			IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0188: ldc.i4.0
-			IL_0189: conv.r8
-			IL_018a: ldstr ""
-			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0194: stloc.s 6
-			IL_0196: ldloc.s 5
-			IL_0198: ldstr "on"
-			IL_019d: ldstr "end"
-			IL_01a2: ldloc.s 6
-			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: pop
-			IL_01aa: ldnull
-			IL_01ab: ret
+			IL_005a: ldloc.1
+			IL_005b: ldstr "port"
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0065: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_006a: ldc.r8 0.0
+			IL_0073: cgt
+			IL_0075: box [System.Runtime]System.Boolean
+			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007f: stloc.3
+			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0085: ldloc.3
+			IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_008b: pop
+			IL_008c: ldarg.0
+			IL_008d: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
+			IL_0092: stloc.2
+			IL_0093: ldloc.1
+			IL_0094: ldstr "port"
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009e: stloc.s 4
+			IL_00a0: ldloc.1
+			IL_00a1: ldstr "address"
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ab: stloc.s 5
+			IL_00ad: ldc.i4.2
+			IL_00ae: newarr [System.Runtime]System.Object
+			IL_00b3: dup
+			IL_00b4: ldc.i4.0
+			IL_00b5: ldarg.0
+			IL_00b6: stelem.ref
+			IL_00b7: dup
+			IL_00b8: ldc.i4.1
+			IL_00b9: ldloc.0
+			IL_00ba: stelem.ref
+			IL_00bb: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00c6: ldc.i4.0
+			IL_00c7: conv.r8
+			IL_00c8: ldstr ""
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00d2: stloc.s 6
+			IL_00d4: ldloc.2
+			IL_00d5: ldstr "connect"
+			IL_00da: ldloc.s 4
+			IL_00dc: ldloc.s 5
+			IL_00de: ldloc.s 6
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00e5: stloc.s 6
+			IL_00e7: ldloc.0
+			IL_00e8: ldloc.s 6
+			IL_00ea: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_00ef: ldloc.0
+			IL_00f0: ldstr ""
+			IL_00f5: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
+			IL_00fa: ldloc.0
+			IL_00fb: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_0100: ldstr "Cannot access 'client' before initialization"
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_010a: stloc.s 6
+			IL_010c: ldc.i4.2
+			IL_010d: newarr [System.Runtime]System.Object
+			IL_0112: dup
+			IL_0113: ldc.i4.0
+			IL_0114: ldarg.0
+			IL_0115: stelem.ref
+			IL_0116: dup
+			IL_0117: ldc.i4.1
+			IL_0118: ldloc.0
+			IL_0119: stelem.ref
+			IL_011a: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
+			IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0125: ldc.i4.1
+			IL_0126: conv.r8
+			IL_0127: ldstr ""
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0131: stloc.s 5
+			IL_0133: ldloc.s 6
+			IL_0135: ldstr "on"
+			IL_013a: ldstr "data"
+			IL_013f: ldloc.s 5
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0146: pop
+			IL_0147: ldloc.0
+			IL_0148: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_014d: ldstr "Cannot access 'client' before initialization"
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0157: stloc.s 5
+			IL_0159: ldc.i4.2
+			IL_015a: newarr [System.Runtime]System.Object
+			IL_015f: dup
+			IL_0160: ldc.i4.0
+			IL_0161: ldarg.0
+			IL_0162: stelem.ref
+			IL_0163: dup
+			IL_0164: ldc.i4.1
+			IL_0165: ldloc.0
+			IL_0166: stelem.ref
+			IL_0167: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
+			IL_016d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0172: ldc.i4.0
+			IL_0173: conv.r8
+			IL_0174: ldstr ""
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_017e: stloc.s 6
+			IL_0180: ldloc.s 5
+			IL_0182: ldstr "on"
+			IL_0187: ldstr "end"
+			IL_018c: ldloc.s 6
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0193: pop
+			IL_0194: ldnull
+			IL_0195: ret
 		} // end of method FunctionExpression_L19C30::__js_call__
 
 	} // end of class FunctionExpression_L19C30
@@ -794,21 +783,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x254d
+			// Method begins at RVA 0x2515
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -826,7 +809,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_CreateServer_Connect_Basic/Scope,
@@ -843,65 +826,59 @@
 		IL_0012: ldloc.0
 		IL_0013: ldloc.1
 		IL_0014: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
-		IL_001f: ldstr "Cannot access 'net' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
-		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.i4.0
-		IL_0035: ldelem.ref
-		IL_0036: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_003b: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0046: ldc.i4.1
-		IL_0047: conv.r8
-		IL_0048: ldstr ""
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldstr "createServer"
-		IL_0059: ldloc.2
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_005f: stloc.2
-		IL_0060: ldloc.0
-		IL_0061: ldloc.2
-		IL_0062: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-		IL_0067: ldloc.0
-		IL_0068: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-		IL_006d: ldstr "Cannot access 'server' before initialization"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0077: stloc.2
-		IL_0078: ldc.i4.1
-		IL_0079: newarr [System.Runtime]System.Object
-		IL_007e: dup
-		IL_007f: ldc.i4.0
-		IL_0080: ldloc.0
-		IL_0081: stelem.ref
-		IL_0082: ldc.i4.0
-		IL_0083: ldelem.ref
-		IL_0084: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_0089: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
-		IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0094: ldc.i4.0
-		IL_0095: conv.r8
-		IL_0096: ldstr ""
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00a0: stloc.1
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "listen"
-		IL_00a7: ldc.r8 0.0
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: ldstr "127.0.0.1"
-		IL_00ba: ldloc.1
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: ldc.i4.0
+		IL_0024: ldelem.ref
+		IL_0025: castclass Modules.Net_CreateServer_Connect_Basic/Scope
+		IL_002a: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0035: ldc.i4.1
+		IL_0036: conv.r8
+		IL_0037: ldstr ""
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0041: stloc.1
+		IL_0042: ldloc.0
+		IL_0043: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
+		IL_0048: ldstr "createServer"
+		IL_004d: ldloc.1
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0053: stloc.1
+		IL_0054: ldloc.0
+		IL_0055: ldloc.1
+		IL_0056: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
+		IL_005b: ldloc.0
+		IL_005c: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
+		IL_0061: stloc.1
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.0
+		IL_006b: stelem.ref
+		IL_006c: ldc.i4.0
+		IL_006d: ldelem.ref
+		IL_006e: castclass Modules.Net_CreateServer_Connect_Basic/Scope
+		IL_0073: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
+		IL_0079: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_007e: ldc.i4.0
+		IL_007f: conv.r8
+		IL_0080: ldstr ""
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_008a: stloc.2
+		IL_008b: ldloc.1
+		IL_008c: ldstr "listen"
+		IL_0091: ldc.r8 0.0
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: ldstr "127.0.0.1"
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method Net_CreateServer_Connect_Basic::__js_module_init__
 
 } // end of class Modules.Net_CreateServer_Connect_Basic
@@ -913,7 +890,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25bf
+		// Method begins at RVA 0x2571
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
+++ b/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x279b
+						// Method begins at RVA 0x2700
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2792
+					// Method begins at RVA 0x26f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,17 +69,17 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22d4
+				// Method begins at RVA 0x22a8
 				// Header size: 12
-				// Code size: 553 (0x229)
+				// Code size: 522 (0x20a)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 					[1] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/Scope/Block_L12C39,
-					[2] object,
-					[3] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[4] float64,
-					[5] bool,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+					[3] float64,
+					[4] bool,
+					[5] object,
 					[6] object,
 					[7] object,
 					[8] object,
@@ -92,181 +92,172 @@
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_0008: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
-				IL_000d: ldstr "Cannot access 'received' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldstr "push"
-				IL_001e: ldarg.2
-				IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0024: pop
-				IL_0025: ldarg.0
-				IL_0026: ldc.i4.1
-				IL_0027: ldelem.ref
-				IL_0028: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_002d: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
-				IL_0032: ldstr "Cannot access 'received' before initialization"
-				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_003c: stloc.2
-				IL_003d: ldloc.2
-				IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: stloc.0
-				IL_0046: ldloc.0
-				IL_0047: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-				IL_004c: stloc.s 4
-				IL_004e: ldloc.s 4
-				IL_0050: ldc.r8 4
-				IL_0059: clt
-				IL_005b: stloc.s 5
-				IL_005d: ldloc.s 5
-				IL_005f: box [System.Runtime]System.Boolean
-				IL_0064: stloc.s 6
-				IL_0066: ldloc.s 6
-				IL_0068: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_006d: stloc.s 5
-				IL_006f: ldloc.s 5
-				IL_0071: brtrue IL_008a
+				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
+				IL_000d: ldarg.2
+				IL_000e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0013: pop
+				IL_0014: ldarg.0
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
+				IL_001c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
+				IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+				IL_0026: stloc.2
+				IL_0027: ldloc.2
+				IL_0028: stloc.0
+				IL_0029: ldloc.0
+				IL_002a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+				IL_002f: stloc.3
+				IL_0030: ldloc.3
+				IL_0031: ldc.r8 4
+				IL_003a: clt
+				IL_003c: stloc.s 4
+				IL_003e: ldloc.s 4
+				IL_0040: box [System.Runtime]System.Boolean
+				IL_0045: stloc.s 5
+				IL_0047: ldloc.s 5
+				IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_004e: stloc.s 4
+				IL_0050: ldloc.s 4
+				IL_0052: brtrue IL_006b
 
-				IL_0076: ldarg.0
-				IL_0077: ldc.i4.1
-				IL_0078: ldelem.ref
-				IL_0079: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_007e: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::replied
-				IL_0083: stloc.s 8
-				IL_0085: br IL_008e
+				IL_0057: ldarg.0
+				IL_0058: ldc.i4.1
+				IL_0059: ldelem.ref
+				IL_005a: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
+				IL_005f: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::replied
+				IL_0064: stloc.s 7
+				IL_0066: br IL_006f
 
-				IL_008a: ldloc.s 6
-				IL_008c: stloc.s 8
+				IL_006b: ldloc.s 5
+				IL_006d: stloc.s 7
 
-				IL_008e: ldloc.s 8
-				IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0095: stloc.s 5
-				IL_0097: ldloc.s 5
-				IL_0099: brfalse IL_00a6
+				IL_006f: ldloc.s 7
+				IL_0071: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0076: stloc.s 4
+				IL_0078: ldloc.s 4
+				IL_007a: brfalse IL_0087
 
-				IL_009e: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/Scope/Block_L12C39::.ctor()
-				IL_00a3: stloc.1
-				IL_00a4: ldnull
-				IL_00a5: ret
+				IL_007f: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/Scope/Block_L12C39::.ctor()
+				IL_0084: stloc.1
+				IL_0085: ldnull
+				IL_0086: ret
 
-				IL_00a6: ldarg.0
-				IL_00a7: ldc.i4.1
-				IL_00a8: ldelem.ref
-				IL_00a9: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_00ae: ldc.i4.1
-				IL_00af: box [System.Runtime]System.Boolean
-				IL_00b4: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::replied
-				IL_00b9: ldloc.0
-				IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-				IL_00bf: stloc.s 5
-				IL_00c1: ldloc.s 5
-				IL_00c3: box [System.Runtime]System.Boolean
-				IL_00c8: stloc.s 6
-				IL_00ca: ldstr "server buffer:"
-				IL_00cf: ldloc.s 6
-				IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d6: stloc.s 8
-				IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_00dd: ldloc.s 8
-				IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_00e4: pop
-				IL_00e5: ldloc.0
-				IL_00e6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-				IL_00eb: stloc.s 4
-				IL_00ed: ldstr "server bytes:"
-				IL_00f2: ldloc.s 4
-				IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_00f9: stloc.s 8
-				IL_00fb: ldloc.s 8
-				IL_00fd: ldstr ":"
-				IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0107: stloc.s 8
-				IL_0109: ldloc.s 8
-				IL_010b: ldloc.0
-				IL_010c: ldc.r8 0.0
-				IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_011f: stloc.s 8
-				IL_0121: ldloc.s 8
-				IL_0123: ldstr ":"
-				IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_012d: stloc.s 8
-				IL_012f: ldloc.s 8
-				IL_0131: ldloc.0
-				IL_0132: ldc.r8 1
-				IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0145: stloc.s 8
-				IL_0147: ldloc.s 8
-				IL_0149: ldstr ":"
-				IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0153: stloc.s 8
-				IL_0155: ldloc.s 8
-				IL_0157: ldloc.0
-				IL_0158: ldc.r8 2
-				IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_016b: stloc.s 8
-				IL_016d: ldloc.s 8
-				IL_016f: ldstr ":"
-				IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0179: stloc.s 8
-				IL_017b: ldloc.s 8
-				IL_017d: ldloc.0
-				IL_017e: ldc.r8 3
-				IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0191: stloc.s 8
-				IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0198: ldloc.s 8
-				IL_019a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_019f: pop
-				IL_01a0: ldarg.0
-				IL_01a1: ldc.i4.1
-				IL_01a2: ldelem.ref
-				IL_01a3: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_01a8: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::socket
-				IL_01ad: stloc.2
-				IL_01ae: ldloc.0
-				IL_01af: ldc.r8 3
-				IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01bd: stloc.s 9
-				IL_01bf: ldloc.0
-				IL_01c0: ldc.r8 2
-				IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01ce: stloc.s 10
-				IL_01d0: ldloc.0
-				IL_01d1: ldc.r8 1
-				IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01df: stloc.s 11
-				IL_01e1: ldc.i4.4
-				IL_01e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_01e7: dup
-				IL_01e8: ldloc.s 9
-				IL_01ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_01ef: dup
-				IL_01f0: ldloc.s 10
-				IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_01f7: dup
-				IL_01f8: ldloc.s 11
-				IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_01ff: dup
-				IL_0200: ldloc.0
-				IL_0201: ldc.r8 0.0
-				IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_020f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0214: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0219: stloc.3
-				IL_021a: ldloc.2
-				IL_021b: ldstr "end"
-				IL_0220: ldloc.3
-				IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0226: pop
-				IL_0227: ldnull
-				IL_0228: ret
+				IL_0087: ldarg.0
+				IL_0088: ldc.i4.1
+				IL_0089: ldelem.ref
+				IL_008a: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
+				IL_008f: ldc.i4.1
+				IL_0090: box [System.Runtime]System.Boolean
+				IL_0095: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::replied
+				IL_009a: ldloc.0
+				IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+				IL_00a0: stloc.s 4
+				IL_00a2: ldloc.s 4
+				IL_00a4: box [System.Runtime]System.Boolean
+				IL_00a9: stloc.s 5
+				IL_00ab: ldstr "server buffer:"
+				IL_00b0: ldloc.s 5
+				IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00b7: stloc.s 7
+				IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_00be: ldloc.s 7
+				IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_00c5: pop
+				IL_00c6: ldloc.0
+				IL_00c7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+				IL_00cc: stloc.3
+				IL_00cd: ldstr "server bytes:"
+				IL_00d2: ldloc.3
+				IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_00d8: stloc.s 7
+				IL_00da: ldloc.s 7
+				IL_00dc: ldstr ":"
+				IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00e6: stloc.s 7
+				IL_00e8: ldloc.s 7
+				IL_00ea: ldloc.0
+				IL_00eb: ldc.r8 0.0
+				IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00fe: stloc.s 7
+				IL_0100: ldloc.s 7
+				IL_0102: ldstr ":"
+				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_010c: stloc.s 7
+				IL_010e: ldloc.s 7
+				IL_0110: ldloc.0
+				IL_0111: ldc.r8 1
+				IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0124: stloc.s 7
+				IL_0126: ldloc.s 7
+				IL_0128: ldstr ":"
+				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0132: stloc.s 7
+				IL_0134: ldloc.s 7
+				IL_0136: ldloc.0
+				IL_0137: ldc.r8 2
+				IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_014a: stloc.s 7
+				IL_014c: ldloc.s 7
+				IL_014e: ldstr ":"
+				IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0158: stloc.s 7
+				IL_015a: ldloc.s 7
+				IL_015c: ldloc.0
+				IL_015d: ldc.r8 3
+				IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0170: stloc.s 7
+				IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0177: ldloc.s 7
+				IL_0179: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_017e: pop
+				IL_017f: ldarg.0
+				IL_0180: ldc.i4.1
+				IL_0181: ldelem.ref
+				IL_0182: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
+				IL_0187: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::socket
+				IL_018c: stloc.s 8
+				IL_018e: ldloc.0
+				IL_018f: ldc.r8 3
+				IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_019d: stloc.s 9
+				IL_019f: ldloc.0
+				IL_01a0: ldc.r8 2
+				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01ae: stloc.s 10
+				IL_01b0: ldloc.0
+				IL_01b1: ldc.r8 1
+				IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01bf: stloc.s 11
+				IL_01c1: ldc.i4.4
+				IL_01c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_01c7: dup
+				IL_01c8: ldloc.s 9
+				IL_01ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_01cf: dup
+				IL_01d0: ldloc.s 10
+				IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_01d7: dup
+				IL_01d8: ldloc.s 11
+				IL_01da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_01df: dup
+				IL_01e0: ldloc.0
+				IL_01e1: ldc.r8 0.0
+				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_01f4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_01f9: stloc.2
+				IL_01fa: ldloc.s 8
+				IL_01fc: ldstr "end"
+				IL_0201: ldloc.2
+				IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0207: pop
+				IL_0208: ldnull
+				IL_0209: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -283,25 +274,22 @@
 			)
 			// Fields
 			.field public object socket
-			.field public object received
+			.field public class [JavaScriptRuntime]JavaScriptRuntime.Array received
 			.field public object replied
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x277e
+				// Method begins at RVA 0x26ee
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -320,7 +308,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 100 (0x64)
 			.maxstack 8
@@ -337,7 +325,7 @@
 			IL_000d: ldloc.0
 			IL_000e: ldc.i4.0
 			IL_000f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0014: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
+			IL_0014: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
 			IL_0019: ldloc.0
 			IL_001a: ldc.i4.0
 			IL_001b: box [System.Runtime]System.Boolean
@@ -387,7 +375,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27c3
+					// Method begins at RVA 0x271d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -411,7 +399,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x250c
+				// Method begins at RVA 0x24c0
 				// Header size: 12
 				// Code size: 131 (0x83)
 				.maxstack 8
@@ -470,7 +458,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27cc
+					// Method begins at RVA 0x2726
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -495,9 +483,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x259c
+				// Method begins at RVA 0x2550
 				// Header size: 12
-				// Code size: 113 (0x71)
+				// Code size: 96 (0x60)
 				.maxstack 8
 				.locals init (
 					[0] bool,
@@ -524,29 +512,24 @@
 				IL_0027: ldc.i4.1
 				IL_0028: ldelem.ref
 				IL_0029: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
-				IL_002e: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
-				IL_0033: ldstr "Cannot access 'reply' before initialization"
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_003d: stloc.3
-				IL_003e: ldloc.3
-				IL_003f: ldstr "push"
-				IL_0044: ldarg.2
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004a: pop
-				IL_004b: ldarg.0
-				IL_004c: ldc.i4.1
-				IL_004d: ldelem.ref
-				IL_004e: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
-				IL_0053: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-				IL_0058: ldstr "Cannot access 'client' before initialization"
-				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0062: stloc.3
-				IL_0063: ldloc.3
-				IL_0064: ldstr "end"
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_006e: pop
-				IL_006f: ldnull
-				IL_0070: ret
+				IL_002e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
+				IL_0033: ldarg.2
+				IL_0034: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0039: pop
+				IL_003a: ldarg.0
+				IL_003b: ldc.i4.1
+				IL_003c: ldelem.ref
+				IL_003d: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
+				IL_0042: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+				IL_0047: ldstr "Cannot access 'client' before initialization"
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0051: stloc.3
+				IL_0052: ldloc.3
+				IL_0053: ldstr "end"
+				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_005d: pop
+				IL_005e: ldnull
+				IL_005f: ret
 			} // end of method FunctionExpression_L30C20::__js_call__
 
 		} // end of class FunctionExpression_L30C20
@@ -566,7 +549,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27de
+						// Method begins at RVA 0x2738
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -589,7 +572,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x274c
+					// Method begins at RVA 0x26d2
 					// Header size: 1
 					// Code size: 18 (0x12)
 					.maxstack 8
@@ -611,7 +594,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27d5
+					// Method begins at RVA 0x272f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -635,18 +618,17 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x261c
+				// Method begins at RVA 0x25bc
 				// Header size: 12
-				// Code size: 292 (0x124)
+				// Code size: 266 (0x10a)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/Scope,
 					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[2] object,
-					[3] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[4] float64,
-					[5] object,
-					[6] object
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+					[3] float64,
+					[4] object,
+					[5] object
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/Scope::.ctor()
@@ -655,89 +637,81 @@
 				IL_0007: ldc.i4.1
 				IL_0008: ldelem.ref
 				IL_0009: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
-				IL_000e: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
-				IL_0013: ldstr "Cannot access 'reply' before initialization"
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_001d: stloc.2
-				IL_001e: ldloc.2
-				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
-				IL_0024: stloc.3
-				IL_0025: ldloc.3
-				IL_0026: stloc.1
-				IL_0027: ldloc.1
-				IL_0028: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+				IL_000e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+				IL_0018: stloc.2
+				IL_0019: ldloc.2
+				IL_001a: stloc.1
+				IL_001b: ldloc.1
+				IL_001c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+				IL_0021: stloc.3
+				IL_0022: ldstr "client bytes:"
+				IL_0027: ldloc.3
+				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
 				IL_002d: stloc.s 4
-				IL_002f: ldstr "client bytes:"
-				IL_0034: ldloc.s 4
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_003b: stloc.s 5
-				IL_003d: ldloc.s 5
-				IL_003f: ldstr ":"
-				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0049: stloc.s 5
-				IL_004b: ldloc.s 5
-				IL_004d: ldloc.1
-				IL_004e: ldc.r8 0.0
-				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_002f: ldloc.s 4
+				IL_0031: ldstr ":"
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_003b: stloc.s 4
+				IL_003d: ldloc.s 4
+				IL_003f: ldloc.1
+				IL_0040: ldc.r8 0.0
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0053: stloc.s 4
+				IL_0055: ldloc.s 4
+				IL_0057: ldstr ":"
 				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0061: stloc.s 5
-				IL_0063: ldloc.s 5
-				IL_0065: ldstr ":"
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_006f: stloc.s 5
-				IL_0071: ldloc.s 5
-				IL_0073: ldloc.1
-				IL_0074: ldc.r8 1
-				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0061: stloc.s 4
+				IL_0063: ldloc.s 4
+				IL_0065: ldloc.1
+				IL_0066: ldc.r8 1
+				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0079: stloc.s 4
+				IL_007b: ldloc.s 4
+				IL_007d: ldstr ":"
 				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0087: stloc.s 5
-				IL_0089: ldloc.s 5
-				IL_008b: ldstr ":"
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0095: stloc.s 5
-				IL_0097: ldloc.s 5
-				IL_0099: ldloc.1
-				IL_009a: ldc.r8 2
-				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0087: stloc.s 4
+				IL_0089: ldloc.s 4
+				IL_008b: ldloc.1
+				IL_008c: ldc.r8 2
+				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_009f: stloc.s 4
+				IL_00a1: ldloc.s 4
+				IL_00a3: ldstr ":"
 				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00ad: stloc.s 5
-				IL_00af: ldloc.s 5
-				IL_00b1: ldstr ":"
-				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00bb: stloc.s 5
-				IL_00bd: ldloc.s 5
-				IL_00bf: ldloc.1
-				IL_00c0: ldc.r8 3
-				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d3: stloc.s 5
-				IL_00d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_00da: ldloc.s 5
-				IL_00dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_00e1: pop
-				IL_00e2: ldarg.0
-				IL_00e3: ldc.i4.0
-				IL_00e4: ldelem.ref
-				IL_00e5: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-				IL_00ea: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-				IL_00ef: ldstr "Cannot access 'server' before initialization"
-				IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00f9: stloc.2
-				IL_00fa: ldnull
-				IL_00fb: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
-				IL_0101: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0106: ldc.i4.0
-				IL_0107: conv.r8
-				IL_0108: ldstr ""
-				IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_0112: stloc.s 6
-				IL_0114: ldloc.2
-				IL_0115: ldstr "close"
-				IL_011a: ldloc.s 6
-				IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0121: pop
-				IL_0122: ldnull
-				IL_0123: ret
+				IL_00ad: stloc.s 4
+				IL_00af: ldloc.s 4
+				IL_00b1: ldloc.1
+				IL_00b2: ldc.r8 3
+				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00c5: stloc.s 4
+				IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_00cc: ldloc.s 4
+				IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_00d3: pop
+				IL_00d4: ldnull
+				IL_00d5: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
+				IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_00e0: ldc.i4.0
+				IL_00e1: conv.r8
+				IL_00e2: ldstr ""
+				IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_00ec: stloc.s 5
+				IL_00ee: ldarg.0
+				IL_00ef: ldc.i4.0
+				IL_00f0: ldelem.ref
+				IL_00f1: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
+				IL_00f6: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
+				IL_00fb: ldstr "close"
+				IL_0100: ldloc.s 5
+				IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0107: pop
+				IL_0108: ldnull
+				IL_0109: ret
 			} // end of method FunctionExpression_L36C19::__js_call__
 
 		} // end of class FunctionExpression_L36C19
@@ -752,15 +726,15 @@
 			)
 			// Fields
 			.field public object client
-			.field public object reply
+			.field public class [JavaScriptRuntime]JavaScriptRuntime.Array reply
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a4
+				// Method begins at RVA 0x2709
 				// Header size: 1
-				// Code size: 30 (0x1e)
+				// Code size: 19 (0x13)
 				.maxstack 8
 
 				IL_0000: ldarg.0
@@ -768,11 +742,8 @@
 				IL_0006: ldarg.0
 				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
 				IL_000c: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-				IL_0011: ldarg.0
-				IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_0017: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
-				IL_001c: nop
-				IL_001d: ret
+				IL_0011: nop
+				IL_0012: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -790,9 +761,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2190
+			// Method begins at RVA 0x2178
 			// Header size: 12
-			// Code size: 312 (0x138)
+			// Code size: 290 (0x122)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope,
@@ -807,117 +778,111 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
-			IL_002b: ldstr "Cannot access 'net' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.2
-			IL_0036: ldloc.1
-			IL_0037: ldstr "port"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.3
-			IL_0042: ldloc.1
-			IL_0043: ldstr "address"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 4
-			IL_004f: ldc.i4.2
-			IL_0050: newarr [System.Runtime]System.Object
-			IL_0055: dup
-			IL_0056: ldc.i4.0
-			IL_0057: ldarg.0
-			IL_0058: stelem.ref
-			IL_0059: dup
-			IL_005a: ldc.i4.1
-			IL_005b: ldloc.0
-			IL_005c: stelem.ref
-			IL_005d: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0068: ldc.i4.0
-			IL_0069: conv.r8
-			IL_006a: ldstr ""
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0074: stloc.s 5
-			IL_0076: ldloc.2
-			IL_0077: ldstr "connect"
-			IL_007c: ldloc.3
-			IL_007d: ldloc.s 4
-			IL_007f: ldloc.s 5
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0086: stloc.s 5
-			IL_0088: ldloc.0
-			IL_0089: ldloc.s 5
-			IL_008b: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_0090: ldloc.0
-			IL_0091: ldc.i4.0
-			IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0097: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
-			IL_009c: ldloc.0
-			IL_009d: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_00a2: ldstr "Cannot access 'client' before initialization"
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00ac: stloc.s 5
-			IL_00ae: ldc.i4.2
-			IL_00af: newarr [System.Runtime]System.Object
-			IL_00b4: dup
-			IL_00b5: ldc.i4.0
-			IL_00b6: ldarg.0
-			IL_00b7: stelem.ref
-			IL_00b8: dup
-			IL_00b9: ldc.i4.1
-			IL_00ba: ldloc.0
-			IL_00bb: stelem.ref
-			IL_00bc: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_00c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00c7: ldc.i4.1
-			IL_00c8: conv.r8
-			IL_00c9: ldstr ""
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00d3: stloc.s 4
-			IL_00d5: ldloc.s 5
-			IL_00d7: ldstr "on"
-			IL_00dc: ldstr "data"
-			IL_00e1: ldloc.s 4
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00e8: pop
-			IL_00e9: ldloc.0
-			IL_00ea: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_00ef: ldstr "Cannot access 'client' before initialization"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00f9: stloc.s 4
-			IL_00fb: ldc.i4.2
-			IL_00fc: newarr [System.Runtime]System.Object
-			IL_0101: dup
-			IL_0102: ldc.i4.0
-			IL_0103: ldarg.0
-			IL_0104: stelem.ref
-			IL_0105: dup
-			IL_0106: ldc.i4.1
-			IL_0107: ldloc.0
-			IL_0108: stelem.ref
-			IL_0109: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
-			IL_010f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0114: ldc.i4.0
-			IL_0115: conv.r8
-			IL_0116: ldstr ""
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0120: stloc.s 5
-			IL_0122: ldloc.s 4
-			IL_0124: ldstr "on"
-			IL_0129: ldstr "end"
-			IL_012e: ldloc.s 5
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0135: pop
-			IL_0136: ldnull
-			IL_0137: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
+			IL_001f: stloc.2
+			IL_0020: ldloc.1
+			IL_0021: ldstr "port"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.3
+			IL_002c: ldloc.1
+			IL_002d: ldstr "address"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: ldc.i4.2
+			IL_003a: newarr [System.Runtime]System.Object
+			IL_003f: dup
+			IL_0040: ldc.i4.0
+			IL_0041: ldarg.0
+			IL_0042: stelem.ref
+			IL_0043: dup
+			IL_0044: ldc.i4.1
+			IL_0045: ldloc.0
+			IL_0046: stelem.ref
+			IL_0047: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0052: ldc.i4.0
+			IL_0053: conv.r8
+			IL_0054: ldstr ""
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_005e: stloc.s 5
+			IL_0060: ldloc.2
+			IL_0061: ldstr "connect"
+			IL_0066: ldloc.3
+			IL_0067: ldloc.s 4
+			IL_0069: ldloc.s 5
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0070: stloc.s 5
+			IL_0072: ldloc.0
+			IL_0073: ldloc.s 5
+			IL_0075: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_007a: ldloc.0
+			IL_007b: ldc.i4.0
+			IL_007c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0081: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
+			IL_0086: ldloc.0
+			IL_0087: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_008c: ldstr "Cannot access 'client' before initialization"
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0096: stloc.s 5
+			IL_0098: ldc.i4.2
+			IL_0099: newarr [System.Runtime]System.Object
+			IL_009e: dup
+			IL_009f: ldc.i4.0
+			IL_00a0: ldarg.0
+			IL_00a1: stelem.ref
+			IL_00a2: dup
+			IL_00a3: ldc.i4.1
+			IL_00a4: ldloc.0
+			IL_00a5: stelem.ref
+			IL_00a6: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00b1: ldc.i4.1
+			IL_00b2: conv.r8
+			IL_00b3: ldstr ""
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00bd: stloc.s 4
+			IL_00bf: ldloc.s 5
+			IL_00c1: ldstr "on"
+			IL_00c6: ldstr "data"
+			IL_00cb: ldloc.s 4
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d2: pop
+			IL_00d3: ldloc.0
+			IL_00d4: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_00d9: ldstr "Cannot access 'client' before initialization"
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00e3: stloc.s 4
+			IL_00e5: ldc.i4.2
+			IL_00e6: newarr [System.Runtime]System.Object
+			IL_00eb: dup
+			IL_00ec: ldc.i4.0
+			IL_00ed: ldarg.0
+			IL_00ee: stelem.ref
+			IL_00ef: dup
+			IL_00f0: ldc.i4.1
+			IL_00f1: ldloc.0
+			IL_00f2: stelem.ref
+			IL_00f3: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
+			IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00fe: ldc.i4.0
+			IL_00ff: conv.r8
+			IL_0100: ldstr ""
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_010a: stloc.s 5
+			IL_010c: ldloc.s 4
+			IL_010e: ldstr "on"
+			IL_0113: ldstr "end"
+			IL_0118: ldloc.s 5
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_011f: pop
+			IL_0120: ldnull
+			IL_0121: ret
 		} // end of method FunctionExpression_L23C30::__js_call__
 
 	} // end of class FunctionExpression_L23C30
@@ -938,21 +903,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x275f
+			// Method begins at RVA 0x26e5
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -970,7 +929,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope,
@@ -987,65 +946,59 @@
 		IL_0012: ldloc.0
 		IL_0013: ldloc.1
 		IL_0014: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
-		IL_001f: ldstr "Cannot access 'net' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
-		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.i4.0
-		IL_0035: ldelem.ref
-		IL_0036: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_003b: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0046: ldc.i4.1
-		IL_0047: conv.r8
-		IL_0048: ldstr ""
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldstr "createServer"
-		IL_0059: ldloc.2
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_005f: stloc.2
-		IL_0060: ldloc.0
-		IL_0061: ldloc.2
-		IL_0062: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-		IL_0067: ldloc.0
-		IL_0068: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-		IL_006d: ldstr "Cannot access 'server' before initialization"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0077: stloc.2
-		IL_0078: ldc.i4.1
-		IL_0079: newarr [System.Runtime]System.Object
-		IL_007e: dup
-		IL_007f: ldc.i4.0
-		IL_0080: ldloc.0
-		IL_0081: stelem.ref
-		IL_0082: ldc.i4.0
-		IL_0083: ldelem.ref
-		IL_0084: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_0089: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
-		IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0094: ldc.i4.0
-		IL_0095: conv.r8
-		IL_0096: ldstr ""
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00a0: stloc.1
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "listen"
-		IL_00a7: ldc.r8 0.0
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: ldstr "127.0.0.1"
-		IL_00ba: ldloc.1
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: ldc.i4.0
+		IL_0024: ldelem.ref
+		IL_0025: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
+		IL_002a: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0035: ldc.i4.1
+		IL_0036: conv.r8
+		IL_0037: ldstr ""
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0041: stloc.1
+		IL_0042: ldloc.0
+		IL_0043: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
+		IL_0048: ldstr "createServer"
+		IL_004d: ldloc.1
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0053: stloc.1
+		IL_0054: ldloc.0
+		IL_0055: ldloc.1
+		IL_0056: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
+		IL_005b: ldloc.0
+		IL_005c: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
+		IL_0061: stloc.1
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.0
+		IL_006b: stelem.ref
+		IL_006c: ldc.i4.0
+		IL_006d: ldelem.ref
+		IL_006e: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
+		IL_0073: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
+		IL_0079: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_007e: ldc.i4.0
+		IL_007f: conv.r8
+		IL_0080: ldstr ""
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_008a: stloc.2
+		IL_008b: ldloc.1
+		IL_008c: ldstr "listen"
+		IL_0091: ldc.r8 0.0
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: ldstr "127.0.0.1"
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method Net_Socket_Binary_Data_Defaults_To_Buffer::__js_module_init__
 
 } // end of class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer
@@ -1057,7 +1010,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27e7
+		// Method begins at RVA 0x2741
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
+++ b/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e0
+				// Method begins at RVA 0x2592
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x215c
+			// Method begins at RVA 0x2144
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2606
+						// Method begins at RVA 0x25b8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x260f
+						// Method begins at RVA 0x25c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25fd
+					// Method begins at RVA 0x25af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -168,7 +168,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x230c
+				// Method begins at RVA 0x22e0
 				// Header size: 12
 				// Code size: 404 (0x194)
 				.maxstack 8
@@ -348,7 +348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2618
+					// Method begins at RVA 0x25ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -373,7 +373,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24bc
+				// Method begins at RVA 0x2490
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -412,7 +412,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x262a
+						// Method begins at RVA 0x25dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -435,7 +435,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25ae
+					// Method begins at RVA 0x2576
 					// Header size: 1
 					// Code size: 18 (0x12)
 					.maxstack 8
@@ -457,7 +457,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2621
+					// Method begins at RVA 0x25d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -481,14 +481,13 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24e4
+				// Method begins at RVA 0x24b8
 				// Header size: 12
-				// Code size: 190 (0xbe)
+				// Code size: 178 (0xb2)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/Scope,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/Scope::.ctor()
@@ -533,29 +532,25 @@
 				IL_0073: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientDataLine
 				IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 				IL_007d: pop
-				IL_007e: ldarg.0
-				IL_007f: ldc.i4.0
-				IL_0080: ldelem.ref
-				IL_0081: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0086: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-				IL_008b: ldstr "Cannot access 'server' before initialization"
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0095: stloc.1
-				IL_0096: ldnull
-				IL_0097: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
-				IL_009d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_00a2: ldc.i4.0
-				IL_00a3: conv.r8
-				IL_00a4: ldstr ""
-				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_00ae: stloc.2
-				IL_00af: ldloc.1
-				IL_00b0: ldstr "close"
-				IL_00b5: ldloc.2
-				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00bb: pop
-				IL_00bc: ldnull
-				IL_00bd: ret
+				IL_007e: ldnull
+				IL_007f: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
+				IL_0085: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_008a: ldc.i4.0
+				IL_008b: conv.r8
+				IL_008c: ldstr ""
+				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_0096: stloc.1
+				IL_0097: ldarg.0
+				IL_0098: ldc.i4.0
+				IL_0099: ldelem.ref
+				IL_009a: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_009f: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
+				IL_00a4: ldstr "close"
+				IL_00a9: ldloc.1
+				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00af: pop
+				IL_00b0: ldnull
+				IL_00b1: ret
 			} // end of method FunctionExpression_L34C19::__js_call__
 
 		} // end of class FunctionExpression_L34C19
@@ -574,7 +569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e9
+				// Method begins at RVA 0x259b
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -603,9 +598,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x21b0
+			// Method begins at RVA 0x2198
 			// Header size: 12
-			// Code size: 336 (0x150)
+			// Code size: 314 (0x13a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope,
@@ -620,123 +615,117 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
-			IL_002b: ldstr "Cannot access 'net' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.2
-			IL_0036: ldloc.1
-			IL_0037: ldstr "port"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.3
-			IL_0042: ldloc.1
-			IL_0043: ldstr "address"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 4
-			IL_004f: ldc.i4.2
-			IL_0050: newarr [System.Runtime]System.Object
-			IL_0055: dup
-			IL_0056: ldc.i4.0
-			IL_0057: ldarg.0
-			IL_0058: stelem.ref
-			IL_0059: dup
-			IL_005a: ldc.i4.1
-			IL_005b: ldloc.0
-			IL_005c: stelem.ref
-			IL_005d: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0068: ldc.i4.0
-			IL_0069: conv.r8
-			IL_006a: ldstr ""
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0074: stloc.s 5
-			IL_0076: ldloc.2
-			IL_0077: ldstr "connect"
-			IL_007c: ldloc.3
-			IL_007d: ldloc.s 4
-			IL_007f: ldloc.s 5
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0086: stloc.s 5
-			IL_0088: ldloc.0
-			IL_0089: ldloc.s 5
-			IL_008b: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_0090: ldloc.0
-			IL_0091: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_0096: ldstr "Cannot access 'client' before initialization"
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a0: stloc.s 5
-			IL_00a2: ldloc.s 5
-			IL_00a4: ldstr "setEncoding"
-			IL_00a9: ldstr "utf8"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b3: pop
-			IL_00b4: ldloc.0
-			IL_00b5: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_00ba: ldstr "Cannot access 'client' before initialization"
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c4: stloc.s 5
-			IL_00c6: ldc.i4.2
-			IL_00c7: newarr [System.Runtime]System.Object
-			IL_00cc: dup
-			IL_00cd: ldc.i4.0
-			IL_00ce: ldarg.0
-			IL_00cf: stelem.ref
-			IL_00d0: dup
-			IL_00d1: ldc.i4.1
-			IL_00d2: ldloc.0
-			IL_00d3: stelem.ref
-			IL_00d4: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_00da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00df: ldc.i4.1
-			IL_00e0: conv.r8
-			IL_00e1: ldstr ""
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00eb: stloc.s 4
-			IL_00ed: ldloc.s 5
-			IL_00ef: ldstr "on"
-			IL_00f4: ldstr "data"
-			IL_00f9: ldloc.s 4
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0100: pop
-			IL_0101: ldloc.0
-			IL_0102: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_0107: ldstr "Cannot access 'client' before initialization"
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0111: stloc.s 4
-			IL_0113: ldc.i4.2
-			IL_0114: newarr [System.Runtime]System.Object
-			IL_0119: dup
-			IL_011a: ldc.i4.0
-			IL_011b: ldarg.0
-			IL_011c: stelem.ref
-			IL_011d: dup
-			IL_011e: ldc.i4.1
-			IL_011f: ldloc.0
-			IL_0120: stelem.ref
-			IL_0121: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
-			IL_0127: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_012c: ldc.i4.0
-			IL_012d: conv.r8
-			IL_012e: ldstr ""
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0138: stloc.s 5
-			IL_013a: ldloc.s 4
-			IL_013c: ldstr "on"
-			IL_0141: ldstr "end"
-			IL_0146: ldloc.s 5
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_014d: pop
-			IL_014e: ldnull
-			IL_014f: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
+			IL_001f: stloc.2
+			IL_0020: ldloc.1
+			IL_0021: ldstr "port"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.3
+			IL_002c: ldloc.1
+			IL_002d: ldstr "address"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: ldc.i4.2
+			IL_003a: newarr [System.Runtime]System.Object
+			IL_003f: dup
+			IL_0040: ldc.i4.0
+			IL_0041: ldarg.0
+			IL_0042: stelem.ref
+			IL_0043: dup
+			IL_0044: ldc.i4.1
+			IL_0045: ldloc.0
+			IL_0046: stelem.ref
+			IL_0047: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0052: ldc.i4.0
+			IL_0053: conv.r8
+			IL_0054: ldstr ""
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_005e: stloc.s 5
+			IL_0060: ldloc.2
+			IL_0061: ldstr "connect"
+			IL_0066: ldloc.3
+			IL_0067: ldloc.s 4
+			IL_0069: ldloc.s 5
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0070: stloc.s 5
+			IL_0072: ldloc.0
+			IL_0073: ldloc.s 5
+			IL_0075: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_007a: ldloc.0
+			IL_007b: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_0080: ldstr "Cannot access 'client' before initialization"
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_008a: stloc.s 5
+			IL_008c: ldloc.s 5
+			IL_008e: ldstr "setEncoding"
+			IL_0093: ldstr "utf8"
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_009d: pop
+			IL_009e: ldloc.0
+			IL_009f: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_00a4: ldstr "Cannot access 'client' before initialization"
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00ae: stloc.s 5
+			IL_00b0: ldc.i4.2
+			IL_00b1: newarr [System.Runtime]System.Object
+			IL_00b6: dup
+			IL_00b7: ldc.i4.0
+			IL_00b8: ldarg.0
+			IL_00b9: stelem.ref
+			IL_00ba: dup
+			IL_00bb: ldc.i4.1
+			IL_00bc: ldloc.0
+			IL_00bd: stelem.ref
+			IL_00be: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00c9: ldc.i4.1
+			IL_00ca: conv.r8
+			IL_00cb: ldstr ""
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00d5: stloc.s 4
+			IL_00d7: ldloc.s 5
+			IL_00d9: ldstr "on"
+			IL_00de: ldstr "data"
+			IL_00e3: ldloc.s 4
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ea: pop
+			IL_00eb: ldloc.0
+			IL_00ec: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_00f1: ldstr "Cannot access 'client' before initialization"
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00fb: stloc.s 4
+			IL_00fd: ldc.i4.2
+			IL_00fe: newarr [System.Runtime]System.Object
+			IL_0103: dup
+			IL_0104: ldc.i4.0
+			IL_0105: ldarg.0
+			IL_0106: stelem.ref
+			IL_0107: dup
+			IL_0108: ldc.i4.1
+			IL_0109: ldloc.0
+			IL_010a: stelem.ref
+			IL_010b: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
+			IL_0111: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0116: ldc.i4.0
+			IL_0117: conv.r8
+			IL_0118: ldstr ""
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0122: stloc.s 5
+			IL_0124: ldloc.s 4
+			IL_0126: ldstr "on"
+			IL_012b: ldstr "end"
+			IL_0130: ldloc.s 5
+			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0137: pop
+			IL_0138: ldnull
+			IL_0139: ret
 		} // end of method FunctionExpression_L16C30::__js_call__
 
 	} // end of class FunctionExpression_L16C30
@@ -775,21 +764,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25c1
+			// Method begins at RVA 0x2589
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -807,7 +790,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 254 (0xfe)
+		// Code size: 232 (0xe8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope,
@@ -844,65 +827,59 @@
 		IL_004a: ldc.i4.0
 		IL_004b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 		IL_0050: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientDataLine
-		IL_0055: ldloc.0
-		IL_0056: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
-		IL_005b: ldstr "Cannot access 'net' before initialization"
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0065: stloc.1
-		IL_0066: ldc.i4.1
-		IL_0067: newarr [System.Runtime]System.Object
-		IL_006c: dup
-		IL_006d: ldc.i4.0
-		IL_006e: ldloc.0
-		IL_006f: stelem.ref
-		IL_0070: ldc.i4.0
-		IL_0071: ldelem.ref
-		IL_0072: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_0077: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
-		IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0082: ldc.i4.1
-		IL_0083: conv.r8
-		IL_0084: ldstr ""
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_008e: stloc.2
-		IL_008f: ldloc.1
-		IL_0090: ldstr "createServer"
-		IL_0095: ldloc.2
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_009b: stloc.2
-		IL_009c: ldloc.0
-		IL_009d: ldloc.2
-		IL_009e: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-		IL_00a3: ldloc.0
-		IL_00a4: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-		IL_00a9: ldstr "Cannot access 'server' before initialization"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00b3: stloc.2
-		IL_00b4: ldc.i4.1
-		IL_00b5: newarr [System.Runtime]System.Object
-		IL_00ba: dup
-		IL_00bb: ldc.i4.0
-		IL_00bc: ldloc.0
-		IL_00bd: stelem.ref
-		IL_00be: ldc.i4.0
-		IL_00bf: ldelem.ref
-		IL_00c0: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_00c5: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
-		IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00d0: ldc.i4.0
-		IL_00d1: conv.r8
-		IL_00d2: ldstr ""
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00dc: stloc.1
-		IL_00dd: ldloc.2
-		IL_00de: ldstr "listen"
-		IL_00e3: ldc.r8 0.0
-		IL_00ec: box [System.Runtime]System.Double
-		IL_00f1: ldstr "127.0.0.1"
-		IL_00f6: ldloc.1
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00fc: pop
-		IL_00fd: ret
+		IL_0055: ldc.i4.1
+		IL_0056: newarr [System.Runtime]System.Object
+		IL_005b: dup
+		IL_005c: ldc.i4.0
+		IL_005d: ldloc.0
+		IL_005e: stelem.ref
+		IL_005f: ldc.i4.0
+		IL_0060: ldelem.ref
+		IL_0061: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+		IL_0066: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
+		IL_006c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0071: ldc.i4.1
+		IL_0072: conv.r8
+		IL_0073: ldstr ""
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_007d: stloc.1
+		IL_007e: ldloc.0
+		IL_007f: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
+		IL_0084: ldstr "createServer"
+		IL_0089: ldloc.1
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008f: stloc.1
+		IL_0090: ldloc.0
+		IL_0091: ldloc.1
+		IL_0092: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
+		IL_0097: ldloc.0
+		IL_0098: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
+		IL_009d: stloc.1
+		IL_009e: ldc.i4.1
+		IL_009f: newarr [System.Runtime]System.Object
+		IL_00a4: dup
+		IL_00a5: ldc.i4.0
+		IL_00a6: ldloc.0
+		IL_00a7: stelem.ref
+		IL_00a8: ldc.i4.0
+		IL_00a9: ldelem.ref
+		IL_00aa: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+		IL_00af: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
+		IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ba: ldc.i4.0
+		IL_00bb: conv.r8
+		IL_00bc: ldstr ""
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00c6: stloc.2
+		IL_00c7: ldloc.1
+		IL_00c8: ldstr "listen"
+		IL_00cd: ldc.r8 0.0
+		IL_00d6: box [System.Runtime]System.Double
+		IL_00db: ldstr "127.0.0.1"
+		IL_00e0: ldloc.2
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00e6: pop
+		IL_00e7: ret
 	} // end of method Net_Socket_KeepAlive_And_Unsupported_Options::__js_module_init__
 
 } // end of class Modules.Net_Socket_KeepAlive_And_Unsupported_Options
@@ -914,7 +891,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2633
+		// Method begins at RVA 0x25e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
+++ b/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x263a
+					// Method begins at RVA 0x25ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2340
+				// Method begins at RVA 0x2314
 				// Header size: 12
 				// Code size: 81 (0x51)
 				.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2643
+					// Method begins at RVA 0x25f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -123,7 +123,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23a0
+				// Method begins at RVA 0x2374
 				// Header size: 12
 				// Code size: 89 (0x59)
 				.maxstack 8
@@ -185,7 +185,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2631
+				// Method begins at RVA 0x25e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -212,7 +212,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 170 (0xaa)
 			.maxstack 8
@@ -308,7 +308,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2669
+						// Method begins at RVA 0x261b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -332,7 +332,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2598
+					// Method begins at RVA 0x2560
 					// Header size: 12
 					// Code size: 91 (0x5b)
 					.maxstack 8
@@ -379,7 +379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2660
+					// Method begins at RVA 0x2612
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -403,7 +403,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2408
+				// Method begins at RVA 0x23dc
 				// Header size: 12
 				// Code size: 170 (0xaa)
 				.maxstack 8
@@ -489,7 +489,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2672
+					// Method begins at RVA 0x2624
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -514,7 +514,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24c0
+				// Method begins at RVA 0x2494
 				// Header size: 12
 				// Code size: 81 (0x51)
 				.maxstack 8
@@ -570,7 +570,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2684
+						// Method begins at RVA 0x2636
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -593,7 +593,7 @@
 					.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25ff
+					// Method begins at RVA 0x25c7
 					// Header size: 1
 					// Code size: 18 (0x12)
 					.maxstack 8
@@ -615,7 +615,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x267b
+					// Method begins at RVA 0x262d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -639,15 +639,14 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2520
+				// Method begins at RVA 0x24f4
 				// Header size: 12
-				// Code size: 106 (0x6a)
+				// Code size: 94 (0x5e)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/Scope,
 					[1] object,
-					[2] object,
-					[3] object
+					[2] object
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/Scope::.ctor()
@@ -664,29 +663,25 @@
 				IL_0023: ldloc.1
 				IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 				IL_0029: pop
-				IL_002a: ldarg.0
-				IL_002b: ldc.i4.0
-				IL_002c: ldelem.ref
-				IL_002d: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-				IL_0032: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-				IL_0037: ldstr "Cannot access 'server' before initialization"
-				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0041: stloc.2
-				IL_0042: ldnull
-				IL_0043: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
-				IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004e: ldc.i4.0
-				IL_004f: conv.r8
-				IL_0050: ldstr ""
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_005a: stloc.3
-				IL_005b: ldloc.2
-				IL_005c: ldstr "close"
-				IL_0061: ldloc.3
-				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0067: pop
-				IL_0068: ldnull
-				IL_0069: ret
+				IL_002a: ldnull
+				IL_002b: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
+				IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0036: ldc.i4.0
+				IL_0037: conv.r8
+				IL_0038: ldstr ""
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_0042: stloc.2
+				IL_0043: ldarg.0
+				IL_0044: ldc.i4.0
+				IL_0045: ldelem.ref
+				IL_0046: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+				IL_004b: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
+				IL_0050: ldstr "close"
+				IL_0055: ldloc.2
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005b: pop
+				IL_005c: ldnull
+				IL_005d: ret
 			} // end of method FunctionExpression_L36C19::__js_call__
 
 		} // end of class FunctionExpression_L36C19
@@ -707,7 +702,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x264c
+				// Method begins at RVA 0x25fe
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -736,9 +731,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21c0
 			// Header size: 12
-			// Code size: 347 (0x15b)
+			// Code size: 325 (0x145)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope,
@@ -753,126 +748,120 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
-			IL_002b: ldstr "Cannot access 'net' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.2
-			IL_0036: ldloc.1
-			IL_0037: ldstr "port"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.3
-			IL_0042: ldloc.1
-			IL_0043: ldstr "address"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 4
-			IL_004f: ldc.i4.2
-			IL_0050: newarr [System.Runtime]System.Object
-			IL_0055: dup
-			IL_0056: ldc.i4.0
-			IL_0057: ldarg.0
-			IL_0058: stelem.ref
-			IL_0059: dup
-			IL_005a: ldc.i4.1
-			IL_005b: ldloc.0
-			IL_005c: stelem.ref
-			IL_005d: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0068: ldc.i4.0
-			IL_0069: conv.r8
-			IL_006a: ldstr ""
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0074: stloc.s 5
-			IL_0076: ldloc.2
-			IL_0077: ldstr "connect"
-			IL_007c: ldloc.3
-			IL_007d: ldloc.s 4
-			IL_007f: ldloc.s 5
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0086: stloc.s 5
-			IL_0088: ldloc.0
-			IL_0089: ldloc.s 5
-			IL_008b: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_0090: ldloc.0
-			IL_0091: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_0096: ldstr "Cannot access 'client' before initialization"
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a0: stloc.s 5
-			IL_00a2: ldloc.s 5
-			IL_00a4: ldstr "setEncoding"
-			IL_00a9: ldstr "utf8"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b3: pop
-			IL_00b4: ldloc.0
-			IL_00b5: ldstr ""
-			IL_00ba: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
-			IL_00bf: ldloc.0
-			IL_00c0: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_00c5: ldstr "Cannot access 'client' before initialization"
-			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00cf: stloc.s 5
-			IL_00d1: ldc.i4.2
-			IL_00d2: newarr [System.Runtime]System.Object
-			IL_00d7: dup
-			IL_00d8: ldc.i4.0
-			IL_00d9: ldarg.0
-			IL_00da: stelem.ref
-			IL_00db: dup
-			IL_00dc: ldc.i4.1
-			IL_00dd: ldloc.0
-			IL_00de: stelem.ref
-			IL_00df: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
-			IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ea: ldc.i4.1
-			IL_00eb: conv.r8
-			IL_00ec: ldstr ""
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00f6: stloc.s 4
-			IL_00f8: ldloc.s 5
-			IL_00fa: ldstr "on"
-			IL_00ff: ldstr "data"
-			IL_0104: ldloc.s 4
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_010b: pop
-			IL_010c: ldloc.0
-			IL_010d: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_0112: ldstr "Cannot access 'client' before initialization"
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_011c: stloc.s 4
-			IL_011e: ldc.i4.2
-			IL_011f: newarr [System.Runtime]System.Object
-			IL_0124: dup
-			IL_0125: ldc.i4.0
-			IL_0126: ldarg.0
-			IL_0127: stelem.ref
-			IL_0128: dup
-			IL_0129: ldc.i4.1
-			IL_012a: ldloc.0
-			IL_012b: stelem.ref
-			IL_012c: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
-			IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0137: ldc.i4.0
-			IL_0138: conv.r8
-			IL_0139: ldstr ""
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0143: stloc.s 5
-			IL_0145: ldloc.s 4
-			IL_0147: ldstr "on"
-			IL_014c: ldstr "end"
-			IL_0151: ldloc.s 5
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0158: pop
-			IL_0159: ldnull
-			IL_015a: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
+			IL_001f: stloc.2
+			IL_0020: ldloc.1
+			IL_0021: ldstr "port"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.3
+			IL_002c: ldloc.1
+			IL_002d: ldstr "address"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: ldc.i4.2
+			IL_003a: newarr [System.Runtime]System.Object
+			IL_003f: dup
+			IL_0040: ldc.i4.0
+			IL_0041: ldarg.0
+			IL_0042: stelem.ref
+			IL_0043: dup
+			IL_0044: ldc.i4.1
+			IL_0045: ldloc.0
+			IL_0046: stelem.ref
+			IL_0047: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0052: ldc.i4.0
+			IL_0053: conv.r8
+			IL_0054: ldstr ""
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_005e: stloc.s 5
+			IL_0060: ldloc.2
+			IL_0061: ldstr "connect"
+			IL_0066: ldloc.3
+			IL_0067: ldloc.s 4
+			IL_0069: ldloc.s 5
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0070: stloc.s 5
+			IL_0072: ldloc.0
+			IL_0073: ldloc.s 5
+			IL_0075: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_007a: ldloc.0
+			IL_007b: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_0080: ldstr "Cannot access 'client' before initialization"
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_008a: stloc.s 5
+			IL_008c: ldloc.s 5
+			IL_008e: ldstr "setEncoding"
+			IL_0093: ldstr "utf8"
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_009d: pop
+			IL_009e: ldloc.0
+			IL_009f: ldstr ""
+			IL_00a4: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
+			IL_00a9: ldloc.0
+			IL_00aa: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_00af: ldstr "Cannot access 'client' before initialization"
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00b9: stloc.s 5
+			IL_00bb: ldc.i4.2
+			IL_00bc: newarr [System.Runtime]System.Object
+			IL_00c1: dup
+			IL_00c2: ldc.i4.0
+			IL_00c3: ldarg.0
+			IL_00c4: stelem.ref
+			IL_00c5: dup
+			IL_00c6: ldc.i4.1
+			IL_00c7: ldloc.0
+			IL_00c8: stelem.ref
+			IL_00c9: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
+			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00d4: ldc.i4.1
+			IL_00d5: conv.r8
+			IL_00d6: ldstr ""
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00e0: stloc.s 4
+			IL_00e2: ldloc.s 5
+			IL_00e4: ldstr "on"
+			IL_00e9: ldstr "data"
+			IL_00ee: ldloc.s 4
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f5: pop
+			IL_00f6: ldloc.0
+			IL_00f7: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_00fc: ldstr "Cannot access 'client' before initialization"
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0106: stloc.s 4
+			IL_0108: ldc.i4.2
+			IL_0109: newarr [System.Runtime]System.Object
+			IL_010e: dup
+			IL_010f: ldc.i4.0
+			IL_0110: ldarg.0
+			IL_0111: stelem.ref
+			IL_0112: dup
+			IL_0113: ldc.i4.1
+			IL_0114: ldloc.0
+			IL_0115: stelem.ref
+			IL_0116: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
+			IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0121: ldc.i4.0
+			IL_0122: conv.r8
+			IL_0123: ldstr ""
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_012d: stloc.s 5
+			IL_012f: ldloc.s 4
+			IL_0131: ldstr "on"
+			IL_0136: ldstr "end"
+			IL_013b: ldloc.s 5
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0142: pop
+			IL_0143: ldnull
+			IL_0144: ret
 		} // end of method FunctionExpression_L20C30::__js_call__
 
 	} // end of class FunctionExpression_L20C30
@@ -893,21 +882,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2612
+			// Method begins at RVA 0x25da
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -925,7 +908,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_SetEncoding_Utf8/Scope,
@@ -942,65 +925,59 @@
 		IL_0012: ldloc.0
 		IL_0013: ldloc.1
 		IL_0014: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
-		IL_001f: ldstr "Cannot access 'net' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
-		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.i4.0
-		IL_0035: ldelem.ref
-		IL_0036: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_003b: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0046: ldc.i4.1
-		IL_0047: conv.r8
-		IL_0048: ldstr ""
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldstr "createServer"
-		IL_0059: ldloc.2
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_005f: stloc.2
-		IL_0060: ldloc.0
-		IL_0061: ldloc.2
-		IL_0062: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-		IL_0067: ldloc.0
-		IL_0068: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-		IL_006d: ldstr "Cannot access 'server' before initialization"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0077: stloc.2
-		IL_0078: ldc.i4.1
-		IL_0079: newarr [System.Runtime]System.Object
-		IL_007e: dup
-		IL_007f: ldc.i4.0
-		IL_0080: ldloc.0
-		IL_0081: stelem.ref
-		IL_0082: ldc.i4.0
-		IL_0083: ldelem.ref
-		IL_0084: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_0089: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
-		IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0094: ldc.i4.0
-		IL_0095: conv.r8
-		IL_0096: ldstr ""
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00a0: stloc.1
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "listen"
-		IL_00a7: ldc.r8 0.0
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: ldstr "127.0.0.1"
-		IL_00ba: ldloc.1
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: ldc.i4.0
+		IL_0024: ldelem.ref
+		IL_0025: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+		IL_002a: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0035: ldc.i4.1
+		IL_0036: conv.r8
+		IL_0037: ldstr ""
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0041: stloc.1
+		IL_0042: ldloc.0
+		IL_0043: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
+		IL_0048: ldstr "createServer"
+		IL_004d: ldloc.1
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0053: stloc.1
+		IL_0054: ldloc.0
+		IL_0055: ldloc.1
+		IL_0056: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
+		IL_005b: ldloc.0
+		IL_005c: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
+		IL_0061: stloc.1
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.0
+		IL_006b: stelem.ref
+		IL_006c: ldc.i4.0
+		IL_006d: ldelem.ref
+		IL_006e: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+		IL_0073: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
+		IL_0079: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_007e: ldc.i4.0
+		IL_007f: conv.r8
+		IL_0080: ldstr ""
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_008a: stloc.2
+		IL_008b: ldloc.1
+		IL_008c: ldstr "listen"
+		IL_0091: ldc.r8 0.0
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: ldstr "127.0.0.1"
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method Net_Socket_SetEncoding_Utf8::__js_module_init__
 
 } // end of class Modules.Net_Socket_SetEncoding_Utf8
@@ -1012,7 +989,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x268d
+		// Method begins at RVA 0x263f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
+++ b/tests/Js2IL.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23f6
+					// Method begins at RVA 0x2397
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22bc
+				// Method begins at RVA 0x228c
 				// Header size: 12
 				// Code size: 93 (0x5d)
 				.maxstack 8
@@ -98,7 +98,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23ff
+					// Method begins at RVA 0x23a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -122,7 +122,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2328
+				// Method begins at RVA 0x22f8
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ed
+				// Method begins at RVA 0x238e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -185,7 +185,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 135 (0x87)
 			.maxstack 8
@@ -263,7 +263,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2411
+					// Method begins at RVA 0x23b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -286,7 +286,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x234e
+				// Method begins at RVA 0x231e
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -312,7 +312,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x241a
+					// Method begins at RVA 0x23bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -336,7 +336,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2364
+				// Method begins at RVA 0x2334
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -369,7 +369,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2423
+					// Method begins at RVA 0x23c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -393,13 +393,10 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x238c
-				// Header size: 12
-				// Code size: 54 (0x36)
+				// Method begins at RVA 0x235a
+				// Header size: 1
+				// Code size: 42 (0x2a)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0005: ldstr "client end"
@@ -410,15 +407,11 @@
 				IL_0012: ldelem.ref
 				IL_0013: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
 				IL_0018: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-				IL_001d: ldstr "Cannot access 'server' before initialization"
-				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0027: stloc.0
-				IL_0028: ldloc.0
-				IL_0029: ldstr "close"
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0033: pop
-				IL_0034: ldnull
-				IL_0035: ret
+				IL_001d: ldstr "close"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0027: pop
+				IL_0028: ldnull
+				IL_0029: ret
 			} // end of method FunctionExpression_L28C19::__js_call__
 
 		} // end of class FunctionExpression_L28C19
@@ -430,7 +423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2408
+				// Method begins at RVA 0x23a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -456,9 +449,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x21b4
+			// Method begins at RVA 0x219c
 			// Header size: 12
-			// Code size: 250 (0xfa)
+			// Code size: 228 (0xe4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/Scope,
@@ -474,89 +467,83 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-			IL_000c: ldstr "Cannot access 'server' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "address"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.3
 			IL_0017: ldloc.3
-			IL_0018: ldstr "address"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.3
-			IL_0023: ldloc.3
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
-			IL_002b: ldstr "Cannot access 'net' before initialization"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0035: stloc.3
-			IL_0036: ldloc.1
-			IL_0037: ldstr "port"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.s 4
-			IL_0043: ldloc.1
-			IL_0044: ldstr "address"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004e: stloc.s 5
-			IL_0050: ldnull
-			IL_0051: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
-			IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_005c: ldc.i4.0
-			IL_005d: conv.r8
-			IL_005e: ldstr ""
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0068: stloc.s 6
-			IL_006a: ldloc.3
-			IL_006b: ldstr "connect"
-			IL_0070: ldloc.s 4
-			IL_0072: ldloc.s 5
-			IL_0074: ldloc.s 6
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_007b: stloc.s 6
-			IL_007d: ldloc.s 6
-			IL_007f: stloc.2
-			IL_0080: ldloc.2
-			IL_0081: ldstr "setEncoding"
-			IL_0086: ldstr "utf8"
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0090: pop
-			IL_0091: ldnull
-			IL_0092: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
-			IL_0098: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_009d: ldc.i4.1
-			IL_009e: conv.r8
-			IL_009f: ldstr ""
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00a9: stloc.s 6
-			IL_00ab: ldloc.2
-			IL_00ac: ldstr "on"
-			IL_00b1: ldstr "data"
-			IL_00b6: ldloc.s 6
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00bd: pop
-			IL_00be: ldc.i4.2
-			IL_00bf: newarr [System.Runtime]System.Object
-			IL_00c4: dup
-			IL_00c5: ldc.i4.0
-			IL_00c6: ldarg.0
-			IL_00c7: stelem.ref
-			IL_00c8: dup
-			IL_00c9: ldc.i4.1
-			IL_00ca: ldloc.0
-			IL_00cb: stelem.ref
-			IL_00cc: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
-			IL_00d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00d7: ldc.i4.0
-			IL_00d8: conv.r8
-			IL_00d9: ldstr ""
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00e3: stloc.s 6
-			IL_00e5: ldloc.2
-			IL_00e6: ldstr "on"
-			IL_00eb: ldstr "end"
-			IL_00f0: ldloc.s 6
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f7: pop
-			IL_00f8: ldnull
-			IL_00f9: ret
+			IL_0018: stloc.1
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
+			IL_001f: stloc.3
+			IL_0020: ldloc.1
+			IL_0021: ldstr "port"
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002b: stloc.s 4
+			IL_002d: ldloc.1
+			IL_002e: ldstr "address"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0038: stloc.s 5
+			IL_003a: ldnull
+			IL_003b: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
+			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0046: ldc.i4.0
+			IL_0047: conv.r8
+			IL_0048: ldstr ""
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0052: stloc.s 6
+			IL_0054: ldloc.3
+			IL_0055: ldstr "connect"
+			IL_005a: ldloc.s 4
+			IL_005c: ldloc.s 5
+			IL_005e: ldloc.s 6
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0065: stloc.s 6
+			IL_0067: ldloc.s 6
+			IL_0069: stloc.2
+			IL_006a: ldloc.2
+			IL_006b: ldstr "setEncoding"
+			IL_0070: ldstr "utf8"
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_007a: pop
+			IL_007b: ldnull
+			IL_007c: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
+			IL_0082: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0087: ldc.i4.1
+			IL_0088: conv.r8
+			IL_0089: ldstr ""
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0093: stloc.s 6
+			IL_0095: ldloc.2
+			IL_0096: ldstr "on"
+			IL_009b: ldstr "data"
+			IL_00a0: ldloc.s 6
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00a7: pop
+			IL_00a8: ldc.i4.2
+			IL_00a9: newarr [System.Runtime]System.Object
+			IL_00ae: dup
+			IL_00af: ldc.i4.0
+			IL_00b0: ldarg.0
+			IL_00b1: stelem.ref
+			IL_00b2: dup
+			IL_00b3: ldc.i4.1
+			IL_00b4: ldloc.0
+			IL_00b5: stelem.ref
+			IL_00b6: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
+			IL_00bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00c1: ldc.i4.0
+			IL_00c2: conv.r8
+			IL_00c3: ldstr ""
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00cd: stloc.s 6
+			IL_00cf: ldloc.2
+			IL_00d0: ldstr "on"
+			IL_00d5: ldstr "end"
+			IL_00da: ldloc.s 6
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00e1: pop
+			IL_00e2: ldnull
+			IL_00e3: ret
 		} // end of method FunctionExpression_L17C30::__js_call__
 
 	} // end of class FunctionExpression_L17C30
@@ -577,21 +564,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ce
+			// Method begins at RVA 0x2385
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -609,7 +590,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope,
@@ -626,65 +607,59 @@
 		IL_0012: ldloc.0
 		IL_0013: ldloc.1
 		IL_0014: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
-		IL_0019: ldloc.0
-		IL_001a: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
-		IL_001f: ldstr "Cannot access 'net' before initialization"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldc.i4.1
-		IL_002b: newarr [System.Runtime]System.Object
-		IL_0030: dup
-		IL_0031: ldc.i4.0
-		IL_0032: ldloc.0
-		IL_0033: stelem.ref
-		IL_0034: ldc.i4.0
-		IL_0035: ldelem.ref
-		IL_0036: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_003b: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0046: ldc.i4.1
-		IL_0047: conv.r8
-		IL_0048: ldstr ""
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldstr "createServer"
-		IL_0059: ldloc.2
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_005f: stloc.2
-		IL_0060: ldloc.0
-		IL_0061: ldloc.2
-		IL_0062: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-		IL_0067: ldloc.0
-		IL_0068: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-		IL_006d: ldstr "Cannot access 'server' before initialization"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0077: stloc.2
-		IL_0078: ldc.i4.1
-		IL_0079: newarr [System.Runtime]System.Object
-		IL_007e: dup
-		IL_007f: ldc.i4.0
-		IL_0080: ldloc.0
-		IL_0081: stelem.ref
-		IL_0082: ldc.i4.0
-		IL_0083: ldelem.ref
-		IL_0084: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_0089: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
-		IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0094: ldc.i4.0
-		IL_0095: conv.r8
-		IL_0096: ldstr ""
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00a0: stloc.1
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "listen"
-		IL_00a7: ldc.r8 0.0
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: ldstr "127.0.0.1"
-		IL_00ba: ldloc.1
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: ldc.i4.0
+		IL_0024: ldelem.ref
+		IL_0025: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
+		IL_002a: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0035: ldc.i4.1
+		IL_0036: conv.r8
+		IL_0037: ldstr ""
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0041: stloc.1
+		IL_0042: ldloc.0
+		IL_0043: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
+		IL_0048: ldstr "createServer"
+		IL_004d: ldloc.1
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0053: stloc.1
+		IL_0054: ldloc.0
+		IL_0055: ldloc.1
+		IL_0056: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
+		IL_005b: ldloc.0
+		IL_005c: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
+		IL_0061: stloc.1
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.0
+		IL_006b: stelem.ref
+		IL_006c: ldc.i4.0
+		IL_006d: ldelem.ref
+		IL_006e: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
+		IL_0073: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
+		IL_0079: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_007e: ldc.i4.0
+		IL_007f: conv.r8
+		IL_0080: ldstr ""
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_008a: stloc.2
+		IL_008b: ldloc.1
+		IL_008c: ldstr "listen"
+		IL_0091: ldc.r8 0.0
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: ldstr "127.0.0.1"
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method Net_Socket_Timeout_Allows_Graceful_End::__js_module_init__
 
 } // end of class Modules.Net_Socket_Timeout_Allows_Graceful_End
@@ -696,7 +671,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x242c
+		// Method begins at RVA 0x23cd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/tests/Js2IL.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2135
+				// Method begins at RVA 0x211e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			)
 			// Method begins at RVA 0x20f4
 			// Header size: 12
-			// Code size: 33 (0x21)
+			// Code size: 21 (0x15)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -56,17 +56,13 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Path_Join_NestedFunction/Scope::path
-			IL_0006: ldstr "Cannot access 'path' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "join"
-			IL_0017: ldarg.2
-			IL_0018: ldarg.3
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ret
+			IL_0006: ldstr "join"
+			IL_000b: ldarg.2
+			IL_000c: ldarg.3
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0012: stloc.0
+			IL_0013: ldloc.0
+			IL_0014: ret
 		} // end of method joinWrapper::__js_call__
 
 	} // end of class joinWrapper
@@ -87,18 +83,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2121
+			// Method begins at RVA 0x2115
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_Path_Join_NestedFunction/Scope::path
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -192,7 +185,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213e
+		// Method begins at RVA 0x2127
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Process/Snapshots/GeneratorTests.Process_Chdir_And_NextTick_Basics.verified.txt
+++ b/tests/Js2IL.Tests/Node/Process/Snapshots/GeneratorTests.Process_Chdir_And_NextTick_Basics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226b
+				// Method begins at RVA 0x222f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,26 +44,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21b4
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
+			IL_0006: ldstr "tick"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "tick"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L10C18::__js_call__
 
 	} // end of class ArrowFunction_L10C18
@@ -79,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2274
+				// Method begins at RVA 0x2238
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,41 +104,36 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x21dc
 			// Header size: 12
-			// Code size: 87 (0x57)
+			// Code size: 62 (0x3e)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] string
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "immediate"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-			IL_0028: ldstr "Cannot access 'order' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.0
-			IL_0033: ldloc.0
-			IL_0034: ldstr "join"
-			IL_0039: ldstr ","
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0043: stloc.0
-			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0049: ldstr "order"
-			IL_004e: ldloc.0
-			IL_004f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0054: pop
-			IL_0055: ldnull
-			IL_0056: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
+			IL_0006: ldstr "immediate"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldarg.0
+			IL_0012: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
+			IL_0017: ldc.i4.1
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: dup
+			IL_001e: ldc.i4.0
+			IL_001f: ldstr ","
+			IL_0024: stelem.ref
+			IL_0025: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_002a: stloc.0
+			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0030: ldstr "order"
+			IL_0035: ldloc.0
+			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_003b: pop
+			IL_003c: ldnull
+			IL_003d: ret
 		} // end of method ArrowFunction_L12C14::__js_call__
 
 	} // end of class ArrowFunction_L12C14
@@ -152,24 +146,21 @@
 			6f 72 64 65 72 7d 00 00
 		)
 		// Fields
-		.field public object order
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array order
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2257
+			// Method begins at RVA 0x2226
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -187,7 +178,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 359 (0x167)
+		// Code size: 342 (0x156)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_Chdir_And_NextTick_Basics/Scope,
@@ -250,7 +241,7 @@
 		IL_00a0: ldloc.0
 		IL_00a1: ldc.i4.0
 		IL_00a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00a7: stfld object Modules.Process_Chdir_And_NextTick_Basics/Scope::order
+		IL_00a7: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
 		IL_00ac: ldc.i4.1
 		IL_00ad: newarr [System.Runtime]System.Object
 		IL_00b2: dup
@@ -281,45 +272,40 @@
 		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00f9: pop
 		IL_00fa: ldloc.0
-		IL_00fb: ldfld object Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-		IL_0100: ldstr "Cannot access 'order' before initialization"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_010a: stloc.2
-		IL_010b: ldloc.2
-		IL_010c: ldstr "push"
-		IL_0111: ldstr "sync"
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011b: pop
-		IL_011c: ldc.i4.1
-		IL_011d: newarr [System.Runtime]System.Object
-		IL_0122: dup
-		IL_0123: ldc.i4.0
-		IL_0124: ldloc.0
-		IL_0125: stelem.ref
-		IL_0126: ldc.i4.0
-		IL_0127: ldelem.ref
-		IL_0128: castclass Modules.Process_Chdir_And_NextTick_Basics/Scope
-		IL_012d: ldftn object Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L12C14::__js_call__(class Modules.Process_Chdir_And_NextTick_Basics/Scope, object)
-		IL_0133: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0138: ldc.i4.1
-		IL_0139: newarr [System.Runtime]System.Object
-		IL_013e: dup
-		IL_013f: ldc.i4.0
-		IL_0140: ldloc.0
-		IL_0141: stelem.ref
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_014c: ldc.i4.0
-		IL_014d: conv.r8
-		IL_014e: ldstr ""
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0158: stloc.2
-		IL_0159: ldloc.2
-		IL_015a: ldc.i4.0
-		IL_015b: newarr [System.Runtime]System.Object
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0165: pop
-		IL_0166: ret
+		IL_00fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
+		IL_0100: ldstr "sync"
+		IL_0105: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_010a: pop
+		IL_010b: ldc.i4.1
+		IL_010c: newarr [System.Runtime]System.Object
+		IL_0111: dup
+		IL_0112: ldc.i4.0
+		IL_0113: ldloc.0
+		IL_0114: stelem.ref
+		IL_0115: ldc.i4.0
+		IL_0116: ldelem.ref
+		IL_0117: castclass Modules.Process_Chdir_And_NextTick_Basics/Scope
+		IL_011c: ldftn object Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L12C14::__js_call__(class Modules.Process_Chdir_And_NextTick_Basics/Scope, object)
+		IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0127: ldc.i4.1
+		IL_0128: newarr [System.Runtime]System.Object
+		IL_012d: dup
+		IL_012e: ldc.i4.0
+		IL_012f: ldloc.0
+		IL_0130: stelem.ref
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_013b: ldc.i4.0
+		IL_013c: conv.r8
+		IL_013d: ldstr ""
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0147: stloc.2
+		IL_0148: ldloc.2
+		IL_0149: ldc.i4.0
+		IL_014a: newarr [System.Runtime]System.Object
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0154: pop
+		IL_0155: ret
 	} // end of method Process_Chdir_And_NextTick_Basics::__js_module_init__
 
 } // end of class Modules.Process_Chdir_And_NextTick_Basics
@@ -331,7 +317,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x227d
+		// Method begins at RVA 0x2241
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_And_Promise_Ordering.verified.txt
+++ b/tests/Js2IL.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_And_Promise_Ordering.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2450
+				// Method begins at RVA 0x23d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,26 +44,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x21d4
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+			IL_0006: ldstr "nextTick1"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "nextTick1"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L7C18::__js_call__
 
 	} // end of class ArrowFunction_L7C18
@@ -83,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2462
+					// Method begins at RVA 0x23ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -107,29 +106,28 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2344
+				// Method begins at RVA 0x2300
 				// Header size: 12
-				// Code size: 43 (0x2b)
+				// Code size: 33 (0x21)
 				.maxstack 8
 				.locals init (
-					[0] object
+					[0] float64,
+					[1] object
 				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-				IL_0008: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-				IL_000d: ldstr "Cannot access 'order' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+				IL_000d: ldstr "nextTickFromPromise"
+				IL_0012: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 				IL_0017: stloc.0
 				IL_0018: ldloc.0
-				IL_0019: ldstr "push"
-				IL_001e: ldstr "nextTickFromPromise"
-				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0028: stloc.0
-				IL_0029: ldloc.0
-				IL_002a: ret
+				IL_0019: box [System.Runtime]System.Double
+				IL_001e: stloc.1
+				IL_001f: ldloc.1
+				IL_0020: ret
 			} // end of method ArrowFunction_L11C20::__js_call__
 
 		} // end of class ArrowFunction_L11C20
@@ -141,7 +139,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2459
+				// Method begins at RVA 0x23e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -167,9 +165,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2218
+			// Method begins at RVA 0x21fc
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 91 (0x5b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/Scope,
@@ -179,42 +177,37 @@
 			IL_0000: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_000c: ldstr "Cannot access 'order' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0016: stloc.1
-			IL_0017: ldloc.1
-			IL_0018: ldstr "push"
-			IL_001d: ldstr "promise1"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0027: pop
-			IL_0028: ldnull
-			IL_0029: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/ArrowFunction_L11C20::__js_call__(object[], object)
-			IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0034: ldc.i4.2
-			IL_0035: newarr [System.Runtime]System.Object
-			IL_003a: dup
+			IL_0007: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+			IL_000c: ldstr "promise1"
+			IL_0011: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0016: pop
+			IL_0017: ldnull
+			IL_0018: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/ArrowFunction_L11C20::__js_call__(object[], object)
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0023: ldc.i4.2
+			IL_0024: newarr [System.Runtime]System.Object
+			IL_0029: dup
+			IL_002a: ldc.i4.0
+			IL_002b: ldarg.0
+			IL_002c: stelem.ref
+			IL_002d: dup
+			IL_002e: ldc.i4.1
+			IL_002f: ldloc.0
+			IL_0030: stelem.ref
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 			IL_003b: ldc.i4.0
-			IL_003c: ldarg.0
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.1
-			IL_0040: ldloc.0
-			IL_0041: stelem.ref
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_004c: ldc.i4.0
-			IL_004d: conv.r8
-			IL_004e: ldstr ""
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0058: stloc.1
-			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_005e: ldstr "nextTick"
-			IL_0063: ldloc.1
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0069: pop
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_003c: conv.r8
+			IL_003d: ldstr ""
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0047: stloc.1
+			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_004d: ldstr "nextTick"
+			IL_0052: ldloc.1
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0058: pop
+			IL_0059: ldnull
+			IL_005a: ret
 		} // end of method ArrowFunction_L9C25::__js_call__
 
 	} // end of class ArrowFunction_L9C25
@@ -230,7 +223,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246b
+				// Method begins at RVA 0x23f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -256,26 +249,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2290
+			// Method begins at RVA 0x2264
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+			IL_0006: ldstr "promise2"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "promise2"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L14C25::__js_call__
 
 	} // end of class ArrowFunction_L14C25
@@ -295,7 +287,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x247d
+					// Method begins at RVA 0x2405
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -319,13 +311,13 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x237c
+				// Method begins at RVA 0x2330
 				// Header size: 12
-				// Code size: 180 (0xb4)
+				// Code size: 147 (0x93)
 				.maxstack 8
 				.locals init (
 					[0] string,
-					[1] object,
+					[1] string,
 					[2] bool,
 					[3] object
 				)
@@ -334,62 +326,57 @@
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-				IL_0008: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-				IL_000d: ldstr "Cannot access 'order' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.1
-				IL_0018: ldloc.1
-				IL_0019: ldstr "push"
-				IL_001e: ldstr "setTimeout"
-				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0028: pop
-				IL_0029: ldarg.0
-				IL_002a: ldc.i4.0
-				IL_002b: ldelem.ref
-				IL_002c: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-				IL_0031: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-				IL_0036: ldstr "Cannot access 'order' before initialization"
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0040: stloc.1
-				IL_0041: ldloc.1
-				IL_0042: ldstr "join"
-				IL_0047: ldstr ","
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0051: stloc.1
-				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0057: ldstr "order"
-				IL_005c: ldloc.1
-				IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0062: pop
-				IL_0063: ldstr "sync,nextTick1,promise1,nextTickFromPromise,promise2,setImmediate,setTimeout"
-				IL_0068: stloc.0
-				IL_0069: ldarg.0
-				IL_006a: ldc.i4.0
-				IL_006b: ldelem.ref
-				IL_006c: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-				IL_0071: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-				IL_0076: ldstr "Cannot access 'order' before initialization"
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0080: stloc.1
-				IL_0081: ldloc.1
-				IL_0082: ldstr "join"
-				IL_0087: ldstr ","
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: ldloc.0
-				IL_0094: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0099: stloc.2
-				IL_009a: ldloc.2
-				IL_009b: box [System.Runtime]System.Boolean
-				IL_00a0: stloc.3
-				IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_00a6: ldstr "correct order"
-				IL_00ab: ldloc.3
-				IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_00b1: pop
-				IL_00b2: ldnull
-				IL_00b3: ret
+				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+				IL_000d: ldstr "setTimeout"
+				IL_0012: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0017: pop
+				IL_0018: ldarg.0
+				IL_0019: ldc.i4.0
+				IL_001a: ldelem.ref
+				IL_001b: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+				IL_0020: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+				IL_0025: ldc.i4.1
+				IL_0026: newarr [System.Runtime]System.Object
+				IL_002b: dup
+				IL_002c: ldc.i4.0
+				IL_002d: ldstr ","
+				IL_0032: stelem.ref
+				IL_0033: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_0038: stloc.1
+				IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_003e: ldstr "order"
+				IL_0043: ldloc.1
+				IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0049: pop
+				IL_004a: ldstr "sync,nextTick1,promise1,nextTickFromPromise,promise2,setImmediate,setTimeout"
+				IL_004f: stloc.0
+				IL_0050: ldarg.0
+				IL_0051: ldc.i4.0
+				IL_0052: ldelem.ref
+				IL_0053: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+				IL_0058: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+				IL_005d: ldc.i4.1
+				IL_005e: newarr [System.Runtime]System.Object
+				IL_0063: dup
+				IL_0064: ldc.i4.0
+				IL_0065: ldstr ","
+				IL_006a: stelem.ref
+				IL_006b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_0070: stloc.1
+				IL_0071: ldloc.1
+				IL_0072: ldloc.0
+				IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0078: stloc.2
+				IL_0079: ldloc.2
+				IL_007a: box [System.Runtime]System.Boolean
+				IL_007f: stloc.3
+				IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0085: ldstr "correct order"
+				IL_008a: ldloc.3
+				IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0090: pop
+				IL_0091: ldnull
+				IL_0092: ret
 			} // end of method ArrowFunction_L18C14::__js_call__
 
 		} // end of class ArrowFunction_L18C14
@@ -401,7 +388,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2474
+				// Method begins at RVA 0x23fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -427,9 +414,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x22c0
+			// Method begins at RVA 0x228c
 			// Header size: 12
-			// Code size: 118 (0x76)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/Scope,
@@ -439,44 +426,39 @@
 			IL_0000: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_000c: ldstr "Cannot access 'order' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0016: stloc.1
-			IL_0017: ldloc.1
-			IL_0018: ldstr "push"
-			IL_001d: ldstr "setImmediate"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0027: pop
-			IL_0028: ldnull
-			IL_0029: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/ArrowFunction_L18C14::__js_call__(object[], object)
-			IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0034: ldc.i4.2
-			IL_0035: newarr [System.Runtime]System.Object
-			IL_003a: dup
+			IL_0007: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+			IL_000c: ldstr "setImmediate"
+			IL_0011: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0016: pop
+			IL_0017: ldnull
+			IL_0018: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/ArrowFunction_L18C14::__js_call__(object[], object)
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0023: ldc.i4.2
+			IL_0024: newarr [System.Runtime]System.Object
+			IL_0029: dup
+			IL_002a: ldc.i4.0
+			IL_002b: ldarg.0
+			IL_002c: stelem.ref
+			IL_002d: dup
+			IL_002e: ldc.i4.1
+			IL_002f: ldloc.0
+			IL_0030: stelem.ref
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 			IL_003b: ldc.i4.0
-			IL_003c: ldarg.0
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.1
-			IL_0040: ldloc.0
-			IL_0041: stelem.ref
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_004c: ldc.i4.0
-			IL_004d: conv.r8
-			IL_004e: ldstr ""
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0058: stloc.1
-			IL_0059: ldloc.1
-			IL_005a: ldc.r8 0.0
-			IL_0063: box [System.Runtime]System.Double
-			IL_0068: ldc.i4.0
-			IL_0069: newarr [System.Runtime]System.Object
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-			IL_0073: pop
-			IL_0074: ldnull
-			IL_0075: ret
+			IL_003c: conv.r8
+			IL_003d: ldstr ""
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0047: stloc.1
+			IL_0048: ldloc.1
+			IL_0049: ldc.r8 0.0
+			IL_0052: box [System.Runtime]System.Double
+			IL_0057: ldc.i4.0
+			IL_0058: newarr [System.Runtime]System.Object
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+			IL_0062: pop
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method ArrowFunction_L16C14::__js_call__
 
 	} // end of class ArrowFunction_L16C14
@@ -489,24 +471,21 @@
 			6f 72 64 65 72 7d 00 00
 		)
 		// Fields
-		.field public object order
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array order
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x243c
+			// Method begins at RVA 0x23cf
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -524,7 +503,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 393 (0x189)
+		// Code size: 376 (0x178)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_NextTick_And_Promise_Ordering/Scope,
@@ -537,142 +516,137 @@
 		IL_0006: ldloc.0
 		IL_0007: ldc.i4.0
 		IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_000d: stfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+		IL_000d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
 		IL_0012: ldloc.0
-		IL_0013: ldfld object Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-		IL_0018: ldstr "Cannot access 'order' before initialization"
-		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0022: stloc.1
-		IL_0023: ldloc.1
-		IL_0024: ldstr "push"
-		IL_0029: ldstr "sync"
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0033: pop
-		IL_0034: ldc.i4.1
-		IL_0035: newarr [System.Runtime]System.Object
-		IL_003a: dup
-		IL_003b: ldc.i4.0
-		IL_003c: ldloc.0
-		IL_003d: stelem.ref
-		IL_003e: ldc.i4.0
-		IL_003f: ldelem.ref
-		IL_0040: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-		IL_0045: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L7C18::__js_call__(class Modules.Process_NextTick_And_Promise_Ordering/Scope, object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.0
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0070: stloc.1
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_0076: ldstr "nextTick"
-		IL_007b: ldloc.1
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ldc.r8 0.0
-		IL_008b: box [System.Runtime]System.Double
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_0095: stloc.1
-		IL_0096: ldc.i4.1
-		IL_0097: newarr [System.Runtime]System.Object
-		IL_009c: dup
-		IL_009d: ldc.i4.0
-		IL_009e: ldloc.0
-		IL_009f: stelem.ref
-		IL_00a0: ldc.i4.0
-		IL_00a1: ldelem.ref
-		IL_00a2: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-		IL_00a7: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25::__js_call__(class Modules.Process_NextTick_And_Promise_Ordering/Scope, object)
-		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00b2: ldc.i4.1
-		IL_00b3: newarr [System.Runtime]System.Object
-		IL_00b8: dup
-		IL_00b9: ldc.i4.0
-		IL_00ba: ldloc.0
-		IL_00bb: stelem.ref
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00c6: ldc.i4.0
-		IL_00c7: conv.r8
-		IL_00c8: ldstr ""
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00d2: stloc.2
-		IL_00d3: ldloc.1
-		IL_00d4: ldstr "then"
-		IL_00d9: ldloc.2
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00df: pop
-		IL_00e0: ldc.r8 0.0
-		IL_00e9: box [System.Runtime]System.Double
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_00f3: stloc.2
-		IL_00f4: ldc.i4.1
-		IL_00f5: newarr [System.Runtime]System.Object
-		IL_00fa: dup
-		IL_00fb: ldc.i4.0
-		IL_00fc: ldloc.0
-		IL_00fd: stelem.ref
-		IL_00fe: ldc.i4.0
-		IL_00ff: ldelem.ref
-		IL_0100: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-		IL_0105: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L14C25::__js_call__(class Modules.Process_NextTick_And_Promise_Ordering/Scope, object)
-		IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0110: ldc.i4.1
-		IL_0111: newarr [System.Runtime]System.Object
-		IL_0116: dup
-		IL_0117: ldc.i4.0
-		IL_0118: ldloc.0
-		IL_0119: stelem.ref
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0124: ldc.i4.0
-		IL_0125: conv.r8
-		IL_0126: ldstr ""
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0130: stloc.1
-		IL_0131: ldloc.2
-		IL_0132: ldstr "then"
-		IL_0137: ldloc.1
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_013d: pop
-		IL_013e: ldc.i4.1
-		IL_013f: newarr [System.Runtime]System.Object
-		IL_0144: dup
-		IL_0145: ldc.i4.0
-		IL_0146: ldloc.0
-		IL_0147: stelem.ref
-		IL_0148: ldc.i4.0
-		IL_0149: ldelem.ref
-		IL_014a: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-		IL_014f: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14::__js_call__(class Modules.Process_NextTick_And_Promise_Ordering/Scope, object)
-		IL_0155: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_015a: ldc.i4.1
-		IL_015b: newarr [System.Runtime]System.Object
-		IL_0160: dup
-		IL_0161: ldc.i4.0
-		IL_0162: ldloc.0
-		IL_0163: stelem.ref
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_016e: ldc.i4.0
-		IL_016f: conv.r8
-		IL_0170: ldstr ""
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_017a: stloc.1
-		IL_017b: ldloc.1
-		IL_017c: ldc.i4.0
-		IL_017d: newarr [System.Runtime]System.Object
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0187: pop
-		IL_0188: ret
+		IL_0013: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+		IL_0018: ldstr "sync"
+		IL_001d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_0022: pop
+		IL_0023: ldc.i4.1
+		IL_0024: newarr [System.Runtime]System.Object
+		IL_0029: dup
+		IL_002a: ldc.i4.0
+		IL_002b: ldloc.0
+		IL_002c: stelem.ref
+		IL_002d: ldc.i4.0
+		IL_002e: ldelem.ref
+		IL_002f: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+		IL_0034: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L7C18::__js_call__(class Modules.Process_NextTick_And_Promise_Ordering/Scope, object)
+		IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_003f: ldc.i4.1
+		IL_0040: newarr [System.Runtime]System.Object
+		IL_0045: dup
+		IL_0046: ldc.i4.0
+		IL_0047: ldloc.0
+		IL_0048: stelem.ref
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0053: ldc.i4.0
+		IL_0054: conv.r8
+		IL_0055: ldstr ""
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_005f: stloc.1
+		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_0065: ldstr "nextTick"
+		IL_006a: ldloc.1
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0070: pop
+		IL_0071: ldc.r8 0.0
+		IL_007a: box [System.Runtime]System.Double
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_0084: stloc.1
+		IL_0085: ldc.i4.1
+		IL_0086: newarr [System.Runtime]System.Object
+		IL_008b: dup
+		IL_008c: ldc.i4.0
+		IL_008d: ldloc.0
+		IL_008e: stelem.ref
+		IL_008f: ldc.i4.0
+		IL_0090: ldelem.ref
+		IL_0091: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+		IL_0096: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25::__js_call__(class Modules.Process_NextTick_And_Promise_Ordering/Scope, object)
+		IL_009c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a1: ldc.i4.1
+		IL_00a2: newarr [System.Runtime]System.Object
+		IL_00a7: dup
+		IL_00a8: ldc.i4.0
+		IL_00a9: ldloc.0
+		IL_00aa: stelem.ref
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00b5: ldc.i4.0
+		IL_00b6: conv.r8
+		IL_00b7: ldstr ""
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00c1: stloc.2
+		IL_00c2: ldloc.1
+		IL_00c3: ldstr "then"
+		IL_00c8: ldloc.2
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ce: pop
+		IL_00cf: ldc.r8 0.0
+		IL_00d8: box [System.Runtime]System.Double
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_00e2: stloc.2
+		IL_00e3: ldc.i4.1
+		IL_00e4: newarr [System.Runtime]System.Object
+		IL_00e9: dup
+		IL_00ea: ldc.i4.0
+		IL_00eb: ldloc.0
+		IL_00ec: stelem.ref
+		IL_00ed: ldc.i4.0
+		IL_00ee: ldelem.ref
+		IL_00ef: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+		IL_00f4: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L14C25::__js_call__(class Modules.Process_NextTick_And_Promise_Ordering/Scope, object)
+		IL_00fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ff: ldc.i4.1
+		IL_0100: newarr [System.Runtime]System.Object
+		IL_0105: dup
+		IL_0106: ldc.i4.0
+		IL_0107: ldloc.0
+		IL_0108: stelem.ref
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0113: ldc.i4.0
+		IL_0114: conv.r8
+		IL_0115: ldstr ""
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_011f: stloc.1
+		IL_0120: ldloc.2
+		IL_0121: ldstr "then"
+		IL_0126: ldloc.1
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_012c: pop
+		IL_012d: ldc.i4.1
+		IL_012e: newarr [System.Runtime]System.Object
+		IL_0133: dup
+		IL_0134: ldc.i4.0
+		IL_0135: ldloc.0
+		IL_0136: stelem.ref
+		IL_0137: ldc.i4.0
+		IL_0138: ldelem.ref
+		IL_0139: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+		IL_013e: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14::__js_call__(class Modules.Process_NextTick_And_Promise_Ordering/Scope, object)
+		IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0149: ldc.i4.1
+		IL_014a: newarr [System.Runtime]System.Object
+		IL_014f: dup
+		IL_0150: ldc.i4.0
+		IL_0151: ldloc.0
+		IL_0152: stelem.ref
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_015d: ldc.i4.0
+		IL_015e: conv.r8
+		IL_015f: ldstr ""
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0169: stloc.1
+		IL_016a: ldloc.1
+		IL_016b: ldc.i4.0
+		IL_016c: newarr [System.Runtime]System.Object
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0176: pop
+		IL_0177: ret
 	} // end of method Process_NextTick_And_Promise_Ordering::__js_module_init__
 
 } // end of class Modules.Process_NextTick_And_Promise_Ordering
@@ -684,7 +658,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2486
+		// Method begins at RVA 0x240e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Precedes_SetImmediate_When_Queued_Later.verified.txt
+++ b/tests/Js2IL.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Precedes_SetImmediate_When_Queued_Later.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2281
+				// Method begins at RVA 0x223a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,24 +46,23 @@
 			)
 			// Method begins at RVA 0x2160
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
+			IL_0006: ldstr "setImmediate"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "setImmediate"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L5C14::__js_call__
 
 	} // end of class ArrowFunction_L5C14
@@ -79,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228a
+				// Method begins at RVA 0x2243
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,26 +104,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2190
+			// Method begins at RVA 0x2188
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
+			IL_0006: ldstr "nextTick"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "nextTick"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L6C18::__js_call__
 
 	} // end of class ArrowFunction_L6C18
@@ -140,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2293
+				// Method begins at RVA 0x224c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -166,65 +164,53 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21c0
+			// Method begins at RVA 0x21b0
 			// Header size: 12
-			// Code size: 161 (0xa1)
+			// Code size: 117 (0x75)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] string,
 				[1] bool,
 				[2] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "setTimeout"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0028: ldstr "Cannot access 'order' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.0
-			IL_0033: ldloc.0
-			IL_0034: ldstr "join"
-			IL_0039: ldstr ","
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0043: stloc.0
-			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0049: ldstr "order"
-			IL_004e: ldloc.0
-			IL_004f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0054: pop
-			IL_0055: ldarg.0
-			IL_0056: ldfld object Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_005b: ldstr "Cannot access 'order' before initialization"
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0065: stloc.0
-			IL_0066: ldloc.0
-			IL_0067: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_006c: ldc.r8 0.0
-			IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_007a: stloc.0
-			IL_007b: ldloc.0
-			IL_007c: ldstr "nextTick"
-			IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0086: stloc.1
-			IL_0087: ldloc.1
-			IL_0088: box [System.Runtime]System.Boolean
-			IL_008d: stloc.2
-			IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0093: ldstr "nextTick first"
-			IL_0098: ldloc.2
-			IL_0099: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_009e: pop
-			IL_009f: ldnull
-			IL_00a0: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
+			IL_0006: ldstr "setTimeout"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldarg.0
+			IL_0012: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
+			IL_0017: ldc.i4.1
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: dup
+			IL_001e: ldc.i4.0
+			IL_001f: ldstr ","
+			IL_0024: stelem.ref
+			IL_0025: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_002a: stloc.0
+			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0030: ldstr "order"
+			IL_0035: ldloc.0
+			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_003b: pop
+			IL_003c: ldarg.0
+			IL_003d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
+			IL_0042: ldc.r8 0.0
+			IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0050: ldstr "nextTick"
+			IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_005a: stloc.1
+			IL_005b: ldloc.1
+			IL_005c: box [System.Runtime]System.Boolean
+			IL_0061: stloc.2
+			IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0067: ldstr "nextTick first"
+			IL_006c: ldloc.2
+			IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0072: pop
+			IL_0073: ldnull
+			IL_0074: ret
 		} // end of method ArrowFunction_L8C12::__js_call__
 
 	} // end of class ArrowFunction_L8C12
@@ -237,24 +223,21 @@
 			6f 72 64 65 72 7d 00 00
 		)
 		// Fields
-		.field public object order
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array order
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x226d
+			// Method begins at RVA 0x2231
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -284,7 +267,7 @@
 		IL_0006: ldloc.0
 		IL_0007: ldc.i4.0
 		IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_000d: stfld object Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
+		IL_000d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
 		IL_0012: ldc.i4.1
 		IL_0013: newarr [System.Runtime]System.Object
 		IL_0018: dup
@@ -386,7 +369,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x229c
+		// Method begins at RVA 0x2255
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Queue_Semantics.verified.txt
+++ b/tests/Js2IL.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Queue_Semantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2317
+				// Method begins at RVA 0x22bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,26 +44,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21c8
+			// Method begins at RVA 0x21b4
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_0006: ldstr "nextTick1"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "nextTick1"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L6C18::__js_call__
 
 	} // end of class ArrowFunction_L6C18
@@ -79,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2320
+				// Method begins at RVA 0x22c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,26 +104,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21dc
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_0006: ldstr "nextTick2"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "nextTick2"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L7C18::__js_call__
 
 	} // end of class ArrowFunction_L7C18
@@ -140,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2329
+				// Method begins at RVA 0x22d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -166,26 +164,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2228
+			// Method begins at RVA 0x2204
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_0006: ldstr "nextTick3"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "nextTick3"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L11C18::__js_call__
 
 	} // end of class ArrowFunction_L11C18
@@ -201,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2332
+				// Method begins at RVA 0x22da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -227,68 +224,63 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2258
+			// Method begins at RVA 0x222c
 			// Header size: 12
-			// Code size: 159 (0x9f)
+			// Code size: 126 (0x7e)
 			.maxstack 8
 			.locals init (
 				[0] string,
-				[1] object,
+				[1] string,
 				[2] bool,
 				[3] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "setImmediate"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0028: ldstr "Cannot access 'order' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.1
-			IL_0033: ldloc.1
-			IL_0034: ldstr "join"
-			IL_0039: ldstr ","
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0043: stloc.1
-			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0049: ldstr "order"
-			IL_004e: ldloc.1
-			IL_004f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0054: pop
-			IL_0055: ldstr "sync,nextTick1,nextTick2,nextTick3,setImmediate"
-			IL_005a: stloc.0
-			IL_005b: ldarg.0
-			IL_005c: ldfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0061: ldstr "Cannot access 'order' before initialization"
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_006b: stloc.1
-			IL_006c: ldloc.1
-			IL_006d: ldstr "join"
-			IL_0072: ldstr ","
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007c: stloc.1
-			IL_007d: ldloc.1
-			IL_007e: ldloc.0
-			IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0084: stloc.2
-			IL_0085: ldloc.2
-			IL_0086: box [System.Runtime]System.Boolean
-			IL_008b: stloc.3
-			IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0091: ldstr "correct order"
-			IL_0096: ldloc.3
-			IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_009c: pop
-			IL_009d: ldnull
-			IL_009e: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_0006: ldstr "setImmediate"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldarg.0
+			IL_0012: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_0017: ldc.i4.1
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: dup
+			IL_001e: ldc.i4.0
+			IL_001f: ldstr ","
+			IL_0024: stelem.ref
+			IL_0025: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_002a: stloc.1
+			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0030: ldstr "order"
+			IL_0035: ldloc.1
+			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_003b: pop
+			IL_003c: ldstr "sync,nextTick1,nextTick2,nextTick3,setImmediate"
+			IL_0041: stloc.0
+			IL_0042: ldarg.0
+			IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_0048: ldc.i4.1
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: dup
+			IL_004f: ldc.i4.0
+			IL_0050: ldstr ","
+			IL_0055: stelem.ref
+			IL_0056: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_005b: stloc.1
+			IL_005c: ldloc.1
+			IL_005d: ldloc.0
+			IL_005e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0063: stloc.2
+			IL_0064: ldloc.2
+			IL_0065: box [System.Runtime]System.Boolean
+			IL_006a: stloc.3
+			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0070: ldstr "correct order"
+			IL_0075: ldloc.3
+			IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_007b: pop
+			IL_007c: ldnull
+			IL_007d: ret
 		} // end of method ArrowFunction_L13C14::__js_call__
 
 	} // end of class ArrowFunction_L13C14
@@ -301,24 +293,21 @@
 			6f 72 64 65 72 7d 00 00
 		)
 		// Fields
-		.field public object order
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array order
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2303
+			// Method begins at RVA 0x22b6
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -336,7 +325,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 361 (0x169)
+		// Code size: 344 (0x158)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_NextTick_Queue_Semantics/Scope,
@@ -348,7 +337,7 @@
 		IL_0006: ldloc.0
 		IL_0007: ldc.i4.0
 		IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_000d: stfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
+		IL_000d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
 		IL_0012: ldc.i4.1
 		IL_0013: newarr [System.Runtime]System.Object
 		IL_0018: dup
@@ -408,74 +397,69 @@
 		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00ad: pop
 		IL_00ae: ldloc.0
-		IL_00af: ldfld object Modules.Process_NextTick_Queue_Semantics/Scope::order
-		IL_00b4: ldstr "Cannot access 'order' before initialization"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00be: stloc.1
-		IL_00bf: ldloc.1
-		IL_00c0: ldstr "push"
-		IL_00c5: ldstr "sync"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00cf: pop
-		IL_00d0: ldc.i4.1
-		IL_00d1: newarr [System.Runtime]System.Object
-		IL_00d6: dup
-		IL_00d7: ldc.i4.0
-		IL_00d8: ldloc.0
-		IL_00d9: stelem.ref
-		IL_00da: ldc.i4.0
-		IL_00db: ldelem.ref
-		IL_00dc: castclass Modules.Process_NextTick_Queue_Semantics/Scope
-		IL_00e1: ldftn object Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L11C18::__js_call__(class Modules.Process_NextTick_Queue_Semantics/Scope, object)
-		IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ec: ldc.i4.1
-		IL_00ed: newarr [System.Runtime]System.Object
-		IL_00f2: dup
-		IL_00f3: ldc.i4.0
-		IL_00f4: ldloc.0
-		IL_00f5: stelem.ref
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0100: ldc.i4.0
-		IL_0101: conv.r8
-		IL_0102: ldstr ""
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_010c: stloc.1
-		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_0112: ldstr "nextTick"
-		IL_0117: ldloc.1
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011d: pop
-		IL_011e: ldc.i4.1
-		IL_011f: newarr [System.Runtime]System.Object
-		IL_0124: dup
-		IL_0125: ldc.i4.0
-		IL_0126: ldloc.0
-		IL_0127: stelem.ref
-		IL_0128: ldc.i4.0
-		IL_0129: ldelem.ref
-		IL_012a: castclass Modules.Process_NextTick_Queue_Semantics/Scope
-		IL_012f: ldftn object Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L13C14::__js_call__(class Modules.Process_NextTick_Queue_Semantics/Scope, object)
-		IL_0135: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_013a: ldc.i4.1
-		IL_013b: newarr [System.Runtime]System.Object
-		IL_0140: dup
-		IL_0141: ldc.i4.0
-		IL_0142: ldloc.0
-		IL_0143: stelem.ref
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_014e: ldc.i4.0
-		IL_014f: conv.r8
-		IL_0150: ldstr ""
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_015a: stloc.1
-		IL_015b: ldloc.1
-		IL_015c: ldc.i4.0
-		IL_015d: newarr [System.Runtime]System.Object
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0167: pop
-		IL_0168: ret
+		IL_00af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+		IL_00b4: ldstr "sync"
+		IL_00b9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_00be: pop
+		IL_00bf: ldc.i4.1
+		IL_00c0: newarr [System.Runtime]System.Object
+		IL_00c5: dup
+		IL_00c6: ldc.i4.0
+		IL_00c7: ldloc.0
+		IL_00c8: stelem.ref
+		IL_00c9: ldc.i4.0
+		IL_00ca: ldelem.ref
+		IL_00cb: castclass Modules.Process_NextTick_Queue_Semantics/Scope
+		IL_00d0: ldftn object Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L11C18::__js_call__(class Modules.Process_NextTick_Queue_Semantics/Scope, object)
+		IL_00d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00db: ldc.i4.1
+		IL_00dc: newarr [System.Runtime]System.Object
+		IL_00e1: dup
+		IL_00e2: ldc.i4.0
+		IL_00e3: ldloc.0
+		IL_00e4: stelem.ref
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00ef: ldc.i4.0
+		IL_00f0: conv.r8
+		IL_00f1: ldstr ""
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00fb: stloc.1
+		IL_00fc: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_0101: ldstr "nextTick"
+		IL_0106: ldloc.1
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_010c: pop
+		IL_010d: ldc.i4.1
+		IL_010e: newarr [System.Runtime]System.Object
+		IL_0113: dup
+		IL_0114: ldc.i4.0
+		IL_0115: ldloc.0
+		IL_0116: stelem.ref
+		IL_0117: ldc.i4.0
+		IL_0118: ldelem.ref
+		IL_0119: castclass Modules.Process_NextTick_Queue_Semantics/Scope
+		IL_011e: ldftn object Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L13C14::__js_call__(class Modules.Process_NextTick_Queue_Semantics/Scope, object)
+		IL_0124: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0129: ldc.i4.1
+		IL_012a: newarr [System.Runtime]System.Object
+		IL_012f: dup
+		IL_0130: ldc.i4.0
+		IL_0131: ldloc.0
+		IL_0132: stelem.ref
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_013d: ldc.i4.0
+		IL_013e: conv.r8
+		IL_013f: ldstr ""
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0149: stloc.1
+		IL_014a: ldloc.1
+		IL_014b: ldc.i4.0
+		IL_014c: newarr [System.Runtime]System.Object
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0156: pop
+		IL_0157: ret
 	} // end of method Process_NextTick_Queue_Semantics::__js_module_init__
 
 } // end of class Modules.Process_NextTick_Queue_Semantics
@@ -487,7 +471,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x233b
+		// Method begins at RVA 0x22e3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2205
+				// Method begins at RVA 0x21b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x2138
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220e
+				// Method begins at RVA 0x21c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,16 +90,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x216c
+			// Method begins at RVA 0x213c
 			// Header size: 12
-			// Code size: 121 (0x79)
+			// Code size: 103 (0x67)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[2] bool,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -127,25 +126,19 @@
 			IL_0037: ldloc.3
 			IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_003d: pop
-			IL_003e: ldarg.0
-			IL_003f: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
-			IL_0044: ldstr "Cannot access 'writable' before initialization"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004e: stloc.s 4
-			IL_0050: ldloc.s 4
-			IL_0052: ldstr "destroyed"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005c: stloc.s 4
-			IL_005e: ldstr "destroyed:"
-			IL_0063: ldloc.s 4
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006a: stloc.3
-			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0070: ldloc.3
-			IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0076: pop
-			IL_0077: ldnull
-			IL_0078: ret
+			IL_003e: ldstr "destroyed:"
+			IL_0043: ldarg.0
+			IL_0044: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
+			IL_0049: ldstr "destroyed"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0058: stloc.3
+			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_005e: ldloc.3
+			IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0064: pop
+			IL_0065: ldnull
+			IL_0066: ret
 		} // end of method FunctionExpression_L8C26::__js_call__
 
 	} // end of class FunctionExpression_L8C26
@@ -164,18 +157,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f1
+			// Method begins at RVA 0x21af
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -193,7 +183,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 268 (0x10c)
+		// Code size: 220 (0xdc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Finished_Callback_Basic/Scope,
@@ -231,70 +221,54 @@
 		IL_004a: stloc.2
 		IL_004b: ldloc.0
 		IL_004c: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
-		IL_0051: ldstr "Cannot access 'writable' before initialization"
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_005b: stloc.3
-		IL_005c: ldloc.3
-		IL_005d: ldstr "_write"
-		IL_0062: ldloc.2
-		IL_0063: ldc.i4.1
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0069: pop
-		IL_006a: ldloc.0
-		IL_006b: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
-		IL_0070: ldstr "Cannot access 'writable' before initialization"
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_007a: stloc.2
-		IL_007b: ldc.i4.1
-		IL_007c: newarr [System.Runtime]System.Object
-		IL_0081: dup
-		IL_0082: ldc.i4.0
-		IL_0083: ldloc.0
-		IL_0084: stelem.ref
-		IL_0085: ldc.i4.0
-		IL_0086: ldelem.ref
-		IL_0087: castclass Modules.Stream_Finished_Callback_Basic/Scope
-		IL_008c: ldftn object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26::__js_call__(class Modules.Stream_Finished_Callback_Basic/Scope, object, object)
-		IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0097: ldc.i4.1
-		IL_0098: conv.r8
-		IL_0099: ldstr ""
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00a3: stloc.3
-		IL_00a4: ldloc.1
-		IL_00a5: ldstr "finished"
-		IL_00aa: ldloc.2
-		IL_00ab: ldloc.3
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0051: ldstr "_write"
+		IL_0056: ldloc.2
+		IL_0057: ldc.i4.1
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_005d: pop
+		IL_005e: ldloc.0
+		IL_005f: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
+		IL_0064: stloc.2
+		IL_0065: ldc.i4.1
+		IL_0066: newarr [System.Runtime]System.Object
+		IL_006b: dup
+		IL_006c: ldc.i4.0
+		IL_006d: ldloc.0
+		IL_006e: stelem.ref
+		IL_006f: ldc.i4.0
+		IL_0070: ldelem.ref
+		IL_0071: castclass Modules.Stream_Finished_Callback_Basic/Scope
+		IL_0076: ldftn object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26::__js_call__(class Modules.Stream_Finished_Callback_Basic/Scope, object, object)
+		IL_007c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0081: ldc.i4.1
+		IL_0082: conv.r8
+		IL_0083: ldstr ""
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_008d: stloc.3
+		IL_008e: ldloc.1
+		IL_008f: ldstr "finished"
+		IL_0094: ldloc.2
+		IL_0095: ldloc.3
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_009b: pop
+		IL_009c: ldloc.0
+		IL_009d: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
+		IL_00a2: ldstr "end"
+		IL_00a7: ldstr "done"
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00b1: pop
-		IL_00b2: ldloc.0
-		IL_00b3: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
-		IL_00b8: ldstr "Cannot access 'writable' before initialization"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00c2: stloc.3
-		IL_00c3: ldloc.3
-		IL_00c4: ldstr "end"
-		IL_00c9: ldstr "done"
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ldloc.0
-		IL_00d5: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
-		IL_00da: ldstr "Cannot access 'writable' before initialization"
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00e4: stloc.3
-		IL_00e5: ldloc.3
-		IL_00e6: ldstr "writable"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f0: stloc.3
-		IL_00f1: ldstr "after-end:"
-		IL_00f6: ldloc.3
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00fc: stloc.s 4
-		IL_00fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0103: ldloc.s 4
-		IL_0105: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010a: pop
-		IL_010b: ret
+		IL_00b2: ldstr "after-end:"
+		IL_00b7: ldloc.0
+		IL_00b8: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
+		IL_00bd: ldstr "writable"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00cc: stloc.s 4
+		IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d3: ldloc.s 4
+		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00da: pop
+		IL_00db: ret
 	} // end of method Stream_Finished_Callback_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Finished_Callback_Basic
@@ -306,7 +280,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2217
+		// Method begins at RVA 0x21ca
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a1
+				// Method begins at RVA 0x216c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,16 +45,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2108
+			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 121 (0x79)
+			// Code size: 103 (0x67)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[2] bool,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -82,25 +81,19 @@
 			IL_0037: ldloc.3
 			IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_003d: pop
-			IL_003e: ldarg.0
-			IL_003f: ldfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
-			IL_0044: ldstr "Cannot access 'readable' before initialization"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004e: stloc.s 4
-			IL_0050: ldloc.s 4
-			IL_0052: ldstr "destroyed"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005c: stloc.s 4
-			IL_005e: ldstr "destroyed:"
-			IL_0063: ldloc.s 4
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006a: stloc.3
-			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0070: ldloc.3
-			IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0076: pop
-			IL_0077: ldnull
-			IL_0078: ret
+			IL_003e: ldstr "destroyed:"
+			IL_0043: ldarg.0
+			IL_0044: ldfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
+			IL_0049: ldstr "destroyed"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0058: stloc.3
+			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_005e: ldloc.3
+			IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0064: pop
+			IL_0065: ldnull
+			IL_0066: ret
 		} // end of method FunctionExpression_L7C26::__js_call__
 
 	} // end of class FunctionExpression_L7C26
@@ -119,18 +112,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218d
+			// Method begins at RVA 0x2163
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -148,7 +138,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 169 (0xa9)
+		// Code size: 147 (0x93)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Finished_Callback_DestroyError/Scope,
@@ -177,46 +167,40 @@
 		IL_002d: stfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
 		IL_0032: ldloc.0
 		IL_0033: ldfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
-		IL_0038: ldstr "Cannot access 'readable' before initialization"
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0042: stloc.2
-		IL_0043: ldc.i4.1
-		IL_0044: newarr [System.Runtime]System.Object
-		IL_0049: dup
-		IL_004a: ldc.i4.0
-		IL_004b: ldloc.0
-		IL_004c: stelem.ref
-		IL_004d: ldc.i4.0
-		IL_004e: ldelem.ref
-		IL_004f: castclass Modules.Stream_Finished_Callback_DestroyError/Scope
-		IL_0054: ldftn object Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26::__js_call__(class Modules.Stream_Finished_Callback_DestroyError/Scope, object, object)
-		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_005f: ldc.i4.1
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_006b: stloc.3
-		IL_006c: ldloc.1
-		IL_006d: ldstr "finished"
-		IL_0072: ldloc.2
-		IL_0073: ldloc.3
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0079: pop
-		IL_007a: ldloc.0
-		IL_007b: ldfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
-		IL_0080: ldstr "Cannot access 'readable' before initialization"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_008a: stloc.3
-		IL_008b: ldstr "read boom"
-		IL_0090: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-		IL_009a: stloc.2
-		IL_009b: ldloc.3
-		IL_009c: ldstr "destroy"
-		IL_00a1: ldloc.2
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a7: pop
-		IL_00a8: ret
+		IL_0038: stloc.2
+		IL_0039: ldc.i4.1
+		IL_003a: newarr [System.Runtime]System.Object
+		IL_003f: dup
+		IL_0040: ldc.i4.0
+		IL_0041: ldloc.0
+		IL_0042: stelem.ref
+		IL_0043: ldc.i4.0
+		IL_0044: ldelem.ref
+		IL_0045: castclass Modules.Stream_Finished_Callback_DestroyError/Scope
+		IL_004a: ldftn object Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26::__js_call__(class Modules.Stream_Finished_Callback_DestroyError/Scope, object, object)
+		IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0055: ldc.i4.1
+		IL_0056: conv.r8
+		IL_0057: ldstr ""
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0061: stloc.3
+		IL_0062: ldloc.1
+		IL_0063: ldstr "finished"
+		IL_0068: ldloc.2
+		IL_0069: ldloc.3
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_006f: pop
+		IL_0070: ldstr "read boom"
+		IL_0075: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_007f: stloc.3
+		IL_0080: ldloc.0
+		IL_0081: ldfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
+		IL_0086: ldstr "destroy"
+		IL_008b: ldloc.3
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0091: pop
+		IL_0092: ret
 	} // end of method Stream_Finished_Callback_DestroyError::__js_module_init__
 
 } // end of class Modules.Stream_Finished_Callback_DestroyError
@@ -228,7 +212,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21aa
+		// Method begins at RVA 0x2175
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2999
+					// Method begins at RVA 0x2943
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2968
+				// Method begins at RVA 0x2928
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2990
+				// Method begins at RVA 0x293a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -92,7 +92,7 @@
 			)
 			// Method begins at RVA 0x2120
 			// Header size: 12
-			// Code size: 111 (0x6f)
+			// Code size: 99 (0x63)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/Scope,
@@ -104,44 +104,40 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-			IL_000c: ldstr "Cannot access 'stream' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "Writable"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0016: stloc.2
 			IL_0017: ldloc.2
-			IL_0018: ldstr "Writable"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0022: stloc.2
-			IL_0023: ldloc.2
-			IL_0024: ldc.i4.1
-			IL_0025: newarr [System.Runtime]System.Object
-			IL_002a: dup
-			IL_002b: ldc.i4.0
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "objectMode"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: stelem.ref
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0043: stloc.2
-			IL_0044: ldloc.2
-			IL_0045: stloc.1
-			IL_0046: ldnull
-			IL_0047: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
-			IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0052: ldc.i4.1
-			IL_0053: conv.r8
-			IL_0054: ldstr ""
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_005e: stloc.2
-			IL_005f: ldloc.1
-			IL_0060: ldstr "_write"
-			IL_0065: ldloc.2
-			IL_0066: ldc.i4.1
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_006c: pop
-			IL_006d: ldloc.1
-			IL_006e: ret
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0025: dup
+			IL_0026: ldstr "objectMode"
+			IL_002b: ldc.i4.1
+			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0031: stelem.ref
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0037: stloc.2
+			IL_0038: ldloc.2
+			IL_0039: stloc.1
+			IL_003a: ldnull
+			IL_003b: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
+			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0046: ldc.i4.1
+			IL_0047: conv.r8
+			IL_0048: ldstr ""
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0052: stloc.2
+			IL_0053: ldloc.1
+			IL_0054: ldstr "_write"
+			IL_0059: ldloc.2
+			IL_005a: ldc.i4.1
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0060: pop
+			IL_0061: ldloc.1
+			IL_0062: ret
 		} // end of method createWritable::__js_call__
 
 	} // end of class createWritable
@@ -157,7 +153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a2
+				// Method begins at RVA 0x294c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -183,9 +179,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x2190
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -193,28 +189,24 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-			IL_0006: ldstr "Cannot access 'stream' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0006: ldstr "Readable"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "Readable"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.i4.1
-			IL_001f: newarr [System.Runtime]System.Object
-			IL_0024: dup
-			IL_0025: ldc.i4.0
-			IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002b: dup
-			IL_002c: ldstr "objectMode"
-			IL_0031: ldc.i4.1
-			IL_0032: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0037: stelem.ref
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_003d: stloc.0
-			IL_003e: ldloc.0
-			IL_003f: ret
+			IL_0012: ldc.i4.1
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001f: dup
+			IL_0020: ldstr "objectMode"
+			IL_0025: ldc.i4.1
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_002b: stelem.ref
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0031: stloc.0
+			IL_0032: ldloc.0
+			IL_0033: ret
 		} // end of method createReadable::__js_call__
 
 	} // end of class createReadable
@@ -234,7 +226,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29bd
+					// Method begins at RVA 0x2967
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -257,7 +249,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x296b
+				// Method begins at RVA 0x292b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -279,7 +271,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29d8
+					// Method begins at RVA 0x2982
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -302,7 +294,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x296e
+				// Method begins at RVA 0x292e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -339,7 +331,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29b4
+					// Method begins at RVA 0x295e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -359,7 +351,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29c6
+					// Method begins at RVA 0x2970
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -379,7 +371,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29cf
+					// Method begins at RVA 0x2979
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -399,7 +391,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29e1
+					// Method begins at RVA 0x298b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -419,7 +411,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29ea
+					// Method begins at RVA 0x2994
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -439,7 +431,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29f3
+					// Method begins at RVA 0x299d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -459,7 +451,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29fc
+					// Method begins at RVA 0x29a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +471,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a05
+					// Method begins at RVA 0x29af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -507,7 +499,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ab
+				// Method begins at RVA 0x2955
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -531,9 +523,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x21d0
 			// Header size: 12
-			// Code size: 1878 (0x756)
+			// Code size: 1838 (0x72e)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope,
@@ -683,7 +675,7 @@
 
 			IL_00d1: ldloc.0
 			IL_00d2: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00d7: switch (IL_00f0, IL_04ce, IL_04b2, IL_06ad, IL_0691)
+			IL_00d7: switch (IL_00f0, IL_04b0, IL_0494, IL_0685, IL_0669)
 			.try
 			{
 				IL_00f0: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L17C6::.ctor()
@@ -693,663 +685,655 @@
 				IL_00f8: ldelem.ref
 				IL_00f9: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
 				IL_00fe: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_0103: ldstr "Cannot access 'stream' before initialization"
-				IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_010d: stloc.s 19
-				IL_010f: ldc.i4.1
-				IL_0110: newarr [System.Runtime]System.Object
-				IL_0115: dup
-				IL_0116: ldc.i4.0
-				IL_0117: ldarg.0
-				IL_0118: ldc.i4.1
-				IL_0119: ldelem.ref
-				IL_011a: stelem.ref
-				IL_011b: ldc.i4.0
-				IL_011c: ldelem.ref
-				IL_011d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0122: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_012d: ldnull
-				IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-				IL_0133: stloc.s 20
-				IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_013a: dup
-				IL_013b: ldstr "signal"
-				IL_0140: ldc.i4.0
-				IL_0141: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0146: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_014b: stloc.s 21
-				IL_014d: ldnull
-				IL_014e: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
-				IL_0154: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0159: ldc.i4.0
-				IL_015a: conv.r8
-				IL_015b: ldstr ""
-				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_0165: stloc.s 22
-				IL_0167: ldloc.s 19
-				IL_0169: ldstr "finished"
-				IL_016e: ldloc.s 20
-				IL_0170: ldloc.s 21
-				IL_0172: ldloc.s 22
-				IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_0179: pop
-				IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_017f: ldstr "callback-finished:ok"
-				IL_0184: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0189: pop
-				IL_018a: leave IL_022e
+				IL_0103: stloc.s 19
+				IL_0105: ldc.i4.1
+				IL_0106: newarr [System.Runtime]System.Object
+				IL_010b: dup
+				IL_010c: ldc.i4.0
+				IL_010d: ldarg.0
+				IL_010e: ldc.i4.1
+				IL_010f: ldelem.ref
+				IL_0110: stelem.ref
+				IL_0111: ldc.i4.0
+				IL_0112: ldelem.ref
+				IL_0113: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0118: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_011e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0123: ldnull
+				IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+				IL_0129: stloc.s 20
+				IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0130: dup
+				IL_0131: ldstr "signal"
+				IL_0136: ldc.i4.0
+				IL_0137: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_013c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0141: stloc.s 21
+				IL_0143: ldnull
+				IL_0144: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
+				IL_014a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_014f: ldc.i4.0
+				IL_0150: conv.r8
+				IL_0151: ldstr ""
+				IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_015b: stloc.s 22
+				IL_015d: ldloc.s 19
+				IL_015f: ldstr "finished"
+				IL_0164: ldloc.s 20
+				IL_0166: ldloc.s 21
+				IL_0168: ldloc.s 22
+				IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_016f: pop
+				IL_0170: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0175: ldstr "callback-finished:ok"
+				IL_017a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_017f: pop
+				IL_0180: leave IL_0224
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_018f: stloc.2
-				IL_0190: ldloc.2
-				IL_0191: dup
-				IL_0192: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0197: dup
-				IL_0198: brtrue IL_01ae
+				IL_0185: stloc.2
+				IL_0186: ldloc.2
+				IL_0187: dup
+				IL_0188: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_018d: dup
+				IL_018e: brtrue IL_01a4
 
-				IL_019d: pop
-				IL_019e: dup
-				IL_019f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_01a4: dup
-				IL_01a5: brtrue IL_01ba
+				IL_0193: pop
+				IL_0194: dup
+				IL_0195: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_019a: dup
+				IL_019b: brtrue IL_01b0
 
-				IL_01aa: pop
-				IL_01ab: pop
-				IL_01ac: rethrow
+				IL_01a0: pop
+				IL_01a1: pop
+				IL_01a2: rethrow
 
-				IL_01ae: pop
-				IL_01af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_01b4: stloc.3
-				IL_01b5: br IL_01bc
+				IL_01a4: pop
+				IL_01a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_01aa: stloc.3
+				IL_01ab: br IL_01b2
 
-				IL_01ba: pop
-				IL_01bb: stloc.3
+				IL_01b0: pop
+				IL_01b1: stloc.3
 
-				IL_01bc: ldloc.3
-				IL_01bd: stloc.s 22
-				IL_01bf: ldloc.s 22
-				IL_01c1: stloc.s 4
-				IL_01c3: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
-				IL_01c8: stloc.s 5
-				IL_01ca: ldstr "callback-finished:"
-				IL_01cf: ldloc.s 4
-				IL_01d1: ldstr "name"
-				IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01e0: stloc.s 23
-				IL_01e2: ldloc.s 23
-				IL_01e4: ldstr ":"
-				IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01ee: stloc.s 23
-				IL_01f0: ldloc.s 23
-				IL_01f2: ldloc.s 4
-				IL_01f4: ldstr "code"
-				IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0203: stloc.s 23
-				IL_0205: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_020a: ldloc.s 23
-				IL_020c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0211: pop
-				IL_0212: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0217: ldloc.s 4
-				IL_0219: ldstr "message"
-				IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0223: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0228: pop
-				IL_0229: leave IL_022e
+				IL_01b2: ldloc.3
+				IL_01b3: stloc.s 22
+				IL_01b5: ldloc.s 22
+				IL_01b7: stloc.s 4
+				IL_01b9: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
+				IL_01be: stloc.s 5
+				IL_01c0: ldstr "callback-finished:"
+				IL_01c5: ldloc.s 4
+				IL_01c7: ldstr "name"
+				IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01d6: stloc.s 23
+				IL_01d8: ldloc.s 23
+				IL_01da: ldstr ":"
+				IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01e4: stloc.s 23
+				IL_01e6: ldloc.s 23
+				IL_01e8: ldloc.s 4
+				IL_01ea: ldstr "code"
+				IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01f9: stloc.s 23
+				IL_01fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0200: ldloc.s 23
+				IL_0202: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0207: pop
+				IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_020d: ldloc.s 4
+				IL_020f: ldstr "message"
+				IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0219: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_021e: pop
+				IL_021f: leave IL_0224
 			} // end handler
 			.try
 			{
-				IL_022e: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L25C6::.ctor()
-				IL_0233: stloc.s 6
-				IL_0235: ldarg.0
-				IL_0236: ldc.i4.1
-				IL_0237: ldelem.ref
-				IL_0238: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_023d: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_0242: ldstr "Cannot access 'stream' before initialization"
-				IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_024c: stloc.s 22
-				IL_024e: ldc.i4.1
-				IL_024f: newarr [System.Runtime]System.Object
-				IL_0254: dup
-				IL_0255: ldc.i4.0
-				IL_0256: ldarg.0
-				IL_0257: ldc.i4.1
-				IL_0258: ldelem.ref
-				IL_0259: stelem.ref
-				IL_025a: ldc.i4.0
-				IL_025b: ldelem.ref
-				IL_025c: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0261: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_026c: ldnull
-				IL_026d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-				IL_0272: stloc.s 20
-				IL_0274: ldc.i4.1
-				IL_0275: newarr [System.Runtime]System.Object
-				IL_027a: dup
-				IL_027b: ldc.i4.0
-				IL_027c: ldarg.0
-				IL_027d: ldc.i4.1
-				IL_027e: ldelem.ref
-				IL_027f: stelem.ref
-				IL_0280: ldc.i4.0
-				IL_0281: ldelem.ref
-				IL_0282: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0287: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_028d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0292: ldnull
-				IL_0293: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-				IL_0298: stloc.s 19
-				IL_029a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_029f: dup
-				IL_02a0: ldstr "signal"
-				IL_02a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_02aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_02af: stloc.s 21
-				IL_02b1: ldnull
-				IL_02b2: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
-				IL_02b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_02bd: ldc.i4.0
-				IL_02be: conv.r8
-				IL_02bf: ldstr ""
-				IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-				IL_02c9: stloc.s 24
-				IL_02cb: ldc.i4.4
-				IL_02cc: newarr [System.Runtime]System.Object
-				IL_02d1: dup
-				IL_02d2: ldc.i4.0
-				IL_02d3: ldloc.s 20
-				IL_02d5: stelem.ref
-				IL_02d6: dup
-				IL_02d7: ldc.i4.1
-				IL_02d8: ldloc.s 19
-				IL_02da: stelem.ref
-				IL_02db: dup
-				IL_02dc: ldc.i4.2
-				IL_02dd: ldloc.s 21
-				IL_02df: stelem.ref
-				IL_02e0: dup
-				IL_02e1: ldc.i4.3
-				IL_02e2: ldloc.s 24
-				IL_02e4: stelem.ref
-				IL_02e5: stloc.s 25
-				IL_02e7: ldloc.s 22
-				IL_02e9: ldstr "pipeline"
-				IL_02ee: ldloc.s 25
-				IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_02f5: pop
-				IL_02f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_02fb: ldstr "callback-pipeline:ok"
-				IL_0300: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0305: pop
-				IL_0306: leave IL_03af
+				IL_0224: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L25C6::.ctor()
+				IL_0229: stloc.s 6
+				IL_022b: ldarg.0
+				IL_022c: ldc.i4.1
+				IL_022d: ldelem.ref
+				IL_022e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0233: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_0238: stloc.s 22
+				IL_023a: ldc.i4.1
+				IL_023b: newarr [System.Runtime]System.Object
+				IL_0240: dup
+				IL_0241: ldc.i4.0
+				IL_0242: ldarg.0
+				IL_0243: ldc.i4.1
+				IL_0244: ldelem.ref
+				IL_0245: stelem.ref
+				IL_0246: ldc.i4.0
+				IL_0247: ldelem.ref
+				IL_0248: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_024d: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_0253: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0258: ldnull
+				IL_0259: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+				IL_025e: stloc.s 20
+				IL_0260: ldc.i4.1
+				IL_0261: newarr [System.Runtime]System.Object
+				IL_0266: dup
+				IL_0267: ldc.i4.0
+				IL_0268: ldarg.0
+				IL_0269: ldc.i4.1
+				IL_026a: ldelem.ref
+				IL_026b: stelem.ref
+				IL_026c: ldc.i4.0
+				IL_026d: ldelem.ref
+				IL_026e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0273: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_0279: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_027e: ldnull
+				IL_027f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+				IL_0284: stloc.s 19
+				IL_0286: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_028b: dup
+				IL_028c: ldstr "signal"
+				IL_0291: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0296: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_029b: stloc.s 21
+				IL_029d: ldnull
+				IL_029e: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
+				IL_02a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_02a9: ldc.i4.0
+				IL_02aa: conv.r8
+				IL_02ab: ldstr ""
+				IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+				IL_02b5: stloc.s 24
+				IL_02b7: ldc.i4.4
+				IL_02b8: newarr [System.Runtime]System.Object
+				IL_02bd: dup
+				IL_02be: ldc.i4.0
+				IL_02bf: ldloc.s 20
+				IL_02c1: stelem.ref
+				IL_02c2: dup
+				IL_02c3: ldc.i4.1
+				IL_02c4: ldloc.s 19
+				IL_02c6: stelem.ref
+				IL_02c7: dup
+				IL_02c8: ldc.i4.2
+				IL_02c9: ldloc.s 21
+				IL_02cb: stelem.ref
+				IL_02cc: dup
+				IL_02cd: ldc.i4.3
+				IL_02ce: ldloc.s 24
+				IL_02d0: stelem.ref
+				IL_02d1: stloc.s 25
+				IL_02d3: ldloc.s 22
+				IL_02d5: ldstr "pipeline"
+				IL_02da: ldloc.s 25
+				IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_02e1: pop
+				IL_02e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_02e7: ldstr "callback-pipeline:ok"
+				IL_02ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_02f1: pop
+				IL_02f2: leave IL_039b
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_030b: stloc.s 7
-				IL_030d: ldloc.s 7
-				IL_030f: dup
-				IL_0310: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0315: dup
-				IL_0316: brtrue IL_032c
+				IL_02f7: stloc.s 7
+				IL_02f9: ldloc.s 7
+				IL_02fb: dup
+				IL_02fc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0301: dup
+				IL_0302: brtrue IL_0318
 
-				IL_031b: pop
-				IL_031c: dup
-				IL_031d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0322: dup
-				IL_0323: brtrue IL_0339
+				IL_0307: pop
+				IL_0308: dup
+				IL_0309: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_030e: dup
+				IL_030f: brtrue IL_0325
 
-				IL_0328: pop
-				IL_0329: pop
-				IL_032a: rethrow
+				IL_0314: pop
+				IL_0315: pop
+				IL_0316: rethrow
 
-				IL_032c: pop
-				IL_032d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0332: stloc.s 8
-				IL_0334: br IL_033c
+				IL_0318: pop
+				IL_0319: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_031e: stloc.s 8
+				IL_0320: br IL_0328
 
-				IL_0339: pop
-				IL_033a: stloc.s 8
+				IL_0325: pop
+				IL_0326: stloc.s 8
 
-				IL_033c: ldloc.s 8
-				IL_033e: stloc.s 22
-				IL_0340: ldloc.s 22
-				IL_0342: stloc.s 9
-				IL_0344: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
-				IL_0349: stloc.s 10
-				IL_034b: ldstr "callback-pipeline:"
-				IL_0350: ldloc.s 9
-				IL_0352: ldstr "name"
-				IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0361: stloc.s 23
-				IL_0363: ldloc.s 23
-				IL_0365: ldstr ":"
-				IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_036f: stloc.s 23
-				IL_0371: ldloc.s 23
-				IL_0373: ldloc.s 9
-				IL_0375: ldstr "code"
-				IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0384: stloc.s 23
-				IL_0386: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_038b: ldloc.s 23
-				IL_038d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0392: pop
-				IL_0393: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0398: ldloc.s 9
-				IL_039a: ldstr "message"
-				IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_03a9: pop
-				IL_03aa: leave IL_03af
+				IL_0328: ldloc.s 8
+				IL_032a: stloc.s 22
+				IL_032c: ldloc.s 22
+				IL_032e: stloc.s 9
+				IL_0330: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
+				IL_0335: stloc.s 10
+				IL_0337: ldstr "callback-pipeline:"
+				IL_033c: ldloc.s 9
+				IL_033e: ldstr "name"
+				IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_034d: stloc.s 23
+				IL_034f: ldloc.s 23
+				IL_0351: ldstr ":"
+				IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_035b: stloc.s 23
+				IL_035d: ldloc.s 23
+				IL_035f: ldloc.s 9
+				IL_0361: ldstr "code"
+				IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0370: stloc.s 23
+				IL_0372: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0377: ldloc.s 23
+				IL_0379: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_037e: pop
+				IL_037f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0384: ldloc.s 9
+				IL_0386: ldstr "message"
+				IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0390: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0395: pop
+				IL_0396: leave IL_039b
 			} // end handler
 
-			IL_03af: ldloc.0
-			IL_03b0: ldc.i4.0
-			IL_03b1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_03b6: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L33C6::.ctor()
-			IL_03bb: stloc.s 11
-			IL_03bd: ldarg.0
-			IL_03be: ldc.i4.1
-			IL_03bf: ldelem.ref
-			IL_03c0: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_03c5: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_03ca: ldstr "Cannot access 'streamPromises' before initialization"
-			IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_03d4: stloc.s 22
-			IL_03d6: ldc.i4.1
-			IL_03d7: newarr [System.Runtime]System.Object
-			IL_03dc: dup
-			IL_03dd: ldc.i4.0
-			IL_03de: ldarg.0
-			IL_03df: ldc.i4.1
-			IL_03e0: ldelem.ref
-			IL_03e1: stelem.ref
-			IL_03e2: ldc.i4.0
-			IL_03e3: ldelem.ref
-			IL_03e4: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_03e9: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_03ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_03f4: ldnull
-			IL_03f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_03fa: stloc.s 24
-			IL_03fc: ldloc.s 22
-			IL_03fe: ldstr "finished"
-			IL_0403: ldloc.s 24
-			IL_0405: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_040a: dup
-			IL_040b: ldstr "signal"
-			IL_0410: ldc.i4.0
-			IL_0411: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0420: stloc.s 24
-			IL_0422: ldloc.0
-			IL_0423: ldc.i4.2
-			IL_0424: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0429: ldloc.0
-			IL_042a: ldloc.s 24
-			IL_042c: ldarg.0
-			IL_042d: ldc.i4.1
-			IL_042e: ldloc.0
-			IL_042f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0434: ldc.i4.1
-			IL_0435: ldstr "_pendingException"
-			IL_043a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_043f: ldloc.0
-			IL_0440: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0445: dup
-			IL_0446: ldc.i4.0
-			IL_0447: ldloc.1
-			IL_0448: stelem.ref
-			IL_0449: dup
-			IL_044a: ldc.i4.1
-			IL_044b: ldloc.2
-			IL_044c: stelem.ref
-			IL_044d: dup
-			IL_044e: ldc.i4.2
-			IL_044f: ldloc.3
+			IL_039b: ldloc.0
+			IL_039c: ldc.i4.0
+			IL_039d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_03a2: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L33C6::.ctor()
+			IL_03a7: stloc.s 11
+			IL_03a9: ldarg.0
+			IL_03aa: ldc.i4.1
+			IL_03ab: ldelem.ref
+			IL_03ac: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_03b1: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_03b6: stloc.s 22
+			IL_03b8: ldc.i4.1
+			IL_03b9: newarr [System.Runtime]System.Object
+			IL_03be: dup
+			IL_03bf: ldc.i4.0
+			IL_03c0: ldarg.0
+			IL_03c1: ldc.i4.1
+			IL_03c2: ldelem.ref
+			IL_03c3: stelem.ref
+			IL_03c4: ldc.i4.0
+			IL_03c5: ldelem.ref
+			IL_03c6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_03cb: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_03d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_03d6: ldnull
+			IL_03d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+			IL_03dc: stloc.s 24
+			IL_03de: ldloc.s 22
+			IL_03e0: ldstr "finished"
+			IL_03e5: ldloc.s 24
+			IL_03e7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03ec: dup
+			IL_03ed: ldstr "signal"
+			IL_03f2: ldc.i4.0
+			IL_03f3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0402: stloc.s 24
+			IL_0404: ldloc.0
+			IL_0405: ldc.i4.2
+			IL_0406: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_040b: ldloc.0
+			IL_040c: ldloc.s 24
+			IL_040e: ldarg.0
+			IL_040f: ldc.i4.1
+			IL_0410: ldloc.0
+			IL_0411: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0416: ldc.i4.1
+			IL_0417: ldstr "_pendingException"
+			IL_041c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0421: ldloc.0
+			IL_0422: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0427: dup
+			IL_0428: ldc.i4.0
+			IL_0429: ldloc.1
+			IL_042a: stelem.ref
+			IL_042b: dup
+			IL_042c: ldc.i4.1
+			IL_042d: ldloc.2
+			IL_042e: stelem.ref
+			IL_042f: dup
+			IL_0430: ldc.i4.2
+			IL_0431: ldloc.3
+			IL_0432: stelem.ref
+			IL_0433: dup
+			IL_0434: ldc.i4.3
+			IL_0435: ldloc.s 4
+			IL_0437: stelem.ref
+			IL_0438: dup
+			IL_0439: ldc.i4.4
+			IL_043a: ldloc.s 5
+			IL_043c: stelem.ref
+			IL_043d: dup
+			IL_043e: ldc.i4.5
+			IL_043f: ldloc.s 6
+			IL_0441: stelem.ref
+			IL_0442: dup
+			IL_0443: ldc.i4.6
+			IL_0444: ldloc.s 7
+			IL_0446: stelem.ref
+			IL_0447: dup
+			IL_0448: ldc.i4.7
+			IL_0449: ldloc.s 8
+			IL_044b: stelem.ref
+			IL_044c: dup
+			IL_044d: ldc.i4.8
+			IL_044e: ldloc.s 9
 			IL_0450: stelem.ref
 			IL_0451: dup
-			IL_0452: ldc.i4.3
-			IL_0453: ldloc.s 4
-			IL_0455: stelem.ref
-			IL_0456: dup
-			IL_0457: ldc.i4.4
-			IL_0458: ldloc.s 5
-			IL_045a: stelem.ref
-			IL_045b: dup
-			IL_045c: ldc.i4.5
-			IL_045d: ldloc.s 6
-			IL_045f: stelem.ref
-			IL_0460: dup
-			IL_0461: ldc.i4.6
-			IL_0462: ldloc.s 7
-			IL_0464: stelem.ref
-			IL_0465: dup
-			IL_0466: ldc.i4.7
-			IL_0467: ldloc.s 8
-			IL_0469: stelem.ref
-			IL_046a: dup
-			IL_046b: ldc.i4.8
-			IL_046c: ldloc.s 9
+			IL_0452: ldc.i4.s 9
+			IL_0454: ldloc.s 10
+			IL_0456: stelem.ref
+			IL_0457: dup
+			IL_0458: ldc.i4.s 10
+			IL_045a: ldloc.s 11
+			IL_045c: stelem.ref
+			IL_045d: dup
+			IL_045e: ldc.i4.s 11
+			IL_0460: ldloc.s 12
+			IL_0462: stelem.ref
+			IL_0463: dup
+			IL_0464: ldc.i4.s 12
+			IL_0466: ldloc.s 13
+			IL_0468: stelem.ref
+			IL_0469: dup
+			IL_046a: ldc.i4.s 13
+			IL_046c: ldloc.s 14
 			IL_046e: stelem.ref
 			IL_046f: dup
-			IL_0470: ldc.i4.s 9
-			IL_0472: ldloc.s 10
+			IL_0470: ldc.i4.s 14
+			IL_0472: ldloc.s 15
 			IL_0474: stelem.ref
 			IL_0475: dup
-			IL_0476: ldc.i4.s 10
-			IL_0478: ldloc.s 11
+			IL_0476: ldc.i4.s 15
+			IL_0478: ldloc.s 16
 			IL_047a: stelem.ref
 			IL_047b: dup
-			IL_047c: ldc.i4.s 11
-			IL_047e: ldloc.s 12
+			IL_047c: ldc.i4.s 16
+			IL_047e: ldloc.s 17
 			IL_0480: stelem.ref
 			IL_0481: dup
-			IL_0482: ldc.i4.s 12
-			IL_0484: ldloc.s 13
+			IL_0482: ldc.i4.s 17
+			IL_0484: ldloc.s 18
 			IL_0486: stelem.ref
-			IL_0487: dup
-			IL_0488: ldc.i4.s 13
-			IL_048a: ldloc.s 14
-			IL_048c: stelem.ref
-			IL_048d: dup
-			IL_048e: ldc.i4.s 14
-			IL_0490: ldloc.s 15
-			IL_0492: stelem.ref
-			IL_0493: dup
-			IL_0494: ldc.i4.s 15
-			IL_0496: ldloc.s 16
-			IL_0498: stelem.ref
-			IL_0499: dup
-			IL_049a: ldc.i4.s 16
-			IL_049c: ldloc.s 17
-			IL_049e: stelem.ref
-			IL_049f: dup
-			IL_04a0: ldc.i4.s 17
-			IL_04a2: ldloc.s 18
-			IL_04a4: stelem.ref
-			IL_04a5: pop
-			IL_04a6: ldloc.0
-			IL_04a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04b1: ret
+			IL_0487: pop
+			IL_0488: ldloc.0
+			IL_0489: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_048e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0493: ret
 
-			IL_04b2: ldloc.0
-			IL_04b3: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
-			IL_04b8: pop
-			IL_04b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04be: ldstr "promise-finished:ok"
-			IL_04c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04c8: pop
-			IL_04c9: br IL_054c
+			IL_0494: ldloc.0
+			IL_0495: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
+			IL_049a: pop
+			IL_049b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04a0: ldstr "promise-finished:ok"
+			IL_04a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04aa: pop
+			IL_04ab: br IL_052e
 
-			IL_04ce: ldloc.0
-			IL_04cf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04d4: stloc.s 24
-			IL_04d6: ldloc.0
-			IL_04d7: ldc.i4.0
-			IL_04d8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04dd: ldloc.s 24
-			IL_04df: stloc.s 12
-			IL_04e1: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
-			IL_04e6: stloc.s 13
-			IL_04e8: ldstr "promise-finished:"
-			IL_04ed: ldloc.s 12
-			IL_04ef: ldstr "name"
-			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04fe: stloc.s 23
-			IL_0500: ldloc.s 23
-			IL_0502: ldstr ":"
-			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_050c: stloc.s 23
-			IL_050e: ldloc.s 23
-			IL_0510: ldloc.s 12
-			IL_0512: ldstr "code"
-			IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0521: stloc.s 23
-			IL_0523: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0528: ldloc.s 23
-			IL_052a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_052f: pop
-			IL_0530: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0535: ldloc.s 12
-			IL_0537: ldstr "message"
-			IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0541: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0546: pop
-			IL_0547: br IL_054c
+			IL_04b0: ldloc.0
+			IL_04b1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04b6: stloc.s 24
+			IL_04b8: ldloc.0
+			IL_04b9: ldc.i4.0
+			IL_04ba: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04bf: ldloc.s 24
+			IL_04c1: stloc.s 12
+			IL_04c3: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
+			IL_04c8: stloc.s 13
+			IL_04ca: ldstr "promise-finished:"
+			IL_04cf: ldloc.s 12
+			IL_04d1: ldstr "name"
+			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04e0: stloc.s 23
+			IL_04e2: ldloc.s 23
+			IL_04e4: ldstr ":"
+			IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04ee: stloc.s 23
+			IL_04f0: ldloc.s 23
+			IL_04f2: ldloc.s 12
+			IL_04f4: ldstr "code"
+			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0503: stloc.s 23
+			IL_0505: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_050a: ldloc.s 23
+			IL_050c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0511: pop
+			IL_0512: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0517: ldloc.s 12
+			IL_0519: ldstr "message"
+			IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0523: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0528: pop
+			IL_0529: br IL_052e
 
-			IL_054c: ldloc.0
-			IL_054d: ldc.i4.0
-			IL_054e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0553: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
-			IL_0558: stloc.s 14
-			IL_055a: ldc.i4.1
-			IL_055b: newarr [System.Runtime]System.Object
-			IL_0560: dup
-			IL_0561: ldc.i4.0
-			IL_0562: ldarg.0
-			IL_0563: ldc.i4.1
-			IL_0564: ldelem.ref
-			IL_0565: stelem.ref
-			IL_0566: ldc.i4.0
-			IL_0567: ldelem.ref
-			IL_0568: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_056d: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_0573: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0578: ldnull
-			IL_0579: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_057e: stloc.s 24
-			IL_0580: ldloc.s 24
-			IL_0582: stloc.s 15
-			IL_0584: ldarg.0
-			IL_0585: ldc.i4.1
-			IL_0586: ldelem.ref
-			IL_0587: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_058c: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_0591: ldstr "Cannot access 'streamPromises' before initialization"
-			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_059b: stloc.s 24
-			IL_059d: ldc.i4.1
-			IL_059e: newarr [System.Runtime]System.Object
-			IL_05a3: dup
-			IL_05a4: ldc.i4.0
-			IL_05a5: ldarg.0
-			IL_05a6: ldc.i4.1
-			IL_05a7: ldelem.ref
-			IL_05a8: stelem.ref
-			IL_05a9: ldc.i4.0
-			IL_05aa: ldelem.ref
-			IL_05ab: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_05b0: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_05b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_05bb: ldnull
-			IL_05bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_05c1: stloc.s 22
-			IL_05c3: ldloc.s 24
-			IL_05c5: ldstr "pipeline"
-			IL_05ca: ldloc.s 15
-			IL_05cc: ldloc.s 22
-			IL_05ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05d3: dup
-			IL_05d4: ldstr "signal"
-			IL_05d9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_05e8: stloc.s 22
-			IL_05ea: ldloc.s 22
-			IL_05ec: stloc.s 16
-			IL_05ee: ldloc.s 15
-			IL_05f0: ldstr "push"
-			IL_05f5: ldc.i4.0
-			IL_05f6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_05fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0600: pop
-			IL_0601: ldloc.0
-			IL_0602: ldc.i4.4
-			IL_0603: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0608: ldloc.0
-			IL_0609: ldloc.s 16
-			IL_060b: ldarg.0
-			IL_060c: ldc.i4.2
-			IL_060d: ldloc.0
-			IL_060e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0613: ldc.i4.3
-			IL_0614: ldstr "_pendingException"
-			IL_0619: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_061e: ldloc.0
-			IL_061f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0624: dup
-			IL_0625: ldc.i4.0
-			IL_0626: ldloc.1
-			IL_0627: stelem.ref
-			IL_0628: dup
-			IL_0629: ldc.i4.1
-			IL_062a: ldloc.2
+			IL_052e: ldloc.0
+			IL_052f: ldc.i4.0
+			IL_0530: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0535: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
+			IL_053a: stloc.s 14
+			IL_053c: ldc.i4.1
+			IL_053d: newarr [System.Runtime]System.Object
+			IL_0542: dup
+			IL_0543: ldc.i4.0
+			IL_0544: ldarg.0
+			IL_0545: ldc.i4.1
+			IL_0546: ldelem.ref
+			IL_0547: stelem.ref
+			IL_0548: ldc.i4.0
+			IL_0549: ldelem.ref
+			IL_054a: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_054f: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_0555: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_055a: ldnull
+			IL_055b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+			IL_0560: stloc.s 24
+			IL_0562: ldloc.s 24
+			IL_0564: stloc.s 15
+			IL_0566: ldarg.0
+			IL_0567: ldc.i4.1
+			IL_0568: ldelem.ref
+			IL_0569: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_056e: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_0573: stloc.s 24
+			IL_0575: ldc.i4.1
+			IL_0576: newarr [System.Runtime]System.Object
+			IL_057b: dup
+			IL_057c: ldc.i4.0
+			IL_057d: ldarg.0
+			IL_057e: ldc.i4.1
+			IL_057f: ldelem.ref
+			IL_0580: stelem.ref
+			IL_0581: ldc.i4.0
+			IL_0582: ldelem.ref
+			IL_0583: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0588: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_058e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0593: ldnull
+			IL_0594: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+			IL_0599: stloc.s 22
+			IL_059b: ldloc.s 24
+			IL_059d: ldstr "pipeline"
+			IL_05a2: ldloc.s 15
+			IL_05a4: ldloc.s 22
+			IL_05a6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05ab: dup
+			IL_05ac: ldstr "signal"
+			IL_05b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_05c0: stloc.s 22
+			IL_05c2: ldloc.s 22
+			IL_05c4: stloc.s 16
+			IL_05c6: ldloc.s 15
+			IL_05c8: ldstr "push"
+			IL_05cd: ldc.i4.0
+			IL_05ce: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05d8: pop
+			IL_05d9: ldloc.0
+			IL_05da: ldc.i4.4
+			IL_05db: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05e0: ldloc.0
+			IL_05e1: ldloc.s 16
+			IL_05e3: ldarg.0
+			IL_05e4: ldc.i4.2
+			IL_05e5: ldloc.0
+			IL_05e6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05eb: ldc.i4.3
+			IL_05ec: ldstr "_pendingException"
+			IL_05f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05f6: ldloc.0
+			IL_05f7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05fc: dup
+			IL_05fd: ldc.i4.0
+			IL_05fe: ldloc.1
+			IL_05ff: stelem.ref
+			IL_0600: dup
+			IL_0601: ldc.i4.1
+			IL_0602: ldloc.2
+			IL_0603: stelem.ref
+			IL_0604: dup
+			IL_0605: ldc.i4.2
+			IL_0606: ldloc.3
+			IL_0607: stelem.ref
+			IL_0608: dup
+			IL_0609: ldc.i4.3
+			IL_060a: ldloc.s 4
+			IL_060c: stelem.ref
+			IL_060d: dup
+			IL_060e: ldc.i4.4
+			IL_060f: ldloc.s 5
+			IL_0611: stelem.ref
+			IL_0612: dup
+			IL_0613: ldc.i4.5
+			IL_0614: ldloc.s 6
+			IL_0616: stelem.ref
+			IL_0617: dup
+			IL_0618: ldc.i4.6
+			IL_0619: ldloc.s 7
+			IL_061b: stelem.ref
+			IL_061c: dup
+			IL_061d: ldc.i4.7
+			IL_061e: ldloc.s 8
+			IL_0620: stelem.ref
+			IL_0621: dup
+			IL_0622: ldc.i4.8
+			IL_0623: ldloc.s 9
+			IL_0625: stelem.ref
+			IL_0626: dup
+			IL_0627: ldc.i4.s 9
+			IL_0629: ldloc.s 10
 			IL_062b: stelem.ref
 			IL_062c: dup
-			IL_062d: ldc.i4.2
-			IL_062e: ldloc.3
-			IL_062f: stelem.ref
-			IL_0630: dup
-			IL_0631: ldc.i4.3
-			IL_0632: ldloc.s 4
-			IL_0634: stelem.ref
-			IL_0635: dup
-			IL_0636: ldc.i4.4
-			IL_0637: ldloc.s 5
-			IL_0639: stelem.ref
-			IL_063a: dup
-			IL_063b: ldc.i4.5
-			IL_063c: ldloc.s 6
-			IL_063e: stelem.ref
-			IL_063f: dup
-			IL_0640: ldc.i4.6
-			IL_0641: ldloc.s 7
+			IL_062d: ldc.i4.s 10
+			IL_062f: ldloc.s 11
+			IL_0631: stelem.ref
+			IL_0632: dup
+			IL_0633: ldc.i4.s 11
+			IL_0635: ldloc.s 12
+			IL_0637: stelem.ref
+			IL_0638: dup
+			IL_0639: ldc.i4.s 12
+			IL_063b: ldloc.s 13
+			IL_063d: stelem.ref
+			IL_063e: dup
+			IL_063f: ldc.i4.s 13
+			IL_0641: ldloc.s 14
 			IL_0643: stelem.ref
 			IL_0644: dup
-			IL_0645: ldc.i4.7
-			IL_0646: ldloc.s 8
-			IL_0648: stelem.ref
-			IL_0649: dup
-			IL_064a: ldc.i4.8
-			IL_064b: ldloc.s 9
-			IL_064d: stelem.ref
-			IL_064e: dup
-			IL_064f: ldc.i4.s 9
-			IL_0651: ldloc.s 10
-			IL_0653: stelem.ref
-			IL_0654: dup
-			IL_0655: ldc.i4.s 10
-			IL_0657: ldloc.s 11
-			IL_0659: stelem.ref
-			IL_065a: dup
-			IL_065b: ldc.i4.s 11
-			IL_065d: ldloc.s 12
-			IL_065f: stelem.ref
-			IL_0660: dup
-			IL_0661: ldc.i4.s 12
-			IL_0663: ldloc.s 13
-			IL_0665: stelem.ref
-			IL_0666: dup
-			IL_0667: ldc.i4.s 13
-			IL_0669: ldloc.s 14
-			IL_066b: stelem.ref
-			IL_066c: dup
-			IL_066d: ldc.i4.s 14
-			IL_066f: ldloc.s 15
-			IL_0671: stelem.ref
-			IL_0672: dup
-			IL_0673: ldc.i4.s 15
-			IL_0675: ldloc.s 16
-			IL_0677: stelem.ref
-			IL_0678: dup
-			IL_0679: ldc.i4.s 16
-			IL_067b: ldloc.s 17
-			IL_067d: stelem.ref
-			IL_067e: dup
-			IL_067f: ldc.i4.s 17
-			IL_0681: ldloc.s 18
-			IL_0683: stelem.ref
-			IL_0684: pop
+			IL_0645: ldc.i4.s 14
+			IL_0647: ldloc.s 15
+			IL_0649: stelem.ref
+			IL_064a: dup
+			IL_064b: ldc.i4.s 15
+			IL_064d: ldloc.s 16
+			IL_064f: stelem.ref
+			IL_0650: dup
+			IL_0651: ldc.i4.s 16
+			IL_0653: ldloc.s 17
+			IL_0655: stelem.ref
+			IL_0656: dup
+			IL_0657: ldc.i4.s 17
+			IL_0659: ldloc.s 18
+			IL_065b: stelem.ref
+			IL_065c: pop
+			IL_065d: ldloc.0
+			IL_065e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0663: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0668: ret
+
+			IL_0669: ldloc.0
+			IL_066a: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
+			IL_066f: pop
+			IL_0670: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0675: ldstr "promise-pipeline:ok"
+			IL_067a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_067f: pop
+			IL_0680: br IL_0703
+
 			IL_0685: ldloc.0
-			IL_0686: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_068b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0690: ret
-
-			IL_0691: ldloc.0
-			IL_0692: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
-			IL_0697: pop
-			IL_0698: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_069d: ldstr "promise-pipeline:ok"
-			IL_06a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06a7: pop
-			IL_06a8: br IL_072b
-
-			IL_06ad: ldloc.0
-			IL_06ae: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_06b3: stloc.s 22
-			IL_06b5: ldloc.0
-			IL_06b6: ldc.i4.0
-			IL_06b7: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_06bc: ldloc.s 22
-			IL_06be: stloc.s 17
-			IL_06c0: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
-			IL_06c5: stloc.s 18
-			IL_06c7: ldstr "promise-pipeline:"
-			IL_06cc: ldloc.s 17
-			IL_06ce: ldstr "name"
-			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06dd: stloc.s 23
+			IL_0686: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_068b: stloc.s 22
+			IL_068d: ldloc.0
+			IL_068e: ldc.i4.0
+			IL_068f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0694: ldloc.s 22
+			IL_0696: stloc.s 17
+			IL_0698: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
+			IL_069d: stloc.s 18
+			IL_069f: ldstr "promise-pipeline:"
+			IL_06a4: ldloc.s 17
+			IL_06a6: ldstr "name"
+			IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06b5: stloc.s 23
+			IL_06b7: ldloc.s 23
+			IL_06b9: ldstr ":"
+			IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06c3: stloc.s 23
+			IL_06c5: ldloc.s 23
+			IL_06c7: ldloc.s 17
+			IL_06c9: ldstr "code"
+			IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06d8: stloc.s 23
+			IL_06da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_06df: ldloc.s 23
-			IL_06e1: ldstr ":"
-			IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06eb: stloc.s 23
-			IL_06ed: ldloc.s 23
-			IL_06ef: ldloc.s 17
-			IL_06f1: ldstr "code"
-			IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0700: stloc.s 23
-			IL_0702: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0707: ldloc.s 23
-			IL_0709: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_070e: pop
-			IL_070f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0714: ldloc.s 17
-			IL_0716: ldstr "message"
-			IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0720: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0725: pop
-			IL_0726: br IL_072b
+			IL_06e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06e6: pop
+			IL_06e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06ec: ldloc.s 17
+			IL_06ee: ldstr "message"
+			IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06fd: pop
+			IL_06fe: br IL_0703
 
-			IL_072b: ldloc.0
-			IL_072c: ldc.i4.m1
-			IL_072d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0732: ldloc.0
-			IL_0733: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0738: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_073d: ldarg.0
-			IL_073e: ldc.i4.1
-			IL_073f: newarr [System.Runtime]System.Object
-			IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0749: pop
-			IL_074a: ldloc.0
-			IL_074b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0750: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0755: ret
+			IL_0703: ldloc.0
+			IL_0704: ldc.i4.m1
+			IL_0705: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_070a: ldloc.0
+			IL_070b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0710: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0715: ldarg.0
+			IL_0716: ldc.i4.1
+			IL_0717: newarr [System.Runtime]System.Object
+			IL_071c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0721: pop
+			IL_0722: ldloc.0
+			IL_0723: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0728: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_072d: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1379,21 +1363,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2971
+			// Method begins at RVA 0x2931
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1509,7 +1487,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a0e
+		// Method begins at RVA 0x29b8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b6
+				// Method begins at RVA 0x233b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x224e
+			// Method begins at RVA 0x2221
 			// Header size: 1
 			// Code size: 15 (0xf)
 			.maxstack 8
@@ -72,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23bf
+				// Method begins at RVA 0x2344
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -95,7 +95,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x225e
+			// Method begins at RVA 0x2231
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -121,7 +121,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c8
+				// Method begins at RVA 0x234d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +147,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2274
+			// Method begins at RVA 0x2244
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -198,7 +198,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23da
+					// Method begins at RVA 0x235f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -218,7 +218,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23e3
+					// Method begins at RVA 0x2368
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -236,7 +236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d1
+				// Method begins at RVA 0x2356
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -262,16 +262,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22c4
+			// Method begins at RVA 0x2294
 			// Header size: 12
-			// Code size: 199 (0xc7)
+			// Code size: 146 (0x92)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L29C29,
 				[1] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L31C9,
 				[2] object,
-				[3] object,
-				[4] float64
+				[3] float64
 			)
 
 			IL_0000: ldarg.0
@@ -286,61 +285,46 @@
 			IL_0021: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
 			IL_0026: stloc.2
 			IL_0027: ldarg.0
-			IL_0028: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
-			IL_002d: ldstr "Cannot access 'chunks' before initialization"
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0037: stloc.3
-			IL_0038: ldloc.3
-			IL_0039: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003e: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0043: conv.r8
-			IL_0044: stloc.s 4
-			IL_0046: ldloc.2
-			IL_0047: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_004c: ldloc.s 4
-			IL_004e: clt
-			IL_0050: brfalse IL_009c
+			IL_0028: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
+			IL_002d: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0032: conv.r8
+			IL_0033: stloc.3
+			IL_0034: ldloc.2
+			IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003a: ldloc.3
+			IL_003b: clt
+			IL_003d: brfalse IL_0071
 
-			IL_0055: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L29C29::.ctor()
-			IL_005a: stloc.0
+			IL_0042: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L29C29::.ctor()
+			IL_0047: stloc.0
+			IL_0048: ldarg.0
+			IL_0049: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
+			IL_004e: stloc.2
+			IL_004f: ldloc.2
+			IL_0050: ldstr "push"
+			IL_0055: ldarg.0
+			IL_0056: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
 			IL_005b: ldarg.0
-			IL_005c: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-			IL_0061: ldstr "Cannot access 'readable' before initialization"
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_006b: stloc.2
-			IL_006c: ldarg.0
-			IL_006d: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
-			IL_0072: ldstr "Cannot access 'chunks' before initialization"
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_007c: stloc.3
-			IL_007d: ldloc.3
-			IL_007e: ldarg.0
-			IL_007f: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0089: stloc.3
-			IL_008a: ldloc.2
-			IL_008b: ldstr "push"
-			IL_0090: ldloc.3
-			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0096: pop
-			IL_0097: br IL_00c5
+			IL_005c: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_006b: pop
+			IL_006c: br IL_0090
 
-			IL_009c: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L31C9::.ctor()
-			IL_00a1: stloc.1
-			IL_00a2: ldarg.0
-			IL_00a3: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-			IL_00a8: ldstr "Cannot access 'readable' before initialization"
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00b2: stloc.3
-			IL_00b3: ldloc.3
-			IL_00b4: ldstr "push"
-			IL_00b9: ldc.i4.0
-			IL_00ba: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00c4: pop
+			IL_0071: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L31C9::.ctor()
+			IL_0076: stloc.1
+			IL_0077: ldarg.0
+			IL_0078: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
+			IL_007d: stloc.2
+			IL_007e: ldloc.2
+			IL_007f: ldstr "push"
+			IL_0084: ldc.i4.0
+			IL_0085: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_008f: pop
 
-			IL_00c5: ldnull
-			IL_00c6: ret
+			IL_0090: ldnull
+			IL_0091: ret
 		} // end of method FunctionExpression_L27C21::__js_call__
 
 	} // end of class FunctionExpression_L27C21
@@ -358,28 +342,22 @@
 		// Fields
 		.field public object readable
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array written
-		.field public object chunks
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array chunks
 		.field public object index
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2397
+			// Method begins at RVA 0x2332
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -397,15 +375,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 498 (0x1f2)
+		// Code size: 453 (0x1c5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipe_Backpressure_Basic/Scope,
 			[1] object,
 			[2] object,
-			[3] object,
-			[4] object,
-			[5] string
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/Scope::.ctor()
@@ -515,7 +491,7 @@
 		IL_0127: dup
 		IL_0128: ldstr "c"
 		IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0132: stfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
+		IL_0132: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
 		IL_0137: ldloc.0
 		IL_0138: ldc.r8 0.0
 		IL_0141: box [System.Runtime]System.Double
@@ -544,36 +520,23 @@
 		IL_0185: pop
 		IL_0186: ldloc.0
 		IL_0187: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-		IL_018c: ldstr "Cannot access 'readable' before initialization"
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0196: stloc.3
-		IL_0197: ldloc.3
-		IL_0198: ldstr "pipe"
-		IL_019d: ldloc.2
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01a3: pop
-		IL_01a4: ldloc.0
-		IL_01a5: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-		IL_01aa: ldstr "Cannot access 'readable' before initialization"
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01b4: stloc.3
-		IL_01b5: ldloc.0
-		IL_01b6: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
-		IL_01bb: ldstr "Cannot access 'chunks' before initialization"
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01c5: stloc.s 4
-		IL_01c7: ldloc.s 4
-		IL_01c9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_01ce: ldc.r8 0.0
-		IL_01d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01dc: castclass [System.Runtime]System.String
-		IL_01e1: stloc.s 5
-		IL_01e3: ldloc.3
-		IL_01e4: ldstr "push"
-		IL_01e9: ldloc.s 5
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01f0: pop
-		IL_01f1: ret
+		IL_018c: ldstr "pipe"
+		IL_0191: ldloc.2
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0197: pop
+		IL_0198: ldloc.0
+		IL_0199: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
+		IL_019e: stloc.3
+		IL_019f: ldloc.3
+		IL_01a0: ldstr "push"
+		IL_01a5: ldloc.0
+		IL_01a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
+		IL_01ab: ldc.r8 0.0
+		IL_01b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01b9: castclass [System.Runtime]System.String
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01c3: pop
+		IL_01c4: ret
 	} // end of method Stream_Pipe_Backpressure_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipe_Backpressure_Basic
@@ -585,7 +548,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23ec
+		// Method begins at RVA 0x2371
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b6
+				// Method begins at RVA 0x225e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,26 +45,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21a8
-			// Header size: 12
-			// Code size: 32 (0x20)
+			// Method begins at RVA 0x219c
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Pipeline_Basic/Scope::written
-			IL_0006: ldstr "Cannot access 'written' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldarg.2
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001d: pop
-			IL_001e: ldnull
-			IL_001f: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipeline_Basic/Scope::written
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L10C18::__js_call__
 
 	} // end of class FunctionExpression_L10C18
@@ -80,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22bf
+				// Method begins at RVA 0x2267
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,16 +99,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21d4
+			// Method begins at RVA 0x21ac
 			// Header size: 12
-			// Code size: 183 (0xb7)
+			// Code size: 157 (0x9d)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[2] bool,
 				[3] object,
-				[4] object
+				[4] string
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -145,42 +137,36 @@
 			IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_003d: pop
 			IL_003e: ldarg.0
-			IL_003f: ldfld object Modules.Stream_Pipeline_Basic/Scope::written
-			IL_0044: ldstr "Cannot access 'written' before initialization"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004e: stloc.s 4
-			IL_0050: ldloc.s 4
-			IL_0052: ldstr "join"
-			IL_0057: ldstr ","
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0061: stloc.s 4
-			IL_0063: ldstr "written:"
-			IL_0068: ldloc.s 4
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006f: stloc.3
-			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0075: ldloc.3
-			IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_007b: pop
-			IL_007c: ldarg.0
-			IL_007d: ldfld object Modules.Stream_Pipeline_Basic/Scope::pass
-			IL_0082: ldstr "Cannot access 'pass' before initialization"
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_008c: stloc.s 4
-			IL_008e: ldloc.s 4
-			IL_0090: ldstr "destroyed"
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009a: stloc.s 4
-			IL_009c: ldstr "pass-destroyed:"
-			IL_00a1: ldloc.s 4
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a8: stloc.3
-			IL_00a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00ae: ldloc.3
-			IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00b4: pop
-			IL_00b5: ldnull
-			IL_00b6: ret
+			IL_003f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipeline_Basic/Scope::written
+			IL_0044: ldc.i4.1
+			IL_0045: newarr [System.Runtime]System.Object
+			IL_004a: dup
+			IL_004b: ldc.i4.0
+			IL_004c: ldstr ","
+			IL_0051: stelem.ref
+			IL_0052: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0057: stloc.s 4
+			IL_0059: ldstr "written:"
+			IL_005e: ldloc.s 4
+			IL_0060: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0065: stloc.s 4
+			IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_006c: ldloc.s 4
+			IL_006e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0073: pop
+			IL_0074: ldstr "pass-destroyed:"
+			IL_0079: ldarg.0
+			IL_007a: ldfld object Modules.Stream_Pipeline_Basic/Scope::pass
+			IL_007f: ldstr "destroyed"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_008e: stloc.3
+			IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0094: ldloc.3
+			IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_009a: pop
+			IL_009b: ldnull
+			IL_009c: ret
 		} // end of method FunctionExpression_L14C42::__js_call__
 
 	} // end of class FunctionExpression_L14C42
@@ -195,27 +181,21 @@
 		)
 		// Fields
 		.field public object pass
-		.field public object written
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array written
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2297
+			// Method begins at RVA 0x2255
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Pipeline_Basic/Scope::pass
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Pipeline_Basic/Scope::written
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -233,7 +213,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 330 (0x14a)
+		// Code size: 320 (0x140)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipeline_Basic/Scope,
@@ -284,7 +264,7 @@
 		IL_006c: ldloc.0
 		IL_006d: ldc.i4.0
 		IL_006e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0073: stfld object Modules.Stream_Pipeline_Basic/Scope::written
+		IL_0073: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipeline_Basic/Scope::written
 		IL_0078: ldc.i4.1
 		IL_0079: newarr [System.Runtime]System.Object
 		IL_007e: dup
@@ -309,66 +289,64 @@
 		IL_00b0: pop
 		IL_00b1: ldloc.0
 		IL_00b2: ldfld object Modules.Stream_Pipeline_Basic/Scope::pass
-		IL_00b7: ldstr "Cannot access 'pass' before initialization"
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00c1: stloc.s 4
-		IL_00c3: ldc.i4.1
-		IL_00c4: newarr [System.Runtime]System.Object
-		IL_00c9: dup
-		IL_00ca: ldc.i4.0
-		IL_00cb: ldloc.0
-		IL_00cc: stelem.ref
-		IL_00cd: ldc.i4.0
-		IL_00ce: ldelem.ref
-		IL_00cf: castclass Modules.Stream_Pipeline_Basic/Scope
-		IL_00d4: ldftn object Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
-		IL_00da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00df: ldc.i4.1
-		IL_00e0: conv.r8
-		IL_00e1: ldstr ""
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00eb: stloc.s 5
-		IL_00ed: ldc.i4.4
-		IL_00ee: newarr [System.Runtime]System.Object
-		IL_00f3: dup
-		IL_00f4: ldc.i4.0
-		IL_00f5: ldloc.2
-		IL_00f6: stelem.ref
-		IL_00f7: dup
-		IL_00f8: ldc.i4.1
-		IL_00f9: ldloc.s 4
-		IL_00fb: stelem.ref
-		IL_00fc: dup
-		IL_00fd: ldc.i4.2
-		IL_00fe: ldloc.3
-		IL_00ff: stelem.ref
-		IL_0100: dup
-		IL_0101: ldc.i4.3
-		IL_0102: ldloc.s 5
-		IL_0104: stelem.ref
-		IL_0105: stloc.s 6
-		IL_0107: ldloc.1
-		IL_0108: ldstr "pipeline"
-		IL_010d: ldloc.s 6
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_0114: pop
-		IL_0115: ldloc.2
-		IL_0116: ldstr "push"
-		IL_011b: ldstr "a"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0125: pop
-		IL_0126: ldloc.2
-		IL_0127: ldstr "push"
-		IL_012c: ldstr "b"
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0136: pop
-		IL_0137: ldloc.2
-		IL_0138: ldstr "push"
-		IL_013d: ldc.i4.0
-		IL_013e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0148: pop
-		IL_0149: ret
+		IL_00b7: stloc.s 4
+		IL_00b9: ldc.i4.1
+		IL_00ba: newarr [System.Runtime]System.Object
+		IL_00bf: dup
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldloc.0
+		IL_00c2: stelem.ref
+		IL_00c3: ldc.i4.0
+		IL_00c4: ldelem.ref
+		IL_00c5: castclass Modules.Stream_Pipeline_Basic/Scope
+		IL_00ca: ldftn object Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
+		IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00d5: ldc.i4.1
+		IL_00d6: conv.r8
+		IL_00d7: ldstr ""
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00e1: stloc.s 5
+		IL_00e3: ldc.i4.4
+		IL_00e4: newarr [System.Runtime]System.Object
+		IL_00e9: dup
+		IL_00ea: ldc.i4.0
+		IL_00eb: ldloc.2
+		IL_00ec: stelem.ref
+		IL_00ed: dup
+		IL_00ee: ldc.i4.1
+		IL_00ef: ldloc.s 4
+		IL_00f1: stelem.ref
+		IL_00f2: dup
+		IL_00f3: ldc.i4.2
+		IL_00f4: ldloc.3
+		IL_00f5: stelem.ref
+		IL_00f6: dup
+		IL_00f7: ldc.i4.3
+		IL_00f8: ldloc.s 5
+		IL_00fa: stelem.ref
+		IL_00fb: stloc.s 6
+		IL_00fd: ldloc.1
+		IL_00fe: ldstr "pipeline"
+		IL_0103: ldloc.s 6
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_010a: pop
+		IL_010b: ldloc.2
+		IL_010c: ldstr "push"
+		IL_0111: ldstr "a"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_011b: pop
+		IL_011c: ldloc.2
+		IL_011d: ldstr "push"
+		IL_0122: ldstr "b"
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_012c: pop
+		IL_012d: ldloc.2
+		IL_012e: ldstr "push"
+		IL_0133: ldc.i4.0
+		IL_0134: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_013e: pop
+		IL_013f: ret
 	} // end of method Stream_Pipeline_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Basic
@@ -380,7 +358,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22c8
+		// Method begins at RVA 0x2270
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2331
+				// Method begins at RVA 0x2292
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e5
+			// Method begins at RVA 0x219d
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x233a
+				// Method begins at RVA 0x229b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x220c
+			// Method begins at RVA 0x21c4
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -123,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2343
+				// Method begins at RVA 0x22a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -150,16 +150,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2210
+			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 235 (0xeb)
+			// Code size: 181 (0xb5)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[2] bool,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -187,59 +186,41 @@
 			IL_0037: ldloc.3
 			IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_003d: pop
-			IL_003e: ldarg.0
-			IL_003f: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
-			IL_0044: ldstr "Cannot access 'readable' before initialization"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004e: stloc.s 4
-			IL_0050: ldloc.s 4
-			IL_0052: ldstr "destroyed"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005c: stloc.s 4
-			IL_005e: ldstr "source-destroyed:"
-			IL_0063: ldloc.s 4
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006a: stloc.3
-			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0070: ldloc.3
-			IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0076: pop
-			IL_0077: ldarg.0
-			IL_0078: ldfld object Modules.Stream_Pipeline_Error/Scope::transform
-			IL_007d: ldstr "Cannot access 'transform' before initialization"
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0087: stloc.s 4
-			IL_0089: ldloc.s 4
-			IL_008b: ldstr "destroyed"
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0095: stloc.s 4
-			IL_0097: ldstr "transform-destroyed:"
-			IL_009c: ldloc.s 4
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a3: stloc.3
-			IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00a9: ldloc.3
-			IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00af: pop
-			IL_00b0: ldarg.0
-			IL_00b1: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
-			IL_00b6: ldstr "Cannot access 'writable' before initialization"
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c0: stloc.s 4
-			IL_00c2: ldloc.s 4
-			IL_00c4: ldstr "destroyed"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ce: stloc.s 4
-			IL_00d0: ldstr "writable-destroyed:"
-			IL_00d5: ldloc.s 4
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00dc: stloc.3
-			IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00e2: ldloc.3
-			IL_00e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00e8: pop
-			IL_00e9: ldnull
-			IL_00ea: ret
+			IL_003e: ldstr "source-destroyed:"
+			IL_0043: ldarg.0
+			IL_0044: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
+			IL_0049: ldstr "destroyed"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0058: stloc.3
+			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_005e: ldloc.3
+			IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0064: pop
+			IL_0065: ldstr "transform-destroyed:"
+			IL_006a: ldarg.0
+			IL_006b: ldfld object Modules.Stream_Pipeline_Error/Scope::transform
+			IL_0070: ldstr "destroyed"
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007f: stloc.3
+			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0085: ldloc.3
+			IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_008b: pop
+			IL_008c: ldstr "writable-destroyed:"
+			IL_0091: ldarg.0
+			IL_0092: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
+			IL_0097: ldstr "destroyed"
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00a6: stloc.3
+			IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ac: ldloc.3
+			IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00b2: pop
+			IL_00b3: ldnull
+			IL_00b4: ret
 		} // end of method FunctionExpression_L15C47::__js_call__
 
 	} // end of class FunctionExpression_L15C47
@@ -263,24 +244,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2307
+			// Method begins at RVA 0x2289
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Pipeline_Error/Scope::readable
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Pipeline_Error/Scope::transform
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Stream_Pipeline_Error/Scope::writable
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -298,7 +270,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 393 (0x189)
+		// Code size: 321 (0x141)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipeline_Error/Scope,
@@ -306,8 +278,7 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object,
-			[6] object[]
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipeline_Error/Scope::.ctor()
@@ -358,100 +329,80 @@
 		IL_0086: stloc.2
 		IL_0087: ldloc.0
 		IL_0088: ldfld object Modules.Stream_Pipeline_Error/Scope::transform
-		IL_008d: ldstr "Cannot access 'transform' before initialization"
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0097: stloc.3
-		IL_0098: ldloc.3
-		IL_0099: ldstr "_transform"
-		IL_009e: ldloc.2
-		IL_009f: ldc.i4.1
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00a5: pop
-		IL_00a6: ldnull
-		IL_00a7: ldftn object Modules.Stream_Pipeline_Error/FunctionExpression_L13C18::__js_call__(object)
-		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00b2: ldc.i4.0
-		IL_00b3: conv.r8
-		IL_00b4: ldstr ""
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00be: stloc.2
-		IL_00bf: ldloc.0
-		IL_00c0: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
-		IL_00c5: ldstr "Cannot access 'writable' before initialization"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00cf: stloc.3
-		IL_00d0: ldloc.3
-		IL_00d1: ldstr "_write"
-		IL_00d6: ldloc.2
-		IL_00d7: ldc.i4.1
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00dd: pop
-		IL_00de: ldloc.0
-		IL_00df: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
-		IL_00e4: ldstr "Cannot access 'readable' before initialization"
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00ee: stloc.2
-		IL_00ef: ldloc.0
-		IL_00f0: ldfld object Modules.Stream_Pipeline_Error/Scope::transform
-		IL_00f5: ldstr "Cannot access 'transform' before initialization"
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00ff: stloc.3
-		IL_0100: ldloc.0
-		IL_0101: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
-		IL_0106: ldstr "Cannot access 'writable' before initialization"
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0110: stloc.s 4
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: stelem.ref
-		IL_011c: ldc.i4.0
-		IL_011d: ldelem.ref
-		IL_011e: castclass Modules.Stream_Pipeline_Error/Scope
-		IL_0123: ldftn object Modules.Stream_Pipeline_Error/FunctionExpression_L15C47::__js_call__(class Modules.Stream_Pipeline_Error/Scope, object, object)
-		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_012e: ldc.i4.1
-		IL_012f: conv.r8
-		IL_0130: ldstr ""
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_013a: stloc.s 5
-		IL_013c: ldc.i4.4
-		IL_013d: newarr [System.Runtime]System.Object
-		IL_0142: dup
-		IL_0143: ldc.i4.0
-		IL_0144: ldloc.2
-		IL_0145: stelem.ref
-		IL_0146: dup
-		IL_0147: ldc.i4.1
-		IL_0148: ldloc.3
-		IL_0149: stelem.ref
-		IL_014a: dup
-		IL_014b: ldc.i4.2
-		IL_014c: ldloc.s 4
-		IL_014e: stelem.ref
-		IL_014f: dup
-		IL_0150: ldc.i4.3
-		IL_0151: ldloc.s 5
-		IL_0153: stelem.ref
-		IL_0154: stloc.s 6
-		IL_0156: ldloc.1
-		IL_0157: ldstr "pipeline"
-		IL_015c: ldloc.s 6
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_0163: pop
-		IL_0164: ldloc.0
-		IL_0165: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
-		IL_016a: ldstr "Cannot access 'readable' before initialization"
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0174: stloc.s 5
-		IL_0176: ldloc.s 5
-		IL_0178: ldstr "push"
-		IL_017d: ldstr "a"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0187: pop
-		IL_0188: ret
+		IL_008d: ldstr "_transform"
+		IL_0092: ldloc.2
+		IL_0093: ldc.i4.1
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0099: pop
+		IL_009a: ldnull
+		IL_009b: ldftn object Modules.Stream_Pipeline_Error/FunctionExpression_L13C18::__js_call__(object)
+		IL_00a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a6: ldc.i4.0
+		IL_00a7: conv.r8
+		IL_00a8: ldstr ""
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00b2: stloc.2
+		IL_00b3: ldloc.0
+		IL_00b4: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
+		IL_00b9: ldstr "_write"
+		IL_00be: ldloc.2
+		IL_00bf: ldc.i4.1
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00c5: pop
+		IL_00c6: ldloc.0
+		IL_00c7: ldfld object Modules.Stream_Pipeline_Error/Scope::transform
+		IL_00cc: stloc.2
+		IL_00cd: ldloc.0
+		IL_00ce: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
+		IL_00d3: stloc.3
+		IL_00d4: ldc.i4.1
+		IL_00d5: newarr [System.Runtime]System.Object
+		IL_00da: dup
+		IL_00db: ldc.i4.0
+		IL_00dc: ldloc.0
+		IL_00dd: stelem.ref
+		IL_00de: ldc.i4.0
+		IL_00df: ldelem.ref
+		IL_00e0: castclass Modules.Stream_Pipeline_Error/Scope
+		IL_00e5: ldftn object Modules.Stream_Pipeline_Error/FunctionExpression_L15C47::__js_call__(class Modules.Stream_Pipeline_Error/Scope, object, object)
+		IL_00eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f0: ldc.i4.1
+		IL_00f1: conv.r8
+		IL_00f2: ldstr ""
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00fc: stloc.s 4
+		IL_00fe: ldc.i4.4
+		IL_00ff: newarr [System.Runtime]System.Object
+		IL_0104: dup
+		IL_0105: ldc.i4.0
+		IL_0106: ldloc.0
+		IL_0107: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
+		IL_010c: stelem.ref
+		IL_010d: dup
+		IL_010e: ldc.i4.1
+		IL_010f: ldloc.2
+		IL_0110: stelem.ref
+		IL_0111: dup
+		IL_0112: ldc.i4.2
+		IL_0113: ldloc.3
+		IL_0114: stelem.ref
+		IL_0115: dup
+		IL_0116: ldc.i4.3
+		IL_0117: ldloc.s 4
+		IL_0119: stelem.ref
+		IL_011a: stloc.s 5
+		IL_011c: ldloc.1
+		IL_011d: ldstr "pipeline"
+		IL_0122: ldloc.s 5
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0129: pop
+		IL_012a: ldloc.0
+		IL_012b: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
+		IL_0130: ldstr "push"
+		IL_0135: ldstr "a"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_013f: pop
+		IL_0140: ret
 	} // end of method Stream_Pipeline_Error::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Error
@@ -463,7 +414,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x234c
+		// Method begins at RVA 0x22ad
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2439
+				// Method begins at RVA 0x2382
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2261
+			// Method begins at RVA 0x2201
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2442
+				// Method begins at RVA 0x238b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2288
+			// Method begins at RVA 0x2228
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -137,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244b
+				// Method begins at RVA 0x2394
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22b8
+			// Method begins at RVA 0x2258
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -196,7 +196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2454
+				// Method begins at RVA 0x239d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -220,7 +220,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e8
+			// Method begins at RVA 0x2288
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -255,7 +255,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245d
+				// Method begins at RVA 0x23a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -282,16 +282,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x22b8
 			// Header size: 12
-			// Code size: 235 (0xeb)
+			// Code size: 181 (0xb5)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[2] bool,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -319,59 +318,41 @@
 			IL_0037: ldloc.3
 			IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_003d: pop
-			IL_003e: ldarg.0
-			IL_003f: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
-			IL_0044: ldstr "Cannot access 'readable' before initialization"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004e: stloc.s 4
-			IL_0050: ldloc.s 4
-			IL_0052: ldstr "destroyed"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005c: stloc.s 4
-			IL_005e: ldstr "source-destroyed:"
-			IL_0063: ldloc.s 4
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006a: stloc.3
-			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0070: ldloc.3
-			IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0076: pop
-			IL_0077: ldarg.0
-			IL_0078: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
-			IL_007d: ldstr "Cannot access 'pass' before initialization"
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0087: stloc.s 4
-			IL_0089: ldloc.s 4
-			IL_008b: ldstr "destroyed"
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0095: stloc.s 4
-			IL_0097: ldstr "pass-destroyed:"
-			IL_009c: ldloc.s 4
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a3: stloc.3
-			IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00a9: ldloc.3
-			IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00af: pop
-			IL_00b0: ldarg.0
-			IL_00b1: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
-			IL_00b6: ldstr "Cannot access 'writable' before initialization"
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c0: stloc.s 4
-			IL_00c2: ldloc.s 4
-			IL_00c4: ldstr "destroyed"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ce: stloc.s 4
-			IL_00d0: ldstr "writable-destroyed:"
-			IL_00d5: ldloc.s 4
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00dc: stloc.3
-			IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00e2: ldloc.3
-			IL_00e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00e8: pop
-			IL_00e9: ldnull
-			IL_00ea: ret
+			IL_003e: ldstr "source-destroyed:"
+			IL_0043: ldarg.0
+			IL_0044: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
+			IL_0049: ldstr "destroyed"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0058: stloc.3
+			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_005e: ldloc.3
+			IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0064: pop
+			IL_0065: ldstr "pass-destroyed:"
+			IL_006a: ldarg.0
+			IL_006b: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
+			IL_0070: ldstr "destroyed"
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007f: stloc.3
+			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0085: ldloc.3
+			IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_008b: pop
+			IL_008c: ldstr "writable-destroyed:"
+			IL_0091: ldarg.0
+			IL_0092: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
+			IL_0097: ldstr "destroyed"
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00a6: stloc.3
+			IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ac: ldloc.3
+			IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00b2: pop
+			IL_00b3: ldnull
+			IL_00b4: ret
 		} // end of method FunctionExpression_L25C42::__js_call__
 
 	} // end of class FunctionExpression_L25C42
@@ -394,24 +375,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x240f
+			// Method begins at RVA 0x2379
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -429,7 +401,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 517 (0x205)
+		// Code size: 421 (0x1a5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope,
@@ -437,8 +409,7 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object,
-			[6] object[]
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::.ctor()
@@ -489,138 +460,110 @@
 		IL_0086: stloc.2
 		IL_0087: ldloc.0
 		IL_0088: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
-		IL_008d: ldstr "Cannot access 'writable' before initialization"
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0097: stloc.3
-		IL_0098: ldloc.3
-		IL_0099: ldstr "_write"
-		IL_009e: ldloc.2
-		IL_009f: ldc.i4.1
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00a5: pop
-		IL_00a6: ldloc.0
-		IL_00a7: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
-		IL_00ac: ldstr "Cannot access 'readable' before initialization"
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00b6: stloc.2
-		IL_00b7: ldnull
-		IL_00b8: ldftn object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21::__js_call__(object, object)
-		IL_00be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00c3: ldc.i4.1
-		IL_00c4: conv.r8
-		IL_00c5: ldstr ""
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00cf: stloc.3
-		IL_00d0: ldloc.2
-		IL_00d1: ldstr "on"
-		IL_00d6: ldstr "error"
-		IL_00db: ldloc.3
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00e1: pop
-		IL_00e2: ldloc.0
-		IL_00e3: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
-		IL_00e8: ldstr "Cannot access 'pass' before initialization"
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00f2: stloc.3
-		IL_00f3: ldnull
-		IL_00f4: ldftn object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17::__js_call__(object, object)
-		IL_00fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00ff: ldc.i4.1
-		IL_0100: conv.r8
-		IL_0101: ldstr ""
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_010b: stloc.2
-		IL_010c: ldloc.3
-		IL_010d: ldstr "on"
-		IL_0112: ldstr "error"
-		IL_0117: ldloc.2
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_011d: pop
-		IL_011e: ldloc.0
-		IL_011f: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
-		IL_0124: ldstr "Cannot access 'writable' before initialization"
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_012e: stloc.2
-		IL_012f: ldnull
-		IL_0130: ldftn object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21::__js_call__(object, object)
-		IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_013b: ldc.i4.1
-		IL_013c: conv.r8
-		IL_013d: ldstr ""
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0147: stloc.3
-		IL_0148: ldloc.2
-		IL_0149: ldstr "on"
-		IL_014e: ldstr "error"
-		IL_0153: ldloc.3
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0159: pop
-		IL_015a: ldloc.0
-		IL_015b: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
-		IL_0160: ldstr "Cannot access 'readable' before initialization"
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_016a: stloc.3
-		IL_016b: ldloc.0
-		IL_016c: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
-		IL_0171: ldstr "Cannot access 'pass' before initialization"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_017b: stloc.2
-		IL_017c: ldloc.0
-		IL_017d: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
-		IL_0182: ldstr "Cannot access 'writable' before initialization"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_018c: stloc.s 4
-		IL_018e: ldc.i4.1
-		IL_018f: newarr [System.Runtime]System.Object
-		IL_0194: dup
-		IL_0195: ldc.i4.0
-		IL_0196: ldloc.0
-		IL_0197: stelem.ref
-		IL_0198: ldc.i4.0
-		IL_0199: ldelem.ref
-		IL_019a: castclass Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope
-		IL_019f: ldftn object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42::__js_call__(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope, object, object)
-		IL_01a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01aa: ldc.i4.1
-		IL_01ab: conv.r8
-		IL_01ac: ldstr ""
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01b6: stloc.s 5
-		IL_01b8: ldc.i4.4
-		IL_01b9: newarr [System.Runtime]System.Object
-		IL_01be: dup
-		IL_01bf: ldc.i4.0
-		IL_01c0: ldloc.3
-		IL_01c1: stelem.ref
-		IL_01c2: dup
-		IL_01c3: ldc.i4.1
-		IL_01c4: ldloc.2
-		IL_01c5: stelem.ref
-		IL_01c6: dup
-		IL_01c7: ldc.i4.2
-		IL_01c8: ldloc.s 4
-		IL_01ca: stelem.ref
-		IL_01cb: dup
-		IL_01cc: ldc.i4.3
-		IL_01cd: ldloc.s 5
-		IL_01cf: stelem.ref
-		IL_01d0: stloc.s 6
-		IL_01d2: ldloc.1
-		IL_01d3: ldstr "pipeline"
-		IL_01d8: ldloc.s 6
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_01df: pop
-		IL_01e0: ldloc.0
-		IL_01e1: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
-		IL_01e6: ldstr "Cannot access 'readable' before initialization"
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01f0: stloc.s 5
-		IL_01f2: ldloc.s 5
-		IL_01f4: ldstr "push"
-		IL_01f9: ldstr "a"
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0203: pop
-		IL_0204: ret
+		IL_008d: ldstr "_write"
+		IL_0092: ldloc.2
+		IL_0093: ldc.i4.1
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0099: pop
+		IL_009a: ldnull
+		IL_009b: ldftn object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21::__js_call__(object, object)
+		IL_00a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00a6: ldc.i4.1
+		IL_00a7: conv.r8
+		IL_00a8: ldstr ""
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00b2: stloc.2
+		IL_00b3: ldloc.0
+		IL_00b4: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
+		IL_00b9: ldstr "on"
+		IL_00be: ldstr "error"
+		IL_00c3: ldloc.2
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00c9: pop
+		IL_00ca: ldnull
+		IL_00cb: ldftn object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17::__js_call__(object, object)
+		IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00d6: ldc.i4.1
+		IL_00d7: conv.r8
+		IL_00d8: ldstr ""
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00e2: stloc.2
+		IL_00e3: ldloc.0
+		IL_00e4: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
+		IL_00e9: ldstr "on"
+		IL_00ee: ldstr "error"
+		IL_00f3: ldloc.2
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00f9: pop
+		IL_00fa: ldnull
+		IL_00fb: ldftn object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21::__js_call__(object, object)
+		IL_0101: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0106: ldc.i4.1
+		IL_0107: conv.r8
+		IL_0108: ldstr ""
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0112: stloc.2
+		IL_0113: ldloc.0
+		IL_0114: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
+		IL_0119: ldstr "on"
+		IL_011e: ldstr "error"
+		IL_0123: ldloc.2
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0129: pop
+		IL_012a: ldloc.0
+		IL_012b: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
+		IL_0130: stloc.2
+		IL_0131: ldloc.0
+		IL_0132: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
+		IL_0137: stloc.3
+		IL_0138: ldc.i4.1
+		IL_0139: newarr [System.Runtime]System.Object
+		IL_013e: dup
+		IL_013f: ldc.i4.0
+		IL_0140: ldloc.0
+		IL_0141: stelem.ref
+		IL_0142: ldc.i4.0
+		IL_0143: ldelem.ref
+		IL_0144: castclass Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope
+		IL_0149: ldftn object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42::__js_call__(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope, object, object)
+		IL_014f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0154: ldc.i4.1
+		IL_0155: conv.r8
+		IL_0156: ldstr ""
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0160: stloc.s 4
+		IL_0162: ldc.i4.4
+		IL_0163: newarr [System.Runtime]System.Object
+		IL_0168: dup
+		IL_0169: ldc.i4.0
+		IL_016a: ldloc.0
+		IL_016b: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
+		IL_0170: stelem.ref
+		IL_0171: dup
+		IL_0172: ldc.i4.1
+		IL_0173: ldloc.2
+		IL_0174: stelem.ref
+		IL_0175: dup
+		IL_0176: ldc.i4.2
+		IL_0177: ldloc.3
+		IL_0178: stelem.ref
+		IL_0179: dup
+		IL_017a: ldc.i4.3
+		IL_017b: ldloc.s 4
+		IL_017d: stelem.ref
+		IL_017e: stloc.s 5
+		IL_0180: ldloc.1
+		IL_0181: ldstr "pipeline"
+		IL_0186: ldloc.s 5
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_018d: pop
+		IL_018e: ldloc.0
+		IL_018f: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
+		IL_0194: ldstr "push"
+		IL_0199: ldstr "a"
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01a3: pop
+		IL_01a4: ret
 	} // end of method Stream_Pipeline_Error_PropagatesToPeers::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Error_PropagatesToPeers
@@ -632,7 +575,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2466
+		// Method begins at RVA 0x23af
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22b5
+					// Method begins at RVA 0x2285
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x228a
+				// Method begins at RVA 0x2270
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ac
+				// Method begins at RVA 0x227c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			)
 			// Method begins at RVA 0x20c0
 			// Header size: 12
-			// Code size: 446 (0x1be)
+			// Code size: 420 (0x1a4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Promises_Finished_Basic/main/Scope,
@@ -162,125 +162,115 @@
 
 			IL_006e: ldloc.0
 			IL_006f: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0074: switch (IL_0081, IL_0144)
+			IL_0074: switch (IL_0081, IL_012a)
 
 			IL_0081: ldarg.0
 			IL_0082: ldc.i4.1
 			IL_0083: ldelem.ref
 			IL_0084: castclass Modules.Stream_Promises_Finished_Basic/Scope
 			IL_0089: ldfld object Modules.Stream_Promises_Finished_Basic/Scope::'stream'
-			IL_008e: ldstr "Cannot access 'stream' before initialization"
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0098: stloc.3
-			IL_0099: ldloc.3
-			IL_009a: ldstr "Writable"
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a4: stloc.3
-			IL_00a5: ldloc.3
-			IL_00a6: ldc.i4.0
-			IL_00a7: newarr [System.Runtime]System.Object
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00b1: stloc.3
-			IL_00b2: ldloc.3
-			IL_00b3: stloc.1
-			IL_00b4: ldnull
-			IL_00b5: ldftn object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
-			IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00c0: ldc.i4.0
-			IL_00c1: conv.r8
-			IL_00c2: ldstr ""
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00cc: stloc.3
-			IL_00cd: ldloc.1
-			IL_00ce: ldstr "_write"
-			IL_00d3: ldloc.3
-			IL_00d4: ldc.i4.1
-			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_00da: pop
-			IL_00db: ldarg.0
-			IL_00dc: ldc.i4.1
-			IL_00dd: ldelem.ref
-			IL_00de: castclass Modules.Stream_Promises_Finished_Basic/Scope
-			IL_00e3: ldfld object Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
-			IL_00e8: ldstr "Cannot access 'streamPromises' before initialization"
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00f2: stloc.3
-			IL_00f3: ldloc.3
-			IL_00f4: ldstr "finished"
-			IL_00f9: ldloc.1
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ff: stloc.3
-			IL_0100: ldloc.3
-			IL_0101: stloc.2
-			IL_0102: ldloc.1
-			IL_0103: ldstr "end"
-			IL_0108: ldstr "done"
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0112: pop
-			IL_0113: ldloc.0
-			IL_0114: ldc.i4.1
-			IL_0115: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_011a: ldloc.0
+			IL_008e: ldstr "Writable"
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0098: ldc.i4.0
+			IL_0099: newarr [System.Runtime]System.Object
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00a3: stloc.3
+			IL_00a4: ldloc.3
+			IL_00a5: stloc.1
+			IL_00a6: ldnull
+			IL_00a7: ldftn object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
+			IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00b2: ldc.i4.0
+			IL_00b3: conv.r8
+			IL_00b4: ldstr ""
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00be: stloc.3
+			IL_00bf: ldloc.1
+			IL_00c0: ldstr "_write"
+			IL_00c5: ldloc.3
+			IL_00c6: ldc.i4.1
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00cc: pop
+			IL_00cd: ldarg.0
+			IL_00ce: ldc.i4.1
+			IL_00cf: ldelem.ref
+			IL_00d0: castclass Modules.Stream_Promises_Finished_Basic/Scope
+			IL_00d5: ldfld object Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
+			IL_00da: ldstr "finished"
+			IL_00df: ldloc.1
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e5: stloc.3
+			IL_00e6: ldloc.3
+			IL_00e7: stloc.2
+			IL_00e8: ldloc.1
+			IL_00e9: ldstr "end"
+			IL_00ee: ldstr "done"
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f8: pop
+			IL_00f9: ldloc.0
+			IL_00fa: ldc.i4.1
+			IL_00fb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0100: ldloc.0
+			IL_0101: ldloc.2
+			IL_0102: ldarg.0
+			IL_0103: ldc.i4.1
+			IL_0104: ldloc.0
+			IL_0105: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_010a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_010f: ldloc.0
+			IL_0110: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0115: dup
+			IL_0116: ldc.i4.0
+			IL_0117: ldloc.1
+			IL_0118: stelem.ref
+			IL_0119: dup
+			IL_011a: ldc.i4.1
 			IL_011b: ldloc.2
-			IL_011c: ldarg.0
-			IL_011d: ldc.i4.1
+			IL_011c: stelem.ref
+			IL_011d: pop
 			IL_011e: ldloc.0
-			IL_011f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0124: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0129: ldloc.0
-			IL_012a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_012f: dup
-			IL_0130: ldc.i4.0
-			IL_0131: ldloc.1
-			IL_0132: stelem.ref
-			IL_0133: dup
-			IL_0134: ldc.i4.1
-			IL_0135: ldloc.2
-			IL_0136: stelem.ref
-			IL_0137: pop
-			IL_0138: ldloc.0
-			IL_0139: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_013e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0143: ret
+			IL_011f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0124: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0129: ret
 
-			IL_0144: ldloc.0
-			IL_0145: ldfld object Modules.Stream_Promises_Finished_Basic/main/Scope::_awaited1
-			IL_014a: pop
-			IL_014b: ldstr "destroyed:"
-			IL_0150: ldloc.1
-			IL_0151: ldstr "destroyed"
-			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0160: stloc.s 4
-			IL_0162: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0167: ldloc.s 4
-			IL_0169: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_016e: pop
-			IL_016f: ldstr "writable:"
-			IL_0174: ldloc.1
-			IL_0175: ldstr "writable"
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0184: stloc.s 4
-			IL_0186: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_018b: ldloc.s 4
-			IL_018d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0192: pop
-			IL_0193: ldloc.0
-			IL_0194: ldc.i4.m1
-			IL_0195: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_019a: ldloc.0
-			IL_019b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01a5: ldarg.0
-			IL_01a6: ldc.i4.1
-			IL_01a7: newarr [System.Runtime]System.Object
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01b1: pop
-			IL_01b2: ldloc.0
-			IL_01b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01bd: ret
+			IL_012a: ldloc.0
+			IL_012b: ldfld object Modules.Stream_Promises_Finished_Basic/main/Scope::_awaited1
+			IL_0130: pop
+			IL_0131: ldstr "destroyed:"
+			IL_0136: ldloc.1
+			IL_0137: ldstr "destroyed"
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0146: stloc.s 4
+			IL_0148: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_014d: ldloc.s 4
+			IL_014f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0154: pop
+			IL_0155: ldstr "writable:"
+			IL_015a: ldloc.1
+			IL_015b: ldstr "writable"
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_016a: stloc.s 4
+			IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0171: ldloc.s 4
+			IL_0173: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0178: pop
+			IL_0179: ldloc.0
+			IL_017a: ldc.i4.m1
+			IL_017b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0180: ldloc.0
+			IL_0181: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_018b: ldarg.0
+			IL_018c: ldc.i4.1
+			IL_018d: newarr [System.Runtime]System.Object
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0197: pop
+			IL_0198: ldloc.0
+			IL_0199: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_019e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01a3: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -304,21 +294,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x228d
+			// Method begins at RVA 0x2273
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Promises_Finished_Basic/Scope::'stream'
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -396,7 +380,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22be
+		// Method begins at RVA 0x228e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x2406
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,28 +45,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22bc
 			// Header size: 12
-			// Code size: 42 (0x2a)
+			// Code size: 27 (0x1b)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
-			IL_0006: ldstr "Cannot access 'written' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldarg.2
-			IL_0018: ldstr "value"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0027: pop
-			IL_0028: ldnull
-			IL_0029: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldarg.2
+			IL_0009: ldstr "value"
+			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0013: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0018: pop
+			IL_0019: ldnull
+			IL_001a: ret
 		} // end of method FunctionExpression_L12C18::__js_call__
 
 	} // end of class FunctionExpression_L12C18
@@ -82,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b9
+				// Method begins at RVA 0x240f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +102,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x232e
+			// Method begins at RVA 0x22e3
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -131,7 +128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c2
+				// Method begins at RVA 0x2418
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -155,7 +152,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2344
+			// Method begins at RVA 0x22f8
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -195,7 +192,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24cb
+				// Method begins at RVA 0x2421
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -221,86 +218,68 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2394
+			// Method begins at RVA 0x2348
 			// Header size: 12
-			// Code size: 219 (0xdb)
+			// Code size: 169 (0xa9)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] string,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
-			IL_0006: ldstr "Cannot access 'written' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "join"
-			IL_0017: ldstr ","
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldstr "written:"
-			IL_0027: ldloc.0
-			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_002d: stloc.1
-			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0033: ldloc.1
-			IL_0034: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0039: pop
-			IL_003a: ldarg.0
-			IL_003b: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
-			IL_0040: ldstr "Cannot access 'readable' before initialization"
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004a: stloc.0
-			IL_004b: ldloc.0
-			IL_004c: ldstr "destroyed"
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0056: stloc.0
-			IL_0057: ldstr "readable-destroyed:"
-			IL_005c: ldloc.0
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0062: stloc.1
-			IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0068: ldloc.1
-			IL_0069: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_006e: pop
-			IL_006f: ldarg.0
-			IL_0070: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
-			IL_0075: ldstr "Cannot access 'pass' before initialization"
-			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_007f: stloc.0
-			IL_0080: ldloc.0
-			IL_0081: ldstr "destroyed"
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008b: stloc.0
-			IL_008c: ldstr "pass-destroyed:"
-			IL_0091: ldloc.0
-			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0097: stloc.1
-			IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_009d: ldloc.1
-			IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00a3: pop
-			IL_00a4: ldarg.0
-			IL_00a5: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
-			IL_00aa: ldstr "Cannot access 'writable' before initialization"
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00b4: stloc.0
-			IL_00b5: ldloc.0
-			IL_00b6: ldstr "destroyed"
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c0: stloc.0
-			IL_00c1: ldstr "writable-destroyed:"
-			IL_00c6: ldloc.0
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00cc: stloc.1
-			IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00d2: ldloc.1
-			IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00d8: pop
-			IL_00d9: ldnull
-			IL_00da: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldstr ","
+			IL_0013: stelem.ref
+			IL_0014: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0019: stloc.0
+			IL_001a: ldstr "written:"
+			IL_001f: ldloc.0
+			IL_0020: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0025: stloc.0
+			IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_002b: ldloc.0
+			IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0031: pop
+			IL_0032: ldstr "readable-destroyed:"
+			IL_0037: ldarg.0
+			IL_0038: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
+			IL_003d: ldstr "destroyed"
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004c: stloc.1
+			IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0052: ldloc.1
+			IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0058: pop
+			IL_0059: ldstr "pass-destroyed:"
+			IL_005e: ldarg.0
+			IL_005f: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
+			IL_0064: ldstr "destroyed"
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0073: stloc.1
+			IL_0074: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0079: ldloc.1
+			IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_007f: pop
+			IL_0080: ldstr "writable-destroyed:"
+			IL_0085: ldarg.0
+			IL_0086: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
+			IL_008b: ldstr "destroyed"
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_009a: stloc.1
+			IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00a0: ldloc.1
+			IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00a6: pop
+			IL_00a7: ldnull
+			IL_00a8: ret
 		} // end of method FunctionExpression_L30C8::__js_call__
 
 	} // end of class FunctionExpression_L30C8
@@ -320,33 +299,21 @@
 		.field public object readable
 		.field public object pass
 		.field public object writable
-		.field public object written
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array written
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x247b
+			// Method begins at RVA 0x23fd
 			// Header size: 1
-			// Code size: 52 (0x34)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
-			IL_0032: nop
-			IL_0033: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -364,8 +331,8 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 666 (0x29a)
-		.maxstack 8
+		// Code size: 608 (0x260)
+		.maxstack 10
 		.locals init (
 			[0] class Modules.Stream_Promises_Pipeline_AbortSignal/Scope,
 			[1] object,
@@ -374,8 +341,7 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object,
-			[8] object[]
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/Scope::.ctor()
@@ -464,7 +430,7 @@
 		IL_00ed: ldloc.0
 		IL_00ee: ldc.i4.0
 		IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00f4: stfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
+		IL_00f4: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
 		IL_00f9: ldc.i4.1
 		IL_00fa: newarr [System.Runtime]System.Object
 		IL_00ff: dup
@@ -483,129 +449,115 @@
 		IL_0121: stloc.s 5
 		IL_0123: ldloc.0
 		IL_0124: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
-		IL_0129: ldstr "Cannot access 'writable' before initialization"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0133: stloc.s 6
-		IL_0135: ldloc.s 6
-		IL_0137: ldstr "_write"
-		IL_013c: ldloc.s 5
-		IL_013e: ldc.i4.1
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0144: pop
-		IL_0145: ldloc.0
-		IL_0146: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
-		IL_014b: ldstr "Cannot access 'readable' before initialization"
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0155: stloc.s 5
-		IL_0157: ldloc.0
-		IL_0158: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
-		IL_015d: ldstr "Cannot access 'pass' before initialization"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0167: stloc.s 6
-		IL_0169: ldloc.0
-		IL_016a: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
-		IL_016f: ldstr "Cannot access 'writable' before initialization"
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0179: stloc.s 7
-		IL_017b: ldc.i4.4
-		IL_017c: newarr [System.Runtime]System.Object
-		IL_0181: dup
-		IL_0182: ldc.i4.0
-		IL_0183: ldloc.s 5
-		IL_0185: stelem.ref
-		IL_0186: dup
-		IL_0187: ldc.i4.1
-		IL_0188: ldloc.s 6
-		IL_018a: stelem.ref
-		IL_018b: dup
-		IL_018c: ldc.i4.2
-		IL_018d: ldloc.s 7
-		IL_018f: stelem.ref
-		IL_0190: dup
-		IL_0191: ldc.i4.3
-		IL_0192: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0197: dup
-		IL_0198: ldstr "signal"
-		IL_019d: ldloc.3
-		IL_019e: ldstr "signal"
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_01ad: stelem.ref
-		IL_01ae: stloc.s 8
-		IL_01b0: ldloc.2
-		IL_01b1: ldstr "pipeline"
-		IL_01b6: ldloc.s 8
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_01bd: stloc.s 7
-		IL_01bf: ldloc.s 7
-		IL_01c1: stloc.s 4
-		IL_01c3: ldloc.0
-		IL_01c4: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
-		IL_01c9: ldstr "Cannot access 'readable' before initialization"
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01d3: stloc.s 7
-		IL_01d5: ldloc.s 7
-		IL_01d7: ldstr "push"
-		IL_01dc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01e1: dup
-		IL_01e2: ldstr "value"
-		IL_01e7: ldc.r8 1
-		IL_01f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0129: ldstr "_write"
+		IL_012e: ldloc.s 5
+		IL_0130: ldc.i4.1
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0136: pop
+		IL_0137: ldloc.0
+		IL_0138: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
+		IL_013d: stloc.s 5
+		IL_013f: ldloc.0
+		IL_0140: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
+		IL_0145: stloc.s 6
+		IL_0147: ldloc.0
+		IL_0148: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
+		IL_014d: stloc.s 7
+		IL_014f: ldloc.2
+		IL_0150: ldstr "pipeline"
+		IL_0155: ldc.i4.4
+		IL_0156: newarr [System.Runtime]System.Object
+		IL_015b: dup
+		IL_015c: ldc.i4.0
+		IL_015d: ldloc.s 5
+		IL_015f: stelem.ref
+		IL_0160: dup
+		IL_0161: ldc.i4.1
+		IL_0162: ldloc.s 6
+		IL_0164: stelem.ref
+		IL_0165: dup
+		IL_0166: ldc.i4.2
+		IL_0167: ldloc.s 7
+		IL_0169: stelem.ref
+		IL_016a: dup
+		IL_016b: ldc.i4.3
+		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0171: dup
+		IL_0172: ldstr "signal"
+		IL_0177: ldloc.3
+		IL_0178: ldstr "signal"
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0182: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0187: stelem.ref
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_018d: stloc.s 7
+		IL_018f: ldloc.s 7
+		IL_0191: stloc.s 4
+		IL_0193: ldloc.0
+		IL_0194: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
+		IL_0199: stloc.s 7
+		IL_019b: ldloc.s 7
+		IL_019d: ldstr "push"
+		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01a7: dup
+		IL_01a8: ldstr "value"
+		IL_01ad: ldc.r8 1
+		IL_01b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01c0: pop
+		IL_01c1: ldloc.3
+		IL_01c2: ldstr "abort"
+		IL_01c7: ldstr "stop"
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01d1: pop
+		IL_01d2: ldnull
+		IL_01d3: ldftn object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8::__js_call__(object)
+		IL_01d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01de: ldc.i4.0
+		IL_01df: conv.r8
+		IL_01e0: ldstr ""
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01ea: stloc.s 7
+		IL_01ec: ldloc.s 4
+		IL_01ee: ldstr "then"
+		IL_01f3: ldloc.s 7
 		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01fa: pop
-		IL_01fb: ldloc.3
-		IL_01fc: ldstr "abort"
-		IL_0201: ldstr "stop"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_020b: pop
-		IL_020c: ldnull
-		IL_020d: ldftn object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8::__js_call__(object)
-		IL_0213: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0218: ldc.i4.0
-		IL_0219: conv.r8
-		IL_021a: ldstr ""
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0224: stloc.s 7
-		IL_0226: ldloc.s 4
-		IL_0228: ldstr "then"
-		IL_022d: ldloc.s 7
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0234: stloc.s 7
-		IL_0236: ldnull
-		IL_0237: ldftn object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9::__js_call__(object, object)
-		IL_023d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0242: ldc.i4.1
+		IL_01fa: stloc.s 7
+		IL_01fc: ldnull
+		IL_01fd: ldftn object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9::__js_call__(object, object)
+		IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0208: ldc.i4.1
+		IL_0209: conv.r8
+		IL_020a: ldstr ""
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0214: stloc.s 6
+		IL_0216: ldloc.s 7
+		IL_0218: ldstr "catch"
+		IL_021d: ldloc.s 6
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0224: stloc.s 6
+		IL_0226: ldc.i4.1
+		IL_0227: newarr [System.Runtime]System.Object
+		IL_022c: dup
+		IL_022d: ldc.i4.0
+		IL_022e: ldloc.0
+		IL_022f: stelem.ref
+		IL_0230: ldc.i4.0
+		IL_0231: ldelem.ref
+		IL_0232: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
+		IL_0237: ldftn object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
+		IL_023d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0242: ldc.i4.0
 		IL_0243: conv.r8
 		IL_0244: ldstr ""
 		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_024e: stloc.s 6
-		IL_0250: ldloc.s 7
-		IL_0252: ldstr "catch"
-		IL_0257: ldloc.s 6
+		IL_024e: stloc.s 7
+		IL_0250: ldloc.s 6
+		IL_0252: ldstr "then"
+		IL_0257: ldloc.s 7
 		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_025e: stloc.s 6
-		IL_0260: ldc.i4.1
-		IL_0261: newarr [System.Runtime]System.Object
-		IL_0266: dup
-		IL_0267: ldc.i4.0
-		IL_0268: ldloc.0
-		IL_0269: stelem.ref
-		IL_026a: ldc.i4.0
-		IL_026b: ldelem.ref
-		IL_026c: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_0271: ldftn object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
-		IL_0277: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_027c: ldc.i4.0
-		IL_027d: conv.r8
-		IL_027e: ldstr ""
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0288: stloc.s 7
-		IL_028a: ldloc.s 6
-		IL_028c: ldstr "then"
-		IL_0291: ldloc.s 7
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0298: pop
-		IL_0299: ret
+		IL_025e: pop
+		IL_025f: ret
 	} // end of method Stream_Promises_Pipeline_AbortSignal::__js_module_init__
 
 } // end of class Modules.Stream_Promises_Pipeline_AbortSignal
@@ -617,7 +569,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24d4
+		// Method begins at RVA 0x242a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x253c
+					// Method begins at RVA 0x24cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2480
+				// Method begins at RVA 0x2440
 				// Header size: 12
 				// Code size: 63 (0x3f)
 				.maxstack 8
@@ -90,7 +90,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2545
+					// Method begins at RVA 0x24d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -115,31 +115,28 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24cc
+				// Method begins at RVA 0x248c
 				// Header size: 12
-				// Code size: 49 (0x31)
+				// Code size: 34 (0x22)
 				.maxstack 8
 				.locals init (
-					[0] object
+					[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope
-				IL_0008: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-				IL_000d: ldstr "Cannot access 'written' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldloc.0
-				IL_0019: ldstr "push"
-				IL_001e: ldarg.2
-				IL_001f: ldstr "value"
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_002e: pop
-				IL_002f: ldnull
-				IL_0030: ret
+				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
+				IL_000d: stloc.0
+				IL_000e: ldloc.0
+				IL_000f: ldarg.2
+				IL_0010: ldstr "value"
+				IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_001a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_001f: pop
+				IL_0020: ldnull
+				IL_0021: ret
 			} // end of method FunctionExpression_L16C20::__js_call__
 
 		} // end of class FunctionExpression_L16C20
@@ -152,7 +149,7 @@
 				3d 7b 77 72 69 74 74 65 6e 7d 00 00
 			)
 			// Fields
-			.field public object written
+			.field public class [JavaScriptRuntime]JavaScriptRuntime.Array written
 			.field public object _awaited1
 			.field public object _awaited2
 
@@ -160,18 +157,15 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2528
+				// Method begins at RVA 0x24c3
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -189,7 +183,7 @@
 			)
 			// Method begins at RVA 0x20c0
 			// Header size: 12
-			// Code size: 948 (0x3b4)
+			// Code size: 882 (0x372)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope,
@@ -198,7 +192,8 @@
 				[3] object,
 				[4] object,
 				[5] object,
-				[6] object
+				[6] object,
+				[7] string
 			)
 
 			IL_0000: ldarg.0
@@ -262,294 +257,278 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_008a, IL_02b2)
+			IL_007d: switch (IL_008a, IL_027a)
 
 			IL_008a: ldarg.0
 			IL_008b: ldc.i4.1
 			IL_008c: ldelem.ref
 			IL_008d: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
 			IL_0092: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_0097: ldstr "Cannot access 'stream' before initialization"
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0097: ldstr "Readable"
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_00a1: stloc.s 5
 			IL_00a3: ldloc.s 5
-			IL_00a5: ldstr "Readable"
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00af: stloc.s 5
-			IL_00b1: ldloc.s 5
-			IL_00b3: ldc.i4.1
-			IL_00b4: newarr [System.Runtime]System.Object
-			IL_00b9: dup
-			IL_00ba: ldc.i4.0
-			IL_00bb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00c0: dup
-			IL_00c1: ldstr "objectMode"
-			IL_00c6: ldc.i4.1
-			IL_00c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00cc: stelem.ref
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00d2: stloc.s 5
-			IL_00d4: ldloc.s 5
-			IL_00d6: stloc.1
-			IL_00d7: ldarg.0
-			IL_00d8: ldc.i4.1
-			IL_00d9: ldelem.ref
-			IL_00da: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_00df: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_00e4: ldstr "Cannot access 'stream' before initialization"
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00ee: stloc.s 5
-			IL_00f0: ldloc.s 5
-			IL_00f2: ldstr "Transform"
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00fc: stloc.s 5
-			IL_00fe: ldloc.s 5
-			IL_0100: ldc.i4.1
-			IL_0101: newarr [System.Runtime]System.Object
-			IL_0106: dup
-			IL_0107: ldc.i4.0
-			IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_010d: dup
-			IL_010e: ldstr "objectMode"
-			IL_0113: ldc.i4.1
-			IL_0114: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0119: stelem.ref
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00a5: ldc.i4.1
+			IL_00a6: newarr [System.Runtime]System.Object
+			IL_00ab: dup
+			IL_00ac: ldc.i4.0
+			IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00b2: dup
+			IL_00b3: ldstr "objectMode"
+			IL_00b8: ldc.i4.1
+			IL_00b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00be: stelem.ref
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00c4: stloc.s 5
+			IL_00c6: ldloc.s 5
+			IL_00c8: stloc.1
+			IL_00c9: ldarg.0
+			IL_00ca: ldc.i4.1
+			IL_00cb: ldelem.ref
+			IL_00cc: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_00d1: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
+			IL_00d6: ldstr "Transform"
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e0: stloc.s 5
+			IL_00e2: ldloc.s 5
+			IL_00e4: ldc.i4.1
+			IL_00e5: newarr [System.Runtime]System.Object
+			IL_00ea: dup
+			IL_00eb: ldc.i4.0
+			IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00f1: dup
+			IL_00f2: ldstr "objectMode"
+			IL_00f7: ldc.i4.1
+			IL_00f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00fd: stelem.ref
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0103: stloc.s 5
+			IL_0105: ldloc.s 5
+			IL_0107: stloc.2
+			IL_0108: ldarg.0
+			IL_0109: ldc.i4.1
+			IL_010a: ldelem.ref
+			IL_010b: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_0110: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
+			IL_0115: ldstr "Writable"
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_011f: stloc.s 5
 			IL_0121: ldloc.s 5
-			IL_0123: stloc.2
-			IL_0124: ldarg.0
-			IL_0125: ldc.i4.1
-			IL_0126: ldelem.ref
-			IL_0127: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_012c: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_0131: ldstr "Cannot access 'stream' before initialization"
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_013b: stloc.s 5
-			IL_013d: ldloc.s 5
-			IL_013f: ldstr "Writable"
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0149: stloc.s 5
-			IL_014b: ldloc.s 5
-			IL_014d: ldc.i4.1
-			IL_014e: newarr [System.Runtime]System.Object
-			IL_0153: dup
-			IL_0154: ldc.i4.0
-			IL_0155: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_015a: dup
-			IL_015b: ldstr "objectMode"
+			IL_0123: ldc.i4.1
+			IL_0124: newarr [System.Runtime]System.Object
+			IL_0129: dup
+			IL_012a: ldc.i4.0
+			IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0130: dup
+			IL_0131: ldstr "objectMode"
+			IL_0136: ldc.i4.1
+			IL_0137: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_013c: stelem.ref
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0142: stloc.s 5
+			IL_0144: ldloc.s 5
+			IL_0146: stloc.3
+			IL_0147: ldloc.0
+			IL_0148: ldc.i4.0
+			IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_014e: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
+			IL_0153: ldc.i4.2
+			IL_0154: newarr [System.Runtime]System.Object
+			IL_0159: dup
+			IL_015a: ldc.i4.0
+			IL_015b: ldarg.0
+			IL_015c: ldc.i4.1
+			IL_015d: ldelem.ref
+			IL_015e: stelem.ref
+			IL_015f: dup
 			IL_0160: ldc.i4.1
-			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0166: stelem.ref
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_016c: stloc.s 5
-			IL_016e: ldloc.s 5
-			IL_0170: stloc.3
-			IL_0171: ldloc.0
-			IL_0172: ldc.i4.0
-			IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0178: stfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-			IL_017d: ldc.i4.2
-			IL_017e: newarr [System.Runtime]System.Object
-			IL_0183: dup
-			IL_0184: ldc.i4.0
-			IL_0185: ldarg.0
-			IL_0186: ldc.i4.1
-			IL_0187: ldelem.ref
-			IL_0188: stelem.ref
-			IL_0189: dup
-			IL_018a: ldc.i4.1
-			IL_018b: ldloc.0
-			IL_018c: stelem.ref
-			IL_018d: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
-			IL_0193: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0161: ldloc.0
+			IL_0162: stelem.ref
+			IL_0163: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
+			IL_0169: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_016e: ldc.i4.1
+			IL_016f: conv.r8
+			IL_0170: ldstr ""
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_017a: stloc.s 5
+			IL_017c: ldloc.2
+			IL_017d: ldstr "_transform"
+			IL_0182: ldloc.s 5
+			IL_0184: ldc.i4.1
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_018a: pop
+			IL_018b: ldc.i4.2
+			IL_018c: newarr [System.Runtime]System.Object
+			IL_0191: dup
+			IL_0192: ldc.i4.0
+			IL_0193: ldarg.0
+			IL_0194: ldc.i4.1
+			IL_0195: ldelem.ref
+			IL_0196: stelem.ref
+			IL_0197: dup
 			IL_0198: ldc.i4.1
-			IL_0199: conv.r8
-			IL_019a: ldstr ""
-			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_01a4: stloc.s 5
-			IL_01a6: ldloc.2
-			IL_01a7: ldstr "_transform"
-			IL_01ac: ldloc.s 5
-			IL_01ae: ldc.i4.1
-			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_01b4: pop
-			IL_01b5: ldc.i4.2
-			IL_01b6: newarr [System.Runtime]System.Object
-			IL_01bb: dup
-			IL_01bc: ldc.i4.0
-			IL_01bd: ldarg.0
-			IL_01be: ldc.i4.1
-			IL_01bf: ldelem.ref
-			IL_01c0: stelem.ref
-			IL_01c1: dup
-			IL_01c2: ldc.i4.1
-			IL_01c3: ldloc.0
-			IL_01c4: stelem.ref
-			IL_01c5: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
-			IL_01cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_01d0: ldc.i4.1
-			IL_01d1: conv.r8
-			IL_01d2: ldstr ""
-			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_01dc: stloc.s 5
-			IL_01de: ldloc.3
-			IL_01df: ldstr "_write"
-			IL_01e4: ldloc.s 5
-			IL_01e6: ldc.i4.1
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_01ec: pop
-			IL_01ed: ldarg.0
-			IL_01ee: ldc.i4.1
-			IL_01ef: ldelem.ref
-			IL_01f0: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_01f5: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
-			IL_01fa: ldstr "Cannot access 'streamPromises' before initialization"
-			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0204: stloc.s 5
-			IL_0206: ldloc.s 5
-			IL_0208: ldstr "pipeline"
-			IL_020d: ldloc.1
-			IL_020e: ldloc.2
-			IL_020f: ldloc.3
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0215: stloc.s 5
-			IL_0217: ldloc.s 5
-			IL_0219: stloc.s 4
-			IL_021b: ldloc.1
-			IL_021c: ldstr "push"
-			IL_0221: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0226: dup
-			IL_0227: ldstr "value"
-			IL_022c: ldc.r8 1
-			IL_0235: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_023f: pop
-			IL_0240: ldloc.1
-			IL_0241: ldstr "push"
-			IL_0246: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_024b: dup
-			IL_024c: ldstr "value"
-			IL_0251: ldc.r8 2
-			IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0264: pop
-			IL_0265: ldloc.1
-			IL_0266: ldstr "push"
-			IL_026b: ldc.i4.0
-			IL_026c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0276: pop
-			IL_0277: ldloc.0
-			IL_0278: ldc.i4.1
-			IL_0279: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_027e: ldloc.0
-			IL_027f: ldloc.s 4
-			IL_0281: ldarg.0
-			IL_0282: ldc.i4.1
-			IL_0283: ldloc.0
-			IL_0284: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0289: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_028e: ldloc.0
-			IL_028f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0294: dup
-			IL_0295: ldc.i4.0
-			IL_0296: ldloc.1
-			IL_0297: stelem.ref
-			IL_0298: dup
-			IL_0299: ldc.i4.1
-			IL_029a: ldloc.2
-			IL_029b: stelem.ref
-			IL_029c: dup
-			IL_029d: ldc.i4.2
-			IL_029e: ldloc.3
-			IL_029f: stelem.ref
-			IL_02a0: dup
-			IL_02a1: ldc.i4.3
-			IL_02a2: ldloc.s 4
-			IL_02a4: stelem.ref
-			IL_02a5: pop
-			IL_02a6: ldloc.0
-			IL_02a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02b1: ret
+			IL_0199: ldloc.0
+			IL_019a: stelem.ref
+			IL_019b: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
+			IL_01a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_01a6: ldc.i4.1
+			IL_01a7: conv.r8
+			IL_01a8: ldstr ""
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_01b2: stloc.s 5
+			IL_01b4: ldloc.3
+			IL_01b5: ldstr "_write"
+			IL_01ba: ldloc.s 5
+			IL_01bc: ldc.i4.1
+			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01c2: pop
+			IL_01c3: ldarg.0
+			IL_01c4: ldc.i4.1
+			IL_01c5: ldelem.ref
+			IL_01c6: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_01cb: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
+			IL_01d0: ldstr "pipeline"
+			IL_01d5: ldloc.1
+			IL_01d6: ldloc.2
+			IL_01d7: ldloc.3
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01dd: stloc.s 5
+			IL_01df: ldloc.s 5
+			IL_01e1: stloc.s 4
+			IL_01e3: ldloc.1
+			IL_01e4: ldstr "push"
+			IL_01e9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01ee: dup
+			IL_01ef: ldstr "value"
+			IL_01f4: ldc.r8 1
+			IL_01fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0207: pop
+			IL_0208: ldloc.1
+			IL_0209: ldstr "push"
+			IL_020e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0213: dup
+			IL_0214: ldstr "value"
+			IL_0219: ldc.r8 2
+			IL_0222: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_022c: pop
+			IL_022d: ldloc.1
+			IL_022e: ldstr "push"
+			IL_0233: ldc.i4.0
+			IL_0234: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_023e: pop
+			IL_023f: ldloc.0
+			IL_0240: ldc.i4.1
+			IL_0241: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0246: ldloc.0
+			IL_0247: ldloc.s 4
+			IL_0249: ldarg.0
+			IL_024a: ldc.i4.1
+			IL_024b: ldloc.0
+			IL_024c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0251: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0256: ldloc.0
+			IL_0257: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_025c: dup
+			IL_025d: ldc.i4.0
+			IL_025e: ldloc.1
+			IL_025f: stelem.ref
+			IL_0260: dup
+			IL_0261: ldc.i4.1
+			IL_0262: ldloc.2
+			IL_0263: stelem.ref
+			IL_0264: dup
+			IL_0265: ldc.i4.2
+			IL_0266: ldloc.3
+			IL_0267: stelem.ref
+			IL_0268: dup
+			IL_0269: ldc.i4.3
+			IL_026a: ldloc.s 4
+			IL_026c: stelem.ref
+			IL_026d: pop
+			IL_026e: ldloc.0
+			IL_026f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0274: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0279: ret
 
-			IL_02b2: ldloc.0
-			IL_02b3: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::_awaited1
-			IL_02b8: pop
-			IL_02b9: ldstr "readableObjectMode:"
-			IL_02be: ldloc.1
-			IL_02bf: ldstr "readableObjectMode"
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02ce: stloc.s 6
-			IL_02d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02d5: ldloc.s 6
-			IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02dc: pop
-			IL_02dd: ldstr "transformReadableObjectMode:"
-			IL_02e2: ldloc.2
-			IL_02e3: ldstr "readableObjectMode"
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02f2: stloc.s 6
-			IL_02f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02f9: ldloc.s 6
-			IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0300: pop
-			IL_0301: ldstr "transformWritableObjectMode:"
-			IL_0306: ldloc.2
-			IL_0307: ldstr "writableObjectMode"
-			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0316: stloc.s 6
-			IL_0318: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_031d: ldloc.s 6
-			IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0324: pop
-			IL_0325: ldstr "writableObjectMode:"
-			IL_032a: ldloc.3
-			IL_032b: ldstr "writableObjectMode"
-			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_033a: stloc.s 6
-			IL_033c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0341: ldloc.s 6
-			IL_0343: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0348: pop
-			IL_0349: ldloc.0
-			IL_034a: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-			IL_034f: ldstr "Cannot access 'written' before initialization"
-			IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0359: stloc.s 5
-			IL_035b: ldloc.s 5
-			IL_035d: ldstr "join"
-			IL_0362: ldstr ","
-			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_036c: stloc.s 5
-			IL_036e: ldstr "written:"
-			IL_0373: ldloc.s 5
-			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_037a: stloc.s 6
-			IL_037c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0381: ldloc.s 6
-			IL_0383: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0388: pop
-			IL_0389: ldloc.0
-			IL_038a: ldc.i4.m1
-			IL_038b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0390: ldloc.0
-			IL_0391: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0396: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_039b: ldarg.0
-			IL_039c: ldc.i4.1
-			IL_039d: newarr [System.Runtime]System.Object
-			IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03a7: pop
-			IL_03a8: ldloc.0
-			IL_03a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ae: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03b3: ret
+			IL_027a: ldloc.0
+			IL_027b: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::_awaited1
+			IL_0280: pop
+			IL_0281: ldstr "readableObjectMode:"
+			IL_0286: ldloc.1
+			IL_0287: ldstr "readableObjectMode"
+			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0296: stloc.s 6
+			IL_0298: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_029d: ldloc.s 6
+			IL_029f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02a4: pop
+			IL_02a5: ldstr "transformReadableObjectMode:"
+			IL_02aa: ldloc.2
+			IL_02ab: ldstr "readableObjectMode"
+			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ba: stloc.s 6
+			IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02c1: ldloc.s 6
+			IL_02c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02c8: pop
+			IL_02c9: ldstr "transformWritableObjectMode:"
+			IL_02ce: ldloc.2
+			IL_02cf: ldstr "writableObjectMode"
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02de: stloc.s 6
+			IL_02e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02e5: ldloc.s 6
+			IL_02e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02ec: pop
+			IL_02ed: ldstr "writableObjectMode:"
+			IL_02f2: ldloc.3
+			IL_02f3: ldstr "writableObjectMode"
+			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0302: stloc.s 6
+			IL_0304: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0309: ldloc.s 6
+			IL_030b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0310: pop
+			IL_0311: ldloc.0
+			IL_0312: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
+			IL_0317: ldc.i4.1
+			IL_0318: newarr [System.Runtime]System.Object
+			IL_031d: dup
+			IL_031e: ldc.i4.0
+			IL_031f: ldstr ","
+			IL_0324: stelem.ref
+			IL_0325: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_032a: stloc.s 7
+			IL_032c: ldstr "written:"
+			IL_0331: ldloc.s 7
+			IL_0333: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0338: stloc.s 7
+			IL_033a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_033f: ldloc.s 7
+			IL_0341: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0346: pop
+			IL_0347: ldloc.0
+			IL_0348: ldc.i4.m1
+			IL_0349: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_034e: ldloc.0
+			IL_034f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0354: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0359: ldarg.0
+			IL_035a: ldc.i4.1
+			IL_035b: newarr [System.Runtime]System.Object
+			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0365: pop
+			IL_0366: ldloc.0
+			IL_0367: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_036c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0371: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -573,21 +552,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2509
+			// Method begins at RVA 0x24ba
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -665,7 +638,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x254e
+		// Method begins at RVA 0x24de
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d4
+				// Method begins at RVA 0x2289
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,26 +44,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21e0
-			// Header size: 12
-			// Code size: 36 (0x24)
+			// Method begins at RVA 0x21df
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Readable_Pause_Resume/Scope::events
-			IL_0006: ldstr "Cannot access 'events' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "pause"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Readable_Pause_Resume/Scope::events
+			IL_0006: ldstr "pause"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L8C21::__js_call__
 
 	} // end of class FunctionExpression_L8C21
@@ -79,7 +71,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22dd
+				// Method begins at RVA 0x2292
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,26 +97,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2210
-			// Header size: 12
-			// Code size: 36 (0x24)
+			// Method begins at RVA 0x21f3
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Readable_Pause_Resume/Scope::events
-			IL_0006: ldstr "Cannot access 'events' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "resume"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Readable_Pause_Resume/Scope::events
+			IL_0006: ldstr "resume"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L12C22::__js_call__
 
 	} // end of class FunctionExpression_L12C22
@@ -140,7 +124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e6
+				// Method begins at RVA 0x229b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +148,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2240
+			// Method begins at RVA 0x2208
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -197,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ef
+				// Method begins at RVA 0x22a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -223,13 +207,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2268
+			// Method begins at RVA 0x2230
 			// Header size: 12
-			// Code size: 76 (0x4c)
+			// Code size: 68 (0x44)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] string
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -237,25 +220,25 @@
 			IL_000a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_000f: pop
 			IL_0010: ldarg.0
-			IL_0011: ldfld object Modules.Stream_Readable_Pause_Resume/Scope::events
-			IL_0016: ldstr "Cannot access 'events' before initialization"
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0020: stloc.0
-			IL_0021: ldloc.0
-			IL_0022: ldstr "join"
-			IL_0027: ldstr ","
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0031: stloc.0
-			IL_0032: ldstr "events:"
-			IL_0037: ldloc.0
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_003d: stloc.1
-			IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0043: ldloc.1
-			IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0049: pop
-			IL_004a: ldnull
-			IL_004b: ret
+			IL_0011: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Readable_Pause_Resume/Scope::events
+			IL_0016: ldc.i4.1
+			IL_0017: newarr [System.Runtime]System.Object
+			IL_001c: dup
+			IL_001d: ldc.i4.0
+			IL_001e: ldstr ","
+			IL_0023: stelem.ref
+			IL_0024: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0029: stloc.0
+			IL_002a: ldstr "events:"
+			IL_002f: ldloc.0
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.0
+			IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_003b: ldloc.0
+			IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0041: pop
+			IL_0042: ldnull
+			IL_0043: ret
 		} // end of method FunctionExpression_L20C19::__js_call__
 
 	} // end of class FunctionExpression_L20C19
@@ -268,24 +251,21 @@
 			7b 65 76 65 6e 74 73 7d 00 00
 		)
 		// Fields
-		.field public object events
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array events
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22c0
+			// Method begins at RVA 0x2280
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Readable_Pause_Resume/Scope::events
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -332,7 +312,7 @@
 		IL_002d: ldloc.0
 		IL_002e: ldc.i4.0
 		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0034: stfld object Modules.Stream_Readable_Pause_Resume/Scope::events
+		IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Readable_Pause_Resume/Scope::events
 		IL_0039: ldc.i4.1
 		IL_003a: newarr [System.Runtime]System.Object
 		IL_003f: dup
@@ -458,7 +438,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22f8
+		// Method begins at RVA 0x22ad
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230b
+				// Method begins at RVA 0x2296
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2274
+			// Method begins at RVA 0x2218
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -84,7 +84,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2314
+				// Method begins at RVA 0x229f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,34 +110,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x22b4
+			// Method begins at RVA 0x2258
 			// Header size: 12
-			// Code size: 55 (0x37)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-			IL_0006: ldstr "Cannot access 'readable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "readableEncoding"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldstr "encoding:"
-			IL_0022: ldloc.0
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0028: stloc.1
-			IL_0029: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_002e: ldloc.1
-			IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0034: pop
-			IL_0035: ldnull
-			IL_0036: ret
+			IL_0000: ldstr "encoding:"
+			IL_0005: ldarg.0
+			IL_0006: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+			IL_000b: ldstr "readableEncoding"
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_001a: stloc.0
+			IL_001b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0020: ldloc.0
+			IL_0021: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0026: pop
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L19C19::__js_call__
 
 	} // end of class FunctionExpression_L19C19
@@ -156,18 +149,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22f7
+			// Method begins at RVA 0x228d
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -185,7 +175,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 535 (0x217)
+		// Code size: 443 (0x1bb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Readable_SetEncoding_Utf8/Scope,
@@ -193,8 +183,7 @@
 			[2] object,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[5] object,
-			[6] object
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/Scope::.ctor()
@@ -217,151 +206,127 @@
 		IL_002d: stfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
 		IL_0032: ldloc.0
 		IL_0033: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_0038: ldstr "Cannot access 'readable' before initialization"
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0042: stloc.3
-		IL_0043: ldc.i4.2
-		IL_0044: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0049: dup
-		IL_004a: ldc.r8 226
-		IL_0053: box [System.Runtime]System.Double
-		IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_005d: dup
-		IL_005e: ldc.r8 130
-		IL_0067: box [System.Runtime]System.Double
-		IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0076: stloc.s 4
-		IL_0078: ldloc.3
-		IL_0079: ldstr "push"
-		IL_007e: ldloc.s 4
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0085: pop
-		IL_0086: ldloc.0
-		IL_0087: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_008c: ldstr "Cannot access 'readable' before initialization"
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0096: stloc.3
-		IL_0097: ldc.i4.1
-		IL_0098: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_009d: dup
-		IL_009e: ldc.r8 172
-		IL_00a7: box [System.Runtime]System.Double
-		IL_00ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_00b6: stloc.s 4
-		IL_00b8: ldloc.3
-		IL_00b9: ldstr "push"
-		IL_00be: ldloc.s 4
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c5: pop
-		IL_00c6: ldloc.0
-		IL_00c7: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_00cc: ldstr "Cannot access 'readable' before initialization"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00d6: stloc.3
-		IL_00d7: ldloc.3
-		IL_00d8: ldstr "setEncoding"
-		IL_00dd: ldstr "utf8"
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e7: pop
-		IL_00e8: ldloc.0
-		IL_00e9: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_00ee: ldstr "Cannot access 'readable' before initialization"
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00f8: stloc.3
-		IL_00f9: ldloc.3
-		IL_00fa: ldstr "read"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0104: stloc.3
-		IL_0105: ldloc.3
-		IL_0106: stloc.2
-		IL_0107: ldstr "buffered:"
-		IL_010c: ldloc.2
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0112: stloc.s 5
-		IL_0114: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0119: ldloc.s 5
-		IL_011b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0120: pop
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0126: ldstr "buffered-type:"
-		IL_012b: ldloc.2
-		IL_012c: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0131: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013b: pop
-		IL_013c: ldloc.0
-		IL_013d: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_0142: ldstr "Cannot access 'readable' before initialization"
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_014c: stloc.3
-		IL_014d: ldnull
-		IL_014e: ldftn object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20::__js_call__(object, object)
-		IL_0154: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0159: ldc.i4.1
-		IL_015a: conv.r8
-		IL_015b: ldstr ""
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0165: stloc.s 6
-		IL_0167: ldloc.3
-		IL_0168: ldstr "on"
-		IL_016d: ldstr "data"
-		IL_0172: ldloc.s 6
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0179: pop
-		IL_017a: ldloc.0
-		IL_017b: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_0180: ldstr "Cannot access 'readable' before initialization"
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_018a: stloc.s 6
-		IL_018c: ldc.i4.1
-		IL_018d: newarr [System.Runtime]System.Object
-		IL_0192: dup
-		IL_0193: ldc.i4.0
-		IL_0194: ldloc.0
-		IL_0195: stelem.ref
-		IL_0196: ldc.i4.0
-		IL_0197: ldelem.ref
-		IL_0198: castclass Modules.Stream_Readable_SetEncoding_Utf8/Scope
-		IL_019d: ldftn object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19::__js_call__(class Modules.Stream_Readable_SetEncoding_Utf8/Scope, object)
-		IL_01a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01a8: ldc.i4.0
-		IL_01a9: conv.r8
-		IL_01aa: ldstr ""
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01b4: stloc.3
-		IL_01b5: ldloc.s 6
-		IL_01b7: ldstr "on"
-		IL_01bc: ldstr "end"
-		IL_01c1: ldloc.3
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01c7: pop
-		IL_01c8: ldloc.0
-		IL_01c9: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_01ce: ldstr "Cannot access 'readable' before initialization"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01d8: stloc.3
-		IL_01d9: ldstr " ok"
-		IL_01de: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_01e3: stloc.s 4
-		IL_01e5: ldloc.3
-		IL_01e6: ldstr "push"
-		IL_01eb: ldloc.s 4
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01f2: pop
-		IL_01f3: ldloc.0
-		IL_01f4: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_01f9: ldstr "Cannot access 'readable' before initialization"
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0203: stloc.3
-		IL_0204: ldloc.3
-		IL_0205: ldstr "push"
-		IL_020a: ldc.i4.0
-		IL_020b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0215: pop
-		IL_0216: ret
+		IL_0038: stloc.3
+		IL_0039: ldc.i4.2
+		IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_003f: dup
+		IL_0040: ldc.r8 226
+		IL_0049: box [System.Runtime]System.Double
+		IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0053: dup
+		IL_0054: ldc.r8 130
+		IL_005d: box [System.Runtime]System.Double
+		IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_006c: stloc.s 4
+		IL_006e: ldloc.3
+		IL_006f: ldstr "push"
+		IL_0074: ldloc.s 4
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007b: pop
+		IL_007c: ldloc.0
+		IL_007d: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_0082: stloc.3
+		IL_0083: ldc.i4.1
+		IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0089: dup
+		IL_008a: ldc.r8 172
+		IL_0093: box [System.Runtime]System.Double
+		IL_0098: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_009d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.3
+		IL_00a5: ldstr "push"
+		IL_00aa: ldloc.s 4
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b1: pop
+		IL_00b2: ldloc.0
+		IL_00b3: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_00b8: ldstr "setEncoding"
+		IL_00bd: ldstr "utf8"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c7: pop
+		IL_00c8: ldloc.0
+		IL_00c9: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_00ce: ldstr "read"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00d8: stloc.3
+		IL_00d9: ldloc.3
+		IL_00da: stloc.2
+		IL_00db: ldstr "buffered:"
+		IL_00e0: ldloc.2
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00e6: stloc.s 5
+		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ed: ldloc.s 5
+		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f4: pop
+		IL_00f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fa: ldstr "buffered-type:"
+		IL_00ff: ldloc.2
+		IL_0100: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0105: call string [System.Runtime]System.String::Concat(string, string)
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010f: pop
+		IL_0110: ldnull
+		IL_0111: ldftn object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20::__js_call__(object, object)
+		IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_011c: ldc.i4.1
+		IL_011d: conv.r8
+		IL_011e: ldstr ""
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0128: stloc.3
+		IL_0129: ldloc.0
+		IL_012a: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_012f: ldstr "on"
+		IL_0134: ldstr "data"
+		IL_0139: ldloc.3
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_013f: pop
+		IL_0140: ldc.i4.1
+		IL_0141: newarr [System.Runtime]System.Object
+		IL_0146: dup
+		IL_0147: ldc.i4.0
+		IL_0148: ldloc.0
+		IL_0149: stelem.ref
+		IL_014a: ldc.i4.0
+		IL_014b: ldelem.ref
+		IL_014c: castclass Modules.Stream_Readable_SetEncoding_Utf8/Scope
+		IL_0151: ldftn object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19::__js_call__(class Modules.Stream_Readable_SetEncoding_Utf8/Scope, object)
+		IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_015c: ldc.i4.0
+		IL_015d: conv.r8
+		IL_015e: ldstr ""
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0168: stloc.3
+		IL_0169: ldloc.0
+		IL_016a: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_016f: ldstr "on"
+		IL_0174: ldstr "end"
+		IL_0179: ldloc.3
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_017f: pop
+		IL_0180: ldloc.0
+		IL_0181: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_0186: stloc.3
+		IL_0187: ldstr " ok"
+		IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0191: stloc.s 4
+		IL_0193: ldloc.3
+		IL_0194: ldstr "push"
+		IL_0199: ldloc.s 4
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01a0: pop
+		IL_01a1: ldloc.0
+		IL_01a2: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_01a7: stloc.3
+		IL_01a8: ldloc.3
+		IL_01a9: ldstr "push"
+		IL_01ae: ldc.i4.0
+		IL_01af: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01b9: pop
+		IL_01ba: ret
 	} // end of method Stream_Readable_SetEncoding_Utf8::__js_module_init__
 
 } // end of class Modules.Stream_Readable_SetEncoding_Utf8
@@ -373,7 +338,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231d
+		// Method begins at RVA 0x22a8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2356
+				// Method begins at RVA 0x22b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -86,7 +86,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235f
+				// Method begins at RVA 0x22ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,33 +113,30 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2230
+			// Method begins at RVA 0x21f4
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::sequence
-			IL_0006: ldstr "Cannot access 'sequence' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldstr "error:"
-			IL_0016: ldarg.2
-			IL_0017: ldstr "message"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0026: stloc.1
-			IL_0027: ldloc.0
-			IL_0028: ldstr "push"
-			IL_002d: ldloc.1
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0033: pop
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
+			IL_0006: stloc.0
+			IL_0007: ldstr "error:"
+			IL_000c: ldarg.2
+			IL_000d: ldstr "message"
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_001c: stloc.1
+			IL_001d: ldloc.0
+			IL_001e: ldloc.1
+			IL_001f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0024: pop
+			IL_0025: ldnull
+			IL_0026: ret
 		} // end of method FunctionExpression_L12C21::__js_call__
 
 	} // end of class FunctionExpression_L12C21
@@ -155,7 +152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2368
+				// Method begins at RVA 0x22c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -181,26 +178,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2274
-			// Header size: 12
-			// Code size: 36 (0x24)
+			// Method begins at RVA 0x2227
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::sequence
-			IL_0006: ldstr "Cannot access 'sequence' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "finish"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
+			IL_0006: ldstr "finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L16C22::__js_call__
 
 	} // end of class FunctionExpression_L16C22
@@ -216,7 +205,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2371
+				// Method begins at RVA 0x22cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -242,58 +231,47 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x223c
 			// Header size: 12
-			// Code size: 135 (0x87)
+			// Code size: 96 (0x60)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] string,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::sequence
-			IL_0006: ldstr "Cannot access 'sequence' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "close"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::sequence
-			IL_0028: ldstr "Cannot access 'sequence' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.0
-			IL_0033: ldloc.0
-			IL_0034: ldstr "join"
-			IL_0039: ldstr ","
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0043: stloc.0
-			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0049: ldloc.0
-			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_004f: pop
-			IL_0050: ldarg.0
-			IL_0051: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
-			IL_0056: ldstr "Cannot access 'writable' before initialization"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0060: stloc.0
-			IL_0061: ldloc.0
-			IL_0062: ldstr "destroyed"
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006c: stloc.0
-			IL_006d: ldstr "destroyed:"
-			IL_0072: ldloc.0
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0078: stloc.1
-			IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_007e: ldloc.1
-			IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0084: pop
-			IL_0085: ldnull
-			IL_0086: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
+			IL_0006: ldstr "close"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldarg.0
+			IL_0012: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
+			IL_0017: ldc.i4.1
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: dup
+			IL_001e: ldc.i4.0
+			IL_001f: ldstr ","
+			IL_0024: stelem.ref
+			IL_0025: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_002a: stloc.0
+			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0030: ldloc.0
+			IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0036: pop
+			IL_0037: ldstr "destroyed:"
+			IL_003c: ldarg.0
+			IL_003d: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
+			IL_0042: ldstr "destroyed"
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0051: stloc.1
+			IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0057: ldloc.1
+			IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_005d: pop
+			IL_005e: ldnull
+			IL_005f: ret
 		} // end of method FunctionExpression_L20C21::__js_call__
 
 	} // end of class FunctionExpression_L20C21
@@ -309,27 +287,21 @@
 		)
 		// Fields
 		.field public object writable
-		.field public object sequence
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array sequence
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2337
+			// Method begins at RVA 0x22a8
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Writable_Destroy_Error/Scope::sequence
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -347,14 +319,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 407 (0x197)
+		// Code size: 345 (0x159)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Writable_Destroy_Error/Scope,
 			[1] object,
 			[2] object,
-			[3] object,
-			[4] object
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Writable_Destroy_Error/Scope::.ctor()
@@ -378,7 +349,7 @@
 		IL_0032: ldloc.0
 		IL_0033: ldc.i4.0
 		IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0039: stfld object Modules.Stream_Writable_Destroy_Error/Scope::sequence
+		IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
 		IL_003e: ldnull
 		IL_003f: ldftn object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18::__js_call__(object, object)
 		IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -389,115 +360,95 @@
 		IL_0056: stloc.2
 		IL_0057: ldloc.0
 		IL_0058: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
-		IL_005d: ldstr "Cannot access 'writable' before initialization"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0067: stloc.3
-		IL_0068: ldloc.3
-		IL_0069: ldstr "_write"
-		IL_006e: ldloc.2
-		IL_006f: ldc.i4.1
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0075: pop
-		IL_0076: ldloc.0
-		IL_0077: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
-		IL_007c: ldstr "Cannot access 'writable' before initialization"
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0086: stloc.2
-		IL_0087: ldc.i4.1
-		IL_0088: newarr [System.Runtime]System.Object
-		IL_008d: dup
-		IL_008e: ldc.i4.0
-		IL_008f: ldloc.0
-		IL_0090: stelem.ref
-		IL_0091: ldc.i4.0
-		IL_0092: ldelem.ref
-		IL_0093: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_0098: ldftn object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object, object)
-		IL_009e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00a3: ldc.i4.1
-		IL_00a4: conv.r8
-		IL_00a5: ldstr ""
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00af: stloc.3
-		IL_00b0: ldloc.2
-		IL_00b1: ldstr "on"
-		IL_00b6: ldstr "error"
-		IL_00bb: ldloc.3
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00c1: pop
-		IL_00c2: ldloc.0
-		IL_00c3: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
-		IL_00c8: ldstr "Cannot access 'writable' before initialization"
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00d2: stloc.3
-		IL_00d3: ldc.i4.1
-		IL_00d4: newarr [System.Runtime]System.Object
-		IL_00d9: dup
-		IL_00da: ldc.i4.0
-		IL_00db: ldloc.0
-		IL_00dc: stelem.ref
-		IL_00dd: ldc.i4.0
-		IL_00de: ldelem.ref
-		IL_00df: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_00e4: ldftn object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
-		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ef: ldc.i4.0
-		IL_00f0: conv.r8
-		IL_00f1: ldstr ""
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00fb: stloc.2
-		IL_00fc: ldloc.3
-		IL_00fd: ldstr "on"
-		IL_0102: ldstr "finish"
-		IL_0107: ldloc.2
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_010d: pop
-		IL_010e: ldloc.0
-		IL_010f: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
-		IL_0114: ldstr "Cannot access 'writable' before initialization"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_011e: stloc.2
-		IL_011f: ldc.i4.1
-		IL_0120: newarr [System.Runtime]System.Object
-		IL_0125: dup
-		IL_0126: ldc.i4.0
-		IL_0127: ldloc.0
-		IL_0128: stelem.ref
-		IL_0129: ldc.i4.0
-		IL_012a: ldelem.ref
-		IL_012b: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_0130: ldftn object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
-		IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_013b: ldc.i4.0
-		IL_013c: conv.r8
-		IL_013d: ldstr ""
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0147: stloc.3
-		IL_0148: ldloc.2
-		IL_0149: ldstr "on"
-		IL_014e: ldstr "close"
-		IL_0153: ldloc.3
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0159: pop
-		IL_015a: ldloc.0
-		IL_015b: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
-		IL_0160: ldstr "Cannot access 'writable' before initialization"
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_016a: stloc.3
-		IL_016b: ldloc.3
-		IL_016c: ldstr "write"
-		IL_0171: ldstr "x"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_017b: stloc.3
-		IL_017c: ldstr "write-return:"
-		IL_0181: ldloc.3
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0187: stloc.s 4
-		IL_0189: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018e: ldloc.s 4
-		IL_0190: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0195: pop
-		IL_0196: ret
+		IL_005d: ldstr "_write"
+		IL_0062: ldloc.2
+		IL_0063: ldc.i4.1
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0069: pop
+		IL_006a: ldc.i4.1
+		IL_006b: newarr [System.Runtime]System.Object
+		IL_0070: dup
+		IL_0071: ldc.i4.0
+		IL_0072: ldloc.0
+		IL_0073: stelem.ref
+		IL_0074: ldc.i4.0
+		IL_0075: ldelem.ref
+		IL_0076: castclass Modules.Stream_Writable_Destroy_Error/Scope
+		IL_007b: ldftn object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object, object)
+		IL_0081: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0086: ldc.i4.1
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0092: stloc.2
+		IL_0093: ldloc.0
+		IL_0094: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
+		IL_0099: ldstr "on"
+		IL_009e: ldstr "error"
+		IL_00a3: ldloc.2
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00a9: pop
+		IL_00aa: ldc.i4.1
+		IL_00ab: newarr [System.Runtime]System.Object
+		IL_00b0: dup
+		IL_00b1: ldc.i4.0
+		IL_00b2: ldloc.0
+		IL_00b3: stelem.ref
+		IL_00b4: ldc.i4.0
+		IL_00b5: ldelem.ref
+		IL_00b6: castclass Modules.Stream_Writable_Destroy_Error/Scope
+		IL_00bb: ldftn object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
+		IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00c6: ldc.i4.0
+		IL_00c7: conv.r8
+		IL_00c8: ldstr ""
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00d2: stloc.2
+		IL_00d3: ldloc.0
+		IL_00d4: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
+		IL_00d9: ldstr "on"
+		IL_00de: ldstr "finish"
+		IL_00e3: ldloc.2
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00e9: pop
+		IL_00ea: ldc.i4.1
+		IL_00eb: newarr [System.Runtime]System.Object
+		IL_00f0: dup
+		IL_00f1: ldc.i4.0
+		IL_00f2: ldloc.0
+		IL_00f3: stelem.ref
+		IL_00f4: ldc.i4.0
+		IL_00f5: ldelem.ref
+		IL_00f6: castclass Modules.Stream_Writable_Destroy_Error/Scope
+		IL_00fb: ldftn object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
+		IL_0101: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0106: ldc.i4.0
+		IL_0107: conv.r8
+		IL_0108: ldstr ""
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0112: stloc.2
+		IL_0113: ldloc.0
+		IL_0114: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
+		IL_0119: ldstr "on"
+		IL_011e: ldstr "close"
+		IL_0123: ldloc.2
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0129: pop
+		IL_012a: ldloc.0
+		IL_012b: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
+		IL_0130: ldstr "write"
+		IL_0135: ldstr "x"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_013f: stloc.2
+		IL_0140: ldstr "write-return:"
+		IL_0145: ldloc.2
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_014b: stloc.3
+		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0151: ldloc.3
+		IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0157: pop
+		IL_0158: ret
 	} // end of method Stream_Writable_Destroy_Error::__js_module_init__
 
 } // end of class Modules.Stream_Writable_Destroy_Error
@@ -509,7 +460,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x237a
+		// Method begins at RVA 0x22d5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
+++ b/tests/Js2IL.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e7
+				// Method begins at RVA 0x2278
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,26 +45,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21c8
-			// Header size: 12
-			// Code size: 32 (0x20)
+			// Method begins at RVA 0x21c5
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::written
-			IL_0006: ldstr "Cannot access 'written' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldarg.2
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001d: pop
-			IL_001e: ldnull
-			IL_001f: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::written
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L10C18::__js_call__
 
 	} // end of class FunctionExpression_L10C18
@@ -80,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f0
+				// Method begins at RVA 0x2281
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,26 +98,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21f4
-			// Header size: 12
-			// Code size: 36 (0x24)
+			// Method begins at RVA 0x21d5
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
-			IL_0006: ldstr "Cannot access 'sequence' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "drain"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
+			IL_0006: ldstr "drain"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L14C21::__js_call__
 
 	} // end of class FunctionExpression_L14C21
@@ -141,7 +125,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f9
+				// Method begins at RVA 0x228a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -167,63 +151,57 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2224
+			// Method begins at RVA 0x21ec
 			// Header size: 12
-			// Code size: 152 (0x98)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] string
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
-			IL_0006: ldstr "Cannot access 'sequence' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "finish"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
-			IL_0028: ldstr "Cannot access 'sequence' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.0
-			IL_0033: ldloc.0
-			IL_0034: ldstr "join"
-			IL_0039: ldstr ","
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0043: stloc.0
-			IL_0044: ldstr "sequence:"
-			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_004f: stloc.1
-			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0055: ldloc.1
-			IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_005b: pop
-			IL_005c: ldarg.0
-			IL_005d: ldfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::written
-			IL_0062: ldstr "Cannot access 'written' before initialization"
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_006c: stloc.0
-			IL_006d: ldloc.0
-			IL_006e: ldstr "join"
-			IL_0073: ldstr ","
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007d: stloc.0
-			IL_007e: ldstr "written:"
-			IL_0083: ldloc.0
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0089: stloc.1
-			IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_008f: ldloc.1
-			IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0095: pop
-			IL_0096: ldnull
-			IL_0097: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
+			IL_0006: ldstr "finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldarg.0
+			IL_0012: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
+			IL_0017: ldc.i4.1
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: dup
+			IL_001e: ldc.i4.0
+			IL_001f: ldstr ","
+			IL_0024: stelem.ref
+			IL_0025: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_002a: stloc.0
+			IL_002b: ldstr "sequence:"
+			IL_0030: ldloc.0
+			IL_0031: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0036: stloc.0
+			IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_003c: ldloc.0
+			IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0042: pop
+			IL_0043: ldarg.0
+			IL_0044: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::written
+			IL_0049: ldc.i4.1
+			IL_004a: newarr [System.Runtime]System.Object
+			IL_004f: dup
+			IL_0050: ldc.i4.0
+			IL_0051: ldstr ","
+			IL_0056: stelem.ref
+			IL_0057: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_005c: stloc.0
+			IL_005d: ldstr "written:"
+			IL_0062: ldloc.0
+			IL_0063: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0068: stloc.0
+			IL_0069: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_006e: ldloc.0
+			IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0074: pop
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L18C22::__js_call__
 
 	} // end of class FunctionExpression_L18C22
@@ -237,28 +215,22 @@
 			65 6e 63 65 3d 7b 73 65 71 75 65 6e 63 65 7d 00 00
 		)
 		// Fields
-		.field public object written
-		.field public object sequence
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array written
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array sequence
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22c8
+			// Method begins at RVA 0x226f
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::written
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -306,11 +278,11 @@
 		IL_002d: ldloc.0
 		IL_002e: ldc.i4.0
 		IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0034: stfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::written
+		IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::written
 		IL_0039: ldloc.0
 		IL_003a: ldc.i4.0
 		IL_003b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0040: stfld object Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
+		IL_0040: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
 		IL_0045: ldloc.2
 		IL_0046: ldstr "highWaterMark"
 		IL_004b: ldc.r8 1
@@ -423,7 +395,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2302
+		// Method begins at RVA 0x2293
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
+++ b/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2396
+				// Method begins at RVA 0x237b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x218a
+			// Method begins at RVA 0x2180
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x239f
+				// Method begins at RVA 0x2384
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b1
+			// Method begins at RVA 0x21a7
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a8
+				// Method begins at RVA 0x238d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -151,7 +151,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21ba
 			// Header size: 1
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -189,7 +189,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23ba
+					// Method begins at RVA 0x239f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -212,7 +212,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2358
+				// Method begins at RVA 0x2348
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -234,7 +234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23c3
+					// Method begins at RVA 0x23a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -257,7 +257,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x235b
+				// Method begins at RVA 0x234b
 				// Header size: 1
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -294,7 +294,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23cc
+					// Method begins at RVA 0x23b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -314,7 +314,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23d5
+					// Method begins at RVA 0x23ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -332,7 +332,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b1
+				// Method begins at RVA 0x2396
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -358,9 +358,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x21ec
 			// Header size: 12
-			// Code size: 328 (0x148)
+			// Code size: 318 (0x13e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope,
@@ -417,79 +417,77 @@
 				IL_0078: stloc.2
 				IL_0079: ldarg.0
 				IL_007a: ldfld object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
-				IL_007f: ldstr "Cannot access 'timersPromises' before initialization"
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0089: stloc.s 7
-				IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0090: dup
-				IL_0091: ldstr "signal"
-				IL_0096: ldloc.1
-				IL_0097: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_009c: stloc.s 8
-				IL_009e: ldloc.s 7
-				IL_00a0: ldstr "setTimeout"
-				IL_00a5: ldc.r8 0.0
-				IL_00ae: box [System.Runtime]System.Double
-				IL_00b3: ldstr "value"
-				IL_00b8: ldloc.s 8
-				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_00bf: pop
-				IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_00c5: ldstr "aborted-getter-no-throw"
-				IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_00cf: pop
-				IL_00d0: leave IL_0146
+				IL_007f: stloc.s 7
+				IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0086: dup
+				IL_0087: ldstr "signal"
+				IL_008c: ldloc.1
+				IL_008d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0092: stloc.s 8
+				IL_0094: ldloc.s 7
+				IL_0096: ldstr "setTimeout"
+				IL_009b: ldc.r8 0.0
+				IL_00a4: box [System.Runtime]System.Double
+				IL_00a9: ldstr "value"
+				IL_00ae: ldloc.s 8
+				IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_00b5: pop
+				IL_00b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_00bb: ldstr "aborted-getter-no-throw"
+				IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_00c5: pop
+				IL_00c6: leave IL_013c
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_00d5: stloc.3
-				IL_00d6: ldloc.3
-				IL_00d7: dup
-				IL_00d8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_00dd: dup
-				IL_00de: brtrue IL_00f4
+				IL_00cb: stloc.3
+				IL_00cc: ldloc.3
+				IL_00cd: dup
+				IL_00ce: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_00d3: dup
+				IL_00d4: brtrue IL_00ea
 
-				IL_00e3: pop
-				IL_00e4: dup
-				IL_00e5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_00ea: dup
-				IL_00eb: brtrue IL_0101
+				IL_00d9: pop
+				IL_00da: dup
+				IL_00db: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_00e0: dup
+				IL_00e1: brtrue IL_00f7
 
-				IL_00f0: pop
-				IL_00f1: pop
-				IL_00f2: rethrow
+				IL_00e6: pop
+				IL_00e7: pop
+				IL_00e8: rethrow
 
-				IL_00f4: pop
-				IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_00fa: stloc.s 4
-				IL_00fc: br IL_0104
+				IL_00ea: pop
+				IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_00f0: stloc.s 4
+				IL_00f2: br IL_00fa
 
-				IL_0101: pop
-				IL_0102: stloc.s 4
+				IL_00f7: pop
+				IL_00f8: stloc.s 4
 
-				IL_0104: ldloc.s 4
-				IL_0106: stloc.s 7
-				IL_0108: ldloc.s 7
-				IL_010a: stloc.s 5
-				IL_010c: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope/Block_L40C20::.ctor()
-				IL_0111: stloc.s 6
-				IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0118: ldloc.s 5
-				IL_011a: ldstr "name"
-				IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0129: pop
-				IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_012f: ldloc.s 5
-				IL_0131: ldstr "message"
-				IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_013b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0140: pop
-				IL_0141: leave IL_0146
+				IL_00fa: ldloc.s 4
+				IL_00fc: stloc.s 7
+				IL_00fe: ldloc.s 7
+				IL_0100: stloc.s 5
+				IL_0102: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope/Block_L40C20::.ctor()
+				IL_0107: stloc.s 6
+				IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_010e: ldloc.s 5
+				IL_0110: ldstr "name"
+				IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_011f: pop
+				IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0125: ldloc.s 5
+				IL_0127: ldstr "message"
+				IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0136: pop
+				IL_0137: leave IL_013c
 			} // end handler
 
-			IL_0146: ldnull
-			IL_0147: ret
+			IL_013c: ldnull
+			IL_013d: ret
 		} // end of method FunctionExpression_L24C8::__js_call__
 
 	} // end of class FunctionExpression_L24C8
@@ -509,18 +507,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2382
+			// Method begins at RVA 0x2372
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -538,7 +533,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 302 (0x12e)
+		// Code size: 292 (0x124)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope,
@@ -581,74 +576,72 @@
 		IL_0058: pop
 		IL_0059: ldloc.0
 		IL_005a: ldfld object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
-		IL_005f: ldstr "Cannot access 'timersPromises' before initialization"
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0069: stloc.3
-		IL_006a: ldloc.3
-		IL_006b: ldstr "setTimeout"
-		IL_0070: ldc.r8 0.0
-		IL_0079: box [System.Runtime]System.Double
-		IL_007e: ldstr "value"
-		IL_0083: ldloc.1
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0089: stloc.3
-		IL_008a: ldloc.3
-		IL_008b: stloc.2
-		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0091: ldloc.2
-		IL_0092: ldstr "then"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009c: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a6: pop
-		IL_00a7: ldnull
-		IL_00a8: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
-		IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00b3: ldc.i4.0
-		IL_00b4: conv.r8
-		IL_00b5: ldstr ""
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00bf: stloc.3
-		IL_00c0: ldloc.2
-		IL_00c1: ldstr "then"
-		IL_00c6: ldloc.3
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00cc: stloc.3
-		IL_00cd: ldnull
-		IL_00ce: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
-		IL_00d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00d9: ldc.i4.1
-		IL_00da: conv.r8
-		IL_00db: ldstr ""
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00e5: stloc.s 5
-		IL_00e7: ldloc.3
-		IL_00e8: ldstr "catch"
-		IL_00ed: ldloc.s 5
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f4: stloc.s 5
-		IL_00f6: ldc.i4.1
-		IL_00f7: newarr [System.Runtime]System.Object
-		IL_00fc: dup
-		IL_00fd: ldc.i4.0
-		IL_00fe: ldloc.0
-		IL_00ff: stelem.ref
-		IL_0100: ldc.i4.0
-		IL_0101: ldelem.ref
-		IL_0102: castclass Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope
-		IL_0107: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
-		IL_010d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0112: ldc.i4.0
-		IL_0113: conv.r8
-		IL_0114: ldstr ""
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_011e: stloc.3
-		IL_011f: ldloc.s 5
-		IL_0121: ldstr "then"
-		IL_0126: ldloc.3
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_012c: pop
-		IL_012d: ret
+		IL_005f: stloc.3
+		IL_0060: ldloc.3
+		IL_0061: ldstr "setTimeout"
+		IL_0066: ldc.r8 0.0
+		IL_006f: box [System.Runtime]System.Double
+		IL_0074: ldstr "value"
+		IL_0079: ldloc.1
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_007f: stloc.3
+		IL_0080: ldloc.3
+		IL_0081: stloc.2
+		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0087: ldloc.2
+		IL_0088: ldstr "then"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0092: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009c: pop
+		IL_009d: ldnull
+		IL_009e: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
+		IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a9: ldc.i4.0
+		IL_00aa: conv.r8
+		IL_00ab: ldstr ""
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00b5: stloc.3
+		IL_00b6: ldloc.2
+		IL_00b7: ldstr "then"
+		IL_00bc: ldloc.3
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c2: stloc.3
+		IL_00c3: ldnull
+		IL_00c4: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
+		IL_00ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00cf: ldc.i4.1
+		IL_00d0: conv.r8
+		IL_00d1: ldstr ""
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00db: stloc.s 5
+		IL_00dd: ldloc.3
+		IL_00de: ldstr "catch"
+		IL_00e3: ldloc.s 5
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ea: stloc.s 5
+		IL_00ec: ldc.i4.1
+		IL_00ed: newarr [System.Runtime]System.Object
+		IL_00f2: dup
+		IL_00f3: ldc.i4.0
+		IL_00f4: ldloc.0
+		IL_00f5: stelem.ref
+		IL_00f6: ldc.i4.0
+		IL_00f7: ldelem.ref
+		IL_00f8: castclass Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope
+		IL_00fd: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
+		IL_0103: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0108: ldc.i4.0
+		IL_0109: conv.r8
+		IL_010a: ldstr ""
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0114: stloc.3
+		IL_0115: ldloc.s 5
+		IL_0117: ldstr "then"
+		IL_011c: ldloc.3
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0122: pop
+		IL_0123: ret
 	} // end of method TimersPromises_Abort_GetterErrors_SurfaceCorrectly::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly
@@ -660,7 +653,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23de
+		// Method begins at RVA 0x23c3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2593
+						// Method begins at RVA 0x2539
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x258a
+					// Method begins at RVA 0x2530
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23f4
+				// Method begins at RVA 0x23d4
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -115,7 +115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25a5
+						// Method begins at RVA 0x254b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x259c
+					// Method begins at RVA 0x2542
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x240c
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -237,7 +237,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25b7
+						// Method begins at RVA 0x255d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ae
+					// Method begins at RVA 0x2554
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -279,9 +279,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x2490
 				// Header size: 12
-				// Code size: 136 (0x88)
+				// Code size: 100 (0x64)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/Scope/Block_L24C27,
@@ -294,51 +294,39 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
 				IL_0008: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
-				IL_000d: ldstr "Cannot access 'signal' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.1
-				IL_0018: ldloc.1
-				IL_0019: ldstr "aborted"
-				IL_001e: ldc.i4.1
-				IL_001f: box [System.Runtime]System.Boolean
-				IL_0024: ldc.i4.1
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_002a: pop
-				IL_002b: ldarg.0
-				IL_002c: ldc.i4.1
-				IL_002d: ldelem.ref
-				IL_002e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
-				IL_0033: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
-				IL_0038: ldstr "Cannot access 'signal' before initialization"
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0042: stloc.1
-				IL_0043: ldloc.1
-				IL_0044: ldstr "listener"
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_004e: stloc.1
-				IL_004f: ldloc.1
-				IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0055: stloc.2
-				IL_0056: ldloc.2
-				IL_0057: brfalse IL_0086
+				IL_000d: stloc.1
+				IL_000e: ldloc.1
+				IL_000f: ldstr "aborted"
+				IL_0014: ldc.i4.1
+				IL_0015: box [System.Runtime]System.Boolean
+				IL_001a: ldc.i4.1
+				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0020: pop
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.1
+				IL_0023: ldelem.ref
+				IL_0024: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
+				IL_0029: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
+				IL_002e: ldstr "listener"
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0038: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_003d: stloc.2
+				IL_003e: ldloc.2
+				IL_003f: brfalse IL_0062
 
-				IL_005c: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/Scope/Block_L24C27::.ctor()
-				IL_0061: stloc.0
-				IL_0062: ldarg.0
-				IL_0063: ldc.i4.1
-				IL_0064: ldelem.ref
-				IL_0065: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
-				IL_006a: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
-				IL_006f: ldstr "Cannot access 'signal' before initialization"
-				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0079: stloc.1
-				IL_007a: ldloc.1
-				IL_007b: ldstr "listener"
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0085: pop
+				IL_0044: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/Scope/Block_L24C27::.ctor()
+				IL_0049: stloc.0
+				IL_004a: ldarg.0
+				IL_004b: ldc.i4.1
+				IL_004c: ldelem.ref
+				IL_004d: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
+				IL_0052: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
+				IL_0057: ldstr "listener"
+				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0061: pop
 
-				IL_0086: ldnull
-				IL_0087: ret
+				IL_0062: ldnull
+				IL_0063: ret
 			} // end of method FunctionExpression_L22C11::__js_call__
 
 		} // end of class FunctionExpression_L22C11
@@ -357,18 +345,15 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2576
+				// Method begins at RVA 0x2527
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -386,9 +371,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x21dc
+			// Method begins at RVA 0x21d0
 			// Header size: 12
-			// Code size: 192 (0xc0)
+			// Code size: 180 (0xb4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope,
@@ -432,40 +417,36 @@
 			IL_0062: ldloc.0
 			IL_0063: ldloc.3
 			IL_0064: stfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
-			IL_0069: ldloc.0
-			IL_006a: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
-			IL_006f: ldstr "Cannot access 'signal' before initialization"
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0079: stloc.2
-			IL_007a: ldc.i4.2
-			IL_007b: newarr [System.Runtime]System.Object
-			IL_0080: dup
-			IL_0081: ldc.i4.0
-			IL_0082: ldarg.0
-			IL_0083: stelem.ref
-			IL_0084: dup
-			IL_0085: ldc.i4.1
-			IL_0086: ldloc.0
-			IL_0087: stelem.ref
-			IL_0088: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11::__js_call__(object[], object)
-			IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0093: ldc.i4.0
-			IL_0094: conv.r8
-			IL_0095: ldstr ""
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_009f: stloc.1
-			IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0069: ldc.i4.2
+			IL_006a: newarr [System.Runtime]System.Object
+			IL_006f: dup
+			IL_0070: ldc.i4.0
+			IL_0071: ldarg.0
+			IL_0072: stelem.ref
+			IL_0073: dup
+			IL_0074: ldc.i4.1
+			IL_0075: ldloc.0
+			IL_0076: stelem.ref
+			IL_0077: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11::__js_call__(object[], object)
+			IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0082: ldc.i4.0
+			IL_0083: conv.r8
+			IL_0084: ldstr ""
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_008e: stloc.2
+			IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0094: dup
+			IL_0095: ldstr "signal"
+			IL_009a: ldloc.0
+			IL_009b: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
+			IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_00a5: dup
-			IL_00a6: ldstr "signal"
+			IL_00a6: ldstr "abort"
 			IL_00ab: ldloc.2
 			IL_00ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00b1: dup
-			IL_00b2: ldstr "abort"
-			IL_00b7: ldloc.1
-			IL_00b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00bd: stloc.3
-			IL_00be: ldloc.3
-			IL_00bf: ret
+			IL_00b1: stloc.3
+			IL_00b2: ldloc.3
+			IL_00b3: ret
 		} // end of method createController::__js_call__
 
 	} // end of class createController
@@ -481,7 +462,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c0
+				// Method begins at RVA 0x2566
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -505,7 +486,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a8
+			// Method begins at RVA 0x2290
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -545,7 +526,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c9
+				// Method begins at RVA 0x256f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -568,7 +549,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22e0
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -594,7 +575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d2
+				// Method begins at RVA 0x2578
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -621,7 +602,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x230b
+			// Method begins at RVA 0x22f3
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -651,7 +632,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25e4
+					// Method begins at RVA 0x258a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +655,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2544
+				// Method begins at RVA 0x2500
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -700,7 +681,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ed
+					// Method begins at RVA 0x2593
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +706,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2557
+				// Method begins at RVA 0x2513
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -747,7 +728,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25db
+				// Method begins at RVA 0x2581
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -773,9 +754,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x2300
 			// Header size: 12
-			// Code size: 207 (0xcf)
+			// Code size: 197 (0xc5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope,
@@ -808,58 +789,56 @@
 			IL_0036: pop
 			IL_0037: ldarg.0
 			IL_0038: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-			IL_003d: ldstr "Cannot access 'timersPromises' before initialization"
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0047: stloc.2
-			IL_0048: ldloc.2
-			IL_0049: ldstr "setImmediate"
-			IL_004e: ldstr "immediate-value"
-			IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0058: dup
-			IL_0059: ldstr "signal"
-			IL_005e: ldloc.1
-			IL_005f: ldstr "signal"
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0069: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0073: stloc.2
-			IL_0074: ldnull
-			IL_0075: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
-			IL_007b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0080: ldc.i4.0
-			IL_0081: conv.r8
-			IL_0082: ldstr ""
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_008c: stloc.3
-			IL_008d: ldloc.2
-			IL_008e: ldstr "then"
-			IL_0093: ldloc.3
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0099: stloc.3
-			IL_009a: ldc.i4.2
-			IL_009b: newarr [System.Runtime]System.Object
-			IL_00a0: dup
-			IL_00a1: ldc.i4.0
-			IL_00a2: ldarg.0
-			IL_00a3: stelem.ref
-			IL_00a4: dup
-			IL_00a5: ldc.i4.1
-			IL_00a6: ldloc.0
-			IL_00a7: stelem.ref
-			IL_00a8: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
-			IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00b3: ldc.i4.1
-			IL_00b4: conv.r8
-			IL_00b5: ldstr ""
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00bf: stloc.2
-			IL_00c0: ldloc.3
-			IL_00c1: ldstr "catch"
-			IL_00c6: ldloc.2
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00cc: stloc.2
-			IL_00cd: ldloc.2
-			IL_00ce: ret
+			IL_003d: stloc.2
+			IL_003e: ldloc.2
+			IL_003f: ldstr "setImmediate"
+			IL_0044: ldstr "immediate-value"
+			IL_0049: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004e: dup
+			IL_004f: ldstr "signal"
+			IL_0054: ldloc.1
+			IL_0055: ldstr "signal"
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0069: stloc.2
+			IL_006a: ldnull
+			IL_006b: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
+			IL_0071: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0076: ldc.i4.0
+			IL_0077: conv.r8
+			IL_0078: ldstr ""
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0082: stloc.3
+			IL_0083: ldloc.2
+			IL_0084: ldstr "then"
+			IL_0089: ldloc.3
+			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_008f: stloc.3
+			IL_0090: ldc.i4.2
+			IL_0091: newarr [System.Runtime]System.Object
+			IL_0096: dup
+			IL_0097: ldc.i4.0
+			IL_0098: ldarg.0
+			IL_0099: stelem.ref
+			IL_009a: dup
+			IL_009b: ldc.i4.1
+			IL_009c: ldloc.0
+			IL_009d: stelem.ref
+			IL_009e: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
+			IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00a9: ldc.i4.1
+			IL_00aa: conv.r8
+			IL_00ab: ldstr ""
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_00b5: stloc.2
+			IL_00b6: ldloc.3
+			IL_00b7: ldstr "catch"
+			IL_00bc: ldloc.2
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c2: stloc.2
+			IL_00c3: ldloc.2
+			IL_00c4: ret
 		} // end of method FunctionExpression_L48C8::__js_call__
 
 	} // end of class FunctionExpression_L48C8
@@ -885,18 +864,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2562
+			// Method begins at RVA 0x251e
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -914,7 +890,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 382 (0x17e)
+		// Code size: 372 (0x174)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope,
@@ -981,85 +957,83 @@
 		IL_008d: stloc.1
 		IL_008e: ldloc.0
 		IL_008f: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-		IL_0094: ldstr "Cannot access 'timersPromises' before initialization"
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_009e: stloc.3
-		IL_009f: ldloc.3
-		IL_00a0: ldstr "setTimeout"
-		IL_00a5: ldc.r8 0.0
-		IL_00ae: box [System.Runtime]System.Double
-		IL_00b3: ldstr "timeout-value"
-		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00bd: dup
-		IL_00be: ldstr "signal"
-		IL_00c3: ldloc.1
-		IL_00c4: ldstr "signal"
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00d8: stloc.3
-		IL_00d9: ldloc.3
-		IL_00da: stloc.2
-		IL_00db: ldloc.1
-		IL_00dc: ldstr "abort"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00e6: pop
-		IL_00e7: ldnull
-		IL_00e8: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
-		IL_00ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00f3: ldc.i4.0
-		IL_00f4: conv.r8
-		IL_00f5: ldstr ""
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00ff: stloc.3
-		IL_0100: ldloc.2
-		IL_0101: ldstr "then"
-		IL_0106: ldloc.3
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010c: stloc.3
-		IL_010d: ldc.i4.1
-		IL_010e: newarr [System.Runtime]System.Object
-		IL_0113: dup
-		IL_0114: ldc.i4.0
-		IL_0115: ldloc.0
-		IL_0116: stelem.ref
-		IL_0117: ldc.i4.0
-		IL_0118: ldelem.ref
-		IL_0119: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_011e: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
-		IL_0124: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0129: ldc.i4.1
-		IL_012a: conv.r8
-		IL_012b: ldstr ""
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0135: stloc.s 4
-		IL_0137: ldloc.3
-		IL_0138: ldstr "catch"
-		IL_013d: ldloc.s 4
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0144: stloc.s 4
-		IL_0146: ldc.i4.1
-		IL_0147: newarr [System.Runtime]System.Object
-		IL_014c: dup
-		IL_014d: ldc.i4.0
-		IL_014e: ldloc.0
-		IL_014f: stelem.ref
-		IL_0150: ldc.i4.0
-		IL_0151: ldelem.ref
-		IL_0152: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0157: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0162: ldc.i4.0
-		IL_0163: conv.r8
-		IL_0164: ldstr ""
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_016e: stloc.3
-		IL_016f: ldloc.s 4
-		IL_0171: ldstr "then"
-		IL_0176: ldloc.3
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_017c: pop
-		IL_017d: ret
+		IL_0094: stloc.3
+		IL_0095: ldloc.3
+		IL_0096: ldstr "setTimeout"
+		IL_009b: ldc.r8 0.0
+		IL_00a4: box [System.Runtime]System.Double
+		IL_00a9: ldstr "timeout-value"
+		IL_00ae: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00b3: dup
+		IL_00b4: ldstr "signal"
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "signal"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00ce: stloc.3
+		IL_00cf: ldloc.3
+		IL_00d0: stloc.2
+		IL_00d1: ldloc.1
+		IL_00d2: ldstr "abort"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00dc: pop
+		IL_00dd: ldnull
+		IL_00de: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
+		IL_00e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00e9: ldc.i4.0
+		IL_00ea: conv.r8
+		IL_00eb: ldstr ""
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00f5: stloc.3
+		IL_00f6: ldloc.2
+		IL_00f7: ldstr "then"
+		IL_00fc: ldloc.3
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0102: stloc.3
+		IL_0103: ldc.i4.1
+		IL_0104: newarr [System.Runtime]System.Object
+		IL_0109: dup
+		IL_010a: ldc.i4.0
+		IL_010b: ldloc.0
+		IL_010c: stelem.ref
+		IL_010d: ldc.i4.0
+		IL_010e: ldelem.ref
+		IL_010f: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0114: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
+		IL_011a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_011f: ldc.i4.1
+		IL_0120: conv.r8
+		IL_0121: ldstr ""
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_012b: stloc.s 4
+		IL_012d: ldloc.3
+		IL_012e: ldstr "catch"
+		IL_0133: ldloc.s 4
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_013a: stloc.s 4
+		IL_013c: ldc.i4.1
+		IL_013d: newarr [System.Runtime]System.Object
+		IL_0142: dup
+		IL_0143: ldc.i4.0
+		IL_0144: ldloc.0
+		IL_0145: stelem.ref
+		IL_0146: ldc.i4.0
+		IL_0147: ldelem.ref
+		IL_0148: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_014d: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+		IL_0153: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0158: ldc.i4.0
+		IL_0159: conv.r8
+		IL_015a: ldstr ""
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0164: stloc.3
+		IL_0165: ldloc.s 4
+		IL_0167: ldstr "then"
+		IL_016c: ldloc.3
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0172: pop
+		IL_0173: ret
 	} // end of method TimersPromises_Abort_RejectsSupportedOneShotApis::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis
@@ -1071,7 +1045,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25f6
+		// Method begins at RVA 0x259c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
+++ b/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2351
+				// Method begins at RVA 0x22aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,26 +44,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2180
-			// Header size: 12
-			// Code size: 36 (0x24)
+			// Method begins at RVA 0x2163
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "nextTick"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+			IL_0006: ldstr "nextTick"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L8C17::__js_call__
 
 	} // end of class FunctionExpression_L8C17
@@ -79,7 +71,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235a
+				// Method begins at RVA 0x22b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,26 +97,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21b0
-			// Header size: 12
-			// Code size: 36 (0x24)
+			// Method begins at RVA 0x2177
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-			IL_0006: ldstr "Cannot access 'order' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "promise"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+			IL_0006: ldstr "promise"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L12C24::__js_call__
 
 	} // end of class FunctionExpression_L12C24
@@ -144,7 +128,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x236c
+					// Method begins at RVA 0x22c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -169,12 +153,12 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2278
+				// Method begins at RVA 0x2208
 				// Header size: 12
-				// Code size: 174 (0xae)
+				// Code size: 141 (0x8d)
 				.maxstack 8
 				.locals init (
-					[0] object,
+					[0] string,
 					[1] bool,
 					[2] object
 				)
@@ -183,60 +167,55 @@
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-				IL_0008: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-				IL_000d: ldstr "Cannot access 'order' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.0
-				IL_0018: ldloc.0
-				IL_0019: ldstr "push"
-				IL_001e: ldarg.2
-				IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0024: pop
-				IL_0025: ldarg.0
-				IL_0026: ldc.i4.0
-				IL_0027: ldelem.ref
-				IL_0028: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-				IL_002d: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-				IL_0032: ldstr "Cannot access 'order' before initialization"
-				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_003c: stloc.0
-				IL_003d: ldloc.0
-				IL_003e: ldstr "join"
-				IL_0043: ldstr ","
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004d: stloc.0
-				IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0053: ldstr "order"
-				IL_0058: ldloc.0
-				IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_005e: pop
-				IL_005f: ldarg.0
-				IL_0060: ldc.i4.0
-				IL_0061: ldelem.ref
-				IL_0062: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-				IL_0067: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-				IL_006c: ldstr "Cannot access 'order' before initialization"
-				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0076: stloc.0
-				IL_0077: ldloc.0
-				IL_0078: ldstr "join"
-				IL_007d: ldstr ","
-				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0087: stloc.0
-				IL_0088: ldloc.0
-				IL_0089: ldstr "sync,nextTick,promise,immediate,timeout"
-				IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0093: stloc.1
-				IL_0094: ldloc.1
-				IL_0095: box [System.Runtime]System.Boolean
-				IL_009a: stloc.2
-				IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_00a0: ldstr "correct"
-				IL_00a5: ldloc.2
-				IL_00a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_00ab: pop
-				IL_00ac: ldnull
-				IL_00ad: ret
+				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+				IL_000d: ldarg.2
+				IL_000e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0013: pop
+				IL_0014: ldarg.0
+				IL_0015: ldc.i4.0
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+				IL_001c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+				IL_0021: ldc.i4.1
+				IL_0022: newarr [System.Runtime]System.Object
+				IL_0027: dup
+				IL_0028: ldc.i4.0
+				IL_0029: ldstr ","
+				IL_002e: stelem.ref
+				IL_002f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_0034: stloc.0
+				IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_003a: ldstr "order"
+				IL_003f: ldloc.0
+				IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0045: pop
+				IL_0046: ldarg.0
+				IL_0047: ldc.i4.0
+				IL_0048: ldelem.ref
+				IL_0049: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+				IL_004e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+				IL_0053: ldc.i4.1
+				IL_0054: newarr [System.Runtime]System.Object
+				IL_0059: dup
+				IL_005a: ldc.i4.0
+				IL_005b: ldstr ","
+				IL_0060: stelem.ref
+				IL_0061: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_0066: stloc.0
+				IL_0067: ldloc.0
+				IL_0068: ldstr "sync,nextTick,promise,immediate,timeout"
+				IL_006d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0072: stloc.1
+				IL_0073: ldloc.1
+				IL_0074: box [System.Runtime]System.Boolean
+				IL_0079: stloc.2
+				IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_007f: ldstr "correct"
+				IL_0084: ldloc.2
+				IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_008a: pop
+				IL_008b: ldnull
+				IL_008c: ret
 			} // end of method FunctionExpression_L19C54::__js_call__
 
 		} // end of class FunctionExpression_L19C54
@@ -248,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2363
+				// Method begins at RVA 0x22bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -275,9 +254,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21e0
+			// Method begins at RVA 0x218c
 			// Header size: 12
-			// Code size: 137 (0x89)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/Scope,
@@ -288,51 +267,44 @@
 			IL_0000: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-			IL_000c: ldstr "Cannot access 'order' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0016: stloc.1
-			IL_0017: ldloc.1
-			IL_0018: ldstr "push"
-			IL_001d: ldarg.2
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
-			IL_002a: ldstr "Cannot access 'timersPromises' before initialization"
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0034: stloc.1
-			IL_0035: ldloc.1
-			IL_0036: ldstr "setTimeout"
-			IL_003b: ldc.r8 0.0
-			IL_0044: box [System.Runtime]System.Double
-			IL_0049: ldstr "timeout"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0053: stloc.1
-			IL_0054: ldc.i4.2
-			IL_0055: newarr [System.Runtime]System.Object
-			IL_005a: dup
-			IL_005b: ldc.i4.0
-			IL_005c: ldarg.0
-			IL_005d: stelem.ref
-			IL_005e: dup
-			IL_005f: ldc.i4.1
-			IL_0060: ldloc.0
-			IL_0061: stelem.ref
-			IL_0062: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
-			IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_006d: ldc.i4.1
-			IL_006e: conv.r8
-			IL_006f: ldstr ""
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0079: stloc.2
-			IL_007a: ldloc.1
-			IL_007b: ldstr "then"
-			IL_0080: ldloc.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: stloc.2
-			IL_0087: ldloc.2
-			IL_0088: ret
+			IL_0007: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+			IL_000c: ldarg.2
+			IL_000d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0012: pop
+			IL_0013: ldarg.0
+			IL_0014: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
+			IL_0019: stloc.1
+			IL_001a: ldloc.1
+			IL_001b: ldstr "setTimeout"
+			IL_0020: ldc.r8 0.0
+			IL_0029: box [System.Runtime]System.Double
+			IL_002e: ldstr "timeout"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0038: stloc.1
+			IL_0039: ldc.i4.2
+			IL_003a: newarr [System.Runtime]System.Object
+			IL_003f: dup
+			IL_0040: ldc.i4.0
+			IL_0041: ldarg.0
+			IL_0042: stelem.ref
+			IL_0043: dup
+			IL_0044: ldc.i4.1
+			IL_0045: ldloc.0
+			IL_0046: stelem.ref
+			IL_0047: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
+			IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0052: ldc.i4.1
+			IL_0053: conv.r8
+			IL_0054: ldstr ""
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_005e: stloc.2
+			IL_005f: ldloc.1
+			IL_0060: ldstr "then"
+			IL_0065: ldloc.2
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_006b: stloc.2
+			IL_006c: ldloc.2
+			IL_006d: ret
 		} // end of method FunctionExpression_L16C46::__js_call__
 
 	} // end of class FunctionExpression_L16C46
@@ -348,27 +320,21 @@
 		)
 		// Fields
 		.field public object timersPromises
-		.field public object order
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array order
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2332
+			// Method begins at RVA 0x22a1
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -386,7 +352,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 292 (0x124)
+		// Code size: 263 (0x107)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope,
@@ -406,95 +372,86 @@
 		IL_0019: ldloc.0
 		IL_001a: ldc.i4.0
 		IL_001b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0020: stfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+		IL_0020: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
 		IL_0025: ldloc.0
-		IL_0026: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-		IL_002b: ldstr "Cannot access 'order' before initialization"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0035: stloc.1
-		IL_0036: ldloc.1
-		IL_0037: ldstr "push"
-		IL_003c: ldstr "sync"
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0046: pop
-		IL_0047: ldc.i4.1
-		IL_0048: newarr [System.Runtime]System.Object
-		IL_004d: dup
-		IL_004e: ldc.i4.0
-		IL_004f: ldloc.0
-		IL_0050: stelem.ref
-		IL_0051: ldc.i4.0
-		IL_0052: ldelem.ref
-		IL_0053: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_0058: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
-		IL_005e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0063: ldc.i4.0
-		IL_0064: conv.r8
-		IL_0065: ldstr ""
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_006f: stloc.1
-		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-		IL_0075: ldstr "nextTick"
-		IL_007a: ldloc.1
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0080: pop
-		IL_0081: ldc.r8 0.0
-		IL_008a: box [System.Runtime]System.Double
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_0094: stloc.1
-		IL_0095: ldc.i4.1
-		IL_0096: newarr [System.Runtime]System.Object
-		IL_009b: dup
-		IL_009c: ldc.i4.0
-		IL_009d: ldloc.0
-		IL_009e: stelem.ref
-		IL_009f: ldc.i4.0
-		IL_00a0: ldelem.ref
-		IL_00a1: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_00a6: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
-		IL_00ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00b1: ldc.i4.0
-		IL_00b2: conv.r8
-		IL_00b3: ldstr ""
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00bd: stloc.2
-		IL_00be: ldloc.1
-		IL_00bf: ldstr "then"
-		IL_00c4: ldloc.2
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ca: pop
-		IL_00cb: ldloc.0
-		IL_00cc: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
-		IL_00d1: ldstr "Cannot access 'timersPromises' before initialization"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00db: stloc.2
-		IL_00dc: ldloc.2
-		IL_00dd: ldstr "setImmediate"
-		IL_00e2: ldstr "immediate"
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ec: stloc.2
-		IL_00ed: ldc.i4.1
-		IL_00ee: newarr [System.Runtime]System.Object
-		IL_00f3: dup
-		IL_00f4: ldc.i4.0
-		IL_00f5: ldloc.0
-		IL_00f6: stelem.ref
-		IL_00f7: ldc.i4.0
-		IL_00f8: ldelem.ref
-		IL_00f9: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_00fe: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
-		IL_0104: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0109: ldc.i4.1
-		IL_010a: conv.r8
-		IL_010b: ldstr ""
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0115: stloc.1
-		IL_0116: ldloc.2
-		IL_0117: ldstr "then"
-		IL_011c: ldloc.1
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0122: pop
-		IL_0123: ret
+		IL_0026: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+		IL_002b: ldstr "sync"
+		IL_0030: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_0035: pop
+		IL_0036: ldc.i4.1
+		IL_0037: newarr [System.Runtime]System.Object
+		IL_003c: dup
+		IL_003d: ldc.i4.0
+		IL_003e: ldloc.0
+		IL_003f: stelem.ref
+		IL_0040: ldc.i4.0
+		IL_0041: ldelem.ref
+		IL_0042: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+		IL_0047: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
+		IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0052: ldc.i4.0
+		IL_0053: conv.r8
+		IL_0054: ldstr ""
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_005e: stloc.1
+		IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_0064: ldstr "nextTick"
+		IL_0069: ldloc.1
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_006f: pop
+		IL_0070: ldc.r8 0.0
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_0083: stloc.1
+		IL_0084: ldc.i4.1
+		IL_0085: newarr [System.Runtime]System.Object
+		IL_008a: dup
+		IL_008b: ldc.i4.0
+		IL_008c: ldloc.0
+		IL_008d: stelem.ref
+		IL_008e: ldc.i4.0
+		IL_008f: ldelem.ref
+		IL_0090: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+		IL_0095: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
+		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a0: ldc.i4.0
+		IL_00a1: conv.r8
+		IL_00a2: ldstr ""
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00ac: stloc.2
+		IL_00ad: ldloc.1
+		IL_00ae: ldstr "then"
+		IL_00b3: ldloc.2
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b9: pop
+		IL_00ba: ldloc.0
+		IL_00bb: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
+		IL_00c0: ldstr "setImmediate"
+		IL_00c5: ldstr "immediate"
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00cf: stloc.2
+		IL_00d0: ldc.i4.1
+		IL_00d1: newarr [System.Runtime]System.Object
+		IL_00d6: dup
+		IL_00d7: ldc.i4.0
+		IL_00d8: ldloc.0
+		IL_00d9: stelem.ref
+		IL_00da: ldc.i4.0
+		IL_00db: ldelem.ref
+		IL_00dc: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+		IL_00e1: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
+		IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00ec: ldc.i4.1
+		IL_00ed: conv.r8
+		IL_00ee: ldstr ""
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00f8: stloc.1
+		IL_00f9: ldloc.2
+		IL_00fa: ldstr "then"
+		IL_00ff: ldloc.1
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0105: pop
+		IL_0106: ret
 	} // end of method TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks::__js_module_init__
 
 } // end of class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
@@ -506,7 +463,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2375
+		// Method begins at RVA 0x22ce
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26a9
+						// Method begins at RVA 0x264f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a0
+					// Method begins at RVA 0x2646
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x245c
+				// Method begins at RVA 0x2448
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -115,7 +115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26bb
+						// Method begins at RVA 0x2661
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b2
+					// Method begins at RVA 0x2658
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2494
+				// Method begins at RVA 0x2480
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -237,7 +237,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26cd
+						// Method begins at RVA 0x2673
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26c4
+					// Method begins at RVA 0x266a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -280,9 +280,9 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2518
+				// Method begins at RVA 0x2504
 				// Header size: 12
-				// Code size: 174 (0xae)
+				// Code size: 126 (0x7e)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/Scope/Block_L26C27,
@@ -295,65 +295,49 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
 				IL_0008: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-				IL_000d: ldstr "Cannot access 'signal' before initialization"
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.1
-				IL_0018: ldloc.1
-				IL_0019: ldstr "aborted"
-				IL_001e: ldc.i4.1
-				IL_001f: box [System.Runtime]System.Boolean
-				IL_0024: ldc.i4.1
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_002a: pop
-				IL_002b: ldarg.0
-				IL_002c: ldc.i4.1
-				IL_002d: ldelem.ref
-				IL_002e: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
-				IL_0033: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-				IL_0038: ldstr "Cannot access 'signal' before initialization"
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0042: stloc.1
-				IL_0043: ldloc.1
-				IL_0044: ldstr "reason"
-				IL_0049: ldarg.2
-				IL_004a: ldc.i4.1
-				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0050: pop
-				IL_0051: ldarg.0
-				IL_0052: ldc.i4.1
-				IL_0053: ldelem.ref
-				IL_0054: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
-				IL_0059: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-				IL_005e: ldstr "Cannot access 'signal' before initialization"
-				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0068: stloc.1
-				IL_0069: ldloc.1
-				IL_006a: ldstr "listener"
-				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0074: stloc.1
-				IL_0075: ldloc.1
-				IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_007b: stloc.2
-				IL_007c: ldloc.2
-				IL_007d: brfalse IL_00ac
+				IL_000d: stloc.1
+				IL_000e: ldloc.1
+				IL_000f: ldstr "aborted"
+				IL_0014: ldc.i4.1
+				IL_0015: box [System.Runtime]System.Boolean
+				IL_001a: ldc.i4.1
+				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0020: pop
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.1
+				IL_0023: ldelem.ref
+				IL_0024: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
+				IL_0029: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
+				IL_002e: ldstr "reason"
+				IL_0033: ldarg.2
+				IL_0034: ldc.i4.1
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_003a: pop
+				IL_003b: ldarg.0
+				IL_003c: ldc.i4.1
+				IL_003d: ldelem.ref
+				IL_003e: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
+				IL_0043: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
+				IL_0048: ldstr "listener"
+				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0057: stloc.2
+				IL_0058: ldloc.2
+				IL_0059: brfalse IL_007c
 
-				IL_0082: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/Scope/Block_L26C27::.ctor()
-				IL_0087: stloc.0
-				IL_0088: ldarg.0
-				IL_0089: ldc.i4.1
-				IL_008a: ldelem.ref
-				IL_008b: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
-				IL_0090: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-				IL_0095: ldstr "Cannot access 'signal' before initialization"
-				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_009f: stloc.1
-				IL_00a0: ldloc.1
-				IL_00a1: ldstr "listener"
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_00ab: pop
+				IL_005e: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/Scope/Block_L26C27::.ctor()
+				IL_0063: stloc.0
+				IL_0064: ldarg.0
+				IL_0065: ldc.i4.1
+				IL_0066: ldelem.ref
+				IL_0067: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
+				IL_006c: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
+				IL_0071: ldstr "listener"
+				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_007b: pop
 
-				IL_00ac: ldnull
-				IL_00ad: ret
+				IL_007c: ldnull
+				IL_007d: ret
 			} // end of method FunctionExpression_L23C11::__js_call__
 
 		} // end of class FunctionExpression_L23C11
@@ -372,18 +356,15 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x268c
+				// Method begins at RVA 0x263d
 				// Header size: 1
-				// Code size: 19 (0x13)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-				IL_000c: stfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-				IL_0011: nop
-				IL_0012: ret
+				IL_0006: nop
+				IL_0007: ret
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
@@ -403,7 +384,7 @@
 			)
 			// Method begins at RVA 0x20dc
 			// Header size: 12
-			// Code size: 209 (0xd1)
+			// Code size: 197 (0xc5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope,
@@ -452,40 +433,36 @@
 			IL_0073: ldloc.0
 			IL_0074: ldloc.3
 			IL_0075: stfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-			IL_007a: ldloc.0
-			IL_007b: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-			IL_0080: ldstr "Cannot access 'signal' before initialization"
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_008a: stloc.2
-			IL_008b: ldc.i4.2
-			IL_008c: newarr [System.Runtime]System.Object
-			IL_0091: dup
-			IL_0092: ldc.i4.0
-			IL_0093: ldarg.0
-			IL_0094: stelem.ref
-			IL_0095: dup
-			IL_0096: ldc.i4.1
-			IL_0097: ldloc.0
-			IL_0098: stelem.ref
-			IL_0099: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11::__js_call__(object[], object, object)
-			IL_009f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00a4: ldc.i4.1
-			IL_00a5: conv.r8
-			IL_00a6: ldstr ""
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_00b0: stloc.1
-			IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_007a: ldc.i4.2
+			IL_007b: newarr [System.Runtime]System.Object
+			IL_0080: dup
+			IL_0081: ldc.i4.0
+			IL_0082: ldarg.0
+			IL_0083: stelem.ref
+			IL_0084: dup
+			IL_0085: ldc.i4.1
+			IL_0086: ldloc.0
+			IL_0087: stelem.ref
+			IL_0088: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11::__js_call__(object[], object, object)
+			IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0093: ldc.i4.1
+			IL_0094: conv.r8
+			IL_0095: ldstr ""
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_009f: stloc.2
+			IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00a5: dup
+			IL_00a6: ldstr "signal"
+			IL_00ab: ldloc.0
+			IL_00ac: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
+			IL_00b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_00b6: dup
-			IL_00b7: ldstr "signal"
+			IL_00b7: ldstr "abort"
 			IL_00bc: ldloc.2
 			IL_00bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00c2: dup
-			IL_00c3: ldstr "abort"
-			IL_00c8: ldloc.1
-			IL_00c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00ce: stloc.3
-			IL_00cf: ldloc.3
-			IL_00d0: ret
+			IL_00c2: stloc.3
+			IL_00c3: ldloc.3
+			IL_00c4: ret
 		} // end of method createController::__js_call__
 
 	} // end of class createController
@@ -505,7 +482,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26df
+					// Method begins at RVA 0x2685
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -528,7 +505,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25d2
+				// Method begins at RVA 0x258e
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -554,7 +531,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26e8
+					// Method begins at RVA 0x268e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -578,7 +555,7 @@
 				.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25e8
+				// Method begins at RVA 0x25a4
 				// Header size: 12
 				// Code size: 132 (0x84)
 				.maxstack 8
@@ -645,7 +622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26d6
+				// Method begins at RVA 0x267c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -669,9 +646,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21bc
+			// Method begins at RVA 0x21b0
 			// Header size: 12
-			// Code size: 659 (0x293)
+			// Code size: 649 (0x289)
 			.maxstack 9
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope,
@@ -744,7 +721,7 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_008e, IL_0157, IL_01c0)
+			IL_007d: switch (IL_008e, IL_014d, IL_01b6)
 
 			IL_008e: ldc.i4.1
 			IL_008f: newarr [System.Runtime]System.Object
@@ -769,181 +746,179 @@
 			IL_00b9: ldelem.ref
 			IL_00ba: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
 			IL_00bf: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
-			IL_00c4: ldstr "Cannot access 'timersPromises' before initialization"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00ce: stloc.s 5
-			IL_00d0: ldloc.s 5
-			IL_00d2: ldstr "setInterval"
-			IL_00d7: ldc.r8 0.0
-			IL_00e0: box [System.Runtime]System.Double
-			IL_00e5: ldstr "tick"
-			IL_00ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00ef: dup
-			IL_00f0: ldstr "signal"
-			IL_00f5: ldloc.1
-			IL_00f6: ldstr "signal"
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0100: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_010a: stloc.s 5
-			IL_010c: ldloc.s 5
-			IL_010e: stloc.2
-			IL_010f: ldloc.2
-			IL_0110: ldstr "next"
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_011a: stloc.s 5
-			IL_011c: ldloc.0
+			IL_00c4: stloc.s 5
+			IL_00c6: ldloc.s 5
+			IL_00c8: ldstr "setInterval"
+			IL_00cd: ldc.r8 0.0
+			IL_00d6: box [System.Runtime]System.Double
+			IL_00db: ldstr "tick"
+			IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00e5: dup
+			IL_00e6: ldstr "signal"
+			IL_00eb: ldloc.1
+			IL_00ec: ldstr "signal"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0100: stloc.s 5
+			IL_0102: ldloc.s 5
+			IL_0104: stloc.2
+			IL_0105: ldloc.2
+			IL_0106: ldstr "next"
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0110: stloc.s 5
+			IL_0112: ldloc.0
+			IL_0113: ldc.i4.1
+			IL_0114: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0119: ldloc.0
+			IL_011a: ldloc.s 5
+			IL_011c: ldarg.0
 			IL_011d: ldc.i4.1
-			IL_011e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0123: ldloc.0
-			IL_0124: ldloc.s 5
-			IL_0126: ldarg.0
-			IL_0127: ldc.i4.1
-			IL_0128: ldloc.0
-			IL_0129: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_012e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0133: ldloc.0
-			IL_0134: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0139: dup
-			IL_013a: ldc.i4.0
-			IL_013b: ldloc.1
-			IL_013c: stelem.ref
-			IL_013d: dup
-			IL_013e: ldc.i4.1
-			IL_013f: ldloc.2
-			IL_0140: stelem.ref
-			IL_0141: dup
-			IL_0142: ldc.i4.2
-			IL_0143: ldloc.3
-			IL_0144: stelem.ref
-			IL_0145: dup
-			IL_0146: ldc.i4.3
-			IL_0147: ldloc.s 4
-			IL_0149: stelem.ref
-			IL_014a: pop
-			IL_014b: ldloc.0
-			IL_014c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0151: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0156: ret
+			IL_011e: ldloc.0
+			IL_011f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0124: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0129: ldloc.0
+			IL_012a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_012f: dup
+			IL_0130: ldc.i4.0
+			IL_0131: ldloc.1
+			IL_0132: stelem.ref
+			IL_0133: dup
+			IL_0134: ldc.i4.1
+			IL_0135: ldloc.2
+			IL_0136: stelem.ref
+			IL_0137: dup
+			IL_0138: ldc.i4.2
+			IL_0139: ldloc.3
+			IL_013a: stelem.ref
+			IL_013b: dup
+			IL_013c: ldc.i4.3
+			IL_013d: ldloc.s 4
+			IL_013f: stelem.ref
+			IL_0140: pop
+			IL_0141: ldloc.0
+			IL_0142: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0147: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_014c: ret
 
-			IL_0157: ldloc.0
-			IL_0158: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
-			IL_015d: stloc.s 5
-			IL_015f: ldloc.s 5
-			IL_0161: stloc.3
-			IL_0162: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0167: ldloc.3
-			IL_0168: ldstr "value"
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0172: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0177: pop
-			IL_0178: ldloc.2
-			IL_0179: ldstr "next"
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0183: stloc.s 5
-			IL_0185: ldloc.0
+			IL_014d: ldloc.0
+			IL_014e: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
+			IL_0153: stloc.s 5
+			IL_0155: ldloc.s 5
+			IL_0157: stloc.3
+			IL_0158: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_015d: ldloc.3
+			IL_015e: ldstr "value"
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0168: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_016d: pop
+			IL_016e: ldloc.2
+			IL_016f: ldstr "next"
+			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0179: stloc.s 5
+			IL_017b: ldloc.0
+			IL_017c: ldc.i4.2
+			IL_017d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0182: ldloc.0
+			IL_0183: ldloc.s 5
+			IL_0185: ldarg.0
 			IL_0186: ldc.i4.2
-			IL_0187: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_018c: ldloc.0
-			IL_018d: ldloc.s 5
-			IL_018f: ldarg.0
-			IL_0190: ldc.i4.2
-			IL_0191: ldloc.0
-			IL_0192: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0197: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_019c: ldloc.0
-			IL_019d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01a2: dup
-			IL_01a3: ldc.i4.0
-			IL_01a4: ldloc.1
-			IL_01a5: stelem.ref
-			IL_01a6: dup
-			IL_01a7: ldc.i4.1
-			IL_01a8: ldloc.2
-			IL_01a9: stelem.ref
-			IL_01aa: dup
-			IL_01ab: ldc.i4.2
-			IL_01ac: ldloc.3
-			IL_01ad: stelem.ref
-			IL_01ae: dup
-			IL_01af: ldc.i4.3
-			IL_01b0: ldloc.s 4
-			IL_01b2: stelem.ref
-			IL_01b3: pop
-			IL_01b4: ldloc.0
-			IL_01b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01bf: ret
+			IL_0187: ldloc.0
+			IL_0188: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_018d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0192: ldloc.0
+			IL_0193: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0198: dup
+			IL_0199: ldc.i4.0
+			IL_019a: ldloc.1
+			IL_019b: stelem.ref
+			IL_019c: dup
+			IL_019d: ldc.i4.1
+			IL_019e: ldloc.2
+			IL_019f: stelem.ref
+			IL_01a0: dup
+			IL_01a1: ldc.i4.2
+			IL_01a2: ldloc.3
+			IL_01a3: stelem.ref
+			IL_01a4: dup
+			IL_01a5: ldc.i4.3
+			IL_01a6: ldloc.s 4
+			IL_01a8: stelem.ref
+			IL_01a9: pop
+			IL_01aa: ldloc.0
+			IL_01ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01b5: ret
 
-			IL_01c0: ldloc.0
-			IL_01c1: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
-			IL_01c6: stloc.s 5
-			IL_01c8: ldloc.s 5
-			IL_01ca: stloc.s 4
-			IL_01cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01d1: ldloc.s 4
-			IL_01d3: ldstr "value"
-			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01e2: pop
-			IL_01e3: ldstr "boom-reason"
-			IL_01e8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01f2: stloc.s 5
-			IL_01f4: ldloc.1
-			IL_01f5: ldstr "abort"
-			IL_01fa: ldloc.s 5
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0201: pop
-			IL_0202: ldloc.2
-			IL_0203: ldstr "next"
-			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_020d: stloc.s 5
-			IL_020f: ldnull
-			IL_0210: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
-			IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_021b: ldc.i4.0
-			IL_021c: conv.r8
-			IL_021d: ldstr ""
-			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0227: stloc.s 6
-			IL_0229: ldloc.s 5
-			IL_022b: ldstr "then"
-			IL_0230: ldloc.s 6
-			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0237: stloc.s 6
-			IL_0239: ldnull
-			IL_023a: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
-			IL_0240: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0245: ldc.i4.1
-			IL_0246: conv.r8
-			IL_0247: ldstr ""
-			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-			IL_0251: stloc.s 5
-			IL_0253: ldloc.s 6
-			IL_0255: ldstr "catch"
-			IL_025a: ldloc.s 5
-			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0261: stloc.s 5
-			IL_0263: ldloc.0
-			IL_0264: ldc.i4.m1
-			IL_0265: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_026a: ldloc.0
-			IL_026b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0270: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0275: ldarg.0
-			IL_0276: ldc.i4.1
-			IL_0277: newarr [System.Runtime]System.Object
-			IL_027c: dup
-			IL_027d: ldc.i4.0
-			IL_027e: ldloc.s 5
-			IL_0280: stelem.ref
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0286: pop
-			IL_0287: ldloc.0
-			IL_0288: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_028d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0292: ret
+			IL_01b6: ldloc.0
+			IL_01b7: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
+			IL_01bc: stloc.s 5
+			IL_01be: ldloc.s 5
+			IL_01c0: stloc.s 4
+			IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01c7: ldloc.s 4
+			IL_01c9: ldstr "value"
+			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01d8: pop
+			IL_01d9: ldstr "boom-reason"
+			IL_01de: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01e8: stloc.s 5
+			IL_01ea: ldloc.1
+			IL_01eb: ldstr "abort"
+			IL_01f0: ldloc.s 5
+			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01f7: pop
+			IL_01f8: ldloc.2
+			IL_01f9: ldstr "next"
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0203: stloc.s 5
+			IL_0205: ldnull
+			IL_0206: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
+			IL_020c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0211: ldc.i4.0
+			IL_0212: conv.r8
+			IL_0213: ldstr ""
+			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_021d: stloc.s 6
+			IL_021f: ldloc.s 5
+			IL_0221: ldstr "then"
+			IL_0226: ldloc.s 6
+			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_022d: stloc.s 6
+			IL_022f: ldnull
+			IL_0230: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
+			IL_0236: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_023b: ldc.i4.1
+			IL_023c: conv.r8
+			IL_023d: ldstr ""
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+			IL_0247: stloc.s 5
+			IL_0249: ldloc.s 6
+			IL_024b: ldstr "catch"
+			IL_0250: ldloc.s 5
+			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0257: stloc.s 5
+			IL_0259: ldloc.0
+			IL_025a: ldc.i4.m1
+			IL_025b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0260: ldloc.0
+			IL_0261: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0266: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_026b: ldarg.0
+			IL_026c: ldc.i4.1
+			IL_026d: newarr [System.Runtime]System.Object
+			IL_0272: dup
+			IL_0273: ldc.i4.0
+			IL_0274: ldloc.s 5
+			IL_0276: stelem.ref
+			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_027c: pop
+			IL_027d: ldloc.0
+			IL_027e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0283: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0288: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -968,18 +943,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2678
+			// Method begins at RVA 0x2634
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1069,7 +1041,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26f1
+		// Method begins at RVA 0x2697
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
+++ b/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
@@ -49,7 +49,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x256a
+				// Method begins at RVA 0x2541
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -75,7 +75,7 @@
 			)
 			// Method begins at RVA 0x20ac
 			// Header size: 12
-			// Code size: 1182 (0x49e)
+			// Code size: 1152 (0x480)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope,
@@ -157,461 +157,455 @@
 
 			IL_0081: ldloc.0
 			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0087: switch (IL_00ac, IL_013b, IL_01ec, IL_026d, IL_02c6, IL_0323, IL_03db, IL_0450)
+			IL_0087: switch (IL_00ac, IL_0131, IL_01d8, IL_024f, IL_02a8, IL_0305, IL_03bd, IL_0432)
 
 			IL_00ac: ldarg.0
 			IL_00ad: ldc.i4.1
 			IL_00ae: ldelem.ref
 			IL_00af: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
 			IL_00b4: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_00b9: ldstr "Cannot access 'timersPromises' before initialization"
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c3: stloc.s 7
-			IL_00c5: ldloc.s 7
-			IL_00c7: ldstr "setInterval"
-			IL_00cc: ldc.r8 0.0
-			IL_00d5: box [System.Runtime]System.Double
-			IL_00da: ldstr "tick"
-			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00e4: stloc.s 7
-			IL_00e6: ldloc.s 7
-			IL_00e8: stloc.1
-			IL_00e9: ldloc.1
-			IL_00ea: ldstr "next"
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00f4: stloc.s 7
-			IL_00f6: ldloc.0
+			IL_00b9: stloc.s 7
+			IL_00bb: ldloc.s 7
+			IL_00bd: ldstr "setInterval"
+			IL_00c2: ldc.r8 0.0
+			IL_00cb: box [System.Runtime]System.Double
+			IL_00d0: ldstr "tick"
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00da: stloc.s 7
+			IL_00dc: ldloc.s 7
+			IL_00de: stloc.1
+			IL_00df: ldloc.1
+			IL_00e0: ldstr "next"
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00ea: stloc.s 7
+			IL_00ec: ldloc.0
+			IL_00ed: ldc.i4.1
+			IL_00ee: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00f3: ldloc.0
+			IL_00f4: ldloc.s 7
+			IL_00f6: ldarg.0
 			IL_00f7: ldc.i4.1
-			IL_00f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00fd: ldloc.0
-			IL_00fe: ldloc.s 7
-			IL_0100: ldarg.0
-			IL_0101: ldc.i4.1
-			IL_0102: ldloc.0
-			IL_0103: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0108: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_010d: ldloc.0
-			IL_010e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0113: dup
-			IL_0114: ldc.i4.0
-			IL_0115: ldloc.1
-			IL_0116: stelem.ref
-			IL_0117: dup
-			IL_0118: ldc.i4.1
-			IL_0119: ldloc.2
-			IL_011a: stelem.ref
-			IL_011b: dup
-			IL_011c: ldc.i4.2
-			IL_011d: ldloc.3
+			IL_00f8: ldloc.0
+			IL_00f9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0103: ldloc.0
+			IL_0104: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0109: dup
+			IL_010a: ldc.i4.0
+			IL_010b: ldloc.1
+			IL_010c: stelem.ref
+			IL_010d: dup
+			IL_010e: ldc.i4.1
+			IL_010f: ldloc.2
+			IL_0110: stelem.ref
+			IL_0111: dup
+			IL_0112: ldc.i4.2
+			IL_0113: ldloc.3
+			IL_0114: stelem.ref
+			IL_0115: dup
+			IL_0116: ldc.i4.3
+			IL_0117: ldloc.s 4
+			IL_0119: stelem.ref
+			IL_011a: dup
+			IL_011b: ldc.i4.4
+			IL_011c: ldloc.s 5
 			IL_011e: stelem.ref
 			IL_011f: dup
-			IL_0120: ldc.i4.3
-			IL_0121: ldloc.s 4
+			IL_0120: ldc.i4.5
+			IL_0121: ldloc.s 6
 			IL_0123: stelem.ref
-			IL_0124: dup
-			IL_0125: ldc.i4.4
-			IL_0126: ldloc.s 5
-			IL_0128: stelem.ref
-			IL_0129: dup
-			IL_012a: ldc.i4.5
-			IL_012b: ldloc.s 6
-			IL_012d: stelem.ref
-			IL_012e: pop
-			IL_012f: ldloc.0
-			IL_0130: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0135: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_013a: ret
+			IL_0124: pop
+			IL_0125: ldloc.0
+			IL_0126: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_012b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0130: ret
 
-			IL_013b: ldloc.0
-			IL_013c: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited1
-			IL_0141: stloc.s 7
-			IL_0143: ldloc.s 7
-			IL_0145: stloc.2
-			IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_014b: ldloc.2
-			IL_014c: ldstr "value"
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_015b: pop
-			IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0161: ldloc.2
-			IL_0162: ldstr "done"
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0171: pop
-			IL_0172: ldarg.0
-			IL_0173: ldc.i4.1
-			IL_0174: ldelem.ref
-			IL_0175: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
-			IL_017a: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_017f: ldstr "Cannot access 'timersPromises' before initialization"
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0189: stloc.s 7
-			IL_018b: ldloc.s 7
-			IL_018d: ldstr "setTimeout"
-			IL_0192: ldc.r8 0.0
-			IL_019b: box [System.Runtime]System.Double
-			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01a5: stloc.s 7
-			IL_01a7: ldloc.0
-			IL_01a8: ldc.i4.2
-			IL_01a9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01ae: ldloc.0
-			IL_01af: ldloc.s 7
-			IL_01b1: ldarg.0
-			IL_01b2: ldc.i4.2
-			IL_01b3: ldloc.0
-			IL_01b4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01be: ldloc.0
-			IL_01bf: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01c4: dup
-			IL_01c5: ldc.i4.0
-			IL_01c6: ldloc.1
-			IL_01c7: stelem.ref
-			IL_01c8: dup
-			IL_01c9: ldc.i4.1
-			IL_01ca: ldloc.2
-			IL_01cb: stelem.ref
-			IL_01cc: dup
-			IL_01cd: ldc.i4.2
-			IL_01ce: ldloc.3
-			IL_01cf: stelem.ref
-			IL_01d0: dup
-			IL_01d1: ldc.i4.3
-			IL_01d2: ldloc.s 4
-			IL_01d4: stelem.ref
-			IL_01d5: dup
-			IL_01d6: ldc.i4.4
-			IL_01d7: ldloc.s 5
-			IL_01d9: stelem.ref
-			IL_01da: dup
-			IL_01db: ldc.i4.5
-			IL_01dc: ldloc.s 6
-			IL_01de: stelem.ref
-			IL_01df: pop
-			IL_01e0: ldloc.0
-			IL_01e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01eb: ret
+			IL_0131: ldloc.0
+			IL_0132: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited1
+			IL_0137: stloc.s 7
+			IL_0139: ldloc.s 7
+			IL_013b: stloc.2
+			IL_013c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0141: ldloc.2
+			IL_0142: ldstr "value"
+			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0151: pop
+			IL_0152: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0157: ldloc.2
+			IL_0158: ldstr "done"
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0162: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0167: pop
+			IL_0168: ldarg.0
+			IL_0169: ldc.i4.1
+			IL_016a: ldelem.ref
+			IL_016b: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
+			IL_0170: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
+			IL_0179: ldstr "setTimeout"
+			IL_017e: ldc.r8 0.0
+			IL_0187: box [System.Runtime]System.Double
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0191: stloc.s 7
+			IL_0193: ldloc.0
+			IL_0194: ldc.i4.2
+			IL_0195: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_019a: ldloc.0
+			IL_019b: ldloc.s 7
+			IL_019d: ldarg.0
+			IL_019e: ldc.i4.2
+			IL_019f: ldloc.0
+			IL_01a0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01aa: ldloc.0
+			IL_01ab: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01b0: dup
+			IL_01b1: ldc.i4.0
+			IL_01b2: ldloc.1
+			IL_01b3: stelem.ref
+			IL_01b4: dup
+			IL_01b5: ldc.i4.1
+			IL_01b6: ldloc.2
+			IL_01b7: stelem.ref
+			IL_01b8: dup
+			IL_01b9: ldc.i4.2
+			IL_01ba: ldloc.3
+			IL_01bb: stelem.ref
+			IL_01bc: dup
+			IL_01bd: ldc.i4.3
+			IL_01be: ldloc.s 4
+			IL_01c0: stelem.ref
+			IL_01c1: dup
+			IL_01c2: ldc.i4.4
+			IL_01c3: ldloc.s 5
+			IL_01c5: stelem.ref
+			IL_01c6: dup
+			IL_01c7: ldc.i4.5
+			IL_01c8: ldloc.s 6
+			IL_01ca: stelem.ref
+			IL_01cb: pop
+			IL_01cc: ldloc.0
+			IL_01cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01d7: ret
 
-			IL_01ec: ldloc.0
-			IL_01ed: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited2
-			IL_01f2: pop
-			IL_01f3: ldarg.0
-			IL_01f4: ldc.i4.1
-			IL_01f5: ldelem.ref
-			IL_01f6: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
-			IL_01fb: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_0200: ldstr "Cannot access 'timersPromises' before initialization"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_020a: stloc.s 7
-			IL_020c: ldloc.s 7
-			IL_020e: ldstr "setTimeout"
-			IL_0213: ldc.r8 0.0
-			IL_021c: box [System.Runtime]System.Double
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0226: stloc.s 7
-			IL_0228: ldloc.0
-			IL_0229: ldc.i4.3
-			IL_022a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_022f: ldloc.0
-			IL_0230: ldloc.s 7
-			IL_0232: ldarg.0
-			IL_0233: ldc.i4.3
-			IL_0234: ldloc.0
-			IL_0235: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_023a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_023f: ldloc.0
-			IL_0240: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0245: dup
-			IL_0246: ldc.i4.0
-			IL_0247: ldloc.1
-			IL_0248: stelem.ref
-			IL_0249: dup
-			IL_024a: ldc.i4.1
-			IL_024b: ldloc.2
-			IL_024c: stelem.ref
-			IL_024d: dup
-			IL_024e: ldc.i4.2
-			IL_024f: ldloc.3
-			IL_0250: stelem.ref
-			IL_0251: dup
-			IL_0252: ldc.i4.3
-			IL_0253: ldloc.s 4
-			IL_0255: stelem.ref
-			IL_0256: dup
-			IL_0257: ldc.i4.4
-			IL_0258: ldloc.s 5
-			IL_025a: stelem.ref
-			IL_025b: dup
-			IL_025c: ldc.i4.5
-			IL_025d: ldloc.s 6
-			IL_025f: stelem.ref
-			IL_0260: pop
-			IL_0261: ldloc.0
-			IL_0262: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0267: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_026c: ret
+			IL_01d8: ldloc.0
+			IL_01d9: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited2
+			IL_01de: pop
+			IL_01df: ldarg.0
+			IL_01e0: ldc.i4.1
+			IL_01e1: ldelem.ref
+			IL_01e2: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
+			IL_01e7: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
+			IL_01ec: stloc.s 7
+			IL_01ee: ldloc.s 7
+			IL_01f0: ldstr "setTimeout"
+			IL_01f5: ldc.r8 0.0
+			IL_01fe: box [System.Runtime]System.Double
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0208: stloc.s 7
+			IL_020a: ldloc.0
+			IL_020b: ldc.i4.3
+			IL_020c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0211: ldloc.0
+			IL_0212: ldloc.s 7
+			IL_0214: ldarg.0
+			IL_0215: ldc.i4.3
+			IL_0216: ldloc.0
+			IL_0217: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_021c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0221: ldloc.0
+			IL_0222: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0227: dup
+			IL_0228: ldc.i4.0
+			IL_0229: ldloc.1
+			IL_022a: stelem.ref
+			IL_022b: dup
+			IL_022c: ldc.i4.1
+			IL_022d: ldloc.2
+			IL_022e: stelem.ref
+			IL_022f: dup
+			IL_0230: ldc.i4.2
+			IL_0231: ldloc.3
+			IL_0232: stelem.ref
+			IL_0233: dup
+			IL_0234: ldc.i4.3
+			IL_0235: ldloc.s 4
+			IL_0237: stelem.ref
+			IL_0238: dup
+			IL_0239: ldc.i4.4
+			IL_023a: ldloc.s 5
+			IL_023c: stelem.ref
+			IL_023d: dup
+			IL_023e: ldc.i4.5
+			IL_023f: ldloc.s 6
+			IL_0241: stelem.ref
+			IL_0242: pop
+			IL_0243: ldloc.0
+			IL_0244: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0249: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_024e: ret
 
-			IL_026d: ldloc.0
-			IL_026e: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited3
-			IL_0273: pop
-			IL_0274: ldloc.1
-			IL_0275: ldstr "next"
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_027f: stloc.s 7
-			IL_0281: ldloc.0
-			IL_0282: ldc.i4.4
-			IL_0283: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0288: ldloc.0
-			IL_0289: ldloc.s 7
-			IL_028b: ldarg.0
-			IL_028c: ldc.i4.4
-			IL_028d: ldloc.0
-			IL_028e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0293: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0298: ldloc.0
-			IL_0299: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_029e: dup
-			IL_029f: ldc.i4.0
-			IL_02a0: ldloc.1
-			IL_02a1: stelem.ref
-			IL_02a2: dup
-			IL_02a3: ldc.i4.1
-			IL_02a4: ldloc.2
-			IL_02a5: stelem.ref
-			IL_02a6: dup
-			IL_02a7: ldc.i4.2
-			IL_02a8: ldloc.3
-			IL_02a9: stelem.ref
-			IL_02aa: dup
-			IL_02ab: ldc.i4.3
-			IL_02ac: ldloc.s 4
-			IL_02ae: stelem.ref
-			IL_02af: dup
-			IL_02b0: ldc.i4.4
-			IL_02b1: ldloc.s 5
-			IL_02b3: stelem.ref
-			IL_02b4: dup
-			IL_02b5: ldc.i4.5
-			IL_02b6: ldloc.s 6
-			IL_02b8: stelem.ref
-			IL_02b9: pop
-			IL_02ba: ldloc.0
-			IL_02bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02c0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02c5: ret
+			IL_024f: ldloc.0
+			IL_0250: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited3
+			IL_0255: pop
+			IL_0256: ldloc.1
+			IL_0257: ldstr "next"
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0261: stloc.s 7
+			IL_0263: ldloc.0
+			IL_0264: ldc.i4.4
+			IL_0265: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_026a: ldloc.0
+			IL_026b: ldloc.s 7
+			IL_026d: ldarg.0
+			IL_026e: ldc.i4.4
+			IL_026f: ldloc.0
+			IL_0270: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0275: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_027a: ldloc.0
+			IL_027b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0280: dup
+			IL_0281: ldc.i4.0
+			IL_0282: ldloc.1
+			IL_0283: stelem.ref
+			IL_0284: dup
+			IL_0285: ldc.i4.1
+			IL_0286: ldloc.2
+			IL_0287: stelem.ref
+			IL_0288: dup
+			IL_0289: ldc.i4.2
+			IL_028a: ldloc.3
+			IL_028b: stelem.ref
+			IL_028c: dup
+			IL_028d: ldc.i4.3
+			IL_028e: ldloc.s 4
+			IL_0290: stelem.ref
+			IL_0291: dup
+			IL_0292: ldc.i4.4
+			IL_0293: ldloc.s 5
+			IL_0295: stelem.ref
+			IL_0296: dup
+			IL_0297: ldc.i4.5
+			IL_0298: ldloc.s 6
+			IL_029a: stelem.ref
+			IL_029b: pop
+			IL_029c: ldloc.0
+			IL_029d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02a2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02a7: ret
 
-			IL_02c6: ldloc.0
-			IL_02c7: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited4
-			IL_02cc: stloc.s 7
-			IL_02ce: ldloc.s 7
-			IL_02d0: stloc.3
-			IL_02d1: ldloc.1
-			IL_02d2: ldstr "next"
-			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02dc: stloc.s 7
-			IL_02de: ldloc.0
-			IL_02df: ldc.i4.5
-			IL_02e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02e5: ldloc.0
-			IL_02e6: ldloc.s 7
-			IL_02e8: ldarg.0
-			IL_02e9: ldc.i4.5
-			IL_02ea: ldloc.0
-			IL_02eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02f5: ldloc.0
-			IL_02f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02fb: dup
-			IL_02fc: ldc.i4.0
-			IL_02fd: ldloc.1
-			IL_02fe: stelem.ref
-			IL_02ff: dup
-			IL_0300: ldc.i4.1
-			IL_0301: ldloc.2
-			IL_0302: stelem.ref
-			IL_0303: dup
-			IL_0304: ldc.i4.2
-			IL_0305: ldloc.3
-			IL_0306: stelem.ref
-			IL_0307: dup
-			IL_0308: ldc.i4.3
-			IL_0309: ldloc.s 4
-			IL_030b: stelem.ref
-			IL_030c: dup
-			IL_030d: ldc.i4.4
-			IL_030e: ldloc.s 5
-			IL_0310: stelem.ref
-			IL_0311: dup
-			IL_0312: ldc.i4.5
-			IL_0313: ldloc.s 6
-			IL_0315: stelem.ref
-			IL_0316: pop
-			IL_0317: ldloc.0
-			IL_0318: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_031d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0322: ret
+			IL_02a8: ldloc.0
+			IL_02a9: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited4
+			IL_02ae: stloc.s 7
+			IL_02b0: ldloc.s 7
+			IL_02b2: stloc.3
+			IL_02b3: ldloc.1
+			IL_02b4: ldstr "next"
+			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_02be: stloc.s 7
+			IL_02c0: ldloc.0
+			IL_02c1: ldc.i4.5
+			IL_02c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02c7: ldloc.0
+			IL_02c8: ldloc.s 7
+			IL_02ca: ldarg.0
+			IL_02cb: ldc.i4.5
+			IL_02cc: ldloc.0
+			IL_02cd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02d7: ldloc.0
+			IL_02d8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02dd: dup
+			IL_02de: ldc.i4.0
+			IL_02df: ldloc.1
+			IL_02e0: stelem.ref
+			IL_02e1: dup
+			IL_02e2: ldc.i4.1
+			IL_02e3: ldloc.2
+			IL_02e4: stelem.ref
+			IL_02e5: dup
+			IL_02e6: ldc.i4.2
+			IL_02e7: ldloc.3
+			IL_02e8: stelem.ref
+			IL_02e9: dup
+			IL_02ea: ldc.i4.3
+			IL_02eb: ldloc.s 4
+			IL_02ed: stelem.ref
+			IL_02ee: dup
+			IL_02ef: ldc.i4.4
+			IL_02f0: ldloc.s 5
+			IL_02f2: stelem.ref
+			IL_02f3: dup
+			IL_02f4: ldc.i4.5
+			IL_02f5: ldloc.s 6
+			IL_02f7: stelem.ref
+			IL_02f8: pop
+			IL_02f9: ldloc.0
+			IL_02fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02ff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0304: ret
 
-			IL_0323: ldloc.0
-			IL_0324: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited5
-			IL_0329: stloc.s 7
-			IL_032b: ldloc.s 7
-			IL_032d: stloc.s 4
-			IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0334: ldloc.3
-			IL_0335: ldstr "value"
-			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_033f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0344: pop
-			IL_0345: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_034a: ldloc.3
-			IL_034b: ldstr "done"
-			IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0355: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_035a: pop
-			IL_035b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0360: ldloc.s 4
-			IL_0362: ldstr "value"
-			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0371: pop
-			IL_0372: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0377: ldloc.s 4
-			IL_0379: ldstr "done"
-			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0383: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0388: pop
-			IL_0389: ldloc.1
-			IL_038a: ldstr "return"
-			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0394: stloc.s 7
-			IL_0396: ldloc.0
-			IL_0397: ldc.i4.6
-			IL_0398: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_039d: ldloc.0
-			IL_039e: ldloc.s 7
-			IL_03a0: ldarg.0
-			IL_03a1: ldc.i4.6
-			IL_03a2: ldloc.0
-			IL_03a3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03ad: ldloc.0
-			IL_03ae: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03b3: dup
-			IL_03b4: ldc.i4.0
-			IL_03b5: ldloc.1
-			IL_03b6: stelem.ref
-			IL_03b7: dup
-			IL_03b8: ldc.i4.1
-			IL_03b9: ldloc.2
-			IL_03ba: stelem.ref
-			IL_03bb: dup
-			IL_03bc: ldc.i4.2
-			IL_03bd: ldloc.3
-			IL_03be: stelem.ref
-			IL_03bf: dup
-			IL_03c0: ldc.i4.3
-			IL_03c1: ldloc.s 4
-			IL_03c3: stelem.ref
-			IL_03c4: dup
-			IL_03c5: ldc.i4.4
-			IL_03c6: ldloc.s 5
-			IL_03c8: stelem.ref
-			IL_03c9: dup
-			IL_03ca: ldc.i4.5
-			IL_03cb: ldloc.s 6
-			IL_03cd: stelem.ref
-			IL_03ce: pop
-			IL_03cf: ldloc.0
-			IL_03d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03d5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03da: ret
+			IL_0305: ldloc.0
+			IL_0306: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited5
+			IL_030b: stloc.s 7
+			IL_030d: ldloc.s 7
+			IL_030f: stloc.s 4
+			IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0316: ldloc.3
+			IL_0317: ldstr "value"
+			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0321: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0326: pop
+			IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_032c: ldloc.3
+			IL_032d: ldstr "done"
+			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0337: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_033c: pop
+			IL_033d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0342: ldloc.s 4
+			IL_0344: ldstr "value"
+			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0353: pop
+			IL_0354: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0359: ldloc.s 4
+			IL_035b: ldstr "done"
+			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0365: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_036a: pop
+			IL_036b: ldloc.1
+			IL_036c: ldstr "return"
+			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0376: stloc.s 7
+			IL_0378: ldloc.0
+			IL_0379: ldc.i4.6
+			IL_037a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_037f: ldloc.0
+			IL_0380: ldloc.s 7
+			IL_0382: ldarg.0
+			IL_0383: ldc.i4.6
+			IL_0384: ldloc.0
+			IL_0385: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_038a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_038f: ldloc.0
+			IL_0390: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0395: dup
+			IL_0396: ldc.i4.0
+			IL_0397: ldloc.1
+			IL_0398: stelem.ref
+			IL_0399: dup
+			IL_039a: ldc.i4.1
+			IL_039b: ldloc.2
+			IL_039c: stelem.ref
+			IL_039d: dup
+			IL_039e: ldc.i4.2
+			IL_039f: ldloc.3
+			IL_03a0: stelem.ref
+			IL_03a1: dup
+			IL_03a2: ldc.i4.3
+			IL_03a3: ldloc.s 4
+			IL_03a5: stelem.ref
+			IL_03a6: dup
+			IL_03a7: ldc.i4.4
+			IL_03a8: ldloc.s 5
+			IL_03aa: stelem.ref
+			IL_03ab: dup
+			IL_03ac: ldc.i4.5
+			IL_03ad: ldloc.s 6
+			IL_03af: stelem.ref
+			IL_03b0: pop
+			IL_03b1: ldloc.0
+			IL_03b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03b7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03bc: ret
 
-			IL_03db: ldloc.0
-			IL_03dc: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited6
-			IL_03e1: stloc.s 7
-			IL_03e3: ldloc.s 7
-			IL_03e5: stloc.s 5
-			IL_03e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03ec: ldloc.s 5
-			IL_03ee: ldstr "done"
-			IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03fd: pop
-			IL_03fe: ldloc.1
-			IL_03ff: ldstr "next"
-			IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0409: stloc.s 7
-			IL_040b: ldloc.0
-			IL_040c: ldc.i4.7
-			IL_040d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0412: ldloc.0
-			IL_0413: ldloc.s 7
-			IL_0415: ldarg.0
-			IL_0416: ldc.i4.7
-			IL_0417: ldloc.0
-			IL_0418: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_041d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0422: ldloc.0
-			IL_0423: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0428: dup
-			IL_0429: ldc.i4.0
-			IL_042a: ldloc.1
-			IL_042b: stelem.ref
-			IL_042c: dup
-			IL_042d: ldc.i4.1
-			IL_042e: ldloc.2
-			IL_042f: stelem.ref
-			IL_0430: dup
-			IL_0431: ldc.i4.2
-			IL_0432: ldloc.3
-			IL_0433: stelem.ref
-			IL_0434: dup
-			IL_0435: ldc.i4.3
-			IL_0436: ldloc.s 4
-			IL_0438: stelem.ref
-			IL_0439: dup
-			IL_043a: ldc.i4.4
-			IL_043b: ldloc.s 5
-			IL_043d: stelem.ref
-			IL_043e: dup
-			IL_043f: ldc.i4.5
-			IL_0440: ldloc.s 6
-			IL_0442: stelem.ref
-			IL_0443: pop
-			IL_0444: ldloc.0
-			IL_0445: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_044a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_044f: ret
+			IL_03bd: ldloc.0
+			IL_03be: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited6
+			IL_03c3: stloc.s 7
+			IL_03c5: ldloc.s 7
+			IL_03c7: stloc.s 5
+			IL_03c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ce: ldloc.s 5
+			IL_03d0: ldstr "done"
+			IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03df: pop
+			IL_03e0: ldloc.1
+			IL_03e1: ldstr "next"
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03eb: stloc.s 7
+			IL_03ed: ldloc.0
+			IL_03ee: ldc.i4.7
+			IL_03ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03f4: ldloc.0
+			IL_03f5: ldloc.s 7
+			IL_03f7: ldarg.0
+			IL_03f8: ldc.i4.7
+			IL_03f9: ldloc.0
+			IL_03fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0404: ldloc.0
+			IL_0405: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_040a: dup
+			IL_040b: ldc.i4.0
+			IL_040c: ldloc.1
+			IL_040d: stelem.ref
+			IL_040e: dup
+			IL_040f: ldc.i4.1
+			IL_0410: ldloc.2
+			IL_0411: stelem.ref
+			IL_0412: dup
+			IL_0413: ldc.i4.2
+			IL_0414: ldloc.3
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.3
+			IL_0418: ldloc.s 4
+			IL_041a: stelem.ref
+			IL_041b: dup
+			IL_041c: ldc.i4.4
+			IL_041d: ldloc.s 5
+			IL_041f: stelem.ref
+			IL_0420: dup
+			IL_0421: ldc.i4.5
+			IL_0422: ldloc.s 6
+			IL_0424: stelem.ref
+			IL_0425: pop
+			IL_0426: ldloc.0
+			IL_0427: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_042c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0431: ret
 
-			IL_0450: ldloc.0
-			IL_0451: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited7
-			IL_0456: stloc.s 7
-			IL_0458: ldloc.s 7
-			IL_045a: stloc.s 6
-			IL_045c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0461: ldloc.s 6
-			IL_0463: ldstr "done"
-			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_046d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0472: pop
-			IL_0473: ldloc.0
-			IL_0474: ldc.i4.m1
-			IL_0475: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_047a: ldloc.0
-			IL_047b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0480: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0485: ldarg.0
-			IL_0486: ldc.i4.1
-			IL_0487: newarr [System.Runtime]System.Object
-			IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0491: pop
-			IL_0492: ldloc.0
-			IL_0493: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0498: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_049d: ret
+			IL_0432: ldloc.0
+			IL_0433: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited7
+			IL_0438: stloc.s 7
+			IL_043a: ldloc.s 7
+			IL_043c: stloc.s 6
+			IL_043e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0443: ldloc.s 6
+			IL_0445: ldstr "done"
+			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_044f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0454: pop
+			IL_0455: ldloc.0
+			IL_0456: ldc.i4.m1
+			IL_0457: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_045c: ldloc.0
+			IL_045d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0462: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0467: ldarg.0
+			IL_0468: ldc.i4.1
+			IL_0469: newarr [System.Runtime]System.Object
+			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0473: pop
+			IL_0474: ldloc.0
+			IL_0475: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_047a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_047f: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -633,18 +627,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2556
+			// Method begins at RVA 0x2538
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -715,7 +706,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2573
+		// Method begins at RVA 0x254a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
+++ b/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247b
+				// Method begins at RVA 0x2466
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2496
+						// Method begins at RVA 0x2481
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x248d
+					// Method begins at RVA 0x2478
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2484
+				// Method begins at RVA 0x246f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			)
 			// Method begins at RVA 0x20ac
 			// Header size: 12
-			// Code size: 943 (0x3af)
+			// Code size: 933 (0x3a5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope,
@@ -222,7 +222,7 @@
 
 			IL_00af: ldloc.0
 			IL_00b0: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00b5: switch (IL_00ce, IL_0229, IL_02d3, IL_01b6, IL_02c7)
+			IL_00b5: switch (IL_00ce, IL_021f, IL_02c9, IL_01ac, IL_02bd)
 
 			IL_00ce: ldc.r8 0.0
 			IL_00d7: stloc.1
@@ -231,312 +231,310 @@
 			IL_00da: ldelem.ref
 			IL_00db: castclass Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope
 			IL_00e0: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope::timersPromises
-			IL_00e5: ldstr "Cannot access 'timersPromises' before initialization"
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00ef: stloc.s 10
-			IL_00f1: ldloc.s 10
-			IL_00f3: ldstr "setInterval"
-			IL_00f8: ldc.r8 0.0
-			IL_0101: box [System.Runtime]System.Double
-			IL_0106: ldstr "tick"
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0110: stloc.s 10
-			IL_0112: ldloc.s 10
-			IL_0114: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_0119: stloc.2
-			IL_011a: ldc.i4.0
-			IL_011b: stloc.3
-			IL_011c: ldc.i4.0
-			IL_011d: stloc.s 4
-			IL_011f: ldloc.0
-			IL_0120: ldc.i4.0
-			IL_0121: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0126: ldloc.0
-			IL_0127: ldc.i4.0
-			IL_0128: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_012d: ldloc.0
-			IL_012e: ldc.i4.0
-			IL_012f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0134: ldloc.0
-			IL_0135: ldc.i4.0
-			IL_0136: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00e5: stloc.s 10
+			IL_00e7: ldloc.s 10
+			IL_00e9: ldstr "setInterval"
+			IL_00ee: ldc.r8 0.0
+			IL_00f7: box [System.Runtime]System.Double
+			IL_00fc: ldstr "tick"
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0106: stloc.s 10
+			IL_0108: ldloc.s 10
+			IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_010f: stloc.2
+			IL_0110: ldc.i4.0
+			IL_0111: stloc.3
+			IL_0112: ldc.i4.0
+			IL_0113: stloc.s 4
+			IL_0115: ldloc.0
+			IL_0116: ldc.i4.0
+			IL_0117: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_011c: ldloc.0
+			IL_011d: ldc.i4.0
+			IL_011e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0123: ldloc.0
+			IL_0124: ldc.i4.0
+			IL_0125: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_012a: ldloc.0
+			IL_012b: ldc.i4.0
+			IL_012c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_013b: ldloc.2
-			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_0141: stloc.s 10
-			IL_0143: ldloc.0
-			IL_0144: ldc.i4.3
-			IL_0145: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_014a: ldloc.0
-			IL_014b: ldloc.s 10
-			IL_014d: ldarg.0
-			IL_014e: ldc.i4.1
-			IL_014f: ldloc.0
-			IL_0150: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0155: ldc.i4.1
-			IL_0156: ldstr "_pendingException"
-			IL_015b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0160: ldloc.0
-			IL_0161: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0166: dup
-			IL_0167: ldc.i4.0
-			IL_0168: ldloc.1
-			IL_0169: box [System.Runtime]System.Double
-			IL_016e: stelem.ref
-			IL_016f: dup
-			IL_0170: ldc.i4.1
-			IL_0171: ldloc.2
-			IL_0172: stelem.ref
-			IL_0173: dup
-			IL_0174: ldc.i4.2
-			IL_0175: ldloc.3
+			IL_0131: ldloc.2
+			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_0137: stloc.s 10
+			IL_0139: ldloc.0
+			IL_013a: ldc.i4.3
+			IL_013b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0140: ldloc.0
+			IL_0141: ldloc.s 10
+			IL_0143: ldarg.0
+			IL_0144: ldc.i4.1
+			IL_0145: ldloc.0
+			IL_0146: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_014b: ldc.i4.1
+			IL_014c: ldstr "_pendingException"
+			IL_0151: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0156: ldloc.0
+			IL_0157: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_015c: dup
+			IL_015d: ldc.i4.0
+			IL_015e: ldloc.1
+			IL_015f: box [System.Runtime]System.Double
+			IL_0164: stelem.ref
+			IL_0165: dup
+			IL_0166: ldc.i4.1
+			IL_0167: ldloc.2
+			IL_0168: stelem.ref
+			IL_0169: dup
+			IL_016a: ldc.i4.2
+			IL_016b: ldloc.3
+			IL_016c: box [System.Runtime]System.Boolean
+			IL_0171: stelem.ref
+			IL_0172: dup
+			IL_0173: ldc.i4.3
+			IL_0174: ldloc.s 4
 			IL_0176: box [System.Runtime]System.Boolean
 			IL_017b: stelem.ref
 			IL_017c: dup
-			IL_017d: ldc.i4.3
-			IL_017e: ldloc.s 4
-			IL_0180: box [System.Runtime]System.Boolean
+			IL_017d: ldc.i4.4
+			IL_017e: ldloc.s 5
+			IL_0180: stelem.ref
+			IL_0181: dup
+			IL_0182: ldc.i4.5
+			IL_0183: ldloc.s 6
 			IL_0185: stelem.ref
 			IL_0186: dup
-			IL_0187: ldc.i4.4
-			IL_0188: ldloc.s 5
+			IL_0187: ldc.i4.6
+			IL_0188: ldloc.s 7
 			IL_018a: stelem.ref
 			IL_018b: dup
-			IL_018c: ldc.i4.5
-			IL_018d: ldloc.s 6
-			IL_018f: stelem.ref
-			IL_0190: dup
-			IL_0191: ldc.i4.6
-			IL_0192: ldloc.s 7
+			IL_018c: ldc.i4.7
+			IL_018d: ldloc.s 8
+			IL_018f: box [System.Runtime]System.Boolean
 			IL_0194: stelem.ref
 			IL_0195: dup
-			IL_0196: ldc.i4.7
-			IL_0197: ldloc.s 8
+			IL_0196: ldc.i4.8
+			IL_0197: ldloc.s 9
 			IL_0199: box [System.Runtime]System.Boolean
 			IL_019e: stelem.ref
-			IL_019f: dup
-			IL_01a0: ldc.i4.8
-			IL_01a1: ldloc.s 9
-			IL_01a3: box [System.Runtime]System.Boolean
-			IL_01a8: stelem.ref
-			IL_01a9: pop
-			IL_01aa: ldloc.0
-			IL_01ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01b5: ret
+			IL_019f: pop
+			IL_01a0: ldloc.0
+			IL_01a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01a6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ab: ret
 
-			IL_01b6: ldloc.0
-			IL_01b7: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited1
-			IL_01bc: stloc.s 10
-			IL_01be: ldloc.s 10
-			IL_01c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_01c5: stloc.s 11
-			IL_01c7: ldloc.s 11
-			IL_01c9: brtrue IL_0222
+			IL_01ac: ldloc.0
+			IL_01ad: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited1
+			IL_01b2: stloc.s 10
+			IL_01b4: ldloc.s 10
+			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_01bb: stloc.s 11
+			IL_01bd: ldloc.s 11
+			IL_01bf: brtrue IL_0218
 
-			IL_01ce: ldloc.s 10
-			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_01d5: stloc.s 10
-			IL_01d7: ldloc.s 10
-			IL_01d9: stloc.s 5
-			IL_01db: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope_ForOf_L8C13/Block_L8C67::.ctor()
-			IL_01e0: stloc.s 6
-			IL_01e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01e7: ldloc.s 5
-			IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01ee: pop
-			IL_01ef: ldloc.1
-			IL_01f0: ldc.r8 1
-			IL_01f9: add
-			IL_01fa: stloc.1
-			IL_01fb: ldloc.1
-			IL_01fc: ldc.r8 3
-			IL_0205: ceq
-			IL_0207: brfalse IL_0218
+			IL_01c4: ldloc.s 10
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_01cb: stloc.s 10
+			IL_01cd: ldloc.s 10
+			IL_01cf: stloc.s 5
+			IL_01d1: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope_ForOf_L8C13/Block_L8C67::.ctor()
+			IL_01d6: stloc.s 6
+			IL_01d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01dd: ldloc.s 5
+			IL_01df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01e4: pop
+			IL_01e5: ldloc.1
+			IL_01e6: ldc.r8 1
+			IL_01ef: add
+			IL_01f0: stloc.1
+			IL_01f1: ldloc.1
+			IL_01f2: ldc.r8 3
+			IL_01fb: ceq
+			IL_01fd: brfalse IL_020e
 
-			IL_020c: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope_ForOf_L8C13/Block_L8C67/Block_L12C21::.ctor()
-			IL_0211: stloc.s 7
-			IL_0213: br IL_021d
+			IL_0202: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope_ForOf_L8C13/Block_L8C67/Block_L12C21::.ctor()
+			IL_0207: stloc.s 7
+			IL_0209: br IL_0213
 
-			IL_0218: br IL_013b
+			IL_020e: br IL_0131
 
-			IL_021d: br IL_023c
+			IL_0213: br IL_0232
 
-			IL_0222: ldc.i4.1
-			IL_0223: stloc.3
-			IL_0224: br IL_023c
+			IL_0218: ldc.i4.1
+			IL_0219: stloc.3
+			IL_021a: br IL_0232
 
-			IL_0229: ldloc.0
-			IL_022a: ldc.i4.1
-			IL_022b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0230: ldloc.0
-			IL_0231: ldc.i4.0
-			IL_0232: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0237: br IL_023c
+			IL_021f: ldloc.0
+			IL_0220: ldc.i4.1
+			IL_0221: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0226: ldloc.0
+			IL_0227: ldc.i4.0
+			IL_0228: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_022d: br IL_0232
 
-			IL_023c: ldloc.3
-			IL_023d: brtrue IL_02ce
+			IL_0232: ldloc.3
+			IL_0233: brtrue IL_02c4
 
-			IL_0242: ldloc.s 4
-			IL_0244: brtrue IL_02ce
+			IL_0238: ldloc.s 4
+			IL_023a: brtrue IL_02c4
 
-			IL_0249: ldc.i4.1
-			IL_024a: stloc.s 4
-			IL_024c: ldloc.2
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_0252: stloc.s 10
-			IL_0254: ldloc.0
-			IL_0255: ldc.i4.4
-			IL_0256: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_025b: ldloc.0
-			IL_025c: ldloc.s 10
-			IL_025e: ldarg.0
-			IL_025f: ldc.i4.2
-			IL_0260: ldloc.0
-			IL_0261: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0266: ldc.i4.2
-			IL_0267: ldstr "_pendingException"
-			IL_026c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0271: ldloc.0
-			IL_0272: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0277: dup
-			IL_0278: ldc.i4.0
-			IL_0279: ldloc.1
-			IL_027a: box [System.Runtime]System.Double
-			IL_027f: stelem.ref
-			IL_0280: dup
-			IL_0281: ldc.i4.1
-			IL_0282: ldloc.2
-			IL_0283: stelem.ref
-			IL_0284: dup
-			IL_0285: ldc.i4.2
-			IL_0286: ldloc.3
+			IL_023f: ldc.i4.1
+			IL_0240: stloc.s 4
+			IL_0242: ldloc.2
+			IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_0248: stloc.s 10
+			IL_024a: ldloc.0
+			IL_024b: ldc.i4.4
+			IL_024c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0251: ldloc.0
+			IL_0252: ldloc.s 10
+			IL_0254: ldarg.0
+			IL_0255: ldc.i4.2
+			IL_0256: ldloc.0
+			IL_0257: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_025c: ldc.i4.2
+			IL_025d: ldstr "_pendingException"
+			IL_0262: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0267: ldloc.0
+			IL_0268: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_026d: dup
+			IL_026e: ldc.i4.0
+			IL_026f: ldloc.1
+			IL_0270: box [System.Runtime]System.Double
+			IL_0275: stelem.ref
+			IL_0276: dup
+			IL_0277: ldc.i4.1
+			IL_0278: ldloc.2
+			IL_0279: stelem.ref
+			IL_027a: dup
+			IL_027b: ldc.i4.2
+			IL_027c: ldloc.3
+			IL_027d: box [System.Runtime]System.Boolean
+			IL_0282: stelem.ref
+			IL_0283: dup
+			IL_0284: ldc.i4.3
+			IL_0285: ldloc.s 4
 			IL_0287: box [System.Runtime]System.Boolean
 			IL_028c: stelem.ref
 			IL_028d: dup
-			IL_028e: ldc.i4.3
-			IL_028f: ldloc.s 4
-			IL_0291: box [System.Runtime]System.Boolean
+			IL_028e: ldc.i4.4
+			IL_028f: ldloc.s 5
+			IL_0291: stelem.ref
+			IL_0292: dup
+			IL_0293: ldc.i4.5
+			IL_0294: ldloc.s 6
 			IL_0296: stelem.ref
 			IL_0297: dup
-			IL_0298: ldc.i4.4
-			IL_0299: ldloc.s 5
+			IL_0298: ldc.i4.6
+			IL_0299: ldloc.s 7
 			IL_029b: stelem.ref
 			IL_029c: dup
-			IL_029d: ldc.i4.5
-			IL_029e: ldloc.s 6
-			IL_02a0: stelem.ref
-			IL_02a1: dup
-			IL_02a2: ldc.i4.6
-			IL_02a3: ldloc.s 7
+			IL_029d: ldc.i4.7
+			IL_029e: ldloc.s 8
+			IL_02a0: box [System.Runtime]System.Boolean
 			IL_02a5: stelem.ref
 			IL_02a6: dup
-			IL_02a7: ldc.i4.7
-			IL_02a8: ldloc.s 8
+			IL_02a7: ldc.i4.8
+			IL_02a8: ldloc.s 9
 			IL_02aa: box [System.Runtime]System.Boolean
 			IL_02af: stelem.ref
-			IL_02b0: dup
-			IL_02b1: ldc.i4.8
-			IL_02b2: ldloc.s 9
-			IL_02b4: box [System.Runtime]System.Boolean
-			IL_02b9: stelem.ref
-			IL_02ba: pop
-			IL_02bb: ldloc.0
-			IL_02bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02c1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02c6: ret
+			IL_02b0: pop
+			IL_02b1: ldloc.0
+			IL_02b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02b7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02bc: ret
 
-			IL_02c7: ldloc.0
-			IL_02c8: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited2
-			IL_02cd: pop
+			IL_02bd: ldloc.0
+			IL_02be: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited2
+			IL_02c3: pop
 
-			IL_02ce: br IL_02e6
+			IL_02c4: br IL_02dc
 
-			IL_02d3: ldloc.0
-			IL_02d4: ldc.i4.1
-			IL_02d5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02da: ldloc.0
-			IL_02db: ldc.i4.0
-			IL_02dc: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02e1: br IL_02e6
+			IL_02c9: ldloc.0
+			IL_02ca: ldc.i4.1
+			IL_02cb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02d0: ldloc.0
+			IL_02d1: ldc.i4.0
+			IL_02d2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02d7: br IL_02dc
 
-			IL_02e6: ldloc.0
-			IL_02e7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02ec: stloc.s 8
-			IL_02ee: ldloc.s 8
-			IL_02f0: brfalse IL_032d
+			IL_02dc: ldloc.0
+			IL_02dd: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02e2: stloc.s 8
+			IL_02e4: ldloc.s 8
+			IL_02e6: brfalse IL_0323
 
-			IL_02f5: ldloc.0
-			IL_02f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_02fb: stloc.s 10
-			IL_02fd: ldloc.0
-			IL_02fe: ldc.i4.m1
-			IL_02ff: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0304: ldloc.0
-			IL_0305: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_030f: ldarg.0
-			IL_0310: ldc.i4.1
-			IL_0311: newarr [System.Runtime]System.Object
-			IL_0316: dup
-			IL_0317: ldc.i4.0
-			IL_0318: ldloc.s 10
-			IL_031a: stelem.ref
-			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0320: pop
-			IL_0321: ldloc.0
-			IL_0322: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0327: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_032c: ret
+			IL_02eb: ldloc.0
+			IL_02ec: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_02f1: stloc.s 10
+			IL_02f3: ldloc.0
+			IL_02f4: ldc.i4.m1
+			IL_02f5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02fa: ldloc.0
+			IL_02fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0300: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0305: ldarg.0
+			IL_0306: ldc.i4.1
+			IL_0307: newarr [System.Runtime]System.Object
+			IL_030c: dup
+			IL_030d: ldc.i4.0
+			IL_030e: ldloc.s 10
+			IL_0310: stelem.ref
+			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0316: pop
+			IL_0317: ldloc.0
+			IL_0318: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_031d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0322: ret
 
-			IL_032d: ldloc.0
-			IL_032e: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0333: stloc.s 9
-			IL_0335: ldloc.s 9
-			IL_0337: brfalse IL_0374
+			IL_0323: ldloc.0
+			IL_0324: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0329: stloc.s 9
+			IL_032b: ldloc.s 9
+			IL_032d: brfalse IL_036a
 
-			IL_033c: ldloc.0
-			IL_033d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0342: stloc.s 10
-			IL_0344: ldloc.0
-			IL_0345: ldc.i4.m1
-			IL_0346: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_034b: ldloc.0
-			IL_034c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0351: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0356: ldarg.0
-			IL_0357: ldc.i4.1
-			IL_0358: newarr [System.Runtime]System.Object
-			IL_035d: dup
-			IL_035e: ldc.i4.0
-			IL_035f: ldloc.s 10
-			IL_0361: stelem.ref
-			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0367: pop
-			IL_0368: ldloc.0
-			IL_0369: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0373: ret
+			IL_0332: ldloc.0
+			IL_0333: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0338: stloc.s 10
+			IL_033a: ldloc.0
+			IL_033b: ldc.i4.m1
+			IL_033c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0341: ldloc.0
+			IL_0342: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0347: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_034c: ldarg.0
+			IL_034d: ldc.i4.1
+			IL_034e: newarr [System.Runtime]System.Object
+			IL_0353: dup
+			IL_0354: ldc.i4.0
+			IL_0355: ldloc.s 10
+			IL_0357: stelem.ref
+			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_035d: pop
+			IL_035e: ldloc.0
+			IL_035f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0364: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0369: ret
 
-			IL_0374: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0379: ldstr "break-done"
-			IL_037e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0383: pop
-			IL_0384: ldloc.0
-			IL_0385: ldc.i4.m1
-			IL_0386: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_038b: ldloc.0
-			IL_038c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0391: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0396: ldarg.0
-			IL_0397: ldc.i4.1
-			IL_0398: newarr [System.Runtime]System.Object
-			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03a2: pop
-			IL_03a3: ldloc.0
-			IL_03a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03a9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03ae: ret
+			IL_036a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_036f: ldstr "break-done"
+			IL_0374: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0379: pop
+			IL_037a: ldloc.0
+			IL_037b: ldc.i4.m1
+			IL_037c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0381: ldloc.0
+			IL_0382: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0387: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_038c: ldarg.0
+			IL_038d: ldc.i4.1
+			IL_038e: newarr [System.Runtime]System.Object
+			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0398: pop
+			IL_0399: ldloc.0
+			IL_039a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_039f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03a4: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -558,18 +556,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2467
+			// Method begins at RVA 0x245d
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope::timersPromises
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -640,7 +635,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x249f
+		// Method begins at RVA 0x248a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
+++ b/tests/Js2IL.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
@@ -33,7 +33,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a0
+				// Method begins at RVA 0x228b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -59,7 +59,7 @@
 			)
 			// Method begins at RVA 0x20ac
 			// Header size: 12
-			// Code size: 468 (0x1d4)
+			// Code size: 458 (0x1ca)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope,
@@ -127,139 +127,137 @@
 
 			IL_0072: ldloc.0
 			IL_0073: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0078: switch (IL_0089, IL_010e, IL_0188)
+			IL_0078: switch (IL_0089, IL_0104, IL_017e)
 
 			IL_0089: ldarg.0
 			IL_008a: ldc.i4.1
 			IL_008b: ldelem.ref
 			IL_008c: castclass Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope
 			IL_0091: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope::timersPromises
-			IL_0096: ldstr "Cannot access 'timersPromises' before initialization"
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a0: stloc.s 4
-			IL_00a2: call class [System.Runtime]System.Func`3<object[], object, float64> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Number()
-			IL_00a7: ldstr "POSITIVE_INFINITY"
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b1: stloc.s 5
-			IL_00b3: ldloc.s 4
-			IL_00b5: ldstr "setInterval"
-			IL_00ba: ldloc.s 5
-			IL_00bc: ldstr "tick"
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00c6: stloc.s 5
-			IL_00c8: ldloc.s 5
-			IL_00ca: stloc.1
-			IL_00cb: ldloc.1
-			IL_00cc: ldstr "next"
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00d6: stloc.s 5
-			IL_00d8: ldloc.0
+			IL_0096: stloc.s 4
+			IL_0098: call class [System.Runtime]System.Func`3<object[], object, float64> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Number()
+			IL_009d: ldstr "POSITIVE_INFINITY"
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a7: stloc.s 5
+			IL_00a9: ldloc.s 4
+			IL_00ab: ldstr "setInterval"
+			IL_00b0: ldloc.s 5
+			IL_00b2: ldstr "tick"
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00bc: stloc.s 5
+			IL_00be: ldloc.s 5
+			IL_00c0: stloc.1
+			IL_00c1: ldloc.1
+			IL_00c2: ldstr "next"
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00cc: stloc.s 5
+			IL_00ce: ldloc.0
+			IL_00cf: ldc.i4.1
+			IL_00d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00d5: ldloc.0
+			IL_00d6: ldloc.s 5
+			IL_00d8: ldarg.0
 			IL_00d9: ldc.i4.1
-			IL_00da: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00df: ldloc.0
-			IL_00e0: ldloc.s 5
-			IL_00e2: ldarg.0
-			IL_00e3: ldc.i4.1
-			IL_00e4: ldloc.0
-			IL_00e5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00ef: ldloc.0
-			IL_00f0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00f5: dup
-			IL_00f6: ldc.i4.0
-			IL_00f7: ldloc.1
-			IL_00f8: stelem.ref
-			IL_00f9: dup
-			IL_00fa: ldc.i4.1
-			IL_00fb: ldloc.2
-			IL_00fc: stelem.ref
-			IL_00fd: dup
-			IL_00fe: ldc.i4.2
-			IL_00ff: ldloc.3
-			IL_0100: stelem.ref
-			IL_0101: pop
-			IL_0102: ldloc.0
-			IL_0103: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0108: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_010d: ret
+			IL_00da: ldloc.0
+			IL_00db: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00e5: ldloc.0
+			IL_00e6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00eb: dup
+			IL_00ec: ldc.i4.0
+			IL_00ed: ldloc.1
+			IL_00ee: stelem.ref
+			IL_00ef: dup
+			IL_00f0: ldc.i4.1
+			IL_00f1: ldloc.2
+			IL_00f2: stelem.ref
+			IL_00f3: dup
+			IL_00f4: ldc.i4.2
+			IL_00f5: ldloc.3
+			IL_00f6: stelem.ref
+			IL_00f7: pop
+			IL_00f8: ldloc.0
+			IL_00f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00fe: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0103: ret
 
-			IL_010e: ldloc.0
-			IL_010f: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited1
-			IL_0114: stloc.s 5
-			IL_0116: ldloc.s 5
-			IL_0118: stloc.2
-			IL_0119: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_011e: ldloc.2
-			IL_011f: ldstr "value"
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_012e: pop
-			IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0134: ldloc.2
-			IL_0135: ldstr "done"
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0144: pop
-			IL_0145: ldloc.1
-			IL_0146: ldstr "return"
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0150: stloc.s 5
-			IL_0152: ldloc.0
+			IL_0104: ldloc.0
+			IL_0105: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited1
+			IL_010a: stloc.s 5
+			IL_010c: ldloc.s 5
+			IL_010e: stloc.2
+			IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0114: ldloc.2
+			IL_0115: ldstr "value"
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0124: pop
+			IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012a: ldloc.2
+			IL_012b: ldstr "done"
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_013a: pop
+			IL_013b: ldloc.1
+			IL_013c: ldstr "return"
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0146: stloc.s 5
+			IL_0148: ldloc.0
+			IL_0149: ldc.i4.2
+			IL_014a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_014f: ldloc.0
+			IL_0150: ldloc.s 5
+			IL_0152: ldarg.0
 			IL_0153: ldc.i4.2
-			IL_0154: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0159: ldloc.0
-			IL_015a: ldloc.s 5
-			IL_015c: ldarg.0
-			IL_015d: ldc.i4.2
-			IL_015e: ldloc.0
-			IL_015f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0164: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0169: ldloc.0
-			IL_016a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_016f: dup
-			IL_0170: ldc.i4.0
-			IL_0171: ldloc.1
-			IL_0172: stelem.ref
-			IL_0173: dup
-			IL_0174: ldc.i4.1
-			IL_0175: ldloc.2
-			IL_0176: stelem.ref
-			IL_0177: dup
-			IL_0178: ldc.i4.2
-			IL_0179: ldloc.3
-			IL_017a: stelem.ref
-			IL_017b: pop
-			IL_017c: ldloc.0
-			IL_017d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0182: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0187: ret
+			IL_0154: ldloc.0
+			IL_0155: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_015a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_015f: ldloc.0
+			IL_0160: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0165: dup
+			IL_0166: ldc.i4.0
+			IL_0167: ldloc.1
+			IL_0168: stelem.ref
+			IL_0169: dup
+			IL_016a: ldc.i4.1
+			IL_016b: ldloc.2
+			IL_016c: stelem.ref
+			IL_016d: dup
+			IL_016e: ldc.i4.2
+			IL_016f: ldloc.3
+			IL_0170: stelem.ref
+			IL_0171: pop
+			IL_0172: ldloc.0
+			IL_0173: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0178: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_017d: ret
 
-			IL_0188: ldloc.0
-			IL_0189: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited2
-			IL_018e: stloc.s 5
-			IL_0190: ldloc.s 5
-			IL_0192: stloc.3
-			IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0198: ldloc.3
-			IL_0199: ldstr "done"
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01a8: pop
-			IL_01a9: ldloc.0
-			IL_01aa: ldc.i4.m1
-			IL_01ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01b0: ldloc.0
-			IL_01b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01bb: ldarg.0
-			IL_01bc: ldc.i4.1
-			IL_01bd: newarr [System.Runtime]System.Object
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01c7: pop
-			IL_01c8: ldloc.0
-			IL_01c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ce: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01d3: ret
+			IL_017e: ldloc.0
+			IL_017f: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited2
+			IL_0184: stloc.s 5
+			IL_0186: ldloc.s 5
+			IL_0188: stloc.3
+			IL_0189: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_018e: ldloc.3
+			IL_018f: ldstr "done"
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_019e: pop
+			IL_019f: ldloc.0
+			IL_01a0: ldc.i4.m1
+			IL_01a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01a6: ldloc.0
+			IL_01a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01b1: ldarg.0
+			IL_01b2: ldc.i4.1
+			IL_01b3: newarr [System.Runtime]System.Object
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01bd: pop
+			IL_01be: ldloc.0
+			IL_01bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01c9: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -281,18 +279,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x228c
+			// Method begins at RVA 0x2282
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope::timersPromises
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -363,7 +358,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22a9
+		// Method begins at RVA 0x2294
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
+++ b/tests/Js2IL.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
@@ -27,7 +27,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24fa
+				// Method begins at RVA 0x24c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f8
+			// Method begins at RVA 0x23dc
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -94,7 +94,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x250c
+					// Method begins at RVA 0x24d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -112,7 +112,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2503
+				// Method begins at RVA 0x24d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -137,7 +137,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x242c
+			// Method begins at RVA 0x2410
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -189,7 +189,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x251e
+					// Method begins at RVA 0x24eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -211,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2515
+				// Method begins at RVA 0x24e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,15 +239,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2474
+			// Method begins at RVA 0x2458
 			// Header size: 12
-			// Code size: 102 (0x66)
+			// Code size: 90 (0x5a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/Scope/Block_L35C21,
 				[1] object,
-				[2] bool,
-				[3] object
+				[2] bool
 			)
 
 			IL_0000: ldarg.3
@@ -268,24 +267,20 @@
 			IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0030: stloc.2
 			IL_0031: ldloc.2
-			IL_0032: brfalse IL_0064
+			IL_0032: brfalse IL_0058
 
 			IL_0037: newobj instance void Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/Scope/Block_L35C21::.ctor()
 			IL_003c: stloc.0
 			IL_003d: ldarg.0
 			IL_003e: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-			IL_0043: ldstr "Cannot access 'mutating' before initialization"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_004d: stloc.3
-			IL_004e: ldloc.3
-			IL_004f: ldstr "append"
-			IL_0054: ldstr "b"
-			IL_0059: ldstr "2"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0063: pop
+			IL_0043: ldstr "append"
+			IL_0048: ldstr "b"
+			IL_004d: ldstr "2"
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0057: pop
 
-			IL_0064: ldnull
-			IL_0065: ret
+			IL_0058: ldnull
+			IL_0059: ret
 		} // end of method ArrowFunction_L33C18::__js_call__
 
 	} // end of class ArrowFunction_L33C18
@@ -304,18 +299,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24e6
+			// Method begins at RVA 0x24be
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -333,7 +325,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 924 (0x39c)
+		// Code size: 896 (0x380)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Url_SearchParams_Mutate/Scope,
@@ -342,8 +334,7 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
 			[5] object,
-			[6] object,
-			[7] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Url_SearchParams_Mutate/Scope::.ctor()
@@ -543,90 +534,82 @@
 		IL_0290: ldloc.0
 		IL_0291: ldloc.s 6
 		IL_0293: stfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-		IL_0298: ldloc.0
-		IL_0299: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-		IL_029e: ldstr "Cannot access 'mutating' before initialization"
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_02a8: stloc.s 6
-		IL_02aa: ldc.i4.1
-		IL_02ab: newarr [System.Runtime]System.Object
-		IL_02b0: dup
-		IL_02b1: ldc.i4.0
-		IL_02b2: ldloc.0
-		IL_02b3: stelem.ref
-		IL_02b4: ldc.i4.0
-		IL_02b5: ldelem.ref
-		IL_02b6: castclass Modules.Require_Url_SearchParams_Mutate/Scope
-		IL_02bb: ldftn object Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18::__js_call__(class Modules.Require_Url_SearchParams_Mutate/Scope, object, object, object)
-		IL_02c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_02c6: ldc.i4.1
-		IL_02c7: newarr [System.Runtime]System.Object
-		IL_02cc: dup
-		IL_02cd: ldc.i4.0
-		IL_02ce: ldloc.0
-		IL_02cf: stelem.ref
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02da: ldc.i4.2
-		IL_02db: conv.r8
-		IL_02dc: ldstr ""
-		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02e6: stloc.s 7
-		IL_02e8: ldloc.s 6
-		IL_02ea: ldstr "forEach"
-		IL_02ef: ldloc.s 7
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02f6: pop
-		IL_02f7: ldloc.0
-		IL_02f8: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-		IL_02fd: ldstr "Cannot access 'mutating' before initialization"
-		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0307: stloc.s 7
-		IL_0309: ldloc.s 7
-		IL_030b: ldstr "toString"
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0315: stloc.s 7
-		IL_0317: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_031c: ldstr "mutating final:"
-		IL_0321: ldloc.s 7
-		IL_0323: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0328: pop
-		IL_0329: ldloc.1
-		IL_032a: ldstr "URLSearchParams"
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0334: stloc.s 7
-		IL_0336: ldloc.s 7
-		IL_0338: ldc.i4.1
-		IL_0339: newarr [System.Runtime]System.Object
-		IL_033e: dup
-		IL_033f: ldc.i4.0
-		IL_0340: ldstr "bad=%&plus=a+b%"
-		IL_0345: stelem.ref
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_034b: stloc.s 7
-		IL_034d: ldloc.s 7
-		IL_034f: stloc.s 5
-		IL_0351: ldloc.s 5
-		IL_0353: ldstr "get"
-		IL_0358: ldstr "bad"
-		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0362: stloc.s 7
-		IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0369: ldstr "malformed bad:"
-		IL_036e: ldloc.s 7
-		IL_0370: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0375: pop
-		IL_0376: ldloc.s 5
-		IL_0378: ldstr "get"
-		IL_037d: ldstr "plus"
-		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0387: stloc.s 7
-		IL_0389: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_038e: ldstr "malformed plus:"
-		IL_0393: ldloc.s 7
-		IL_0395: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_039a: pop
-		IL_039b: ret
+		IL_0298: ldc.i4.1
+		IL_0299: newarr [System.Runtime]System.Object
+		IL_029e: dup
+		IL_029f: ldc.i4.0
+		IL_02a0: ldloc.0
+		IL_02a1: stelem.ref
+		IL_02a2: ldc.i4.0
+		IL_02a3: ldelem.ref
+		IL_02a4: castclass Modules.Require_Url_SearchParams_Mutate/Scope
+		IL_02a9: ldftn object Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18::__js_call__(class Modules.Require_Url_SearchParams_Mutate/Scope, object, object, object)
+		IL_02af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_02b4: ldc.i4.1
+		IL_02b5: newarr [System.Runtime]System.Object
+		IL_02ba: dup
+		IL_02bb: ldc.i4.0
+		IL_02bc: ldloc.0
+		IL_02bd: stelem.ref
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02c8: ldc.i4.2
+		IL_02c9: conv.r8
+		IL_02ca: ldstr ""
+		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_02d4: stloc.s 6
+		IL_02d6: ldloc.0
+		IL_02d7: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
+		IL_02dc: ldstr "forEach"
+		IL_02e1: ldloc.s 6
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02e8: pop
+		IL_02e9: ldloc.0
+		IL_02ea: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
+		IL_02ef: ldstr "toString"
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_02f9: stloc.s 6
+		IL_02fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0300: ldstr "mutating final:"
+		IL_0305: ldloc.s 6
+		IL_0307: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_030c: pop
+		IL_030d: ldloc.1
+		IL_030e: ldstr "URLSearchParams"
+		IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0318: stloc.s 6
+		IL_031a: ldloc.s 6
+		IL_031c: ldc.i4.1
+		IL_031d: newarr [System.Runtime]System.Object
+		IL_0322: dup
+		IL_0323: ldc.i4.0
+		IL_0324: ldstr "bad=%&plus=a+b%"
+		IL_0329: stelem.ref
+		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_032f: stloc.s 6
+		IL_0331: ldloc.s 6
+		IL_0333: stloc.s 5
+		IL_0335: ldloc.s 5
+		IL_0337: ldstr "get"
+		IL_033c: ldstr "bad"
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0346: stloc.s 6
+		IL_0348: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_034d: ldstr "malformed bad:"
+		IL_0352: ldloc.s 6
+		IL_0354: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0359: pop
+		IL_035a: ldloc.s 5
+		IL_035c: ldstr "get"
+		IL_0361: ldstr "plus"
+		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_036b: stloc.s 6
+		IL_036d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0372: ldstr "malformed plus:"
+		IL_0377: ldloc.s 6
+		IL_0379: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_037e: pop
+		IL_037f: ret
 	} // end of method Require_Url_SearchParams_Mutate::__js_module_init__
 
 } // end of class Modules.Require_Url_SearchParams_Mutate
@@ -638,7 +621,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2527
+		// Method begins at RVA 0x24f4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Js2IL.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2726
+					// Method begins at RVA 0x26a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x272f
+					// Method begins at RVA 0x26ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x271d
+				// Method begins at RVA 0x269c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2474
+			// Method begins at RVA 0x2440
 			// Header size: 12
 			// Code size: 226 (0xe2)
 			.maxstack 8
@@ -204,7 +204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2738
+				// Method begins at RVA 0x26b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,9 +230,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2540
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 51 (0x33)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -240,21 +240,19 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: ldstr "Cannot access 'zlib' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "gzipSync"
-			IL_0017: ldstr "abc"
-			IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0021: dup
-			IL_0022: ldstr "chunkSize"
-			IL_0027: ldc.r8 1024
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_003a: stloc.0
-			IL_003b: ldloc.0
-			IL_003c: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "gzipSync"
+			IL_000d: ldstr "abc"
+			IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0017: dup
+			IL_0018: ldstr "chunkSize"
+			IL_001d: ldc.r8 1024
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0030: stloc.0
+			IL_0031: ldloc.0
+			IL_0032: ret
 		} // end of method ArrowFunction_L25C37::__js_call__
 
 	} // end of class ArrowFunction_L25C37
@@ -270,7 +268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2741
+				// Method begins at RVA 0x26c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -296,9 +294,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x25c0
+			// Method begins at RVA 0x2580
 			// Header size: 12
-			// Code size: 91 (0x5b)
+			// Code size: 69 (0x45)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -307,31 +305,25 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: ldstr "Cannot access 'zlib' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldarg.0
-			IL_0012: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0017: ldstr "Cannot access 'zlib' before initialization"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0021: stloc.1
-			IL_0022: ldloc.1
-			IL_0023: ldstr "gzipSync"
-			IL_0028: ldstr "abc"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0032: stloc.1
-			IL_0033: ldloc.0
-			IL_0034: ldstr "gunzipSync"
-			IL_0039: ldloc.1
-			IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003f: dup
-			IL_0040: ldstr "flush"
-			IL_0045: ldc.r8 2
-			IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0058: stloc.1
-			IL_0059: ldloc.1
-			IL_005a: ret
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_000d: ldstr "gzipSync"
+			IL_0012: ldstr "abc"
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001c: stloc.1
+			IL_001d: ldloc.0
+			IL_001e: ldstr "gunzipSync"
+			IL_0023: ldloc.1
+			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0029: dup
+			IL_002a: ldstr "flush"
+			IL_002f: ldc.r8 2
+			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.1
+			IL_0043: ldloc.1
+			IL_0044: ret
 		} // end of method ArrowFunction_L26C39::__js_call__
 
 	} // end of class ArrowFunction_L26C39
@@ -347,7 +339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x274a
+				// Method begins at RVA 0x26c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -373,9 +365,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2628
+			// Method begins at RVA 0x25d4
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 51 (0x33)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -383,21 +375,19 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: ldstr "Cannot access 'zlib' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "gzipSync"
-			IL_0017: ldstr "abc"
-			IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0021: dup
-			IL_0022: ldstr "level"
-			IL_0027: ldc.r8 10
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_003a: stloc.0
-			IL_003b: ldloc.0
-			IL_003c: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "gzipSync"
+			IL_000d: ldstr "abc"
+			IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0017: dup
+			IL_0018: ldstr "level"
+			IL_001d: ldc.r8 10
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0030: stloc.0
+			IL_0031: ldloc.0
+			IL_0032: ret
 		} // end of method ArrowFunction_L27C28::__js_call__
 
 	} // end of class ArrowFunction_L27C28
@@ -413,7 +403,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2753
+				// Method begins at RVA 0x26d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -439,9 +429,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2674
+			// Method begins at RVA 0x2614
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 51 (0x33)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -449,21 +439,19 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: ldstr "Cannot access 'zlib' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "gzipSync"
-			IL_0017: ldstr "abc"
-			IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0021: dup
-			IL_0022: ldstr "level"
-			IL_0027: ldc.r8 (00 00 00 00 00 00 F8 FF)
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_003a: stloc.0
-			IL_003b: ldloc.0
-			IL_003c: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "gzipSync"
+			IL_000d: ldstr "abc"
+			IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0017: dup
+			IL_0018: ldstr "level"
+			IL_001d: ldc.r8 (00 00 00 00 00 00 F8 FF)
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0030: stloc.0
+			IL_0031: ldloc.0
+			IL_0032: ret
 		} // end of method ArrowFunction_L28C28::__js_call__
 
 	} // end of class ArrowFunction_L28C28
@@ -479,7 +467,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x275c
+				// Method begins at RVA 0x26db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -505,9 +493,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x26c0
+			// Method begins at RVA 0x2654
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 51 (0x33)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -515,21 +503,19 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: ldstr "Cannot access 'zlib' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "gzipSync"
-			IL_0017: ldstr "abc"
-			IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0021: dup
-			IL_0022: ldstr "level"
-			IL_0027: ldc.r8 (00 00 00 00 00 00 F0 7F)
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_003a: stloc.0
-			IL_003b: ldloc.0
-			IL_003c: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "gzipSync"
+			IL_000d: ldstr "abc"
+			IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0017: dup
+			IL_0018: ldstr "level"
+			IL_001d: ldc.r8 (00 00 00 00 00 00 F0 7F)
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0030: stloc.0
+			IL_0031: ldloc.0
+			IL_0032: ret
 		} // end of method ArrowFunction_L29C33::__js_call__
 
 	} // end of class ArrowFunction_L29C33
@@ -550,7 +536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2765
+				// Method begins at RVA 0x26e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -570,7 +556,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x276e
+				// Method begins at RVA 0x26ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -592,18 +578,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2709
+			// Method begins at RVA 0x2693
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -621,7 +604,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1029 (0x405)
+		// Code size: 979 (0x3d3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_ErrorPaths/Scope,
@@ -662,333 +645,323 @@
 		IL_0033: stfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
 		IL_0038: ldloc.0
 		IL_0039: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_003e: ldstr "Cannot access 'zlib' before initialization"
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0048: stloc.s 7
-		IL_004a: ldloc.0
-		IL_004b: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_0050: ldstr "Cannot access 'zlib' before initialization"
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_005a: stloc.s 8
-		IL_005c: ldloc.s 8
-		IL_005e: ldstr "gzipSync"
-		IL_0063: ldstr "abc"
-		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_006d: dup
-		IL_006e: ldstr "level"
-		IL_0073: ldc.r8 1
-		IL_007c: neg
-		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0087: stloc.s 8
-		IL_0089: ldloc.s 7
-		IL_008b: ldstr "gunzipSync"
-		IL_0090: ldloc.s 8
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0097: stloc.s 8
-		IL_0099: ldloc.s 8
-		IL_009b: ldstr "toString"
-		IL_00a0: ldstr "utf8"
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00aa: stloc.s 8
-		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b1: ldstr "gzip level -1 roundtrip:"
-		IL_00b6: ldloc.s 8
-		IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00bd: pop
-		IL_00be: ldloc.0
-		IL_00bf: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_00c4: ldstr "Cannot access 'zlib' before initialization"
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00ce: stloc.s 8
-		IL_00d0: ldloc.0
-		IL_00d1: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_00d6: ldstr "Cannot access 'zlib' before initialization"
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00e0: stloc.s 7
-		IL_00e2: ldloc.s 7
-		IL_00e4: ldstr "gzipSync"
-		IL_00e9: ldstr "abc"
-		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00f3: dup
-		IL_00f4: ldstr "level"
-		IL_00f9: ldc.r8 1.5
-		IL_0102: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_010c: stloc.s 7
-		IL_010e: ldloc.s 8
-		IL_0110: ldstr "gunzipSync"
-		IL_0115: ldloc.s 7
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011c: stloc.s 7
-		IL_011e: ldloc.s 7
-		IL_0120: ldstr "toString"
-		IL_0125: ldstr "utf8"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_012f: stloc.s 7
-		IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0136: ldstr "gzip level 1.5 roundtrip:"
-		IL_013b: ldloc.s 7
-		IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0142: pop
-		IL_0143: ldc.i4.1
-		IL_0144: newarr [System.Runtime]System.Object
-		IL_0149: dup
-		IL_014a: ldc.i4.0
-		IL_014b: ldloc.0
-		IL_014c: stelem.ref
-		IL_014d: ldc.i4.0
-		IL_014e: ldelem.ref
-		IL_014f: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0154: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_015f: ldc.i4.1
-		IL_0160: newarr [System.Runtime]System.Object
-		IL_0165: dup
-		IL_0166: ldc.i4.0
-		IL_0167: ldloc.0
-		IL_0168: stelem.ref
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0173: ldc.i4.0
-		IL_0174: conv.r8
-		IL_0175: ldstr ""
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_017f: stloc.s 7
-		IL_0181: ldnull
-		IL_0182: ldstr "gzip unsupported option"
-		IL_0187: ldloc.s 7
-		IL_0189: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_018e: pop
-		IL_018f: ldc.i4.1
-		IL_0190: newarr [System.Runtime]System.Object
-		IL_0195: dup
-		IL_0196: ldc.i4.0
-		IL_0197: ldloc.0
-		IL_0198: stelem.ref
-		IL_0199: ldc.i4.0
-		IL_019a: ldelem.ref
-		IL_019b: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_01a0: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_01a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01ab: ldc.i4.1
-		IL_01ac: newarr [System.Runtime]System.Object
-		IL_01b1: dup
-		IL_01b2: ldc.i4.0
-		IL_01b3: ldloc.0
-		IL_01b4: stelem.ref
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01bf: ldc.i4.0
-		IL_01c0: conv.r8
-		IL_01c1: ldstr ""
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01cb: stloc.s 7
-		IL_01cd: ldnull
-		IL_01ce: ldstr "gunzip unsupported option"
-		IL_01d3: ldloc.s 7
-		IL_01d5: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_01da: pop
-		IL_01db: ldc.i4.1
-		IL_01dc: newarr [System.Runtime]System.Object
-		IL_01e1: dup
-		IL_01e2: ldc.i4.0
-		IL_01e3: ldloc.0
-		IL_01e4: stelem.ref
-		IL_01e5: ldc.i4.0
-		IL_01e6: ldelem.ref
-		IL_01e7: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_01ec: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_01f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01f7: ldc.i4.1
-		IL_01f8: newarr [System.Runtime]System.Object
-		IL_01fd: dup
-		IL_01fe: ldc.i4.0
-		IL_01ff: ldloc.0
-		IL_0200: stelem.ref
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_020b: ldc.i4.0
-		IL_020c: conv.r8
-		IL_020d: ldstr ""
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0217: stloc.s 7
-		IL_0219: ldnull
-		IL_021a: ldstr "gzip bad level"
-		IL_021f: ldloc.s 7
-		IL_0221: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0226: pop
-		IL_0227: ldc.i4.1
-		IL_0228: newarr [System.Runtime]System.Object
-		IL_022d: dup
-		IL_022e: ldc.i4.0
-		IL_022f: ldloc.0
-		IL_0230: stelem.ref
-		IL_0231: ldc.i4.0
-		IL_0232: ldelem.ref
-		IL_0233: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0238: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0243: ldc.i4.1
-		IL_0244: newarr [System.Runtime]System.Object
-		IL_0249: dup
-		IL_024a: ldc.i4.0
-		IL_024b: ldloc.0
-		IL_024c: stelem.ref
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0257: ldc.i4.0
-		IL_0258: conv.r8
-		IL_0259: ldstr ""
-		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0263: stloc.s 7
-		IL_0265: ldnull
-		IL_0266: ldstr "gzip NaN level"
-		IL_026b: ldloc.s 7
-		IL_026d: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0272: pop
-		IL_0273: ldc.i4.1
-		IL_0274: newarr [System.Runtime]System.Object
-		IL_0279: dup
-		IL_027a: ldc.i4.0
-		IL_027b: ldloc.0
-		IL_027c: stelem.ref
-		IL_027d: ldc.i4.0
-		IL_027e: ldelem.ref
-		IL_027f: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0284: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_028a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_028f: ldc.i4.1
-		IL_0290: newarr [System.Runtime]System.Object
-		IL_0295: dup
-		IL_0296: ldc.i4.0
-		IL_0297: ldloc.0
-		IL_0298: stelem.ref
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02a3: ldc.i4.0
-		IL_02a4: conv.r8
-		IL_02a5: ldstr ""
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02af: stloc.s 7
-		IL_02b1: ldnull
-		IL_02b2: ldstr "gzip Infinity level"
-		IL_02b7: ldloc.s 7
-		IL_02b9: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_02be: pop
+		IL_003e: stloc.s 7
+		IL_0040: ldloc.0
+		IL_0041: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_0046: stloc.s 8
+		IL_0048: ldloc.s 8
+		IL_004a: ldstr "gzipSync"
+		IL_004f: ldstr "abc"
+		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0059: dup
+		IL_005a: ldstr "level"
+		IL_005f: ldc.r8 1
+		IL_0068: neg
+		IL_0069: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0073: stloc.s 8
+		IL_0075: ldloc.s 7
+		IL_0077: ldstr "gunzipSync"
+		IL_007c: ldloc.s 8
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0083: stloc.s 8
+		IL_0085: ldloc.s 8
+		IL_0087: ldstr "toString"
+		IL_008c: ldstr "utf8"
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0096: stloc.s 8
+		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009d: ldstr "gzip level -1 roundtrip:"
+		IL_00a2: ldloc.s 8
+		IL_00a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a9: pop
+		IL_00aa: ldloc.0
+		IL_00ab: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_00b0: stloc.s 8
+		IL_00b2: ldloc.0
+		IL_00b3: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_00b8: stloc.s 7
+		IL_00ba: ldloc.s 7
+		IL_00bc: ldstr "gzipSync"
+		IL_00c1: ldstr "abc"
+		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00cb: dup
+		IL_00cc: ldstr "level"
+		IL_00d1: ldc.r8 1.5
+		IL_00da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00e4: stloc.s 7
+		IL_00e6: ldloc.s 8
+		IL_00e8: ldstr "gunzipSync"
+		IL_00ed: ldloc.s 7
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f4: stloc.s 7
+		IL_00f6: ldloc.s 7
+		IL_00f8: ldstr "toString"
+		IL_00fd: ldstr "utf8"
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0107: stloc.s 7
+		IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010e: ldstr "gzip level 1.5 roundtrip:"
+		IL_0113: ldloc.s 7
+		IL_0115: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_011a: pop
+		IL_011b: ldc.i4.1
+		IL_011c: newarr [System.Runtime]System.Object
+		IL_0121: dup
+		IL_0122: ldc.i4.0
+		IL_0123: ldloc.0
+		IL_0124: stelem.ref
+		IL_0125: ldc.i4.0
+		IL_0126: ldelem.ref
+		IL_0127: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_012c: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0137: ldc.i4.1
+		IL_0138: newarr [System.Runtime]System.Object
+		IL_013d: dup
+		IL_013e: ldc.i4.0
+		IL_013f: ldloc.0
+		IL_0140: stelem.ref
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_014b: ldc.i4.0
+		IL_014c: conv.r8
+		IL_014d: ldstr ""
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0157: stloc.s 7
+		IL_0159: ldnull
+		IL_015a: ldstr "gzip unsupported option"
+		IL_015f: ldloc.s 7
+		IL_0161: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
+		IL_0166: pop
+		IL_0167: ldc.i4.1
+		IL_0168: newarr [System.Runtime]System.Object
+		IL_016d: dup
+		IL_016e: ldc.i4.0
+		IL_016f: ldloc.0
+		IL_0170: stelem.ref
+		IL_0171: ldc.i4.0
+		IL_0172: ldelem.ref
+		IL_0173: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0178: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_017e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0183: ldc.i4.1
+		IL_0184: newarr [System.Runtime]System.Object
+		IL_0189: dup
+		IL_018a: ldc.i4.0
+		IL_018b: ldloc.0
+		IL_018c: stelem.ref
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0197: ldc.i4.0
+		IL_0198: conv.r8
+		IL_0199: ldstr ""
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01a3: stloc.s 7
+		IL_01a5: ldnull
+		IL_01a6: ldstr "gunzip unsupported option"
+		IL_01ab: ldloc.s 7
+		IL_01ad: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
+		IL_01b2: pop
+		IL_01b3: ldc.i4.1
+		IL_01b4: newarr [System.Runtime]System.Object
+		IL_01b9: dup
+		IL_01ba: ldc.i4.0
+		IL_01bb: ldloc.0
+		IL_01bc: stelem.ref
+		IL_01bd: ldc.i4.0
+		IL_01be: ldelem.ref
+		IL_01bf: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_01c4: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01cf: ldc.i4.1
+		IL_01d0: newarr [System.Runtime]System.Object
+		IL_01d5: dup
+		IL_01d6: ldc.i4.0
+		IL_01d7: ldloc.0
+		IL_01d8: stelem.ref
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01e3: ldc.i4.0
+		IL_01e4: conv.r8
+		IL_01e5: ldstr ""
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01ef: stloc.s 7
+		IL_01f1: ldnull
+		IL_01f2: ldstr "gzip bad level"
+		IL_01f7: ldloc.s 7
+		IL_01f9: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
+		IL_01fe: pop
+		IL_01ff: ldc.i4.1
+		IL_0200: newarr [System.Runtime]System.Object
+		IL_0205: dup
+		IL_0206: ldc.i4.0
+		IL_0207: ldloc.0
+		IL_0208: stelem.ref
+		IL_0209: ldc.i4.0
+		IL_020a: ldelem.ref
+		IL_020b: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0210: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0216: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_021b: ldc.i4.1
+		IL_021c: newarr [System.Runtime]System.Object
+		IL_0221: dup
+		IL_0222: ldc.i4.0
+		IL_0223: ldloc.0
+		IL_0224: stelem.ref
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_022f: ldc.i4.0
+		IL_0230: conv.r8
+		IL_0231: ldstr ""
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_023b: stloc.s 7
+		IL_023d: ldnull
+		IL_023e: ldstr "gzip NaN level"
+		IL_0243: ldloc.s 7
+		IL_0245: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
+		IL_024a: pop
+		IL_024b: ldc.i4.1
+		IL_024c: newarr [System.Runtime]System.Object
+		IL_0251: dup
+		IL_0252: ldc.i4.0
+		IL_0253: ldloc.0
+		IL_0254: stelem.ref
+		IL_0255: ldc.i4.0
+		IL_0256: ldelem.ref
+		IL_0257: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_025c: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0262: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0267: ldc.i4.1
+		IL_0268: newarr [System.Runtime]System.Object
+		IL_026d: dup
+		IL_026e: ldc.i4.0
+		IL_026f: ldloc.0
+		IL_0270: stelem.ref
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_027b: ldc.i4.0
+		IL_027c: conv.r8
+		IL_027d: ldstr ""
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0287: stloc.s 7
+		IL_0289: ldnull
+		IL_028a: ldstr "gzip Infinity level"
+		IL_028f: ldloc.s 7
+		IL_0291: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
+		IL_0296: pop
 		.try
 		{
-			IL_02bf: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L31C4::.ctor()
-			IL_02c4: stloc.2
-			IL_02c5: ldloc.0
-			IL_02c6: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_02cb: ldstr "Cannot access 'zlib' before initialization"
-			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_02d5: stloc.s 7
-			IL_02d7: ldstr "not gzip"
-			IL_02dc: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_02e1: stloc.s 9
-			IL_02e3: ldloc.s 7
-			IL_02e5: ldstr "gunzipSync"
-			IL_02ea: ldloc.s 9
-			IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02f1: pop
-			IL_02f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02f7: ldstr "gunzip invalid data threw:"
-			IL_02fc: ldc.i4.0
-			IL_02fd: box [System.Runtime]System.Boolean
-			IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0307: pop
-			IL_0308: leave IL_0404
+			IL_0297: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L31C4::.ctor()
+			IL_029c: stloc.2
+			IL_029d: ldloc.0
+			IL_029e: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_02a3: stloc.s 7
+			IL_02a5: ldstr "not gzip"
+			IL_02aa: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_02af: stloc.s 9
+			IL_02b1: ldloc.s 7
+			IL_02b3: ldstr "gunzipSync"
+			IL_02b8: ldloc.s 9
+			IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02bf: pop
+			IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02c5: ldstr "gunzip invalid data threw:"
+			IL_02ca: ldc.i4.0
+			IL_02cb: box [System.Runtime]System.Boolean
+			IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_02d5: pop
+			IL_02d6: leave IL_03d2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_030d: stloc.3
-			IL_030e: ldloc.3
-			IL_030f: dup
-			IL_0310: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0315: dup
-			IL_0316: brtrue IL_032c
+			IL_02db: stloc.3
+			IL_02dc: ldloc.3
+			IL_02dd: dup
+			IL_02de: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02e3: dup
+			IL_02e4: brtrue IL_02fa
 
-			IL_031b: pop
-			IL_031c: dup
-			IL_031d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0322: dup
-			IL_0323: brtrue IL_0339
+			IL_02e9: pop
+			IL_02ea: dup
+			IL_02eb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02f0: dup
+			IL_02f1: brtrue IL_0307
 
-			IL_0328: pop
-			IL_0329: pop
-			IL_032a: rethrow
+			IL_02f6: pop
+			IL_02f7: pop
+			IL_02f8: rethrow
 
-			IL_032c: pop
-			IL_032d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0332: stloc.s 4
-			IL_0334: br IL_033c
+			IL_02fa: pop
+			IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0300: stloc.s 4
+			IL_0302: br IL_030a
 
-			IL_0339: pop
-			IL_033a: stloc.s 4
+			IL_0307: pop
+			IL_0308: stloc.s 4
 
-			IL_033c: ldloc.s 4
-			IL_033e: stloc.s 7
-			IL_0340: ldloc.s 7
-			IL_0342: stloc.s 5
-			IL_0344: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L34C16::.ctor()
-			IL_0349: stloc.s 6
+			IL_030a: ldloc.s 4
+			IL_030c: stloc.s 7
+			IL_030e: ldloc.s 7
+			IL_0310: stloc.s 5
+			IL_0312: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L34C16::.ctor()
+			IL_0317: stloc.s 6
+			IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_031e: ldstr "gunzip invalid data threw:"
+			IL_0323: ldc.i4.1
+			IL_0324: box [System.Runtime]System.Boolean
+			IL_0329: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_032e: pop
+			IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0334: ldstr "gunzip invalid data name:"
+			IL_0339: ldloc.s 5
+			IL_033b: ldstr "name"
+			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_034a: pop
 			IL_034b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0350: ldstr "gunzip invalid data threw:"
-			IL_0355: ldc.i4.1
-			IL_0356: box [System.Runtime]System.Boolean
-			IL_035b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0360: pop
-			IL_0361: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0366: ldstr "gunzip invalid data name:"
-			IL_036b: ldloc.s 5
-			IL_036d: ldstr "name"
-			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0377: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_037c: pop
-			IL_037d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0382: stloc.s 10
-			IL_0384: ldloc.s 5
-			IL_0386: ldstr "message"
-			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0390: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_0395: ldstr "string"
-			IL_039a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_039f: stloc.s 11
-			IL_03a1: ldloc.s 11
-			IL_03a3: box [System.Runtime]System.Boolean
-			IL_03a8: stloc.s 12
-			IL_03aa: ldloc.s 12
-			IL_03ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03b1: stloc.s 11
-			IL_03b3: ldloc.s 11
-			IL_03b5: brfalse IL_03ec
+			IL_0350: stloc.s 10
+			IL_0352: ldloc.s 5
+			IL_0354: ldstr "message"
+			IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_035e: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0363: ldstr "string"
+			IL_0368: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_036d: stloc.s 11
+			IL_036f: ldloc.s 11
+			IL_0371: box [System.Runtime]System.Boolean
+			IL_0376: stloc.s 12
+			IL_0378: ldloc.s 12
+			IL_037a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_037f: stloc.s 11
+			IL_0381: ldloc.s 11
+			IL_0383: brfalse IL_03ba
 
-			IL_03ba: ldloc.s 5
-			IL_03bc: ldstr "message"
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c6: ldstr "length"
-			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_03d5: ldc.r8 0.0
-			IL_03de: cgt
-			IL_03e0: box [System.Runtime]System.Boolean
-			IL_03e5: stloc.s 14
-			IL_03e7: br IL_03f0
+			IL_0388: ldloc.s 5
+			IL_038a: ldstr "message"
+			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0394: ldstr "length"
+			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_039e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_03a3: ldc.r8 0.0
+			IL_03ac: cgt
+			IL_03ae: box [System.Runtime]System.Boolean
+			IL_03b3: stloc.s 14
+			IL_03b5: br IL_03be
 
-			IL_03ec: ldloc.s 12
-			IL_03ee: stloc.s 14
+			IL_03ba: ldloc.s 12
+			IL_03bc: stloc.s 14
 
-			IL_03f0: ldloc.s 10
-			IL_03f2: ldstr "gunzip invalid data message length > 0:"
-			IL_03f7: ldloc.s 14
-			IL_03f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_03fe: pop
-			IL_03ff: leave IL_0404
+			IL_03be: ldloc.s 10
+			IL_03c0: ldstr "gunzip invalid data message length > 0:"
+			IL_03c5: ldloc.s 14
+			IL_03c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_03cc: pop
+			IL_03cd: leave IL_03d2
 		} // end handler
 
-		IL_0404: ret
+		IL_03d2: ret
 	} // end of method Require_Zlib_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Zlib_ErrorPaths
@@ -1000,7 +973,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2777
+		// Method begins at RVA 0x26f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
+++ b/tests/Js2IL.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ec
+				// Method begins at RVA 0x2475
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,24 +46,23 @@
 			)
 			// Method begins at RVA 0x2344
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: ldstr "Cannot access 'events' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0006: ldstr "gzip:finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "gzip:finish"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L14C19::__js_call__
 
 	} // end of class ArrowFunction_L14C19
@@ -79,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f5
+				// Method begins at RVA 0x247e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,26 +104,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2374
+			// Method begins at RVA 0x236c
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: ldstr "Cannot access 'events' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0006: ldstr "gzip:end"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "gzip:end"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L15C16::__js_call__
 
 	} // end of class ArrowFunction_L15C16
@@ -140,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24fe
+				// Method begins at RVA 0x2487
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -166,26 +164,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x23a4
+			// Method begins at RVA 0x2394
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: ldstr "Cannot access 'events' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0006: ldstr "gunzip:finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "gunzip:finish"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L16C21::__js_call__
 
 	} // end of class ArrowFunction_L16C21
@@ -201,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2507
+				// Method begins at RVA 0x2490
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -227,26 +224,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x23d4
+			// Method begins at RVA 0x23bc
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] float64,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: ldstr "Cannot access 'events' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0006: ldstr "gunzip:end"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "gunzip:end"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L17C18::__js_call__
 
 	} // end of class ArrowFunction_L17C18
@@ -262,7 +258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2510
+				// Method begins at RVA 0x2499
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -289,26 +285,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2404
-			// Header size: 12
-			// Code size: 32 (0x20)
+			// Method begins at RVA 0x23e2
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
-			IL_0006: ldstr "Cannot access 'chunks' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldarg.2
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001d: pop
-			IL_001e: ldnull
-			IL_001f: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L19C18::__js_call__
 
 	} // end of class FunctionExpression_L19C18
@@ -324,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2519
+				// Method begins at RVA 0x24a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -350,60 +338,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2430
+			// Method begins at RVA 0x23f4
 			// Header size: 12
-			// Code size: 145 (0x91)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[1] object,
+				[2] string
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: ldstr "Cannot access 'events' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldstr "writable:finish"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0021: pop
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
-			IL_0028: ldstr "Cannot access 'chunks' before initialization"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0032: stloc.0
-			IL_0033: ldloc.0
-			IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
-			IL_0039: stloc.1
-			IL_003a: ldloc.1
-			IL_003b: ldstr "toString"
-			IL_0040: ldstr "utf8"
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_004a: stloc.0
-			IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0050: ldstr "output:"
-			IL_0055: ldloc.0
-			IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_005b: pop
-			IL_005c: ldarg.0
-			IL_005d: ldfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0062: ldstr "Cannot access 'events' before initialization"
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_006c: stloc.0
-			IL_006d: ldloc.0
-			IL_006e: ldstr "join"
-			IL_0073: ldstr ","
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007d: stloc.0
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0083: ldstr "events:"
-			IL_0088: ldloc.0
-			IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_008e: pop
-			IL_008f: ldnull
-			IL_0090: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0006: ldstr "writable:finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldarg.0
+			IL_0012: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
+			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldstr "toString"
+			IL_0023: ldstr "utf8"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002d: stloc.1
+			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0033: ldstr "output:"
+			IL_0038: ldloc.1
+			IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_003e: pop
+			IL_003f: ldarg.0
+			IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0045: ldc.i4.1
+			IL_0046: newarr [System.Runtime]System.Object
+			IL_004b: dup
+			IL_004c: ldc.i4.0
+			IL_004d: ldstr ","
+			IL_0052: stelem.ref
+			IL_0053: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0058: stloc.2
+			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_005e: ldstr "events:"
+			IL_0063: ldloc.2
+			IL_0064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0069: pop
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L23C22::__js_call__
 
 	} // end of class FunctionExpression_L23C22
@@ -417,28 +397,22 @@
 			3d 7b 65 76 65 6e 74 73 7d 00 00
 		)
 		// Fields
-		.field public object chunks
-		.field public object events
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array chunks
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array events
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24cd
+			// Method begins at RVA 0x246c
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -523,11 +497,11 @@
 		IL_0099: ldloc.0
 		IL_009a: ldc.i4.0
 		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00a0: stfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
+		IL_00a0: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
 		IL_00a5: ldloc.0
 		IL_00a6: ldc.i4.0
 		IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00ac: stfld object Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+		IL_00ac: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
 		IL_00b1: ldc.i4.1
 		IL_00b2: newarr [System.Runtime]System.Object
 		IL_00b7: dup
@@ -741,7 +715,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2522
+		// Method begins at RVA 0x24ab
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
+++ b/tests/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ae
+				// Method begins at RVA 0x218b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b7
+				// Method begins at RVA 0x2194
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,21 +102,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2160
-			// Header size: 12
-			// Code size: 19 (0x13)
+			// Method begins at RVA 0x215e
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/Scope::thenable
-			IL_0006: ldstr "Cannot access 'thenable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ret
+			IL_0006: ret
 		} // end of method ArrowFunction_L9C29::__js_call__
 
 	} // end of class ArrowFunction_L9C29
@@ -138,7 +131,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c0
+				// Method begins at RVA 0x219d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +155,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x2168
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -197,18 +190,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219a
+			// Method begins at RVA 0x2182
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/Scope::thenable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -323,7 +313,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c9
+		// Method begins at RVA 0x21a6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
+++ b/tests/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a6
+				// Method begins at RVA 0x2183
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21af
+				// Method begins at RVA 0x218c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,21 +102,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2158
-			// Header size: 12
-			// Code size: 19 (0x13)
+			// Method begins at RVA 0x2156
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/Scope::thenable
-			IL_0006: ldstr "Cannot access 'thenable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ret
+			IL_0006: ret
 		} // end of method ArrowFunction_L9C32::__js_call__
 
 	} // end of class ArrowFunction_L9C32
@@ -138,7 +131,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b8
+				// Method begins at RVA 0x2195
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +155,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x2160
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -197,18 +190,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2192
+			// Method begins at RVA 0x217a
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/Scope::thenable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -322,7 +312,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c1
+		// Method begins at RVA 0x219e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
+++ b/tests/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b2
+				// Method begins at RVA 0x219b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21bb
+				// Method begins at RVA 0x21a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,11 +106,10 @@
 			)
 			// Method begins at RVA 0x2150
 			// Header size: 12
-			// Code size: 39 (0x27)
+			// Code size: 27 (0x1b)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object[]
 			)
 
 			IL_0000: ldc.i4.1
@@ -120,18 +119,14 @@
 			IL_0008: ldarg.0
 			IL_0009: stelem.ref
 			IL_000a: stloc.0
-			IL_000b: ldarg.0
-			IL_000c: ldfld object Modules.Promise_Thenable_Nested/Scope::innerThenable
-			IL_0011: ldstr "Cannot access 'innerThenable' before initialization"
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_001b: stloc.1
-			IL_001c: ldarg.2
-			IL_001d: ldloc.0
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
-			IL_0024: pop
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_000b: ldarg.2
+			IL_000c: ldloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Promise_Thenable_Nested/Scope::innerThenable
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs1(object, object[], object)
+			IL_0018: pop
+			IL_0019: ldnull
+			IL_001a: ret
 		} // end of method outerThen::__js_call__
 
 	} // end of class outerThen
@@ -154,7 +149,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c4
+				// Method begins at RVA 0x21ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -178,7 +173,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2184
+			// Method begins at RVA 0x2178
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -216,18 +211,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219e
+			// Method begins at RVA 0x2192
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Promise_Thenable_Nested/Scope::innerThenable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -340,7 +332,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21cd
+		// Method begins at RVA 0x21b6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
+++ b/tests/Js2IL.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ae
+				// Method begins at RVA 0x218b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b7
+				// Method begins at RVA 0x2194
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,21 +102,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2160
-			// Header size: 12
-			// Code size: 19 (0x13)
+			// Method begins at RVA 0x215e
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Promise_Thenable_Returned_FromHandler/Scope::thenable
-			IL_0006: ldstr "Cannot access 'thenable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ret
+			IL_0006: ret
 		} // end of method ArrowFunction_L9C26::__js_call__
 
 	} // end of class ArrowFunction_L9C26
@@ -139,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c0
+				// Method begins at RVA 0x219d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -163,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x2168
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -198,18 +191,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219a
+			// Method begins at RVA 0x2182
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Promise_Thenable_Returned_FromHandler/Scope::thenable
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -324,7 +314,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c9
+		// Method begins at RVA 0x21a6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
+++ b/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2402
+				// Method begins at RVA 0x23cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e4
+			// Method begins at RVA 0x22d8
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -72,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x240b
+				// Method begins at RVA 0x23d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,58 +101,53 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22fc
+			// Method begins at RVA 0x22f0
 			// Header size: 12
-			// Code size: 133 (0x85)
+			// Code size: 103 (0x67)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] object,
+				[2] float64,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
-			IL_0006: ldstr "Cannot access 'applySeen' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "push"
-			IL_0017: ldarg.s args
-			IL_0019: ldc.r8 0.0
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002c: pop
-			IL_002d: ldarg.0
-			IL_002e: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
-			IL_0033: ldstr "Cannot access 'applySeen' before initialization"
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_003d: stloc.0
-			IL_003e: ldloc.0
-			IL_003f: ldstr "push"
-			IL_0044: ldarg.s args
-			IL_0046: ldc.r8 1
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0059: pop
-			IL_005a: ldarg.2
-			IL_005b: ldstr "apply"
-			IL_0060: ldarg.3
-			IL_0061: ldarg.s args
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0068: stloc.0
-			IL_0069: ldloc.0
-			IL_006a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_006f: stloc.1
-			IL_0070: ldloc.1
-			IL_0071: ldc.r8 2
-			IL_007a: mul
-			IL_007b: stloc.1
-			IL_007c: ldloc.1
-			IL_007d: box [System.Runtime]System.Double
-			IL_0082: stloc.2
-			IL_0083: ldloc.2
-			IL_0084: ret
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldarg.s args
+			IL_000a: ldc.r8 0.0
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0018: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_001d: pop
+			IL_001e: ldarg.0
+			IL_001f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
+			IL_0024: stloc.0
+			IL_0025: ldloc.0
+			IL_0026: ldarg.s args
+			IL_0028: ldc.r8 1
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0036: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_003b: pop
+			IL_003c: ldarg.2
+			IL_003d: ldstr "apply"
+			IL_0042: ldarg.3
+			IL_0043: ldarg.s args
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_004a: stloc.1
+			IL_004b: ldloc.1
+			IL_004c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0051: stloc.2
+			IL_0052: ldloc.2
+			IL_0053: ldc.r8 2
+			IL_005c: mul
+			IL_005d: stloc.2
+			IL_005e: ldloc.2
+			IL_005f: box [System.Runtime]System.Double
+			IL_0064: stloc.3
+			IL_0065: ldloc.3
+			IL_0066: ret
 		} // end of method FunctionExpression_applyProxy::__js_call__
 
 	} // end of class FunctionExpression_applyProxy
@@ -168,7 +163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2414
+				// Method begins at RVA 0x23dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -192,7 +187,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x238d
+			// Method begins at RVA 0x2363
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -220,7 +215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241d
+				// Method begins at RVA 0x23e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -249,7 +244,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x23a4
+			// Method begins at RVA 0x2378
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -297,7 +292,7 @@
 		)
 		// Fields
 		.field public object 'add'
-		.field public object applySeen
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array applySeen
 		.field public object Box
 		.field public object constructProxy
 
@@ -305,18 +300,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ee
+			// Method begins at RVA 0x23c2
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -334,7 +326,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 645 (0x285)
+		// Code size: 635 (0x27b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope,
@@ -349,8 +341,9 @@
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[11] object[],
-			[12] bool,
-			[13] object
+			[12] string,
+			[13] bool,
+			[14] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -379,7 +372,7 @@
 		IL_0045: ldloc.0
 		IL_0046: ldc.i4.0
 		IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_004c: stfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
+		IL_004c: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
 		IL_0051: ldc.i4.1
 		IL_0052: newarr [System.Runtime]System.Object
 		IL_0057: dup
@@ -423,139 +416,139 @@
 		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_00d5: pop
 		IL_00d6: ldloc.0
-		IL_00d7: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
-		IL_00dc: ldstr "Cannot access 'applySeen' before initialization"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00e6: stloc.s 8
-		IL_00e8: ldloc.s 8
-		IL_00ea: ldstr "join"
-		IL_00ef: ldstr "|"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f9: stloc.s 8
-		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0100: ldloc.s 8
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0107: pop
-		IL_0108: ldloc.0
-		IL_0109: ldnull
-		IL_010a: stfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::constructProxy
-		IL_010f: ldc.i4.1
-		IL_0110: newarr [System.Runtime]System.Object
-		IL_0115: dup
-		IL_0116: ldc.i4.0
-		IL_0117: ldloc.0
-		IL_0118: stelem.ref
-		IL_0119: ldc.i4.0
-		IL_011a: ldelem.ref
-		IL_011b: castclass Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope
-		IL_0120: ldftn object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
-		IL_0126: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-		IL_012b: ldc.i4.3
-		IL_012c: conv.r8
-		IL_012d: ldstr ""
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0137: stloc.s 8
-		IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_013e: dup
-		IL_013f: ldstr "construct"
-		IL_0144: ldloc.s 8
-		IL_0146: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_014b: stloc.s 9
-		IL_014d: ldloc.2
-		IL_014e: ldloc.s 9
-		IL_0150: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0155: stloc.s 10
-		IL_0157: ldloc.0
-		IL_0158: ldloc.s 10
-		IL_015a: stfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::constructProxy
-		IL_015f: ldloc.0
-		IL_0160: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::constructProxy
-		IL_0165: stloc.s 8
-		IL_0167: ldloc.s 8
-		IL_0169: ldc.i4.1
-		IL_016a: newarr [System.Runtime]System.Object
-		IL_016f: dup
-		IL_0170: ldc.i4.0
-		IL_0171: ldc.r8 7
-		IL_017a: box [System.Runtime]System.Double
-		IL_017f: stelem.ref
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0185: stloc.s 8
-		IL_0187: ldloc.s 8
-		IL_0189: stloc.s 4
-		IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0190: ldloc.s 4
-		IL_0192: ldstr "value"
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_019c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a1: pop
-		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a7: ldloc.s 4
-		IL_01a9: ldstr "sameNewTarget"
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b8: pop
-		IL_01b9: ldloc.1
-		IL_01ba: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_01c4: stloc.s 10
-		IL_01c6: ldloc.s 10
-		IL_01c8: stloc.s 5
-		IL_01ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01cf: stloc.s 11
-		IL_01d1: ldloc.s 5
-		IL_01d3: ldloc.s 11
-		IL_01d5: ldc.r8 4
-		IL_01de: box [System.Runtime]System.Double
-		IL_01e3: ldc.r8 5
-		IL_01ec: box [System.Runtime]System.Double
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs2(object, object[], object, object)
-		IL_01f6: stloc.s 8
-		IL_01f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fd: ldloc.s 8
-		IL_01ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0204: pop
-		IL_0205: ldloc.2
-		IL_0206: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_020b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0210: stloc.s 10
-		IL_0212: ldloc.s 10
-		IL_0214: stloc.s 6
-		IL_0216: ldloc.s 6
-		IL_0218: ldc.i4.1
-		IL_0219: newarr [System.Runtime]System.Object
-		IL_021e: dup
-		IL_021f: ldc.i4.0
-		IL_0220: ldc.r8 9
-		IL_0229: box [System.Runtime]System.Double
-		IL_022e: stelem.ref
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0234: stloc.s 8
-		IL_0236: ldloc.s 8
-		IL_0238: stloc.s 7
-		IL_023a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_023f: ldloc.s 7
-		IL_0241: ldstr "value"
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0250: pop
-		IL_0251: ldloc.s 7
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0258: stloc.s 8
-		IL_025a: ldloc.s 8
-		IL_025c: ldloc.2
-		IL_025d: ldstr "prototype"
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0267: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_026c: stloc.s 12
-		IL_026e: ldloc.s 12
-		IL_0270: box [System.Runtime]System.Boolean
-		IL_0275: stloc.s 13
-		IL_0277: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_027c: ldloc.s 13
-		IL_027e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0283: pop
-		IL_0284: ret
+		IL_00d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
+		IL_00dc: ldc.i4.1
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldstr "|"
+		IL_00e9: stelem.ref
+		IL_00ea: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_00ef: stloc.s 12
+		IL_00f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f6: ldloc.s 12
+		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fd: pop
+		IL_00fe: ldloc.0
+		IL_00ff: ldnull
+		IL_0100: stfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::constructProxy
+		IL_0105: ldc.i4.1
+		IL_0106: newarr [System.Runtime]System.Object
+		IL_010b: dup
+		IL_010c: ldc.i4.0
+		IL_010d: ldloc.0
+		IL_010e: stelem.ref
+		IL_010f: ldc.i4.0
+		IL_0110: ldelem.ref
+		IL_0111: castclass Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope
+		IL_0116: ldftn object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
+		IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_0121: ldc.i4.3
+		IL_0122: conv.r8
+		IL_0123: ldstr ""
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_012d: stloc.s 8
+		IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0134: dup
+		IL_0135: ldstr "construct"
+		IL_013a: ldloc.s 8
+		IL_013c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0141: stloc.s 9
+		IL_0143: ldloc.2
+		IL_0144: ldloc.s 9
+		IL_0146: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_014b: stloc.s 10
+		IL_014d: ldloc.0
+		IL_014e: ldloc.s 10
+		IL_0150: stfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::constructProxy
+		IL_0155: ldloc.0
+		IL_0156: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::constructProxy
+		IL_015b: stloc.s 8
+		IL_015d: ldloc.s 8
+		IL_015f: ldc.i4.1
+		IL_0160: newarr [System.Runtime]System.Object
+		IL_0165: dup
+		IL_0166: ldc.i4.0
+		IL_0167: ldc.r8 7
+		IL_0170: box [System.Runtime]System.Double
+		IL_0175: stelem.ref
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_017b: stloc.s 8
+		IL_017d: ldloc.s 8
+		IL_017f: stloc.s 4
+		IL_0181: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0186: ldloc.s 4
+		IL_0188: ldstr "value"
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0197: pop
+		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019d: ldloc.s 4
+		IL_019f: ldstr "sameNewTarget"
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ae: pop
+		IL_01af: ldloc.1
+		IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_01ba: stloc.s 10
+		IL_01bc: ldloc.s 10
+		IL_01be: stloc.s 5
+		IL_01c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01c5: stloc.s 11
+		IL_01c7: ldloc.s 5
+		IL_01c9: ldloc.s 11
+		IL_01cb: ldc.r8 4
+		IL_01d4: box [System.Runtime]System.Double
+		IL_01d9: ldc.r8 5
+		IL_01e2: box [System.Runtime]System.Double
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs2(object, object[], object, object)
+		IL_01ec: stloc.s 8
+		IL_01ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f3: ldloc.s 8
+		IL_01f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01fa: pop
+		IL_01fb: ldloc.2
+		IL_01fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0201: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0206: stloc.s 10
+		IL_0208: ldloc.s 10
+		IL_020a: stloc.s 6
+		IL_020c: ldloc.s 6
+		IL_020e: ldc.i4.1
+		IL_020f: newarr [System.Runtime]System.Object
+		IL_0214: dup
+		IL_0215: ldc.i4.0
+		IL_0216: ldc.r8 9
+		IL_021f: box [System.Runtime]System.Double
+		IL_0224: stelem.ref
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_022a: stloc.s 8
+		IL_022c: ldloc.s 8
+		IL_022e: stloc.s 7
+		IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0235: ldloc.s 7
+		IL_0237: ldstr "value"
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0241: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0246: pop
+		IL_0247: ldloc.s 7
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_024e: stloc.s 8
+		IL_0250: ldloc.s 8
+		IL_0252: ldloc.2
+		IL_0253: ldstr "prototype"
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0262: stloc.s 13
+		IL_0264: ldloc.s 13
+		IL_0266: box [System.Runtime]System.Boolean
+		IL_026b: stloc.s 14
+		IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0272: ldloc.s 14
+		IL_0274: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0279: pop
+		IL_027a: ret
 	} // end of method Proxy_ApplyAndConstructTraps_WithFallback::__js_module_init__
 
 } // end of class Modules.Proxy_ApplyAndConstructTraps_WithFallback
@@ -567,7 +560,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2426
+		// Method begins at RVA 0x23ef
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_DeletePropertyTrap_And_Fallback.verified.txt
+++ b/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_DeletePropertyTrap_And_Fallback.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22a3
+					// Method begins at RVA 0x227f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229a
+				// Method begins at RVA 0x2276
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,49 +68,43 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x2224
 			// Header size: 12
-			// Code size: 78 (0x4e)
+			// Code size: 61 (0x3d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/Scope/Block_L9C28,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::seen
-			IL_0006: ldstr "Cannot access 'seen' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: ldstr "push"
-			IL_0017: ldarg.3
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001d: pop
-			IL_001e: ldarg.3
-			IL_001f: ldstr "blocked"
-			IL_0024: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0029: stloc.2
-			IL_002a: ldloc.2
-			IL_002b: brfalse IL_003d
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::seen
+			IL_0006: ldarg.3
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldarg.3
+			IL_000e: ldstr "blocked"
+			IL_0013: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0018: stloc.1
+			IL_0019: ldloc.1
+			IL_001a: brfalse IL_002c
 
-			IL_0030: newobj instance void Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/Scope/Block_L9C28::.ctor()
-			IL_0035: stloc.0
-			IL_0036: ldc.i4.0
-			IL_0037: box [System.Runtime]System.Boolean
+			IL_001f: newobj instance void Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/Scope/Block_L9C28::.ctor()
+			IL_0024: stloc.0
+			IL_0025: ldc.i4.0
+			IL_0026: box [System.Runtime]System.Boolean
+			IL_002b: ret
+
+			IL_002c: ldarg.2
+			IL_002d: ldarg.3
+			IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
+			IL_0033: stloc.1
+			IL_0034: ldloc.1
+			IL_0035: box [System.Runtime]System.Boolean
+			IL_003a: stloc.2
+			IL_003b: ldloc.2
 			IL_003c: ret
-
-			IL_003d: ldarg.2
-			IL_003e: ldarg.3
-			IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
-			IL_0044: stloc.2
-			IL_0045: ldloc.2
-			IL_0046: box [System.Runtime]System.Boolean
-			IL_004b: stloc.3
-			IL_004c: ldloc.3
-			IL_004d: ret
 		} // end of method FunctionExpression_trappedProxy::__js_call__
 
 	} // end of class FunctionExpression_trappedProxy
@@ -123,24 +117,21 @@
 			65 65 6e 7d 00 00
 		)
 		// Fields
-		.field public object seen
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array seen
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2286
+			// Method begins at RVA 0x226d
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::seen
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -158,7 +149,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 464 (0x1d0)
+		// Code size: 454 (0x1c6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope,
@@ -170,7 +161,8 @@
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[8] bool,
-			[9] object
+			[9] object,
+			[10] string
 		)
 
 		IL_0000: newobj instance void Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::.ctor()
@@ -192,7 +184,7 @@
 		IL_0048: ldloc.0
 		IL_0049: ldc.i4.0
 		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_004f: stfld object Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::seen
+		IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::seen
 		IL_0054: ldc.i4.1
 		IL_0055: newarr [System.Runtime]System.Object
 		IL_005a: dup
@@ -266,54 +258,54 @@
 		IL_0125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_012a: pop
 		IL_012b: ldloc.0
-		IL_012c: ldfld object Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::seen
-		IL_0131: ldstr "Cannot access 'seen' before initialization"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_013b: stloc.s 5
-		IL_013d: ldloc.s 5
-		IL_013f: ldstr "join"
-		IL_0144: ldstr ","
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014e: stloc.s 5
-		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0155: ldloc.s 5
-		IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015c: pop
-		IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0162: dup
-		IL_0163: ldstr "fallback"
-		IL_0168: ldc.r8 1
-		IL_0171: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0176: stloc.3
-		IL_0177: ldloc.3
-		IL_0178: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0182: stloc.s 7
-		IL_0184: ldloc.s 7
-		IL_0186: stloc.s 4
-		IL_0188: ldloc.s 4
-		IL_018a: ldstr "fallback"
-		IL_018f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_0194: stloc.s 8
-		IL_0196: ldloc.s 8
-		IL_0198: box [System.Runtime]System.Boolean
-		IL_019d: stloc.s 9
-		IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a4: ldloc.s 9
-		IL_01a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ab: pop
-		IL_01ac: ldstr "fallback"
-		IL_01b1: ldloc.3
-		IL_01b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_01b7: stloc.s 8
-		IL_01b9: ldloc.s 8
-		IL_01bb: box [System.Runtime]System.Boolean
-		IL_01c0: stloc.s 9
-		IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c7: ldloc.s 9
-		IL_01c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ce: pop
-		IL_01cf: ret
+		IL_012c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::seen
+		IL_0131: ldc.i4.1
+		IL_0132: newarr [System.Runtime]System.Object
+		IL_0137: dup
+		IL_0138: ldc.i4.0
+		IL_0139: ldstr ","
+		IL_013e: stelem.ref
+		IL_013f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0144: stloc.s 10
+		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014b: ldloc.s 10
+		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0152: pop
+		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0158: dup
+		IL_0159: ldstr "fallback"
+		IL_015e: ldc.r8 1
+		IL_0167: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_016c: stloc.3
+		IL_016d: ldloc.3
+		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0178: stloc.s 7
+		IL_017a: ldloc.s 7
+		IL_017c: stloc.s 4
+		IL_017e: ldloc.s 4
+		IL_0180: ldstr "fallback"
+		IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_018a: stloc.s 8
+		IL_018c: ldloc.s 8
+		IL_018e: box [System.Runtime]System.Boolean
+		IL_0193: stloc.s 9
+		IL_0195: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019a: ldloc.s 9
+		IL_019c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a1: pop
+		IL_01a2: ldstr "fallback"
+		IL_01a7: ldloc.3
+		IL_01a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_01ad: stloc.s 8
+		IL_01af: ldloc.s 8
+		IL_01b1: box [System.Runtime]System.Boolean
+		IL_01b6: stloc.s 9
+		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01bd: ldloc.s 9
+		IL_01bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c4: pop
+		IL_01c5: ret
 	} // end of method Proxy_DeletePropertyTrap_And_Fallback::__js_module_init__
 
 } // end of class Modules.Proxy_DeletePropertyTrap_And_Fallback
@@ -325,7 +317,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22ac
+		// Method begins at RVA 0x2288
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
+++ b/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2365
+				// Method begins at RVA 0x2342
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236e
+				// Method begins at RVA 0x234b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,21 +99,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2304
-			// Header size: 12
-			// Code size: 19 (0x13)
+			// Method begins at RVA 0x2302
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope::trappedPrototype
-			IL_0006: ldstr "Cannot access 'trappedPrototype' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_prototypeProxy::__js_call__
 
 	} // end of class FunctionExpression_prototypeProxy
@@ -129,7 +122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2377
+				// Method begins at RVA 0x2354
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -154,7 +147,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2324
+			// Method begins at RVA 0x230c
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -194,18 +187,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2351
+			// Method begins at RVA 0x2339
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope::trappedPrototype
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -451,7 +441,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2380
+		// Method begins at RVA 0x235d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28d8
+					// Method begins at RVA 0x27cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28e1
+					// Method begins at RVA 0x27d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28cf
+				// Method begins at RVA 0x27c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x254c
+			// Method begins at RVA 0x24fc
 			// Header size: 12
 			// Code size: 181 (0xb5)
 			.maxstack 8
@@ -199,7 +199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28ea
+				// Method begins at RVA 0x27e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,7 +224,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2620
+			// Method begins at RVA 0x25d0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -248,7 +248,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28f3
+				// Method begins at RVA 0x27ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2629
+			// Method begins at RVA 0x25d9
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -303,7 +303,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28fc
+				// Method begins at RVA 0x27f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -329,29 +329,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x263c
-			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Method begins at RVA 0x25eb
+			// Header size: 1
+			// Code size: 27 (0x1b)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: ldstr "Cannot access 'revocable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldstr "a"
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0028: stloc.0
-			IL_0029: ldloc.0
-			IL_002a: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ldstr "a"
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001a: ret
 		} // end of method FunctionExpression_L28C16::__js_call__
 
 	} // end of class FunctionExpression_L28C16
@@ -367,7 +356,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2905
+				// Method begins at RVA 0x27fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -393,31 +382,22 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2674
-			// Header size: 12
-			// Code size: 57 (0x39)
+			// Method begins at RVA 0x2607
+			// Header size: 1
+			// Code size: 43 (0x2b)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: ldstr "Cannot access 'revocable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldstr "c"
-			IL_0023: ldc.r8 3
-			IL_002c: ldc.i4.1
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0032: pop
-			IL_0033: ldstr "set"
-			IL_0038: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ldstr "c"
+			IL_0015: ldc.r8 3
+			IL_001e: ldc.i4.1
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0024: pop
+			IL_0025: ldstr "set"
+			IL_002a: ret
 		} // end of method FunctionExpression_L29C16::__js_call__
 
 	} // end of class FunctionExpression_L29C16
@@ -433,7 +413,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x290e
+				// Method begins at RVA 0x2805
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -459,34 +439,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x26bc
+			// Method begins at RVA 0x2634
 			// Header size: 12
-			// Code size: 50 (0x32)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] bool,
-				[2] object
+				[0] bool,
+				[1] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: ldstr "Cannot access 'revocable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldstr "a"
-			IL_0022: ldloc.0
-			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-			IL_0028: stloc.1
-			IL_0029: ldloc.1
-			IL_002a: box [System.Runtime]System.Boolean
-			IL_002f: stloc.2
-			IL_0030: ldloc.2
-			IL_0031: ret
+			IL_0000: ldstr "a"
+			IL_0005: ldarg.0
+			IL_0006: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
+			IL_000b: ldstr "proxy"
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+			IL_001a: stloc.0
+			IL_001b: ldloc.0
+			IL_001c: box [System.Runtime]System.Boolean
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: ret
 		} // end of method FunctionExpression_L30C16::__js_call__
 
 	} // end of class FunctionExpression_L30C16
@@ -502,7 +475,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2917
+				// Method begins at RVA 0x280e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -528,34 +501,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x26fc
+			// Method begins at RVA 0x2664
 			// Header size: 12
-			// Code size: 50 (0x32)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] bool,
-				[2] object
+				[0] bool,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: ldstr "Cannot access 'revocable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldstr "a"
-			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-			IL_0028: stloc.1
-			IL_0029: ldloc.1
-			IL_002a: box [System.Runtime]System.Boolean
-			IL_002f: stloc.2
-			IL_0030: ldloc.2
-			IL_0031: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ldstr "a"
+			IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_001a: stloc.0
+			IL_001b: ldloc.0
+			IL_001c: box [System.Runtime]System.Boolean
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: ret
 		} // end of method FunctionExpression_L31C19::__js_call__
 
 	} // end of class FunctionExpression_L31C19
@@ -571,7 +537,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2920
+				// Method begins at RVA 0x2817
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -597,9 +563,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x273c
+			// Method begins at RVA 0x2694
 			// Header size: 12
-			// Code size: 55 (0x37)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -607,23 +573,17 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: ldstr "Cannot access 'revocable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: ldstr "join"
-			IL_002a: ldstr ","
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0034: stloc.0
-			IL_0035: ldloc.0
-			IL_0036: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ldstr "join"
+			IL_001c: ldstr ","
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0026: stloc.0
+			IL_0027: ldloc.0
+			IL_0028: ret
 		} // end of method FunctionExpression_L32C17::__js_call__
 
 	} // end of class FunctionExpression_L32C17
@@ -639,7 +599,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2929
+				// Method begins at RVA 0x2820
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -665,9 +625,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2780
+			// Method begins at RVA 0x26cc
 			// Header size: 12
-			// Code size: 38 (0x26)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -675,18 +635,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: ldstr "Cannot access 'revocable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ret
 		} // end of method FunctionExpression_L33C27::__js_call__
 
 	} // end of class FunctionExpression_L33C27
@@ -702,7 +656,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2932
+				// Method begins at RVA 0x2829
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -728,9 +682,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x27b4
+			// Method begins at RVA 0x26f0
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 32 (0x20)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -738,20 +692,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: ldstr "Cannot access 'revocable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.i4.0
-			IL_001f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ret
+			IL_0012: ldc.i4.0
+			IL_0013: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_001d: stloc.0
+			IL_001e: ldloc.0
+			IL_001f: ret
 		} // end of method FunctionExpression_L34C27::__js_call__
 
 	} // end of class FunctionExpression_L34C27
@@ -767,7 +717,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x293b
+				// Method begins at RVA 0x2832
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -791,7 +741,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27ec
+			// Method begins at RVA 0x271c
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -820,7 +770,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2944
+				// Method begins at RVA 0x283b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -846,9 +796,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x280c
+			// Method begins at RVA 0x273c
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -856,17 +806,15 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-			IL_0006: ldstr "Cannot access 'callable' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: ldc.r8 1
-			IL_0020: box [System.Runtime]System.Double
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.0
-			IL_002b: ldloc.0
-			IL_002c: ret
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "proxy"
+			IL_000d: ldc.r8 1
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0020: stloc.0
+			IL_0021: ldloc.0
+			IL_0022: ret
 		} // end of method FunctionExpression_L40C17::__js_call__
 
 	} // end of class FunctionExpression_L40C17
@@ -888,7 +836,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x294d
+				// Method begins at RVA 0x2844
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -912,7 +860,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2845
+			// Method begins at RVA 0x276b
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -940,7 +888,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2956
+				// Method begins at RVA 0x284d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -966,9 +914,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x285c
+			// Method begins at RVA 0x2780
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 49 (0x31)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -976,25 +924,21 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-			IL_0006: ldstr "Cannot access 'constructible' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0010: stloc.0
 			IL_0011: ldloc.0
-			IL_0012: ldstr "proxy"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.i4.1
-			IL_001f: newarr [System.Runtime]System.Object
-			IL_0024: dup
-			IL_0025: ldc.i4.0
-			IL_0026: ldc.r8 1
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: stelem.ref
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_003a: stloc.0
-			IL_003b: ldloc.0
-			IL_003c: ret
+			IL_0012: ldc.i4.1
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldc.r8 1
+			IL_0023: box [System.Runtime]System.Double
+			IL_0028: stelem.ref
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_002e: stloc.0
+			IL_002f: ldloc.0
+			IL_0030: ret
 		} // end of method FunctionExpression_L46C22::__js_call__
 
 	} // end of class FunctionExpression_L46C22
@@ -1021,24 +965,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x28a5
+			// Method begins at RVA 0x27bd
 			// Header size: 1
-			// Code size: 41 (0x29)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-			IL_0027: nop
-			IL_0028: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1056,7 +991,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1263 (0x4ef)
+		// Code size: 1181 (0x49d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope,
@@ -1127,390 +1062,364 @@
 		IL_00ad: ldloc.0
 		IL_00ae: ldloc.s 4
 		IL_00b0: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-		IL_00b5: ldloc.0
-		IL_00b6: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-		IL_00bb: ldstr "Cannot access 'revocable' before initialization"
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00c5: stloc.s 4
-		IL_00c7: ldloc.s 4
-		IL_00c9: ldstr "proxy"
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d3: stloc.s 4
-		IL_00d5: ldloc.s 4
-		IL_00d7: ldstr "a"
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e1: stloc.s 4
-		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e8: ldloc.s 4
-		IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ef: pop
-		IL_00f0: ldloc.0
-		IL_00f1: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-		IL_00f6: ldstr "Cannot access 'revocable' before initialization"
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0100: stloc.s 4
-		IL_0102: ldloc.s 4
-		IL_0104: ldstr "proxy"
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010e: stloc.s 4
-		IL_0110: ldloc.s 4
-		IL_0112: ldstr "b"
-		IL_0117: ldc.r8 2
-		IL_0120: ldc.i4.1
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0126: pop
-		IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012c: ldloc.2
-		IL_012d: ldstr "b"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0137: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013c: pop
-		IL_013d: ldloc.0
-		IL_013e: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-		IL_0143: ldstr "Cannot access 'revocable' before initialization"
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_014d: stloc.s 4
-		IL_014f: ldloc.s 4
-		IL_0151: ldstr "revoke"
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_015b: pop
-		IL_015c: ldc.i4.1
-		IL_015d: newarr [System.Runtime]System.Object
-		IL_0162: dup
-		IL_0163: ldc.i4.0
-		IL_0164: ldloc.0
-		IL_0165: stelem.ref
-		IL_0166: ldc.i4.0
-		IL_0167: ldelem.ref
-		IL_0168: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_016d: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0178: ldc.i4.0
-		IL_0179: conv.r8
-		IL_017a: ldstr ""
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0184: stloc.s 4
-		IL_0186: ldc.i4.1
-		IL_0187: newarr [System.Runtime]System.Object
-		IL_018c: dup
-		IL_018d: ldc.i4.0
-		IL_018e: ldloc.0
-		IL_018f: stelem.ref
-		IL_0190: ldc.i4.0
-		IL_0191: ldelem.ref
-		IL_0192: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0197: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01a2: ldnull
-		IL_01a3: ldstr "get"
-		IL_01a8: ldloc.s 4
-		IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01af: pop
-		IL_01b0: ldc.i4.1
-		IL_01b1: newarr [System.Runtime]System.Object
-		IL_01b6: dup
-		IL_01b7: ldc.i4.0
-		IL_01b8: ldloc.0
-		IL_01b9: stelem.ref
-		IL_01ba: ldc.i4.0
-		IL_01bb: ldelem.ref
-		IL_01bc: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01c1: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_01c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01cc: ldc.i4.0
-		IL_01cd: conv.r8
-		IL_01ce: ldstr ""
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_01d8: stloc.s 4
-		IL_01da: ldc.i4.1
-		IL_01db: newarr [System.Runtime]System.Object
-		IL_01e0: dup
-		IL_01e1: ldc.i4.0
-		IL_01e2: ldloc.0
-		IL_01e3: stelem.ref
-		IL_01e4: ldc.i4.0
-		IL_01e5: ldelem.ref
-		IL_01e6: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01eb: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_01f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01f6: ldnull
-		IL_01f7: ldstr "set"
-		IL_01fc: ldloc.s 4
-		IL_01fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0203: pop
-		IL_0204: ldc.i4.1
-		IL_0205: newarr [System.Runtime]System.Object
-		IL_020a: dup
-		IL_020b: ldc.i4.0
-		IL_020c: ldloc.0
-		IL_020d: stelem.ref
-		IL_020e: ldc.i4.0
-		IL_020f: ldelem.ref
-		IL_0210: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0215: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_021b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0220: ldc.i4.0
-		IL_0221: conv.r8
-		IL_0222: ldstr ""
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_022c: stloc.s 4
-		IL_022e: ldc.i4.1
-		IL_022f: newarr [System.Runtime]System.Object
-		IL_0234: dup
-		IL_0235: ldc.i4.0
-		IL_0236: ldloc.0
-		IL_0237: stelem.ref
-		IL_0238: ldc.i4.0
-		IL_0239: ldelem.ref
-		IL_023a: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_023f: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_024a: ldnull
-		IL_024b: ldstr "has"
-		IL_0250: ldloc.s 4
-		IL_0252: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0257: pop
-		IL_0258: ldc.i4.1
-		IL_0259: newarr [System.Runtime]System.Object
-		IL_025e: dup
-		IL_025f: ldc.i4.0
-		IL_0260: ldloc.0
-		IL_0261: stelem.ref
-		IL_0262: ldc.i4.0
-		IL_0263: ldelem.ref
-		IL_0264: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0269: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_026f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0274: ldc.i4.0
-		IL_0275: conv.r8
-		IL_0276: ldstr ""
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0280: stloc.s 4
-		IL_0282: ldc.i4.1
-		IL_0283: newarr [System.Runtime]System.Object
-		IL_0288: dup
-		IL_0289: ldc.i4.0
-		IL_028a: ldloc.0
-		IL_028b: stelem.ref
-		IL_028c: ldc.i4.0
-		IL_028d: ldelem.ref
-		IL_028e: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0293: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0299: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_029e: ldnull
-		IL_029f: ldstr "delete"
-		IL_02a4: ldloc.s 4
-		IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_02ab: pop
-		IL_02ac: ldc.i4.1
-		IL_02ad: newarr [System.Runtime]System.Object
-		IL_02b2: dup
-		IL_02b3: ldc.i4.0
-		IL_02b4: ldloc.0
-		IL_02b5: stelem.ref
-		IL_02b6: ldc.i4.0
-		IL_02b7: ldelem.ref
-		IL_02b8: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02bd: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_02c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02c8: ldc.i4.0
-		IL_02c9: conv.r8
-		IL_02ca: ldstr ""
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_02d4: stloc.s 4
-		IL_02d6: ldc.i4.1
-		IL_02d7: newarr [System.Runtime]System.Object
-		IL_02dc: dup
-		IL_02dd: ldc.i4.0
-		IL_02de: ldloc.0
-		IL_02df: stelem.ref
-		IL_02e0: ldc.i4.0
-		IL_02e1: ldelem.ref
-		IL_02e2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02e7: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_02ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_02f2: ldnull
-		IL_02f3: ldstr "keys"
-		IL_02f8: ldloc.s 4
-		IL_02fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_02ff: pop
-		IL_0300: ldc.i4.1
-		IL_0301: newarr [System.Runtime]System.Object
-		IL_0306: dup
-		IL_0307: ldc.i4.0
-		IL_0308: ldloc.0
-		IL_0309: stelem.ref
-		IL_030a: ldc.i4.0
-		IL_030b: ldelem.ref
-		IL_030c: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0311: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0317: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_031c: ldc.i4.0
-		IL_031d: conv.r8
-		IL_031e: ldstr ""
-		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0328: stloc.s 4
-		IL_032a: ldc.i4.1
-		IL_032b: newarr [System.Runtime]System.Object
-		IL_0330: dup
-		IL_0331: ldc.i4.0
-		IL_0332: ldloc.0
-		IL_0333: stelem.ref
-		IL_0334: ldc.i4.0
-		IL_0335: ldelem.ref
-		IL_0336: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_033b: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0341: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0346: ldnull
-		IL_0347: ldstr "getPrototypeOf"
-		IL_034c: ldloc.s 4
-		IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0353: pop
-		IL_0354: ldc.i4.1
-		IL_0355: newarr [System.Runtime]System.Object
-		IL_035a: dup
-		IL_035b: ldc.i4.0
-		IL_035c: ldloc.0
-		IL_035d: stelem.ref
-		IL_035e: ldc.i4.0
-		IL_035f: ldelem.ref
-		IL_0360: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0365: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_036b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0370: ldc.i4.0
-		IL_0371: conv.r8
-		IL_0372: ldstr ""
-		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_037c: stloc.s 4
+		IL_00b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ba: ldloc.0
+		IL_00bb: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
+		IL_00c0: ldstr "proxy"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ca: ldstr "a"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d9: pop
+		IL_00da: ldloc.0
+		IL_00db: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
+		IL_00e0: ldstr "proxy"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ea: ldstr "b"
+		IL_00ef: ldc.r8 2
+		IL_00f8: ldc.i4.1
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_00fe: pop
+		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0104: ldloc.2
+		IL_0105: ldstr "b"
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0114: pop
+		IL_0115: ldloc.0
+		IL_0116: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
+		IL_011b: ldstr "revoke"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0125: pop
+		IL_0126: ldc.i4.1
+		IL_0127: newarr [System.Runtime]System.Object
+		IL_012c: dup
+		IL_012d: ldc.i4.0
+		IL_012e: ldloc.0
+		IL_012f: stelem.ref
+		IL_0130: ldc.i4.0
+		IL_0131: ldelem.ref
+		IL_0132: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0137: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_013d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0142: ldc.i4.0
+		IL_0143: conv.r8
+		IL_0144: ldstr ""
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_014e: stloc.s 4
+		IL_0150: ldc.i4.1
+		IL_0151: newarr [System.Runtime]System.Object
+		IL_0156: dup
+		IL_0157: ldc.i4.0
+		IL_0158: ldloc.0
+		IL_0159: stelem.ref
+		IL_015a: ldc.i4.0
+		IL_015b: ldelem.ref
+		IL_015c: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0161: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_0167: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_016c: ldnull
+		IL_016d: ldstr "get"
+		IL_0172: ldloc.s 4
+		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0179: pop
+		IL_017a: ldc.i4.1
+		IL_017b: newarr [System.Runtime]System.Object
+		IL_0180: dup
+		IL_0181: ldc.i4.0
+		IL_0182: ldloc.0
+		IL_0183: stelem.ref
+		IL_0184: ldc.i4.0
+		IL_0185: ldelem.ref
+		IL_0186: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_018b: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0196: ldc.i4.0
+		IL_0197: conv.r8
+		IL_0198: ldstr ""
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01a2: stloc.s 4
+		IL_01a4: ldc.i4.1
+		IL_01a5: newarr [System.Runtime]System.Object
+		IL_01aa: dup
+		IL_01ab: ldc.i4.0
+		IL_01ac: ldloc.0
+		IL_01ad: stelem.ref
+		IL_01ae: ldc.i4.0
+		IL_01af: ldelem.ref
+		IL_01b0: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_01b5: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_01bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_01c0: ldnull
+		IL_01c1: ldstr "set"
+		IL_01c6: ldloc.s 4
+		IL_01c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_01cd: pop
+		IL_01ce: ldc.i4.1
+		IL_01cf: newarr [System.Runtime]System.Object
+		IL_01d4: dup
+		IL_01d5: ldc.i4.0
+		IL_01d6: ldloc.0
+		IL_01d7: stelem.ref
+		IL_01d8: ldc.i4.0
+		IL_01d9: ldelem.ref
+		IL_01da: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_01df: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_01e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01ea: ldc.i4.0
+		IL_01eb: conv.r8
+		IL_01ec: ldstr ""
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_01f6: stloc.s 4
+		IL_01f8: ldc.i4.1
+		IL_01f9: newarr [System.Runtime]System.Object
+		IL_01fe: dup
+		IL_01ff: ldc.i4.0
+		IL_0200: ldloc.0
+		IL_0201: stelem.ref
+		IL_0202: ldc.i4.0
+		IL_0203: ldelem.ref
+		IL_0204: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0209: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_020f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0214: ldnull
+		IL_0215: ldstr "has"
+		IL_021a: ldloc.s 4
+		IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0221: pop
+		IL_0222: ldc.i4.1
+		IL_0223: newarr [System.Runtime]System.Object
+		IL_0228: dup
+		IL_0229: ldc.i4.0
+		IL_022a: ldloc.0
+		IL_022b: stelem.ref
+		IL_022c: ldc.i4.0
+		IL_022d: ldelem.ref
+		IL_022e: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0233: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_0239: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_023e: ldc.i4.0
+		IL_023f: conv.r8
+		IL_0240: ldstr ""
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_024a: stloc.s 4
+		IL_024c: ldc.i4.1
+		IL_024d: newarr [System.Runtime]System.Object
+		IL_0252: dup
+		IL_0253: ldc.i4.0
+		IL_0254: ldloc.0
+		IL_0255: stelem.ref
+		IL_0256: ldc.i4.0
+		IL_0257: ldelem.ref
+		IL_0258: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_025d: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0268: ldnull
+		IL_0269: ldstr "delete"
+		IL_026e: ldloc.s 4
+		IL_0270: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0275: pop
+		IL_0276: ldc.i4.1
+		IL_0277: newarr [System.Runtime]System.Object
+		IL_027c: dup
+		IL_027d: ldc.i4.0
+		IL_027e: ldloc.0
+		IL_027f: stelem.ref
+		IL_0280: ldc.i4.0
+		IL_0281: ldelem.ref
+		IL_0282: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0287: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_028d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0292: ldc.i4.0
+		IL_0293: conv.r8
+		IL_0294: ldstr ""
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_029e: stloc.s 4
+		IL_02a0: ldc.i4.1
+		IL_02a1: newarr [System.Runtime]System.Object
+		IL_02a6: dup
+		IL_02a7: ldc.i4.0
+		IL_02a8: ldloc.0
+		IL_02a9: stelem.ref
+		IL_02aa: ldc.i4.0
+		IL_02ab: ldelem.ref
+		IL_02ac: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02b1: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_02b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_02bc: ldnull
+		IL_02bd: ldstr "keys"
+		IL_02c2: ldloc.s 4
+		IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_02c9: pop
+		IL_02ca: ldc.i4.1
+		IL_02cb: newarr [System.Runtime]System.Object
+		IL_02d0: dup
+		IL_02d1: ldc.i4.0
+		IL_02d2: ldloc.0
+		IL_02d3: stelem.ref
+		IL_02d4: ldc.i4.0
+		IL_02d5: ldelem.ref
+		IL_02d6: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02db: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_02e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02e6: ldc.i4.0
+		IL_02e7: conv.r8
+		IL_02e8: ldstr ""
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_02f2: stloc.s 4
+		IL_02f4: ldc.i4.1
+		IL_02f5: newarr [System.Runtime]System.Object
+		IL_02fa: dup
+		IL_02fb: ldc.i4.0
+		IL_02fc: ldloc.0
+		IL_02fd: stelem.ref
+		IL_02fe: ldc.i4.0
+		IL_02ff: ldelem.ref
+		IL_0300: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0305: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_030b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0310: ldnull
+		IL_0311: ldstr "getPrototypeOf"
+		IL_0316: ldloc.s 4
+		IL_0318: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_031d: pop
+		IL_031e: ldc.i4.1
+		IL_031f: newarr [System.Runtime]System.Object
+		IL_0324: dup
+		IL_0325: ldc.i4.0
+		IL_0326: ldloc.0
+		IL_0327: stelem.ref
+		IL_0328: ldc.i4.0
+		IL_0329: ldelem.ref
+		IL_032a: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_032f: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_0335: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_033a: ldc.i4.0
+		IL_033b: conv.r8
+		IL_033c: ldstr ""
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0346: stloc.s 4
+		IL_0348: ldc.i4.1
+		IL_0349: newarr [System.Runtime]System.Object
+		IL_034e: dup
+		IL_034f: ldc.i4.0
+		IL_0350: ldloc.0
+		IL_0351: stelem.ref
+		IL_0352: ldc.i4.0
+		IL_0353: ldelem.ref
+		IL_0354: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0359: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_035f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0364: ldnull
+		IL_0365: ldstr "setPrototypeOf"
+		IL_036a: ldloc.s 4
+		IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0371: pop
+		IL_0372: ldnull
+		IL_0373: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
+		IL_0379: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
 		IL_037e: ldc.i4.1
-		IL_037f: newarr [System.Runtime]System.Object
-		IL_0384: dup
-		IL_0385: ldc.i4.0
-		IL_0386: ldloc.0
-		IL_0387: stelem.ref
-		IL_0388: ldc.i4.0
-		IL_0389: ldelem.ref
-		IL_038a: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_038f: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0395: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_039a: ldnull
-		IL_039b: ldstr "setPrototypeOf"
-		IL_03a0: ldloc.s 4
-		IL_03a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_03a7: pop
-		IL_03a8: ldnull
-		IL_03a9: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
-		IL_03af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_03b4: ldc.i4.1
-		IL_03b5: conv.r8
-		IL_03b6: ldstr ""
-		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_03c0: stloc.s 4
-		IL_03c2: ldloc.s 4
-		IL_03c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
-		IL_03ce: stloc.s 4
-		IL_03d0: ldloc.0
-		IL_03d1: ldloc.s 4
-		IL_03d3: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-		IL_03d8: ldloc.0
-		IL_03d9: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-		IL_03de: ldstr "Cannot access 'callable' before initialization"
-		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_03e8: stloc.s 4
-		IL_03ea: ldloc.s 4
-		IL_03ec: ldstr "revoke"
-		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_03f6: pop
-		IL_03f7: ldc.i4.1
-		IL_03f8: newarr [System.Runtime]System.Object
-		IL_03fd: dup
-		IL_03fe: ldc.i4.0
-		IL_03ff: ldloc.0
-		IL_0400: stelem.ref
-		IL_0401: ldc.i4.0
-		IL_0402: ldelem.ref
-		IL_0403: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0408: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_040e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0413: ldc.i4.0
+		IL_037f: conv.r8
+		IL_0380: ldstr ""
+		IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_038a: stloc.s 4
+		IL_038c: ldloc.s 4
+		IL_038e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
+		IL_0398: stloc.s 4
+		IL_039a: ldloc.0
+		IL_039b: ldloc.s 4
+		IL_039d: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
+		IL_03a2: ldloc.0
+		IL_03a3: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
+		IL_03a8: ldstr "revoke"
+		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_03b2: pop
+		IL_03b3: ldc.i4.1
+		IL_03b4: newarr [System.Runtime]System.Object
+		IL_03b9: dup
+		IL_03ba: ldc.i4.0
+		IL_03bb: ldloc.0
+		IL_03bc: stelem.ref
+		IL_03bd: ldc.i4.0
+		IL_03be: ldelem.ref
+		IL_03bf: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_03c4: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_03ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_03cf: ldc.i4.0
+		IL_03d0: conv.r8
+		IL_03d1: ldstr ""
+		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_03db: stloc.s 4
+		IL_03dd: ldc.i4.1
+		IL_03de: newarr [System.Runtime]System.Object
+		IL_03e3: dup
+		IL_03e4: ldc.i4.0
+		IL_03e5: ldloc.0
+		IL_03e6: stelem.ref
+		IL_03e7: ldc.i4.0
+		IL_03e8: ldelem.ref
+		IL_03e9: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_03ee: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_03f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_03f9: ldnull
+		IL_03fa: ldstr "call"
+		IL_03ff: ldloc.s 4
+		IL_0401: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_0406: pop
+		IL_0407: ldnull
+		IL_0408: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
+		IL_040e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0413: ldc.i4.1
 		IL_0414: conv.r8
-		IL_0415: ldstr ""
+		IL_0415: ldstr "C"
 		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
 		IL_041f: stloc.s 4
-		IL_0421: ldc.i4.1
-		IL_0422: newarr [System.Runtime]System.Object
-		IL_0427: dup
-		IL_0428: ldc.i4.0
-		IL_0429: ldloc.0
-		IL_042a: stelem.ref
-		IL_042b: ldc.i4.0
-		IL_042c: ldelem.ref
-		IL_042d: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0432: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0438: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_043d: ldnull
-		IL_043e: ldstr "call"
-		IL_0443: ldloc.s 4
-		IL_0445: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_044a: pop
-		IL_044b: ldnull
-		IL_044c: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
-		IL_0452: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0457: ldc.i4.1
-		IL_0458: conv.r8
-		IL_0459: ldstr "C"
-		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0463: stloc.s 4
-		IL_0465: ldloc.s 4
-		IL_0467: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
-		IL_0471: stloc.s 4
-		IL_0473: ldloc.0
-		IL_0474: ldloc.s 4
-		IL_0476: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-		IL_047b: ldloc.0
-		IL_047c: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-		IL_0481: ldstr "Cannot access 'constructible' before initialization"
-		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_048b: stloc.s 4
-		IL_048d: ldloc.s 4
-		IL_048f: ldstr "revoke"
-		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0499: pop
-		IL_049a: ldc.i4.1
-		IL_049b: newarr [System.Runtime]System.Object
-		IL_04a0: dup
-		IL_04a1: ldc.i4.0
-		IL_04a2: ldloc.0
-		IL_04a3: stelem.ref
-		IL_04a4: ldc.i4.0
-		IL_04a5: ldelem.ref
-		IL_04a6: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_04ab: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_04b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_04b6: ldc.i4.0
-		IL_04b7: conv.r8
-		IL_04b8: ldstr ""
-		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_04c2: stloc.s 4
-		IL_04c4: ldc.i4.1
-		IL_04c5: newarr [System.Runtime]System.Object
-		IL_04ca: dup
-		IL_04cb: ldc.i4.0
-		IL_04cc: ldloc.0
-		IL_04cd: stelem.ref
-		IL_04ce: ldc.i4.0
-		IL_04cf: ldelem.ref
-		IL_04d0: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_04d5: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_04db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_04e0: ldnull
-		IL_04e1: ldstr "construct"
-		IL_04e6: ldloc.s 4
-		IL_04e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_04ed: pop
-		IL_04ee: ret
+		IL_0421: ldloc.s 4
+		IL_0423: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
+		IL_042d: stloc.s 4
+		IL_042f: ldloc.0
+		IL_0430: ldloc.s 4
+		IL_0432: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
+		IL_0437: ldloc.0
+		IL_0438: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
+		IL_043d: ldstr "revoke"
+		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0447: pop
+		IL_0448: ldc.i4.1
+		IL_0449: newarr [System.Runtime]System.Object
+		IL_044e: dup
+		IL_044f: ldc.i4.0
+		IL_0450: ldloc.0
+		IL_0451: stelem.ref
+		IL_0452: ldc.i4.0
+		IL_0453: ldelem.ref
+		IL_0454: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0459: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_045f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0464: ldc.i4.0
+		IL_0465: conv.r8
+		IL_0466: ldstr ""
+		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0470: stloc.s 4
+		IL_0472: ldc.i4.1
+		IL_0473: newarr [System.Runtime]System.Object
+		IL_0478: dup
+		IL_0479: ldc.i4.0
+		IL_047a: ldloc.0
+		IL_047b: stelem.ref
+		IL_047c: ldc.i4.0
+		IL_047d: ldelem.ref
+		IL_047e: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0483: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_0489: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_048e: ldnull
+		IL_048f: ldstr "construct"
+		IL_0494: ldloc.s 4
+		IL_0496: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+		IL_049b: pop
+		IL_049c: ret
 	} // end of method Proxy_Revocable_ThrowsAfterRevoke::__js_module_init__
 
 } // end of class Modules.Proxy_Revocable_ThrowsAfterRevoke
@@ -1522,7 +1431,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x295f
+		// Method begins at RVA 0x2856
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_SetTrap_InterceptsWrites.verified.txt
+++ b/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_SetTrap_InterceptsWrites.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2192
+				// Method begins at RVA 0x2164
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,36 +48,33 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x2124
 			// Header size: 12
-			// Code size: 58 (0x3a)
+			// Code size: 43 (0x2b)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Proxy_SetTrap_InterceptsWrites/Scope::seen
-			IL_0006: ldstr "Cannot access 'seen' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldarg.3
-			IL_0012: ldstr "="
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001c: stloc.1
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_SetTrap_InterceptsWrites/Scope::seen
+			IL_0006: stloc.0
+			IL_0007: ldarg.3
+			IL_0008: ldstr "="
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0012: stloc.1
+			IL_0013: ldloc.1
+			IL_0014: ldarg.s 'value'
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_001b: stloc.1
+			IL_001c: ldloc.0
 			IL_001d: ldloc.1
-			IL_001e: ldarg.s 'value'
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: ldstr "push"
-			IL_002c: ldloc.1
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0032: pop
-			IL_0033: ldc.i4.1
-			IL_0034: box [System.Runtime]System.Boolean
-			IL_0039: ret
+			IL_001e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0023: pop
+			IL_0024: ldc.i4.1
+			IL_0025: box [System.Runtime]System.Boolean
+			IL_002a: ret
 		} // end of method FunctionExpression_handler::__js_call__
 
 	} // end of class FunctionExpression_handler
@@ -90,24 +87,21 @@
 			65 65 6e 7d 00 00
 		)
 		// Fields
-		.field public object seen
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array seen
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217e
+			// Method begins at RVA 0x215b
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Proxy_SetTrap_InterceptsWrites/Scope::seen
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -125,7 +119,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 220 (0xdc)
+		// Code size: 197 (0xc5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_SetTrap_InterceptsWrites/Scope,
@@ -148,7 +142,7 @@
 		IL_0020: ldloc.0
 		IL_0021: ldc.i4.0
 		IL_0022: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0027: stfld object Modules.Proxy_SetTrap_InterceptsWrites/Scope::seen
+		IL_0027: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_SetTrap_InterceptsWrites/Scope::seen
 		IL_002c: ldc.i4.1
 		IL_002d: newarr [System.Runtime]System.Object
 		IL_0032: dup
@@ -185,27 +179,20 @@
 		IL_0088: ldc.i4.1
 		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
 		IL_008e: pop
-		IL_008f: ldloc.0
-		IL_0090: ldfld object Modules.Proxy_SetTrap_InterceptsWrites/Scope::seen
-		IL_0095: ldstr "Cannot access 'seen' before initialization"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_009f: stloc.s 4
-		IL_00a1: ldloc.s 4
-		IL_00a3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_00a8: ldc.r8 0.0
-		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00b6: stloc.s 4
-		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bd: ldloc.s 4
-		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c4: pop
-		IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ca: ldloc.1
-		IL_00cb: ldstr "a"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00da: pop
-		IL_00db: ret
+		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0094: ldloc.0
+		IL_0095: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_SetTrap_InterceptsWrites/Scope::seen
+		IL_009a: ldc.r8 0.0
+		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ad: pop
+		IL_00ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b3: ldloc.1
+		IL_00b4: ldstr "a"
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c3: pop
+		IL_00c4: ret
 	} // end of method Proxy_SetTrap_InterceptsWrites::__js_module_init__
 
 } // end of class Modules.Proxy_SetTrap_InterceptsWrites
@@ -217,7 +204,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219b
+		// Method begins at RVA 0x216d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Js2IL.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ac7
+					// Method begins at RVA 0x2a31
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ad0
+					// Method begins at RVA 0x2a3a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2abe
+				// Method begins at RVA 0x2a28
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,7 +199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad9
+				// Method begins at RVA 0x2a43
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -252,7 +252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae2
+				// Method begins at RVA 0x2a4c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -308,7 +308,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aeb
+				// Method begins at RVA 0x2a55
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -361,7 +361,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af4
+				// Method begins at RVA 0x2a5e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -417,7 +417,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2afd
+				// Method begins at RVA 0x2a67
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -462,7 +462,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b06
+				// Method begins at RVA 0x2a70
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -490,7 +490,7 @@
 			)
 			// Method begins at RVA 0x2858
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -498,20 +498,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
-			IL_0006: ldstr "Cannot access 'applyProxy' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.i4.1
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
-			IL_0021: stloc.0
-			IL_0022: ldloc.0
-			IL_0023: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs0(object, object[])
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ret
 		} // end of method FunctionExpression_L34C25::__js_call__
 
 	} // end of class FunctionExpression_L34C25
@@ -527,7 +523,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b0f
+				// Method begins at RVA 0x2a79
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -553,7 +549,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2888
+			// Method begins at RVA 0x287c
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -579,7 +575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b18
+				// Method begins at RVA 0x2a82
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -605,9 +601,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x289c
+			// Method begins at RVA 0x2890
 			// Header size: 12
-			// Code size: 32 (0x20)
+			// Code size: 20 (0x14)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -615,16 +611,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
-			IL_0006: ldstr "Cannot access 'constructProxy' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.i4.0
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_001d: stloc.0
-			IL_001e: ldloc.0
-			IL_001f: ret
+			IL_0006: ldc.i4.0
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0011: stloc.0
+			IL_0012: ldloc.0
+			IL_0013: ret
 		} // end of method FunctionExpression_L44C34::__js_call__
 
 	} // end of class FunctionExpression_L44C34
@@ -647,7 +639,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b21
+				// Method begins at RVA 0x2a8b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -670,7 +662,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28c8
+			// Method begins at RVA 0x28b0
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -692,7 +684,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2a
+				// Method begins at RVA 0x2a94
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -715,7 +707,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28cb
+			// Method begins at RVA 0x28b3
 			// Header size: 1
 			// Code size: 15 (0xf)
 			.maxstack 8
@@ -738,7 +730,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b33
+				// Method begins at RVA 0x2a9d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -764,9 +756,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x28dc
+			// Method begins at RVA 0x28c4
 			// Header size: 12
-			// Code size: 32 (0x20)
+			// Code size: 20 (0x14)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -774,16 +766,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
-			IL_0006: ldstr "Cannot access 'badConstructResultProxy' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.i4.0
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_001d: stloc.0
-			IL_001e: ldloc.0
-			IL_001f: ret
+			IL_0006: ldc.i4.0
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0011: stloc.0
+			IL_0012: ldloc.0
+			IL_0013: ret
 		} // end of method FunctionExpression_L54C34::__js_call__
 
 	} // end of class FunctionExpression_L54C34
@@ -799,7 +787,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3c
+				// Method begins at RVA 0x2aa6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -822,7 +810,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2908
+			// Method begins at RVA 0x28e4
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -845,7 +833,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b45
+				// Method begins at RVA 0x2aaf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -868,7 +856,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2910
+			// Method begins at RVA 0x28ec
 			// Header size: 1
 			// Code size: 15 (0xf)
 			.maxstack 8
@@ -891,7 +879,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b4e
+				// Method begins at RVA 0x2ab8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -917,9 +905,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2920
+			// Method begins at RVA 0x28fc
 			// Header size: 12
-			// Code size: 26 (0x1a)
+			// Code size: 14 (0xe)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -927,14 +915,10 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
-			IL_0006: ldstr "Cannot access 'badGetPrototypeProxy' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-			IL_0017: stloc.0
-			IL_0018: ldloc.0
-			IL_0019: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: ret
 		} // end of method FunctionExpression_L72C32::__js_call__
 
 	} // end of class FunctionExpression_L72C32
@@ -950,7 +934,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b57
+				// Method begins at RVA 0x2ac1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -976,7 +960,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2946
+			// Method begins at RVA 0x2916
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -1010,7 +994,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b60
+				// Method begins at RVA 0x2aca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1036,7 +1020,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2984
+			// Method begins at RVA 0x2954
 			// Header size: 12
 			// Code size: 67 (0x43)
 			.maxstack 8
@@ -1079,7 +1063,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b69
+				// Method begins at RVA 0x2ad3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1102,7 +1086,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29d3
+			// Method begins at RVA 0x29a3
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1124,7 +1108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b72
+				// Method begins at RVA 0x2adc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1150,9 +1134,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x29dc
+			// Method begins at RVA 0x29ac
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1160,19 +1144,15 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
-			IL_0006: ldstr "Cannot access 'badOwnKeysProxy' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0017: stloc.0
-			IL_0018: ldloc.0
-			IL_0019: ldstr "join"
-			IL_001e: ldstr ","
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0028: stloc.0
-			IL_0029: ldloc.0
-			IL_002a: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: ldstr "join"
+			IL_0012: ldstr ","
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ret
 		} // end of method FunctionExpression_L98C25::__js_call__
 
 	} // end of class FunctionExpression_L98C25
@@ -1188,7 +1168,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b7b
+				// Method begins at RVA 0x2ae5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1211,7 +1191,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a13
+			// Method begins at RVA 0x29d7
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -1238,7 +1218,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b84
+				// Method begins at RVA 0x2aee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1264,9 +1244,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2a30
+			// Method begins at RVA 0x29f4
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1274,19 +1254,15 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
-			IL_0006: ldstr "Cannot access 'badOwnKeysEntryProxy' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0017: stloc.0
-			IL_0018: ldloc.0
-			IL_0019: ldstr "join"
-			IL_001e: ldstr ","
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0028: stloc.0
-			IL_0029: ldloc.0
-			IL_002a: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: ldstr "join"
+			IL_0012: ldstr ","
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ret
 		} // end of method FunctionExpression_L108C21::__js_call__
 
 	} // end of class FunctionExpression_L108C21
@@ -1325,33 +1301,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a68
-			// Header size: 12
-			// Code size: 74 (0x4a)
+			// Method begins at RVA 0x2a1f
+			// Header size: 1
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
-			IL_001c: ldarg.0
-			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
-			IL_0027: ldarg.0
-			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
-			IL_0032: ldarg.0
-			IL_0033: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0038: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
-			IL_003d: ldarg.0
-			IL_003e: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0043: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
-			IL_0048: nop
-			IL_0049: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -1980,7 +1938,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b8d
+		// Method begins at RVA 0x2af7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
+++ b/tests/Js2IL.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2536
+				// Method begins at RVA 0x24a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,42 +45,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x23a8
+			// Method begins at RVA 0x2350
 			// Header size: 12
-			// Code size: 78 (0x4e)
+			// Code size: 66 (0x42)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] bool,
-				[2] object
+				[0] bool,
+				[1] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0006: ldstr "Cannot access 'custom' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldarg.0
+			IL_0006: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+			IL_000b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0010: stloc.0
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0016: ldloc.0
-			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_001c: stloc.1
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Boolean
+			IL_0017: stloc.1
+			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_001d: ldloc.1
-			IL_001e: box [System.Runtime]System.Boolean
-			IL_0023: stloc.2
+			IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0023: pop
 			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0029: ldloc.2
+			IL_0029: ldarg.2
 			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_002f: pop
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldarg.2
-			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003b: pop
-			IL_003c: ldc.i4.1
-			IL_003d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0042: dup
-			IL_0043: ldstr "MATCH"
-			IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_004d: ret
+			IL_0030: ldc.i4.1
+			IL_0031: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0036: dup
+			IL_0037: ldstr "MATCH"
+			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0041: ret
 		} // end of method FunctionExpression_L5C23::__js_call__
 
 	} // end of class FunctionExpression_L5C23
@@ -96,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x253f
+				// Method begins at RVA 0x24ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -124,43 +119,38 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2404
+			// Method begins at RVA 0x23a0
 			// Header size: 12
-			// Code size: 87 (0x57)
+			// Code size: 75 (0x4b)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] bool,
-				[2] object
+				[0] bool,
+				[1] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0006: ldstr "Cannot access 'custom' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldarg.0
+			IL_0006: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+			IL_000b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0010: stloc.0
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0016: ldloc.0
-			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_001c: stloc.1
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Boolean
+			IL_0017: stloc.1
+			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_001d: ldloc.1
-			IL_001e: box [System.Runtime]System.Boolean
-			IL_0023: stloc.2
+			IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0023: pop
 			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0029: ldloc.2
+			IL_0029: ldarg.2
 			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_002f: pop
 			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldarg.2
+			IL_0035: ldarg.3
 			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_003b: pop
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0041: ldarg.3
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0047: pop
-			IL_0048: ldc.r8 17
-			IL_0051: box [System.Runtime]System.Double
-			IL_0056: ret
+			IL_003c: ldc.r8 17
+			IL_0045: box [System.Runtime]System.Double
+			IL_004a: ret
 		} // end of method FunctionExpression_L11C25::__js_call__
 
 	} // end of class FunctionExpression_L11C25
@@ -176,7 +166,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2548
+				// Method begins at RVA 0x24b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -203,38 +193,33 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2468
+			// Method begins at RVA 0x23f8
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] bool,
-				[2] object
+				[0] bool,
+				[1] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0006: ldstr "Cannot access 'custom' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldarg.0
+			IL_0006: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+			IL_000b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0010: stloc.0
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0016: ldloc.0
-			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_001c: stloc.1
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Boolean
+			IL_0017: stloc.1
+			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_001d: ldloc.1
-			IL_001e: box [System.Runtime]System.Boolean
-			IL_0023: stloc.2
+			IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0023: pop
 			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0029: ldloc.2
+			IL_0029: ldarg.2
 			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_002f: pop
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldarg.2
-			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003b: pop
-			IL_003c: ldstr "SEARCH"
-			IL_0041: ret
+			IL_0030: ldstr "SEARCH"
+			IL_0035: ret
 		} // end of method FunctionExpression_L18C24::__js_call__
 
 	} // end of class FunctionExpression_L18C24
@@ -250,7 +235,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2551
+				// Method begins at RVA 0x24be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,46 +263,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24b8
+			// Method begins at RVA 0x243c
 			// Header size: 12
-			// Code size: 94 (0x5e)
+			// Code size: 82 (0x52)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] bool,
-				[2] object
+				[0] bool,
+				[1] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0006: ldstr "Cannot access 'custom' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldarg.0
+			IL_0006: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+			IL_000b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0010: stloc.0
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0016: ldloc.0
-			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_001c: stloc.1
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Boolean
+			IL_0017: stloc.1
+			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_001d: ldloc.1
-			IL_001e: box [System.Runtime]System.Boolean
-			IL_0023: stloc.2
+			IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0023: pop
 			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0029: ldloc.2
+			IL_0029: ldarg.2
 			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_002f: pop
 			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldarg.2
+			IL_0035: ldarg.3
 			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_003b: pop
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0041: ldarg.3
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0047: pop
-			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_004d: dup
-			IL_004e: ldstr "marker"
-			IL_0053: ldstr "split-result"
-			IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_005d: ret
+			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0041: dup
+			IL_0042: ldstr "marker"
+			IL_0047: ldstr "split-result"
+			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0051: ret
 		} // end of method FunctionExpression_L24C23::__js_call__
 
 	} // end of class FunctionExpression_L24C23
@@ -337,7 +317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x255a
+				// Method begins at RVA 0x24c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -357,7 +337,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2563
+				// Method begins at RVA 0x24d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -378,18 +358,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2522
+			// Method begins at RVA 0x249a
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -407,7 +384,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 827 (0x33b)
+		// Code size: 739 (0x2e3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_Custom/Scope,
@@ -449,261 +426,241 @@
 		IL_0039: stloc.s 11
 		IL_003b: ldloc.0
 		IL_003c: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0041: ldstr "Cannot access 'custom' before initialization"
-		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_004b: stloc.s 12
-		IL_004d: ldstr "match"
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0057: stloc.s 13
-		IL_0059: ldloc.s 12
-		IL_005b: ldloc.s 13
-		IL_005d: ldloc.s 11
-		IL_005f: ldc.i4.1
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_0065: pop
-		IL_0066: ldc.i4.1
-		IL_0067: newarr [System.Runtime]System.Object
-		IL_006c: dup
-		IL_006d: ldc.i4.0
-		IL_006e: ldloc.0
-		IL_006f: stelem.ref
-		IL_0070: ldc.i4.0
-		IL_0071: ldelem.ref
-		IL_0072: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_0077: ldftn object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
-		IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0082: ldc.i4.2
-		IL_0083: conv.r8
-		IL_0084: ldstr ""
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_008e: stloc.s 11
-		IL_0090: ldloc.0
-		IL_0091: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0096: ldstr "Cannot access 'custom' before initialization"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00a0: stloc.s 13
-		IL_00a2: ldstr "replace"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00ac: stloc.s 12
-		IL_00ae: ldloc.s 13
-		IL_00b0: ldloc.s 12
-		IL_00b2: ldloc.s 11
-		IL_00b4: ldc.i4.1
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_00ba: pop
-		IL_00bb: ldc.i4.1
-		IL_00bc: newarr [System.Runtime]System.Object
-		IL_00c1: dup
-		IL_00c2: ldc.i4.0
-		IL_00c3: ldloc.0
-		IL_00c4: stelem.ref
-		IL_00c5: ldc.i4.0
-		IL_00c6: ldelem.ref
-		IL_00c7: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_00cc: ldftn object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
-		IL_00d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00d7: ldc.i4.1
-		IL_00d8: conv.r8
-		IL_00d9: ldstr ""
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_00e3: stloc.s 11
-		IL_00e5: ldloc.0
-		IL_00e6: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_00eb: ldstr "Cannot access 'custom' before initialization"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00f5: stloc.s 12
-		IL_00f7: ldstr "search"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0101: stloc.s 13
-		IL_0103: ldloc.s 12
-		IL_0105: ldloc.s 13
-		IL_0107: ldloc.s 11
-		IL_0109: ldc.i4.1
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_010f: pop
-		IL_0110: ldc.i4.1
-		IL_0111: newarr [System.Runtime]System.Object
-		IL_0116: dup
-		IL_0117: ldc.i4.0
-		IL_0118: ldloc.0
-		IL_0119: stelem.ref
-		IL_011a: ldc.i4.0
-		IL_011b: ldelem.ref
-		IL_011c: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_0121: ldftn object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
-		IL_0127: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_012c: ldc.i4.2
-		IL_012d: conv.r8
-		IL_012e: ldstr ""
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_0138: stloc.s 11
-		IL_013a: ldloc.0
-		IL_013b: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0140: ldstr "Cannot access 'custom' before initialization"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_014a: stloc.s 13
-		IL_014c: ldstr "split"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0156: stloc.s 12
-		IL_0158: ldloc.s 13
-		IL_015a: ldloc.s 12
-		IL_015c: ldloc.s 11
-		IL_015e: ldc.i4.1
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_0164: pop
-		IL_0165: ldloc.0
-		IL_0166: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_016b: ldstr "Cannot access 'custom' before initialization"
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0175: stloc.s 11
-		IL_0177: ldstr "abc"
-		IL_017c: ldloc.s 11
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.String::Match(string, object)
-		IL_0183: stloc.s 11
-		IL_0185: ldloc.s 11
-		IL_0187: stloc.1
-		IL_0188: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018d: ldloc.1
-		IL_018e: ldc.r8 0.0
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_019c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a1: pop
-		IL_01a2: ldloc.0
-		IL_01a3: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_01a8: ldstr "Cannot access 'custom' before initialization"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01b2: stloc.s 11
-		IL_01b4: ldstr "abc"
+		IL_0041: stloc.s 12
+		IL_0043: ldstr "match"
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_004d: stloc.s 13
+		IL_004f: ldloc.s 12
+		IL_0051: ldloc.s 13
+		IL_0053: ldloc.s 11
+		IL_0055: ldc.i4.1
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_005b: pop
+		IL_005c: ldc.i4.1
+		IL_005d: newarr [System.Runtime]System.Object
+		IL_0062: dup
+		IL_0063: ldc.i4.0
+		IL_0064: ldloc.0
+		IL_0065: stelem.ref
+		IL_0066: ldc.i4.0
+		IL_0067: ldelem.ref
+		IL_0068: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
+		IL_006d: ldftn object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
+		IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0078: ldc.i4.2
+		IL_0079: conv.r8
+		IL_007a: ldstr ""
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_0084: stloc.s 11
+		IL_0086: ldloc.0
+		IL_0087: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_008c: stloc.s 13
+		IL_008e: ldstr "replace"
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0098: stloc.s 12
+		IL_009a: ldloc.s 13
+		IL_009c: ldloc.s 12
+		IL_009e: ldloc.s 11
+		IL_00a0: ldc.i4.1
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_00a6: pop
+		IL_00a7: ldc.i4.1
+		IL_00a8: newarr [System.Runtime]System.Object
+		IL_00ad: dup
+		IL_00ae: ldc.i4.0
+		IL_00af: ldloc.0
+		IL_00b0: stelem.ref
+		IL_00b1: ldc.i4.0
+		IL_00b2: ldelem.ref
+		IL_00b3: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
+		IL_00b8: ldftn object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
+		IL_00be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00c3: ldc.i4.1
+		IL_00c4: conv.r8
+		IL_00c5: ldstr ""
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_00cf: stloc.s 11
+		IL_00d1: ldloc.0
+		IL_00d2: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_00d7: stloc.s 12
+		IL_00d9: ldstr "search"
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_00e3: stloc.s 13
+		IL_00e5: ldloc.s 12
+		IL_00e7: ldloc.s 13
+		IL_00e9: ldloc.s 11
+		IL_00eb: ldc.i4.1
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_00f1: pop
+		IL_00f2: ldc.i4.1
+		IL_00f3: newarr [System.Runtime]System.Object
+		IL_00f8: dup
+		IL_00f9: ldc.i4.0
+		IL_00fa: ldloc.0
+		IL_00fb: stelem.ref
+		IL_00fc: ldc.i4.0
+		IL_00fd: ldelem.ref
+		IL_00fe: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
+		IL_0103: ldftn object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
+		IL_0109: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_010e: ldc.i4.2
+		IL_010f: conv.r8
+		IL_0110: ldstr ""
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_011a: stloc.s 11
+		IL_011c: ldloc.0
+		IL_011d: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_0122: stloc.s 13
+		IL_0124: ldstr "split"
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_012e: stloc.s 12
+		IL_0130: ldloc.s 13
+		IL_0132: ldloc.s 12
+		IL_0134: ldloc.s 11
+		IL_0136: ldc.i4.1
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_013c: pop
+		IL_013d: ldstr "abc"
+		IL_0142: ldloc.0
+		IL_0143: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.String::Match(string, object)
+		IL_014d: stloc.s 11
+		IL_014f: ldloc.s 11
+		IL_0151: stloc.1
+		IL_0152: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0157: ldloc.1
+		IL_0158: ldc.r8 0.0
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016b: pop
+		IL_016c: ldloc.0
+		IL_016d: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_0172: stloc.s 11
+		IL_0174: ldstr "abc"
+		IL_0179: ldloc.s 11
+		IL_017b: ldstr "x"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.String::Replace(string, object, object)
+		IL_0185: stloc.s 11
+		IL_0187: ldloc.s 11
+		IL_0189: stloc.2
+		IL_018a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_018f: ldloc.2
+		IL_0190: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0195: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019a: pop
+		IL_019b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a0: ldloc.2
+		IL_01a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a6: pop
+		IL_01a7: ldstr "abc"
+		IL_01ac: ldloc.0
+		IL_01ad: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.String::Search(string, object)
+		IL_01b7: stloc.s 11
 		IL_01b9: ldloc.s 11
-		IL_01bb: ldstr "x"
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.String::Replace(string, object, object)
-		IL_01c5: stloc.s 11
-		IL_01c7: ldloc.s 11
-		IL_01c9: stloc.2
-		IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01cf: ldloc.2
-		IL_01d0: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01da: pop
-		IL_01db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e0: ldloc.2
-		IL_01e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e6: pop
-		IL_01e7: ldloc.0
-		IL_01e8: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_01ed: ldstr "Cannot access 'custom' before initialization"
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01f7: stloc.s 11
-		IL_01f9: ldstr "abc"
-		IL_01fe: ldloc.s 11
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.String::Search(string, object)
-		IL_0205: stloc.s 11
-		IL_0207: ldloc.s 11
-		IL_0209: stloc.3
-		IL_020a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_020f: ldloc.3
-		IL_0210: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0215: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_021a: pop
-		IL_021b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0220: ldloc.3
-		IL_0221: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0226: pop
-		IL_0227: ldloc.0
-		IL_0228: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_022d: ldstr "Cannot access 'custom' before initialization"
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0237: stloc.s 11
-		IL_0239: ldstr "abc"
-		IL_023e: ldloc.s 11
-		IL_0240: ldc.r8 5
-		IL_0249: box [System.Runtime]System.Double
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.String::Split(string, object, object)
-		IL_0253: stloc.s 11
-		IL_0255: ldloc.s 11
-		IL_0257: stloc.s 4
-		IL_0259: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_025e: ldloc.s 4
-		IL_0260: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026a: pop
-		IL_026b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0270: ldloc.s 4
-		IL_0272: ldstr "marker"
-		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_027c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0281: pop
-		IL_0282: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0287: stloc.s 5
-		IL_0289: ldstr "match"
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0293: stloc.s 11
-		IL_0295: ldloc.s 5
-		IL_0297: ldloc.s 11
-		IL_0299: ldc.r8 1
-		IL_02a2: box [System.Runtime]System.Double
-		IL_02a7: ldc.i4.1
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_02ad: pop
+		IL_01bb: stloc.3
+		IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c1: ldloc.3
+		IL_01c2: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_01c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01cc: pop
+		IL_01cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d2: ldloc.3
+		IL_01d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d8: pop
+		IL_01d9: ldloc.0
+		IL_01da: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_01df: stloc.s 11
+		IL_01e1: ldstr "abc"
+		IL_01e6: ldloc.s 11
+		IL_01e8: ldc.r8 5
+		IL_01f1: box [System.Runtime]System.Double
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.String::Split(string, object, object)
+		IL_01fb: stloc.s 11
+		IL_01fd: ldloc.s 11
+		IL_01ff: stloc.s 4
+		IL_0201: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0206: ldloc.s 4
+		IL_0208: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0212: pop
+		IL_0213: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0218: ldloc.s 4
+		IL_021a: ldstr "marker"
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0224: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0229: pop
+		IL_022a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_022f: stloc.s 5
+		IL_0231: ldstr "match"
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_023b: stloc.s 11
+		IL_023d: ldloc.s 5
+		IL_023f: ldloc.s 11
+		IL_0241: ldc.r8 1
+		IL_024a: box [System.Runtime]System.Double
+		IL_024f: ldc.i4.1
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_0255: pop
 		.try
 		{
-			IL_02ae: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/Scope/Block_L48C4::.ctor()
-			IL_02b3: stloc.s 6
-			IL_02b5: ldstr "abc"
-			IL_02ba: ldloc.s 5
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.String::Match(string, object)
-			IL_02c1: pop
-			IL_02c2: leave IL_033a
+			IL_0256: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/Scope/Block_L48C4::.ctor()
+			IL_025b: stloc.s 6
+			IL_025d: ldstr "abc"
+			IL_0262: ldloc.s 5
+			IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.String::Match(string, object)
+			IL_0269: pop
+			IL_026a: leave IL_02e2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02c7: stloc.s 7
-			IL_02c9: ldloc.s 7
-			IL_02cb: dup
-			IL_02cc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02d1: dup
-			IL_02d2: brtrue IL_02e8
+			IL_026f: stloc.s 7
+			IL_0271: ldloc.s 7
+			IL_0273: dup
+			IL_0274: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0279: dup
+			IL_027a: brtrue IL_0290
 
-			IL_02d7: pop
-			IL_02d8: dup
-			IL_02d9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02de: dup
-			IL_02df: brtrue IL_02f5
+			IL_027f: pop
+			IL_0280: dup
+			IL_0281: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0286: dup
+			IL_0287: brtrue IL_029d
 
-			IL_02e4: pop
-			IL_02e5: pop
-			IL_02e6: rethrow
+			IL_028c: pop
+			IL_028d: pop
+			IL_028e: rethrow
 
-			IL_02e8: pop
-			IL_02e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02ee: stloc.s 8
-			IL_02f0: br IL_02f8
+			IL_0290: pop
+			IL_0291: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0296: stloc.s 8
+			IL_0298: br IL_02a0
 
-			IL_02f5: pop
-			IL_02f6: stloc.s 8
+			IL_029d: pop
+			IL_029e: stloc.s 8
 
-			IL_02f8: ldloc.s 8
-			IL_02fa: stloc.s 11
-			IL_02fc: ldloc.s 11
-			IL_02fe: stloc.s 9
-			IL_0300: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/Scope/Block_L50C12::.ctor()
-			IL_0305: stloc.s 10
-			IL_0307: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_030c: ldloc.s 9
-			IL_030e: ldstr "name"
-			IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0318: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_031d: pop
-			IL_031e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0323: ldloc.s 9
-			IL_0325: ldstr "message"
-			IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0334: pop
-			IL_0335: leave IL_033a
+			IL_02a0: ldloc.s 8
+			IL_02a2: stloc.s 11
+			IL_02a4: ldloc.s 11
+			IL_02a6: stloc.s 9
+			IL_02a8: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/Scope/Block_L50C12::.ctor()
+			IL_02ad: stloc.s 10
+			IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02b4: ldloc.s 9
+			IL_02b6: ldstr "name"
+			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02c5: pop
+			IL_02c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02cb: ldloc.s 9
+			IL_02cd: ldstr "message"
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02dc: pop
+			IL_02dd: leave IL_02e2
 		} // end handler
 
-		IL_033a: ret
+		IL_02e2: ret
 	} // end of method String_RegExp_SymbolDispatch_Custom::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_Custom
@@ -715,7 +672,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x256c
+		// Method begins at RVA 0x24d9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/SymbolTableBuilderTests.cs
+++ b/tests/Js2IL.Tests/SymbolTableBuilderTests.cs
@@ -537,6 +537,49 @@ namespace Js2IL.Tests
         }
 
         [Fact]
+        public void SymbolTable_CapturedConstInitializedBeforeClassMethod_DoesNotRequireRuntimeTemporalDeadZoneChecks()
+        {
+            var code = @"
+                const WORD_SIZE = 32;
+                class BitArray {
+                    setBitsTrue() {
+                        return WORD_SIZE;
+                    }
+                }
+            ";
+            var ast = _parser.ParseJavaScript(code, "test.js");
+
+            var scopeTree = BuildSymbolTable(ast, "test.js");
+
+            var binding = scopeTree.Root.Bindings["WORD_SIZE"];
+            Assert.True(binding.IsCaptured);
+            Assert.False(binding.RequiresRuntimeTemporalDeadZoneChecks);
+        }
+
+        [Fact]
+        public void SymbolTable_CapturedConstFunctionDeclaredBeforeInitialization_RequiresRuntimeTemporalDeadZoneChecks()
+        {
+            var code = @"
+                {
+                    function f() {
+                        return x + 1;
+                    }
+
+                    f();
+                    const x = 1;
+                }
+            ";
+            var ast = _parser.ParseJavaScript(code, "test.js");
+
+            var scopeTree = BuildSymbolTable(ast, "test.js");
+
+            var blockScope = scopeTree.Root.Children.Single();
+            var binding = blockScope.Bindings["x"];
+            Assert.True(binding.IsCaptured);
+            Assert.True(binding.RequiresRuntimeTemporalDeadZoneChecks);
+        }
+
+        [Fact]
         public void SymbolTable_GlobalVariableCapturedInClassInstanceField_CreatesCorrectBindings()
         {
             // Arrange
@@ -872,4 +915,3 @@ namespace Js2IL.Tests
         }
     }
 }
-

--- a/tests/Js2IL.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Js2IL.Tests/SymbolTableTypeInferenceTests.cs
@@ -837,6 +837,11 @@ public class SymbolTableTypeInferenceTests
             ("range_start", typeof(double)),
             ("step", typeof(double)),
             ("range_stop", typeof(double)));
+
+        var index = FindBindingByName(methodScope!, "index");
+        Assert.NotNull(index);
+        Assert.True(index!.IsStableType);
+        Assert.Equal(typeof(double), index.ClrType);
     }
 
     [Fact]
@@ -883,6 +888,7 @@ public class SymbolTableTypeInferenceTests
         Assert.NotNull(binding);
         Assert.True(binding!.IsStableType);
         Assert.Equal(typeof(double), binding.ClrType);
+
     }
 
     private static Js2IL.SymbolTables.Scope? FindFirstScope(Js2IL.SymbolTables.Scope scope, Func<Js2IL.SymbolTables.Scope, bool> predicate)

--- a/tests/Js2IL.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Js2IL.Tests/SymbolTableTypeInferenceTests.cs
@@ -93,6 +93,25 @@ public class SymbolTableTypeInferenceTests
         Assert.Equal(expectedType, binding.ClrType);
     }
 
+    [Fact]
+    public void SymbolTable_InferType_AssignmentAlias_WidensWhenSourceBecomesNull()
+    {
+        var code = @"
+                var first = 0;
+                var second = 1;
+                first = second;
+                second = null;
+            ";
+
+        var symbolTable = BuildSymbolTable(code);
+        var firstBinding = symbolTable.GetBindingInfo("first");
+        var secondBinding = symbolTable.GetBindingInfo("second");
+        Assert.NotNull(firstBinding);
+        Assert.NotNull(secondBinding);
+        Assert.Null(firstBinding.ClrType);
+        Assert.Null(secondBinding.ClrType);
+    }
+
     [Theory]
     [InlineData(typeof(double), "42", "testVar++")]
     [InlineData(typeof(double), "42", "++testVar")]

--- a/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a36
+				// Method begins at RVA 0x2a0b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a3f
+				// Method begins at RVA 0x2a14
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a51
+					// Method begins at RVA 0x2a26
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a48
+				// Method begins at RVA 0x2a1d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a6c
+						// Method begins at RVA 0x2a41
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2a7e
+							// Method begins at RVA 0x2a53
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a75
+						// Method begins at RVA 0x2a4a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -168,7 +168,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a63
+					// Method begins at RVA 0x2a38
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2a99
+							// Method begins at RVA 0x2a6e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a90
+						// Method begins at RVA 0x2a65
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -232,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a87
+					// Method begins at RVA 0x2a5c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a5a
+				// Method begins at RVA 0x2a2f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aab
+					// Method begins at RVA 0x2a80
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa2
+				// Method begins at RVA 0x2a77
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab4
+				// Method begins at RVA 0x2a89
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ac6
+					// Method begins at RVA 0x2a9b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -354,7 +354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2abd
+				// Method begins at RVA 0x2a92
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -382,7 +382,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2698
+			// Method begins at RVA 0x2690
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -431,7 +431,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x293c
+			// Method begins at RVA 0x291c
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -540,9 +540,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26e8
+			// Method begins at RVA 0x26e0
 			// Header size: 12
-			// Code size: 473 (0x1d9)
+			// Code size: 450 (0x1c2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28,
@@ -559,9 +559,8 @@
 				[11] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7,
 				[12] float64,
 				[13] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67,
-				[14] object,
-				[15] float64,
-				[16] object
+				[14] float64,
+				[15] object
 			)
 
 			IL_0000: ldarg.0
@@ -569,203 +568,196 @@
 			IL_0006: ldc.i4.0
 			IL_0007: ldelem.ref
 			IL_0008: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope
-			IL_000d: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
-			IL_0012: ldstr "Cannot access 'WORD_SIZE' before initialization"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000d: ldfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
+			IL_0012: ldc.r8 2
+			IL_001b: div
 			IL_001c: stloc.s 14
-			IL_001e: ldloc.s 14
-			IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0025: stloc.s 15
-			IL_0027: ldloc.s 15
-			IL_0029: ldc.r8 2
-			IL_0032: div
-			IL_0033: stloc.s 15
-			IL_0035: ldarg.2
-			IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_003b: ldloc.s 15
-			IL_003d: cgt
-			IL_003f: brfalse IL_0194
+			IL_001e: ldarg.2
+			IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0024: ldloc.s 14
+			IL_0026: cgt
+			IL_0028: brfalse IL_017d
 
-			IL_0044: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28::.ctor()
-			IL_0049: stloc.0
-			IL_004a: ldarg.1
-			IL_004b: ldc.r8 32
-			IL_0054: ldarg.2
-			IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_005a: mul
-			IL_005b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
-			IL_0060: stloc.s 15
-			IL_0062: ldloc.s 15
-			IL_0064: stloc.1
-			IL_0065: ldloc.1
-			IL_0066: ldarg.3
-			IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_006c: cgt
-			IL_006e: brfalse IL_00b8
+			IL_002d: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28::.ctor()
+			IL_0032: stloc.0
+			IL_0033: ldarg.1
+			IL_0034: ldc.r8 32
+			IL_003d: ldarg.2
+			IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0043: mul
+			IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
+			IL_0049: stloc.s 14
+			IL_004b: ldloc.s 14
+			IL_004d: stloc.1
+			IL_004e: ldloc.1
+			IL_004f: ldarg.3
+			IL_0050: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0055: cgt
+			IL_0057: brfalse IL_00a1
 
-			IL_0073: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Block_L22C39::.ctor()
-			IL_0078: stloc.2
-			IL_0079: ldarg.1
-			IL_007a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_007f: stloc.3
-			// loop start (head: IL_0080)
-				IL_0080: ldloc.3
-				IL_0081: ldarg.3
-				IL_0082: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0087: clt
-				IL_0089: brfalse IL_00b6
+			IL_005c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Block_L22C39::.ctor()
+			IL_0061: stloc.2
+			IL_0062: ldarg.1
+			IL_0063: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0068: stloc.3
+			// loop start (head: IL_0069)
+				IL_0069: ldloc.3
+				IL_006a: ldarg.3
+				IL_006b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0070: clt
+				IL_0072: brfalse IL_009f
 
-				IL_008e: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Scope_For_L23C9/Block_L23C69::.ctor()
-				IL_0093: stloc.s 4
-				IL_0095: ldloc.3
-				IL_0096: box [System.Runtime]System.Double
-				IL_009b: stloc.s 16
-				IL_009d: ldarg.0
-				IL_009e: ldloc.3
-				IL_009f: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_00a4: pop
-				IL_00a5: ldloc.3
-				IL_00a6: ldarg.2
-				IL_00a7: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_00ac: stloc.s 15
-				IL_00ae: ldloc.s 15
-				IL_00b0: stloc.3
-				IL_00b1: br IL_0080
+				IL_0077: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Scope_For_L23C9/Block_L23C69::.ctor()
+				IL_007c: stloc.s 4
+				IL_007e: ldloc.3
+				IL_007f: box [System.Runtime]System.Double
+				IL_0084: stloc.s 15
+				IL_0086: ldarg.0
+				IL_0087: ldloc.3
+				IL_0088: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_008d: pop
+				IL_008e: ldloc.3
+				IL_008f: ldarg.2
+				IL_0090: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0095: stloc.s 14
+				IL_0097: ldloc.s 14
+				IL_0099: stloc.3
+				IL_009a: br IL_0069
 			// end loop
 
-			IL_00b6: ldnull
-			IL_00b7: ret
+			IL_009f: ldnull
+			IL_00a0: ret
 
-			IL_00b8: ldarg.3
-			IL_00b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00be: conv.i4
-			IL_00bf: conv.u4
-			IL_00c0: ldc.r8 5
-			IL_00c9: conv.i4
-			IL_00ca: shr.un
-			IL_00cb: conv.r.un
-			IL_00cc: stloc.s 15
-			IL_00ce: ldloc.s 15
-			IL_00d0: stloc.s 5
-			IL_00d2: ldarg.1
-			IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00d8: stloc.s 6
-			// loop start (head: IL_00da)
-				IL_00da: ldloc.s 6
-				IL_00dc: ldloc.1
-				IL_00dd: clt
-				IL_00df: brfalse IL_0192
+			IL_00a1: ldarg.3
+			IL_00a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00a7: conv.i4
+			IL_00a8: conv.u4
+			IL_00a9: ldc.r8 5
+			IL_00b2: conv.i4
+			IL_00b3: shr.un
+			IL_00b4: conv.r.un
+			IL_00b5: stloc.s 14
+			IL_00b7: ldloc.s 14
+			IL_00b9: stloc.s 5
+			IL_00bb: ldarg.1
+			IL_00bc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00c1: stloc.s 6
+			// loop start (head: IL_00c3)
+				IL_00c3: ldloc.s 6
+				IL_00c5: ldloc.1
+				IL_00c6: clt
+				IL_00c8: brfalse IL_017b
 
-				IL_00e4: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75::.ctor()
-				IL_00e9: stloc.s 7
-				IL_00eb: ldloc.s 6
-				IL_00ed: conv.i4
-				IL_00ee: conv.u4
-				IL_00ef: ldc.r8 5
-				IL_00f8: conv.i4
-				IL_00f9: shr.un
-				IL_00fa: conv.r.un
-				IL_00fb: stloc.s 15
-				IL_00fd: ldloc.s 15
-				IL_00ff: stloc.s 8
-				IL_0101: ldloc.s 6
-				IL_0103: conv.i4
-				IL_0104: ldc.r8 31
-				IL_010d: conv.i4
-				IL_010e: and
-				IL_010f: conv.r8
-				IL_0110: stloc.s 15
-				IL_0112: ldloc.s 15
-				IL_0114: stloc.s 9
-				IL_0116: ldc.r8 1
-				IL_011f: conv.i4
-				IL_0120: ldloc.s 9
-				IL_0122: conv.i4
-				IL_0123: shl
-				IL_0124: conv.r8
-				IL_0125: stloc.s 15
-				IL_0127: ldloc.s 15
-				IL_0129: stloc.s 10
-				// loop start (head: IL_012b)
-					IL_012b: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7::.ctor()
-					IL_0130: stloc.s 11
-					IL_0132: ldarg.0
-					IL_0133: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
-					IL_0138: ldloc.s 8
-					IL_013a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_013f: stloc.s 15
-					IL_0141: ldloc.s 15
-					IL_0143: stloc.s 15
-					IL_0145: ldloc.s 15
-					IL_0147: conv.i4
-					IL_0148: ldloc.s 10
-					IL_014a: conv.i4
-					IL_014b: or
-					IL_014c: conv.r8
-					IL_014d: stloc.s 15
-					IL_014f: ldarg.0
-					IL_0150: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+				IL_00cd: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75::.ctor()
+				IL_00d2: stloc.s 7
+				IL_00d4: ldloc.s 6
+				IL_00d6: conv.i4
+				IL_00d7: conv.u4
+				IL_00d8: ldc.r8 5
+				IL_00e1: conv.i4
+				IL_00e2: shr.un
+				IL_00e3: conv.r.un
+				IL_00e4: stloc.s 14
+				IL_00e6: ldloc.s 14
+				IL_00e8: stloc.s 8
+				IL_00ea: ldloc.s 6
+				IL_00ec: conv.i4
+				IL_00ed: ldc.r8 31
+				IL_00f6: conv.i4
+				IL_00f7: and
+				IL_00f8: conv.r8
+				IL_00f9: stloc.s 14
+				IL_00fb: ldloc.s 14
+				IL_00fd: stloc.s 9
+				IL_00ff: ldc.r8 1
+				IL_0108: conv.i4
+				IL_0109: ldloc.s 9
+				IL_010b: conv.i4
+				IL_010c: shl
+				IL_010d: conv.r8
+				IL_010e: stloc.s 14
+				IL_0110: ldloc.s 14
+				IL_0112: stloc.s 10
+				// loop start (head: IL_0114)
+					IL_0114: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7::.ctor()
+					IL_0119: stloc.s 11
+					IL_011b: ldarg.0
+					IL_011c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_0121: ldloc.s 8
+					IL_0123: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_0128: stloc.s 14
+					IL_012a: ldloc.s 14
+					IL_012c: stloc.s 14
+					IL_012e: ldloc.s 14
+					IL_0130: conv.i4
+					IL_0131: ldloc.s 10
+					IL_0133: conv.i4
+					IL_0134: or
+					IL_0135: conv.r8
+					IL_0136: stloc.s 14
+					IL_0138: ldarg.0
+					IL_0139: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_013e: ldloc.s 8
+					IL_0140: ldloc.s 14
+					IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_0147: ldloc.s 8
+					IL_0149: ldarg.2
+					IL_014a: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+					IL_014f: stloc.s 14
+					IL_0151: ldloc.s 14
+					IL_0153: stloc.s 8
 					IL_0155: ldloc.s 8
-					IL_0157: ldloc.s 15
-					IL_0159: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_015e: ldloc.s 8
-					IL_0160: ldarg.2
-					IL_0161: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-					IL_0166: stloc.s 15
-					IL_0168: ldloc.s 15
-					IL_016a: stloc.s 8
-					IL_016c: ldloc.s 8
-					IL_016e: ldloc.s 5
-					IL_0170: cgt
-					IL_0172: ldc.i4.0
-					IL_0173: ceq
-					IL_0175: brfalse IL_017f
+					IL_0157: ldloc.s 5
+					IL_0159: cgt
+					IL_015b: ldc.i4.0
+					IL_015c: ceq
+					IL_015e: brfalse IL_0168
 
-					IL_017a: br IL_012b
+					IL_0163: br IL_0114
 				// end loop
 
-				IL_017f: ldloc.s 6
-				IL_0181: ldarg.2
-				IL_0182: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_0187: stloc.s 15
-				IL_0189: ldloc.s 15
-				IL_018b: stloc.s 6
-				IL_018d: br IL_00da
+				IL_0168: ldloc.s 6
+				IL_016a: ldarg.2
+				IL_016b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0170: stloc.s 14
+				IL_0172: ldloc.s 14
+				IL_0174: stloc.s 6
+				IL_0176: br IL_00c3
 			// end loop
 
-			IL_0192: ldnull
-			IL_0193: ret
+			IL_017b: ldnull
+			IL_017c: ret
 
-			IL_0194: ldarg.1
-			IL_0195: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_019a: stloc.s 12
-			// loop start (head: IL_019c)
-				IL_019c: ldloc.s 12
-				IL_019e: ldarg.3
-				IL_019f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01a4: clt
-				IL_01a6: brfalse IL_01d7
+			IL_017d: ldarg.1
+			IL_017e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0183: stloc.s 12
+			// loop start (head: IL_0185)
+				IL_0185: ldloc.s 12
+				IL_0187: ldarg.3
+				IL_0188: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_018d: clt
+				IL_018f: brfalse IL_01c0
 
-				IL_01ab: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67::.ctor()
-				IL_01b0: stloc.s 13
-				IL_01b2: ldloc.s 12
-				IL_01b4: box [System.Runtime]System.Double
-				IL_01b9: stloc.s 16
-				IL_01bb: ldarg.0
-				IL_01bc: ldloc.s 12
-				IL_01be: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_01c3: pop
-				IL_01c4: ldloc.s 12
-				IL_01c6: ldarg.2
-				IL_01c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_01cc: stloc.s 15
-				IL_01ce: ldloc.s 15
-				IL_01d0: stloc.s 12
-				IL_01d2: br IL_019c
+				IL_0194: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67::.ctor()
+				IL_0199: stloc.s 13
+				IL_019b: ldloc.s 12
+				IL_019d: box [System.Runtime]System.Double
+				IL_01a2: stloc.s 15
+				IL_01a4: ldarg.0
+				IL_01a5: ldloc.s 12
+				IL_01a7: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_01ac: pop
+				IL_01ad: ldloc.s 12
+				IL_01af: ldarg.2
+				IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_01b5: stloc.s 14
+				IL_01b7: ldloc.s 14
+				IL_01b9: stloc.s 12
+				IL_01bb: br IL_0185
 			// end loop
 
-			IL_01d7: ldnull
-			IL_01d8: ret
+			IL_01c0: ldnull
+			IL_01c1: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -778,7 +770,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28d0
+			// Method begins at RVA 0x28b0
 			// Header size: 12
 			// Code size: 96 (0x60)
 			.maxstack 8
@@ -864,7 +856,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aea
+				// Method begins at RVA 0x2abf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -879,7 +871,7 @@
 
 
 		// Fields
-		.field public object WORD_SIZE
+		.field public float64 WORD_SIZE
 		.field public object size
 		.field public object range_start
 		.field public object step
@@ -889,30 +881,27 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29f6
+			// Method begins at RVA 0x29d6
 			// Header size: 1
-			// Code size: 63 (0x3f)
+			// Code size: 52 (0x34)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
+			IL_000c: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
 			IL_0011: ldarg.0
 			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+			IL_0017: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
 			IL_001c: ldarg.0
 			IL_001d: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0022: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+			IL_0022: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
 			IL_0027: ldarg.0
 			IL_0028: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_002d: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-			IL_0032: ldarg.0
-			IL_0033: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0038: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-			IL_003d: nop
-			IL_003e: ret
+			IL_002d: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+			IL_0032: nop
+			IL_0033: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -932,7 +921,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ae1
+					// Method begins at RVA 0x2ab6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -950,7 +939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad8
+				// Method begins at RVA 0x2aad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -968,7 +957,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2acf
+			// Method begins at RVA 0x2aa4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -994,7 +983,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1593 (0x639)
+		// Code size: 1588 (0x634)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope,
@@ -1023,527 +1012,526 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldc.r8 32
-		IL_0010: box [System.Runtime]System.Double
-		IL_0015: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
-		IL_001a: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_001f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0024: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0029: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_002e: stloc.s 10
-		IL_0030: ldc.i4.1
-		IL_0031: newarr [System.Runtime]System.Object
-		IL_0036: dup
-		IL_0037: ldc.i4.0
-		IL_0038: ldloc.0
-		IL_0039: stelem.ref
-		IL_003a: stloc.s 11
-		IL_003c: ldc.i4.s 10
-		IL_003e: newarr [System.Runtime]System.Object
+		IL_0010: stfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
+		IL_0015: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_001a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001f: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0024: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0029: stloc.s 10
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldloc.0
+		IL_0034: stelem.ref
+		IL_0035: stloc.s 11
+		IL_0037: ldc.i4.s 10
+		IL_0039: newarr [System.Runtime]System.Object
+		IL_003e: dup
+		IL_003f: ldc.i4.0
+		IL_0040: ldloc.s 10
+		IL_0042: stelem.ref
 		IL_0043: dup
-		IL_0044: ldc.i4.0
-		IL_0045: ldloc.s 10
-		IL_0047: stelem.ref
-		IL_0048: dup
-		IL_0049: ldc.i4.1
-		IL_004a: ldstr "setBitTrue"
-		IL_004f: stelem.ref
-		IL_0050: dup
-		IL_0051: ldc.i4.2
-		IL_0052: ldstr "setBitTrue"
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.3
-		IL_005a: ldc.r8 1
-		IL_0063: box [System.Runtime]System.Double
-		IL_0068: stelem.ref
-		IL_0069: dup
-		IL_006a: ldc.i4.4
-		IL_006b: ldstr "setBitTrue"
-		IL_0070: stelem.ref
-		IL_0071: dup
-		IL_0072: ldc.i4.5
-		IL_0073: ldc.i4.0
-		IL_0074: box [System.Runtime]System.Boolean
-		IL_0079: stelem.ref
-		IL_007a: dup
-		IL_007b: ldc.i4.6
-		IL_007c: ldc.i4.0
-		IL_007d: box [System.Runtime]System.Boolean
-		IL_0082: stelem.ref
-		IL_0083: dup
-		IL_0084: ldc.i4.7
-		IL_0085: ldc.i4.0
-		IL_0086: box [System.Runtime]System.Boolean
-		IL_008b: stelem.ref
-		IL_008c: dup
-		IL_008d: ldc.i4.8
-		IL_008e: ldc.i4.0
-		IL_008f: box [System.Runtime]System.Boolean
-		IL_0094: stelem.ref
-		IL_0095: dup
-		IL_0096: ldc.i4.s 9
-		IL_0098: ldloc.s 11
-		IL_009a: stelem.ref
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00a0: pop
-		IL_00a1: ldc.i4.s 10
-		IL_00a3: newarr [System.Runtime]System.Object
+		IL_0044: ldc.i4.1
+		IL_0045: ldstr "setBitTrue"
+		IL_004a: stelem.ref
+		IL_004b: dup
+		IL_004c: ldc.i4.2
+		IL_004d: ldstr "setBitTrue"
+		IL_0052: stelem.ref
+		IL_0053: dup
+		IL_0054: ldc.i4.3
+		IL_0055: ldc.r8 1
+		IL_005e: box [System.Runtime]System.Double
+		IL_0063: stelem.ref
+		IL_0064: dup
+		IL_0065: ldc.i4.4
+		IL_0066: ldstr "setBitTrue"
+		IL_006b: stelem.ref
+		IL_006c: dup
+		IL_006d: ldc.i4.5
+		IL_006e: ldc.i4.0
+		IL_006f: box [System.Runtime]System.Boolean
+		IL_0074: stelem.ref
+		IL_0075: dup
+		IL_0076: ldc.i4.6
+		IL_0077: ldc.i4.0
+		IL_0078: box [System.Runtime]System.Boolean
+		IL_007d: stelem.ref
+		IL_007e: dup
+		IL_007f: ldc.i4.7
+		IL_0080: ldc.i4.0
+		IL_0081: box [System.Runtime]System.Boolean
+		IL_0086: stelem.ref
+		IL_0087: dup
+		IL_0088: ldc.i4.8
+		IL_0089: ldc.i4.0
+		IL_008a: box [System.Runtime]System.Boolean
+		IL_008f: stelem.ref
+		IL_0090: dup
+		IL_0091: ldc.i4.s 9
+		IL_0093: ldloc.s 11
+		IL_0095: stelem.ref
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_009b: pop
+		IL_009c: ldc.i4.s 10
+		IL_009e: newarr [System.Runtime]System.Object
+		IL_00a3: dup
+		IL_00a4: ldc.i4.0
+		IL_00a5: ldloc.s 10
+		IL_00a7: stelem.ref
 		IL_00a8: dup
-		IL_00a9: ldc.i4.0
-		IL_00aa: ldloc.s 10
-		IL_00ac: stelem.ref
-		IL_00ad: dup
-		IL_00ae: ldc.i4.1
-		IL_00af: ldstr "setBitsTrue"
-		IL_00b4: stelem.ref
-		IL_00b5: dup
-		IL_00b6: ldc.i4.2
-		IL_00b7: ldstr "setBitsTrue"
-		IL_00bc: stelem.ref
-		IL_00bd: dup
-		IL_00be: ldc.i4.3
-		IL_00bf: ldc.r8 3
-		IL_00c8: box [System.Runtime]System.Double
-		IL_00cd: stelem.ref
-		IL_00ce: dup
-		IL_00cf: ldc.i4.4
-		IL_00d0: ldstr "setBitsTrue"
-		IL_00d5: stelem.ref
-		IL_00d6: dup
-		IL_00d7: ldc.i4.5
-		IL_00d8: ldc.i4.0
-		IL_00d9: box [System.Runtime]System.Boolean
-		IL_00de: stelem.ref
-		IL_00df: dup
-		IL_00e0: ldc.i4.6
-		IL_00e1: ldc.i4.0
-		IL_00e2: box [System.Runtime]System.Boolean
-		IL_00e7: stelem.ref
-		IL_00e8: dup
-		IL_00e9: ldc.i4.7
-		IL_00ea: ldc.i4.0
-		IL_00eb: box [System.Runtime]System.Boolean
-		IL_00f0: stelem.ref
-		IL_00f1: dup
-		IL_00f2: ldc.i4.8
-		IL_00f3: ldc.i4.0
-		IL_00f4: box [System.Runtime]System.Boolean
-		IL_00f9: stelem.ref
-		IL_00fa: dup
-		IL_00fb: ldc.i4.s 9
-		IL_00fd: ldloc.s 11
-		IL_00ff: stelem.ref
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0105: pop
-		IL_0106: ldc.i4.s 10
-		IL_0108: newarr [System.Runtime]System.Object
+		IL_00a9: ldc.i4.1
+		IL_00aa: ldstr "setBitsTrue"
+		IL_00af: stelem.ref
+		IL_00b0: dup
+		IL_00b1: ldc.i4.2
+		IL_00b2: ldstr "setBitsTrue"
+		IL_00b7: stelem.ref
+		IL_00b8: dup
+		IL_00b9: ldc.i4.3
+		IL_00ba: ldc.r8 3
+		IL_00c3: box [System.Runtime]System.Double
+		IL_00c8: stelem.ref
+		IL_00c9: dup
+		IL_00ca: ldc.i4.4
+		IL_00cb: ldstr "setBitsTrue"
+		IL_00d0: stelem.ref
+		IL_00d1: dup
+		IL_00d2: ldc.i4.5
+		IL_00d3: ldc.i4.0
+		IL_00d4: box [System.Runtime]System.Boolean
+		IL_00d9: stelem.ref
+		IL_00da: dup
+		IL_00db: ldc.i4.6
+		IL_00dc: ldc.i4.0
+		IL_00dd: box [System.Runtime]System.Boolean
+		IL_00e2: stelem.ref
+		IL_00e3: dup
+		IL_00e4: ldc.i4.7
+		IL_00e5: ldc.i4.0
+		IL_00e6: box [System.Runtime]System.Boolean
+		IL_00eb: stelem.ref
+		IL_00ec: dup
+		IL_00ed: ldc.i4.8
+		IL_00ee: ldc.i4.0
+		IL_00ef: box [System.Runtime]System.Boolean
+		IL_00f4: stelem.ref
+		IL_00f5: dup
+		IL_00f6: ldc.i4.s 9
+		IL_00f8: ldloc.s 11
+		IL_00fa: stelem.ref
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0100: pop
+		IL_0101: ldc.i4.s 10
+		IL_0103: newarr [System.Runtime]System.Object
+		IL_0108: dup
+		IL_0109: ldc.i4.0
+		IL_010a: ldloc.s 10
+		IL_010c: stelem.ref
 		IL_010d: dup
-		IL_010e: ldc.i4.0
-		IL_010f: ldloc.s 10
-		IL_0111: stelem.ref
-		IL_0112: dup
-		IL_0113: ldc.i4.1
-		IL_0114: ldstr "setBitsTrue_Naive"
-		IL_0119: stelem.ref
-		IL_011a: dup
-		IL_011b: ldc.i4.2
-		IL_011c: ldstr "setBitsTrue_Naive"
-		IL_0121: stelem.ref
-		IL_0122: dup
-		IL_0123: ldc.i4.3
-		IL_0124: ldc.r8 3
-		IL_012d: box [System.Runtime]System.Double
-		IL_0132: stelem.ref
-		IL_0133: dup
-		IL_0134: ldc.i4.4
-		IL_0135: ldstr "setBitsTrue_Naive"
-		IL_013a: stelem.ref
-		IL_013b: dup
-		IL_013c: ldc.i4.5
-		IL_013d: ldc.i4.0
-		IL_013e: box [System.Runtime]System.Boolean
-		IL_0143: stelem.ref
-		IL_0144: dup
-		IL_0145: ldc.i4.6
-		IL_0146: ldc.i4.0
-		IL_0147: box [System.Runtime]System.Boolean
-		IL_014c: stelem.ref
-		IL_014d: dup
-		IL_014e: ldc.i4.7
-		IL_014f: ldc.i4.0
-		IL_0150: box [System.Runtime]System.Boolean
-		IL_0155: stelem.ref
-		IL_0156: dup
-		IL_0157: ldc.i4.8
-		IL_0158: ldc.i4.0
-		IL_0159: box [System.Runtime]System.Boolean
-		IL_015e: stelem.ref
-		IL_015f: dup
-		IL_0160: ldc.i4.s 9
-		IL_0162: ldloc.s 11
-		IL_0164: stelem.ref
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_016a: pop
-		IL_016b: ldc.i4.1
-		IL_016c: newarr [System.Runtime]System.Object
-		IL_0171: dup
-		IL_0172: ldc.i4.0
-		IL_0173: ldloc.0
-		IL_0174: stelem.ref
-		IL_0175: stloc.s 11
-		IL_0177: ldloc.s 10
-		IL_0179: ldloc.s 11
-		IL_017b: ldc.r8 1
-		IL_0184: box [System.Runtime]System.Double
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_018e: stloc.s 12
-		IL_0190: ldloc.s 12
-		IL_0192: stloc.1
-		IL_0193: ldloc.0
-		IL_0194: ldc.r8 2048
-		IL_019d: box [System.Runtime]System.Double
-		IL_01a2: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_01a7: ldloc.0
-		IL_01a8: ldc.r8 1
-		IL_01b1: box [System.Runtime]System.Double
-		IL_01b6: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_01bb: ldloc.0
-		IL_01bc: ldc.r8 17
-		IL_01c5: box [System.Runtime]System.Double
-		IL_01ca: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_01cf: ldloc.0
-		IL_01d0: ldc.r8 600
-		IL_01d9: box [System.Runtime]System.Double
-		IL_01de: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_01e3: ldloc.0
-		IL_01e4: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_01e9: ldstr "Cannot access 'size' before initialization"
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01f3: stloc.s 12
-		IL_01f5: ldc.i4.1
-		IL_01f6: newarr [System.Runtime]System.Object
-		IL_01fb: dup
-		IL_01fc: ldc.i4.0
-		IL_01fd: ldloc.0
-		IL_01fe: stelem.ref
-		IL_01ff: ldc.i4.1
-		IL_0200: newarr [System.Runtime]System.Object
-		IL_0205: dup
-		IL_0206: ldc.i4.0
-		IL_0207: ldloc.s 12
-		IL_0209: stelem.ref
-		IL_020a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_020f: ldloc.s 12
-		IL_0211: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], object)
-		IL_0216: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_021b: stloc.s 13
-		IL_021d: ldloc.s 13
-		IL_021f: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0224: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0229: ldstr "prototype"
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_0233: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0238: ldloc.s 13
-		IL_023a: stloc.2
-		IL_023b: ldloc.0
-		IL_023c: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_0241: ldstr "Cannot access 'size' before initialization"
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_024b: stloc.s 12
-		IL_024d: ldc.i4.1
-		IL_024e: newarr [System.Runtime]System.Object
-		IL_0253: dup
-		IL_0254: ldc.i4.0
-		IL_0255: ldloc.0
-		IL_0256: stelem.ref
-		IL_0257: ldc.i4.1
-		IL_0258: newarr [System.Runtime]System.Object
-		IL_025d: dup
-		IL_025e: ldc.i4.0
-		IL_025f: ldloc.s 12
-		IL_0261: stelem.ref
-		IL_0262: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0267: ldloc.s 12
-		IL_0269: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], object)
-		IL_026e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0273: stloc.s 13
-		IL_0275: ldloc.s 13
-		IL_0277: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_027c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0281: ldstr "prototype"
-		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_028b: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0290: ldloc.s 13
-		IL_0292: stloc.3
-		IL_0293: ldloc.2
-		IL_0294: ldstr "wordArray"
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_029e: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_02a3: stloc.s 14
-		IL_02a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02aa: ldstr "types"
-		IL_02af: ldloc.s 14
-		IL_02b1: ldloc.3
-		IL_02b2: ldstr "wordArray"
-		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02bc: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_02c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_02c6: pop
-		IL_02c7: ldloc.2
-		IL_02c8: ldstr "wordArray"
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d2: ldstr "length"
-		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02dc: stloc.s 12
-		IL_02de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02e3: ldstr "lens"
-		IL_02e8: ldloc.s 12
-		IL_02ea: ldloc.3
-		IL_02eb: ldstr "wordArray"
-		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02f5: ldstr "length"
-		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0304: pop
-		IL_0305: ldloc.0
-		IL_0306: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_030b: ldstr "Cannot access 'range_start' before initialization"
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0315: stloc.s 12
-		IL_0317: ldloc.0
-		IL_0318: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_031d: ldstr "Cannot access 'step' before initialization"
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0327: stloc.s 15
-		IL_0329: ldloc.0
-		IL_032a: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_032f: ldstr "Cannot access 'range_stop' before initialization"
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0339: stloc.s 16
-		IL_033b: ldloc.2
-		IL_033c: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0341: ldloc.s 12
-		IL_0343: ldloc.s 15
-		IL_0345: ldloc.s 16
-		IL_0347: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
-		IL_034c: pop
-		IL_034d: ldloc.0
-		IL_034e: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_0353: ldstr "Cannot access 'range_start' before initialization"
-		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_035d: stloc.s 16
-		IL_035f: ldloc.0
-		IL_0360: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_0365: ldstr "Cannot access 'step' before initialization"
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_036f: stloc.s 15
-		IL_0371: ldloc.0
-		IL_0372: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_0377: ldstr "Cannot access 'range_stop' before initialization"
-		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0381: stloc.s 12
-		IL_0383: ldloc.3
-		IL_0384: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0389: ldloc.s 16
-		IL_038b: ldloc.s 15
-		IL_038d: ldloc.s 12
-		IL_038f: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
-		IL_0394: pop
-		IL_0395: ldc.r8 0.0
-		IL_039e: stloc.s 4
-		IL_03a0: ldc.r8 1
-		IL_03a9: neg
-		IL_03aa: box [System.Runtime]System.Double
-		IL_03af: stloc.s 5
-		IL_03b1: ldc.r8 0.0
-		IL_03ba: box [System.Runtime]System.Double
-		IL_03bf: stloc.s 6
-		// loop start (head: IL_03c1)
-			IL_03c1: ldloc.2
-			IL_03c2: ldstr "wordArray"
-			IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03cc: ldstr "length"
-			IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d6: stloc.s 12
-			IL_03d8: ldloc.s 6
-			IL_03da: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_03df: stloc.s 17
-			IL_03e1: ldloc.s 17
-			IL_03e3: ldloc.s 12
-			IL_03e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_03ea: clt
-			IL_03ec: brfalse IL_0493
+		IL_010e: ldc.i4.1
+		IL_010f: ldstr "setBitsTrue_Naive"
+		IL_0114: stelem.ref
+		IL_0115: dup
+		IL_0116: ldc.i4.2
+		IL_0117: ldstr "setBitsTrue_Naive"
+		IL_011c: stelem.ref
+		IL_011d: dup
+		IL_011e: ldc.i4.3
+		IL_011f: ldc.r8 3
+		IL_0128: box [System.Runtime]System.Double
+		IL_012d: stelem.ref
+		IL_012e: dup
+		IL_012f: ldc.i4.4
+		IL_0130: ldstr "setBitsTrue_Naive"
+		IL_0135: stelem.ref
+		IL_0136: dup
+		IL_0137: ldc.i4.5
+		IL_0138: ldc.i4.0
+		IL_0139: box [System.Runtime]System.Boolean
+		IL_013e: stelem.ref
+		IL_013f: dup
+		IL_0140: ldc.i4.6
+		IL_0141: ldc.i4.0
+		IL_0142: box [System.Runtime]System.Boolean
+		IL_0147: stelem.ref
+		IL_0148: dup
+		IL_0149: ldc.i4.7
+		IL_014a: ldc.i4.0
+		IL_014b: box [System.Runtime]System.Boolean
+		IL_0150: stelem.ref
+		IL_0151: dup
+		IL_0152: ldc.i4.8
+		IL_0153: ldc.i4.0
+		IL_0154: box [System.Runtime]System.Boolean
+		IL_0159: stelem.ref
+		IL_015a: dup
+		IL_015b: ldc.i4.s 9
+		IL_015d: ldloc.s 11
+		IL_015f: stelem.ref
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0165: pop
+		IL_0166: ldc.i4.1
+		IL_0167: newarr [System.Runtime]System.Object
+		IL_016c: dup
+		IL_016d: ldc.i4.0
+		IL_016e: ldloc.0
+		IL_016f: stelem.ref
+		IL_0170: stloc.s 11
+		IL_0172: ldloc.s 10
+		IL_0174: ldloc.s 11
+		IL_0176: ldc.r8 1
+		IL_017f: box [System.Runtime]System.Double
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0189: stloc.s 12
+		IL_018b: ldloc.s 12
+		IL_018d: stloc.1
+		IL_018e: ldloc.0
+		IL_018f: ldc.r8 2048
+		IL_0198: box [System.Runtime]System.Double
+		IL_019d: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_01a2: ldloc.0
+		IL_01a3: ldc.r8 1
+		IL_01ac: box [System.Runtime]System.Double
+		IL_01b1: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_01b6: ldloc.0
+		IL_01b7: ldc.r8 17
+		IL_01c0: box [System.Runtime]System.Double
+		IL_01c5: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_01ca: ldloc.0
+		IL_01cb: ldc.r8 600
+		IL_01d4: box [System.Runtime]System.Double
+		IL_01d9: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_01de: ldloc.0
+		IL_01df: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_01e4: ldstr "Cannot access 'size' before initialization"
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_01ee: stloc.s 12
+		IL_01f0: ldc.i4.1
+		IL_01f1: newarr [System.Runtime]System.Object
+		IL_01f6: dup
+		IL_01f7: ldc.i4.0
+		IL_01f8: ldloc.0
+		IL_01f9: stelem.ref
+		IL_01fa: ldc.i4.1
+		IL_01fb: newarr [System.Runtime]System.Object
+		IL_0200: dup
+		IL_0201: ldc.i4.0
+		IL_0202: ldloc.s 12
+		IL_0204: stelem.ref
+		IL_0205: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_020a: ldloc.s 12
+		IL_020c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], object)
+		IL_0211: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0216: stloc.s 13
+		IL_0218: ldloc.s 13
+		IL_021a: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_021f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0224: ldstr "prototype"
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_022e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0233: ldloc.s 13
+		IL_0235: stloc.2
+		IL_0236: ldloc.0
+		IL_0237: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_023c: ldstr "Cannot access 'size' before initialization"
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0246: stloc.s 12
+		IL_0248: ldc.i4.1
+		IL_0249: newarr [System.Runtime]System.Object
+		IL_024e: dup
+		IL_024f: ldc.i4.0
+		IL_0250: ldloc.0
+		IL_0251: stelem.ref
+		IL_0252: ldc.i4.1
+		IL_0253: newarr [System.Runtime]System.Object
+		IL_0258: dup
+		IL_0259: ldc.i4.0
+		IL_025a: ldloc.s 12
+		IL_025c: stelem.ref
+		IL_025d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0262: ldloc.s 12
+		IL_0264: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], object)
+		IL_0269: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_026e: stloc.s 13
+		IL_0270: ldloc.s 13
+		IL_0272: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0277: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_027c: ldstr "prototype"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_0286: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_028b: ldloc.s 13
+		IL_028d: stloc.3
+		IL_028e: ldloc.2
+		IL_028f: ldstr "wordArray"
+		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0299: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_029e: stloc.s 14
+		IL_02a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a5: ldstr "types"
+		IL_02aa: ldloc.s 14
+		IL_02ac: ldloc.3
+		IL_02ad: ldstr "wordArray"
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b7: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_02bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_02c1: pop
+		IL_02c2: ldloc.2
+		IL_02c3: ldstr "wordArray"
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02cd: ldstr "length"
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d7: stloc.s 12
+		IL_02d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02de: ldstr "lens"
+		IL_02e3: ldloc.s 12
+		IL_02e5: ldloc.3
+		IL_02e6: ldstr "wordArray"
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f0: ldstr "length"
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_02ff: pop
+		IL_0300: ldloc.0
+		IL_0301: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_0306: ldstr "Cannot access 'range_start' before initialization"
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0310: stloc.s 12
+		IL_0312: ldloc.0
+		IL_0313: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0318: ldstr "Cannot access 'step' before initialization"
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0322: stloc.s 15
+		IL_0324: ldloc.0
+		IL_0325: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_032a: ldstr "Cannot access 'range_stop' before initialization"
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0334: stloc.s 16
+		IL_0336: ldloc.2
+		IL_0337: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_033c: ldloc.s 12
+		IL_033e: ldloc.s 15
+		IL_0340: ldloc.s 16
+		IL_0342: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
+		IL_0347: pop
+		IL_0348: ldloc.0
+		IL_0349: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_034e: ldstr "Cannot access 'range_start' before initialization"
+		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0358: stloc.s 16
+		IL_035a: ldloc.0
+		IL_035b: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0360: ldstr "Cannot access 'step' before initialization"
+		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_036a: stloc.s 15
+		IL_036c: ldloc.0
+		IL_036d: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_0372: ldstr "Cannot access 'range_stop' before initialization"
+		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_037c: stloc.s 12
+		IL_037e: ldloc.3
+		IL_037f: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0384: ldloc.s 16
+		IL_0386: ldloc.s 15
+		IL_0388: ldloc.s 12
+		IL_038a: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
+		IL_038f: pop
+		IL_0390: ldc.r8 0.0
+		IL_0399: stloc.s 4
+		IL_039b: ldc.r8 1
+		IL_03a4: neg
+		IL_03a5: box [System.Runtime]System.Double
+		IL_03aa: stloc.s 5
+		IL_03ac: ldc.r8 0.0
+		IL_03b5: box [System.Runtime]System.Double
+		IL_03ba: stloc.s 6
+		// loop start (head: IL_03bc)
+			IL_03bc: ldloc.2
+			IL_03bd: ldstr "wordArray"
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c7: ldstr "length"
+			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d1: stloc.s 12
+			IL_03d3: ldloc.s 6
+			IL_03d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_03da: stloc.s 17
+			IL_03dc: ldloc.s 17
+			IL_03de: ldloc.s 12
+			IL_03e0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_03e5: clt
+			IL_03e7: brfalse IL_048e
 
-			IL_03f1: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47::.ctor()
-			IL_03f6: stloc.s 7
-			IL_03f8: ldloc.2
-			IL_03f9: ldstr "wordArray"
-			IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0403: ldloc.s 6
-			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_040a: stloc.s 12
-			IL_040c: ldloc.s 12
-			IL_040e: ldloc.3
-			IL_040f: ldstr "wordArray"
-			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0419: ldloc.s 6
-			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0420: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0425: stloc.s 18
-			IL_0427: ldloc.s 18
-			IL_0429: brfalse IL_046a
+			IL_03ec: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47::.ctor()
+			IL_03f1: stloc.s 7
+			IL_03f3: ldloc.2
+			IL_03f4: ldstr "wordArray"
+			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03fe: ldloc.s 6
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0405: stloc.s 12
+			IL_0407: ldloc.s 12
+			IL_0409: ldloc.3
+			IL_040a: ldstr "wordArray"
+			IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0414: ldloc.s 6
+			IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_041b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0420: stloc.s 18
+			IL_0422: ldloc.s 18
+			IL_0424: brfalse IL_0465
 
-			IL_042e: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47/Block_L74C46::.ctor()
-			IL_0433: stloc.s 8
-			IL_0435: ldloc.s 4
-			IL_0437: ldc.r8 1
-			IL_0440: add
-			IL_0441: stloc.s 4
-			IL_0443: ldloc.s 5
-			IL_0445: ldc.r8 1
-			IL_044e: neg
-			IL_044f: box [System.Runtime]System.Double
-			IL_0454: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0459: stloc.s 18
-			IL_045b: ldloc.s 18
-			IL_045d: brfalse IL_046a
+			IL_0429: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47/Block_L74C46::.ctor()
+			IL_042e: stloc.s 8
+			IL_0430: ldloc.s 4
+			IL_0432: ldc.r8 1
+			IL_043b: add
+			IL_043c: stloc.s 4
+			IL_043e: ldloc.s 5
+			IL_0440: ldc.r8 1
+			IL_0449: neg
+			IL_044a: box [System.Runtime]System.Double
+			IL_044f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0454: stloc.s 18
+			IL_0456: ldloc.s 18
+			IL_0458: brfalse IL_0465
 
-			IL_0462: ldloc.s 6
-			IL_0464: stloc.s 19
-			IL_0466: ldloc.s 19
-			IL_0468: stloc.s 5
+			IL_045d: ldloc.s 6
+			IL_045f: stloc.s 19
+			IL_0461: ldloc.s 19
+			IL_0463: stloc.s 5
 
-			IL_046a: ldloc.s 6
-			IL_046c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0471: stloc.s 17
-			IL_0473: ldloc.s 17
-			IL_0475: ldc.r8 1
-			IL_047e: add
-			IL_047f: stloc.s 17
-			IL_0481: ldloc.s 17
-			IL_0483: box [System.Runtime]System.Double
-			IL_0488: stloc.s 19
-			IL_048a: ldloc.s 19
-			IL_048c: stloc.s 6
-			IL_048e: br IL_03c1
+			IL_0465: ldloc.s 6
+			IL_0467: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_046c: stloc.s 17
+			IL_046e: ldloc.s 17
+			IL_0470: ldc.r8 1
+			IL_0479: add
+			IL_047a: stloc.s 17
+			IL_047c: ldloc.s 17
+			IL_047e: box [System.Runtime]System.Double
+			IL_0483: stloc.s 19
+			IL_0485: ldloc.s 19
+			IL_0487: stloc.s 6
+			IL_0489: br IL_03bc
 		// end loop
 
-		IL_0493: ldloc.s 4
-		IL_0495: box [System.Runtime]System.Double
-		IL_049a: stloc.s 19
-		IL_049c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04a1: ldstr "diffs"
-		IL_04a6: ldloc.s 19
-		IL_04a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_04ad: pop
-		IL_04ae: ldloc.s 5
-		IL_04b0: ldc.r8 1
-		IL_04b9: neg
-		IL_04ba: box [System.Runtime]System.Double
-		IL_04bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_04c4: stloc.s 18
-		IL_04c6: ldloc.s 18
-		IL_04c8: brfalse IL_0520
+		IL_048e: ldloc.s 4
+		IL_0490: box [System.Runtime]System.Double
+		IL_0495: stloc.s 19
+		IL_0497: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_049c: ldstr "diffs"
+		IL_04a1: ldloc.s 19
+		IL_04a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_04a8: pop
+		IL_04a9: ldloc.s 5
+		IL_04ab: ldc.r8 1
+		IL_04b4: neg
+		IL_04b5: box [System.Runtime]System.Double
+		IL_04ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_04bf: stloc.s 18
+		IL_04c1: ldloc.s 18
+		IL_04c3: brfalse IL_051b
 
-		IL_04cd: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope/Block_L81C18::.ctor()
-		IL_04d2: stloc.s 9
-		IL_04d4: ldloc.2
-		IL_04d5: ldstr "wordArray"
-		IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04df: ldloc.s 5
-		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_04e6: stloc.s 12
-		IL_04e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04ed: ldc.i4.4
-		IL_04ee: newarr [System.Runtime]System.Object
-		IL_04f3: dup
-		IL_04f4: ldc.i4.0
-		IL_04f5: ldstr "first"
+		IL_04c8: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope/Block_L81C18::.ctor()
+		IL_04cd: stloc.s 9
+		IL_04cf: ldloc.2
+		IL_04d0: ldstr "wordArray"
+		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04da: ldloc.s 5
+		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_04e1: stloc.s 12
+		IL_04e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04e8: ldc.i4.4
+		IL_04e9: newarr [System.Runtime]System.Object
+		IL_04ee: dup
+		IL_04ef: ldc.i4.0
+		IL_04f0: ldstr "first"
+		IL_04f5: stelem.ref
+		IL_04f6: dup
+		IL_04f7: ldc.i4.1
+		IL_04f8: ldloc.s 5
 		IL_04fa: stelem.ref
 		IL_04fb: dup
-		IL_04fc: ldc.i4.1
-		IL_04fd: ldloc.s 5
+		IL_04fc: ldc.i4.2
+		IL_04fd: ldloc.s 12
 		IL_04ff: stelem.ref
 		IL_0500: dup
-		IL_0501: ldc.i4.2
-		IL_0502: ldloc.s 12
-		IL_0504: stelem.ref
-		IL_0505: dup
-		IL_0506: ldc.i4.3
-		IL_0507: ldloc.3
-		IL_0508: ldstr "wordArray"
-		IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0512: ldloc.s 5
-		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0519: stelem.ref
-		IL_051a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_051f: pop
+		IL_0501: ldc.i4.3
+		IL_0502: ldloc.3
+		IL_0503: ldstr "wordArray"
+		IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050d: ldloc.s 5
+		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0514: stelem.ref
+		IL_0515: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_051a: pop
 
-		IL_0520: ldloc.2
-		IL_0521: ldstr "wordArray"
-		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_052b: ldc.r8 0.0
-		IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0539: stloc.s 12
-		IL_053b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0540: ldstr "w0"
-		IL_0545: ldloc.s 12
-		IL_0547: ldloc.3
-		IL_0548: ldstr "wordArray"
-		IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0552: ldc.r8 0.0
-		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0560: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0565: pop
-		IL_0566: ldloc.2
-		IL_0567: ldstr "wordArray"
-		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0571: ldc.r8 1
-		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_057f: stloc.s 12
-		IL_0581: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0586: ldstr "w1"
-		IL_058b: ldloc.s 12
-		IL_058d: ldloc.3
-		IL_058e: ldstr "wordArray"
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0598: ldc.r8 1
-		IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_05ab: pop
-		IL_05ac: ldloc.2
-		IL_05ad: ldstr "wordArray"
-		IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05b7: ldc.r8 2
-		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05c5: stloc.s 12
-		IL_05c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05cc: ldstr "w2"
-		IL_05d1: ldloc.s 12
-		IL_05d3: ldloc.3
-		IL_05d4: ldstr "wordArray"
-		IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05de: ldc.r8 2
-		IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_05f1: pop
-		IL_05f2: ldloc.2
-		IL_05f3: ldstr "wordArray"
-		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05fd: ldc.r8 3
-		IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_060b: stloc.s 12
-		IL_060d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0612: ldstr "w3"
-		IL_0617: ldloc.s 12
-		IL_0619: ldloc.3
-		IL_061a: ldstr "wordArray"
-		IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0624: ldc.r8 3
-		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0632: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0637: pop
-		IL_0638: ret
+		IL_051b: ldloc.2
+		IL_051c: ldstr "wordArray"
+		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0526: ldc.r8 0.0
+		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0534: stloc.s 12
+		IL_0536: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_053b: ldstr "w0"
+		IL_0540: ldloc.s 12
+		IL_0542: ldloc.3
+		IL_0543: ldstr "wordArray"
+		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_054d: ldc.r8 0.0
+		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_055b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0560: pop
+		IL_0561: ldloc.2
+		IL_0562: ldstr "wordArray"
+		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_056c: ldc.r8 1
+		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_057a: stloc.s 12
+		IL_057c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0581: ldstr "w1"
+		IL_0586: ldloc.s 12
+		IL_0588: ldloc.3
+		IL_0589: ldstr "wordArray"
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0593: ldc.r8 1
+		IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_05a6: pop
+		IL_05a7: ldloc.2
+		IL_05a8: ldstr "wordArray"
+		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b2: ldc.r8 2
+		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05c0: stloc.s 12
+		IL_05c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05c7: ldstr "w2"
+		IL_05cc: ldloc.s 12
+		IL_05ce: ldloc.3
+		IL_05cf: ldstr "wordArray"
+		IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05d9: ldc.r8 2
+		IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_05ec: pop
+		IL_05ed: ldloc.2
+		IL_05ee: ldstr "wordArray"
+		IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05f8: ldc.r8 3
+		IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0606: stloc.s 12
+		IL_0608: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_060d: ldstr "w3"
+		IL_0612: ldloc.s 12
+		IL_0614: ldloc.3
+		IL_0615: ldstr "wordArray"
+		IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_061f: ldc.r8 3
+		IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_062d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0632: pop
+		IL_0633: ret
 	} // end of method Prime_SetBitsTrue_LargeStep_OptimizedVsNaive::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive
@@ -1555,7 +1543,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2af3
+		// Method begins at RVA 0x2ac8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Js2IL.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x296b
+				// Method begins at RVA 0x2944
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2974
+				// Method begins at RVA 0x294d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x297d
+				// Method begins at RVA 0x2956
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x298f
+					// Method begins at RVA 0x2968
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29a1
+						// Method begins at RVA 0x297a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29aa
+						// Method begins at RVA 0x2983
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2998
+					// Method begins at RVA 0x2971
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2986
+				// Method begins at RVA 0x295f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29b3
+				// Method begins at RVA 0x298c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24bc
+			// Method begins at RVA 0x24b8
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -259,7 +259,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x250c
+			// Method begins at RVA 0x2508
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -332,9 +332,9 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2578
+			// Method begins at RVA 0x2574
 			// Header size: 12
-			// Code size: 886 (0x376)
+			// Code size: 863 (0x35f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -351,10 +351,9 @@
 				[11] float64,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] bool,
-				[16] object,
-				[17] object
+				[14] bool,
+				[15] object,
+				[16] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -408,327 +407,320 @@
 			IL_007a: ldc.i4.0
 			IL_007b: ldelem.ref
 			IL_007c: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope
-			IL_0081: ldfld object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
-			IL_0086: ldstr "Cannot access 'WORD_SIZE' before initialization"
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0090: stloc.s 12
-			IL_0092: ldloc.s 12
-			IL_0094: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0099: stloc.s 11
-			IL_009b: ldloc.s 11
-			IL_009d: ldc.r8 2
-			IL_00a6: div
-			IL_00a7: stloc.s 11
-			IL_00a9: ldarg.2
-			IL_00aa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00af: ldloc.s 11
-			IL_00b1: cgt
-			IL_00b3: brfalse IL_00e2
+			IL_0081: ldfld float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
+			IL_0086: ldc.r8 2
+			IL_008f: div
+			IL_0090: stloc.s 11
+			IL_0092: ldarg.2
+			IL_0093: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0098: ldloc.s 11
+			IL_009a: cgt
+			IL_009c: brfalse IL_00cb
 
-			IL_00b8: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L19C28::.ctor()
-			IL_00bd: stloc.1
-			IL_00be: ldstr "not used in this test"
-			IL_00c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00cd: dup
-			IL_00ce: isinst [System.Runtime]System.Exception
-			IL_00d3: dup
-			IL_00d4: brtrue IL_00e0
+			IL_00a1: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L19C28::.ctor()
+			IL_00a6: stloc.1
+			IL_00a7: ldstr "not used in this test"
+			IL_00ac: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00b6: dup
+			IL_00b7: isinst [System.Runtime]System.Exception
+			IL_00bc: dup
+			IL_00bd: brtrue IL_00c9
 
-			IL_00d9: pop
-			IL_00da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00df: throw
+			IL_00c2: pop
+			IL_00c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00c8: throw
 
-			IL_00e0: pop
-			IL_00e1: throw
+			IL_00c9: pop
+			IL_00ca: throw
 
-			IL_00e2: ldarg.1
-			IL_00e3: stloc.2
-			IL_00e4: ldloc.2
-			IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ea: stloc.s 11
-			IL_00ec: ldloc.s 11
-			IL_00ee: conv.i4
-			IL_00ef: conv.u4
-			IL_00f0: ldc.r8 5
-			IL_00f9: conv.i4
-			IL_00fa: shr.un
-			IL_00fb: conv.r.un
-			IL_00fc: stloc.s 11
-			IL_00fe: ldloc.s 11
-			IL_0100: stloc.3
-			IL_0101: ldarg.0
-			IL_0102: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0107: ldloc.3
-			IL_0108: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_010d: stloc.s 11
-			IL_010f: ldloc.s 11
-			IL_0111: stloc.s 4
-			IL_0113: ldloc.3
-			IL_0114: box [System.Runtime]System.Double
-			IL_0119: stloc.s 13
-			IL_011b: ldloc.s 4
-			IL_011d: box [System.Runtime]System.Double
-			IL_0122: stloc.s 14
-			IL_0124: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0129: ldc.i4.4
-			IL_012a: newarr [System.Runtime]System.Object
-			IL_012f: dup
-			IL_0130: ldc.i4.0
-			IL_0131: ldstr "init"
-			IL_0136: stelem.ref
-			IL_0137: dup
-			IL_0138: ldc.i4.1
-			IL_0139: ldloc.2
-			IL_013a: stelem.ref
-			IL_013b: dup
-			IL_013c: ldc.i4.2
-			IL_013d: ldloc.s 13
-			IL_013f: stelem.ref
-			IL_0140: dup
-			IL_0141: ldc.i4.3
-			IL_0142: ldloc.s 14
-			IL_0144: stelem.ref
-			IL_0145: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_014a: pop
-			// loop start (head: IL_014b)
-				IL_014b: ldloc.2
-				IL_014c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0151: stloc.s 11
-				IL_0153: ldloc.s 11
-				IL_0155: ldarg.3
-				IL_0156: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_015b: clt
-				IL_015d: brfalse IL_02a9
+			IL_00cb: ldarg.1
+			IL_00cc: stloc.2
+			IL_00cd: ldloc.2
+			IL_00ce: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00d3: stloc.s 11
+			IL_00d5: ldloc.s 11
+			IL_00d7: conv.i4
+			IL_00d8: conv.u4
+			IL_00d9: ldc.r8 5
+			IL_00e2: conv.i4
+			IL_00e3: shr.un
+			IL_00e4: conv.r.un
+			IL_00e5: stloc.s 11
+			IL_00e7: ldloc.s 11
+			IL_00e9: stloc.3
+			IL_00ea: ldarg.0
+			IL_00eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_00f0: ldloc.3
+			IL_00f1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00f6: stloc.s 11
+			IL_00f8: ldloc.s 11
+			IL_00fa: stloc.s 4
+			IL_00fc: ldloc.3
+			IL_00fd: box [System.Runtime]System.Double
+			IL_0102: stloc.s 12
+			IL_0104: ldloc.s 4
+			IL_0106: box [System.Runtime]System.Double
+			IL_010b: stloc.s 13
+			IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0112: ldc.i4.4
+			IL_0113: newarr [System.Runtime]System.Object
+			IL_0118: dup
+			IL_0119: ldc.i4.0
+			IL_011a: ldstr "init"
+			IL_011f: stelem.ref
+			IL_0120: dup
+			IL_0121: ldc.i4.1
+			IL_0122: ldloc.2
+			IL_0123: stelem.ref
+			IL_0124: dup
+			IL_0125: ldc.i4.2
+			IL_0126: ldloc.s 12
+			IL_0128: stelem.ref
+			IL_0129: dup
+			IL_012a: ldc.i4.3
+			IL_012b: ldloc.s 13
+			IL_012d: stelem.ref
+			IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_0133: pop
+			// loop start (head: IL_0134)
+				IL_0134: ldloc.2
+				IL_0135: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_013a: stloc.s 11
+				IL_013c: ldloc.s 11
+				IL_013e: ldarg.3
+				IL_013f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0144: clt
+				IL_0146: brfalse IL_0292
 
-				IL_0162: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29::.ctor()
-				IL_0167: stloc.s 5
-				IL_0169: ldloc.2
-				IL_016a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_016f: stloc.s 11
-				IL_0171: ldloc.s 11
-				IL_0173: conv.i4
-				IL_0174: ldc.r8 31
-				IL_017d: conv.i4
-				IL_017e: and
-				IL_017f: conv.r8
-				IL_0180: stloc.s 11
-				IL_0182: ldloc.s 11
-				IL_0184: stloc.s 6
-				IL_0186: ldc.r8 1
-				IL_018f: conv.i4
-				IL_0190: ldloc.s 6
-				IL_0192: conv.i4
-				IL_0193: shl
-				IL_0194: conv.r8
-				IL_0195: stloc.s 11
-				IL_0197: ldloc.s 4
-				IL_0199: conv.i4
-				IL_019a: ldloc.s 11
-				IL_019c: conv.i4
-				IL_019d: or
-				IL_019e: conv.r8
-				IL_019f: stloc.s 11
-				IL_01a1: ldloc.s 11
-				IL_01a3: stloc.s 4
-				IL_01a5: ldloc.2
-				IL_01a6: ldarg.1
-				IL_01a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01ac: stloc.s 15
-				IL_01ae: ldloc.s 15
-				IL_01b0: brfalse IL_01f5
+				IL_014b: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29::.ctor()
+				IL_0150: stloc.s 5
+				IL_0152: ldloc.2
+				IL_0153: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0158: stloc.s 11
+				IL_015a: ldloc.s 11
+				IL_015c: conv.i4
+				IL_015d: ldc.r8 31
+				IL_0166: conv.i4
+				IL_0167: and
+				IL_0168: conv.r8
+				IL_0169: stloc.s 11
+				IL_016b: ldloc.s 11
+				IL_016d: stloc.s 6
+				IL_016f: ldc.r8 1
+				IL_0178: conv.i4
+				IL_0179: ldloc.s 6
+				IL_017b: conv.i4
+				IL_017c: shl
+				IL_017d: conv.r8
+				IL_017e: stloc.s 11
+				IL_0180: ldloc.s 4
+				IL_0182: conv.i4
+				IL_0183: ldloc.s 11
+				IL_0185: conv.i4
+				IL_0186: or
+				IL_0187: conv.r8
+				IL_0188: stloc.s 11
+				IL_018a: ldloc.s 11
+				IL_018c: stloc.s 4
+				IL_018e: ldloc.2
+				IL_018f: ldarg.1
+				IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0195: stloc.s 14
+				IL_0197: ldloc.s 14
+				IL_0199: brfalse IL_01de
 
-				IL_01b5: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29/Block_L31C30::.ctor()
-				IL_01ba: stloc.s 7
-				IL_01bc: ldloc.s 6
-				IL_01be: box [System.Runtime]System.Double
-				IL_01c3: stloc.s 14
-				IL_01c5: ldloc.s 4
-				IL_01c7: box [System.Runtime]System.Double
-				IL_01cc: stloc.s 13
-				IL_01ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_01d3: ldc.i4.4
-				IL_01d4: newarr [System.Runtime]System.Object
-				IL_01d9: dup
-				IL_01da: ldc.i4.0
-				IL_01db: ldstr "iter0"
-				IL_01e0: stelem.ref
-				IL_01e1: dup
-				IL_01e2: ldc.i4.1
-				IL_01e3: ldloc.2
-				IL_01e4: stelem.ref
-				IL_01e5: dup
-				IL_01e6: ldc.i4.2
-				IL_01e7: ldloc.s 14
-				IL_01e9: stelem.ref
-				IL_01ea: dup
-				IL_01eb: ldc.i4.3
-				IL_01ec: ldloc.s 13
-				IL_01ee: stelem.ref
-				IL_01ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-				IL_01f4: pop
+				IL_019e: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29/Block_L31C30::.ctor()
+				IL_01a3: stloc.s 7
+				IL_01a5: ldloc.s 6
+				IL_01a7: box [System.Runtime]System.Double
+				IL_01ac: stloc.s 13
+				IL_01ae: ldloc.s 4
+				IL_01b0: box [System.Runtime]System.Double
+				IL_01b5: stloc.s 12
+				IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_01bc: ldc.i4.4
+				IL_01bd: newarr [System.Runtime]System.Object
+				IL_01c2: dup
+				IL_01c3: ldc.i4.0
+				IL_01c4: ldstr "iter0"
+				IL_01c9: stelem.ref
+				IL_01ca: dup
+				IL_01cb: ldc.i4.1
+				IL_01cc: ldloc.2
+				IL_01cd: stelem.ref
+				IL_01ce: dup
+				IL_01cf: ldc.i4.2
+				IL_01d0: ldloc.s 13
+				IL_01d2: stelem.ref
+				IL_01d3: dup
+				IL_01d4: ldc.i4.3
+				IL_01d5: ldloc.s 12
+				IL_01d7: stelem.ref
+				IL_01d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+				IL_01dd: pop
 
-				IL_01f5: ldloc.2
-				IL_01f6: ldarg.2
-				IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01fc: stloc.s 16
-				IL_01fe: ldloc.s 16
-				IL_0200: stloc.2
-				IL_0201: ldloc.2
-				IL_0202: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0207: stloc.s 11
-				IL_0209: ldloc.s 11
-				IL_020b: conv.i4
-				IL_020c: conv.u4
-				IL_020d: ldc.r8 5
-				IL_0216: conv.i4
-				IL_0217: shr.un
-				IL_0218: conv.r.un
-				IL_0219: stloc.s 11
-				IL_021b: ldloc.s 11
-				IL_021d: stloc.s 8
-				IL_021f: ldloc.s 8
-				IL_0221: ldloc.3
-				IL_0222: ceq
-				IL_0224: ldc.i4.0
-				IL_0225: ceq
-				IL_0227: brfalse IL_02a4
+				IL_01de: ldloc.2
+				IL_01df: ldarg.2
+				IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01e5: stloc.s 15
+				IL_01e7: ldloc.s 15
+				IL_01e9: stloc.2
+				IL_01ea: ldloc.2
+				IL_01eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01f0: stloc.s 11
+				IL_01f2: ldloc.s 11
+				IL_01f4: conv.i4
+				IL_01f5: conv.u4
+				IL_01f6: ldc.r8 5
+				IL_01ff: conv.i4
+				IL_0200: shr.un
+				IL_0201: conv.r.un
+				IL_0202: stloc.s 11
+				IL_0204: ldloc.s 11
+				IL_0206: stloc.s 8
+				IL_0208: ldloc.s 8
+				IL_020a: ldloc.3
+				IL_020b: ceq
+				IL_020d: ldc.i4.0
+				IL_020e: ceq
+				IL_0210: brfalse IL_028d
 
-				IL_022c: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29/Block_L37C36::.ctor()
-				IL_0231: stloc.s 9
-				IL_0233: ldloc.3
-				IL_0234: box [System.Runtime]System.Double
-				IL_0239: stloc.s 13
-				IL_023b: ldloc.s 4
-				IL_023d: box [System.Runtime]System.Double
-				IL_0242: stloc.s 14
-				IL_0244: ldloc.s 8
-				IL_0246: box [System.Runtime]System.Double
-				IL_024b: stloc.s 17
-				IL_024d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0252: ldc.i4.5
-				IL_0253: newarr [System.Runtime]System.Object
-				IL_0258: dup
-				IL_0259: ldc.i4.0
-				IL_025a: ldstr "commit"
+				IL_0215: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29/Block_L37C36::.ctor()
+				IL_021a: stloc.s 9
+				IL_021c: ldloc.3
+				IL_021d: box [System.Runtime]System.Double
+				IL_0222: stloc.s 12
+				IL_0224: ldloc.s 4
+				IL_0226: box [System.Runtime]System.Double
+				IL_022b: stloc.s 13
+				IL_022d: ldloc.s 8
+				IL_022f: box [System.Runtime]System.Double
+				IL_0234: stloc.s 16
+				IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_023b: ldc.i4.5
+				IL_023c: newarr [System.Runtime]System.Object
+				IL_0241: dup
+				IL_0242: ldc.i4.0
+				IL_0243: ldstr "commit"
+				IL_0248: stelem.ref
+				IL_0249: dup
+				IL_024a: ldc.i4.1
+				IL_024b: ldloc.s 12
+				IL_024d: stelem.ref
+				IL_024e: dup
+				IL_024f: ldc.i4.2
+				IL_0250: ldloc.s 13
+				IL_0252: stelem.ref
+				IL_0253: dup
+				IL_0254: ldc.i4.3
+				IL_0255: ldstr "->"
+				IL_025a: stelem.ref
+				IL_025b: dup
+				IL_025c: ldc.i4.4
+				IL_025d: ldloc.s 16
 				IL_025f: stelem.ref
-				IL_0260: dup
-				IL_0261: ldc.i4.1
-				IL_0262: ldloc.s 13
-				IL_0264: stelem.ref
-				IL_0265: dup
-				IL_0266: ldc.i4.2
-				IL_0267: ldloc.s 14
-				IL_0269: stelem.ref
-				IL_026a: dup
-				IL_026b: ldc.i4.3
-				IL_026c: ldstr "->"
-				IL_0271: stelem.ref
-				IL_0272: dup
-				IL_0273: ldc.i4.4
-				IL_0274: ldloc.s 17
-				IL_0276: stelem.ref
-				IL_0277: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-				IL_027c: pop
-				IL_027d: ldarg.0
-				IL_027e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_0283: ldloc.3
-				IL_0284: ldloc.s 4
-				IL_0286: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_028b: ldloc.s 8
-				IL_028d: stloc.s 11
-				IL_028f: ldloc.s 11
-				IL_0291: stloc.3
-				IL_0292: ldarg.0
-				IL_0293: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_0298: ldloc.3
-				IL_0299: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_029e: stloc.s 11
-				IL_02a0: ldloc.s 11
-				IL_02a2: stloc.s 4
+				IL_0260: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+				IL_0265: pop
+				IL_0266: ldarg.0
+				IL_0267: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_026c: ldloc.3
+				IL_026d: ldloc.s 4
+				IL_026f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_0274: ldloc.s 8
+				IL_0276: stloc.s 11
+				IL_0278: ldloc.s 11
+				IL_027a: stloc.3
+				IL_027b: ldarg.0
+				IL_027c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_0281: ldloc.3
+				IL_0282: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0287: stloc.s 11
+				IL_0289: ldloc.s 11
+				IL_028b: stloc.s 4
 
-				IL_02a4: br IL_014b
+				IL_028d: br IL_0134
 			// end loop
 
-			IL_02a9: ldloc.3
-			IL_02aa: box [System.Runtime]System.Double
-			IL_02af: stloc.s 17
-			IL_02b1: ldloc.s 4
-			IL_02b3: box [System.Runtime]System.Double
-			IL_02b8: stloc.s 14
-			IL_02ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02bf: ldc.i4.4
-			IL_02c0: newarr [System.Runtime]System.Object
-			IL_02c5: dup
-			IL_02c6: ldc.i4.0
-			IL_02c7: ldstr "end"
-			IL_02cc: stelem.ref
-			IL_02cd: dup
-			IL_02ce: ldc.i4.1
-			IL_02cf: ldloc.2
-			IL_02d0: stelem.ref
-			IL_02d1: dup
-			IL_02d2: ldc.i4.2
-			IL_02d3: ldloc.s 17
-			IL_02d5: stelem.ref
-			IL_02d6: dup
-			IL_02d7: ldc.i4.3
-			IL_02d8: ldloc.s 14
-			IL_02da: stelem.ref
-			IL_02db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_02e0: pop
-			IL_02e1: ldarg.0
-			IL_02e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_02e7: ldloc.3
-			IL_02e8: ldloc.s 4
-			IL_02ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_02ef: ldarg.0
-			IL_02f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_02f5: ldc.r8 0.0
-			IL_02fe: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0303: stloc.s 11
-			IL_0305: ldloc.s 11
-			IL_0307: box [System.Runtime]System.Double
-			IL_030c: stloc.s 14
-			IL_030e: ldarg.0
-			IL_030f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0314: ldc.r8 1
-			IL_031d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0322: stloc.s 11
-			IL_0324: ldloc.s 11
-			IL_0326: box [System.Runtime]System.Double
-			IL_032b: stloc.s 17
-			IL_032d: ldarg.0
-			IL_032e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0333: ldc.r8 2
-			IL_033c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0341: stloc.s 11
-			IL_0343: ldloc.s 11
-			IL_0345: box [System.Runtime]System.Double
-			IL_034a: stloc.s 13
-			IL_034c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0351: ldc.i4.4
-			IL_0352: newarr [System.Runtime]System.Object
-			IL_0357: dup
-			IL_0358: ldc.i4.0
-			IL_0359: ldstr "after"
-			IL_035e: stelem.ref
-			IL_035f: dup
-			IL_0360: ldc.i4.1
-			IL_0361: ldloc.s 14
-			IL_0363: stelem.ref
-			IL_0364: dup
-			IL_0365: ldc.i4.2
-			IL_0366: ldloc.s 17
-			IL_0368: stelem.ref
-			IL_0369: dup
-			IL_036a: ldc.i4.3
-			IL_036b: ldloc.s 13
-			IL_036d: stelem.ref
-			IL_036e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_0373: pop
-			IL_0374: ldnull
-			IL_0375: ret
+			IL_0292: ldloc.3
+			IL_0293: box [System.Runtime]System.Double
+			IL_0298: stloc.s 16
+			IL_029a: ldloc.s 4
+			IL_029c: box [System.Runtime]System.Double
+			IL_02a1: stloc.s 13
+			IL_02a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02a8: ldc.i4.4
+			IL_02a9: newarr [System.Runtime]System.Object
+			IL_02ae: dup
+			IL_02af: ldc.i4.0
+			IL_02b0: ldstr "end"
+			IL_02b5: stelem.ref
+			IL_02b6: dup
+			IL_02b7: ldc.i4.1
+			IL_02b8: ldloc.2
+			IL_02b9: stelem.ref
+			IL_02ba: dup
+			IL_02bb: ldc.i4.2
+			IL_02bc: ldloc.s 16
+			IL_02be: stelem.ref
+			IL_02bf: dup
+			IL_02c0: ldc.i4.3
+			IL_02c1: ldloc.s 13
+			IL_02c3: stelem.ref
+			IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_02c9: pop
+			IL_02ca: ldarg.0
+			IL_02cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_02d0: ldloc.3
+			IL_02d1: ldloc.s 4
+			IL_02d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_02d8: ldarg.0
+			IL_02d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_02de: ldc.r8 0.0
+			IL_02e7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_02ec: stloc.s 11
+			IL_02ee: ldloc.s 11
+			IL_02f0: box [System.Runtime]System.Double
+			IL_02f5: stloc.s 13
+			IL_02f7: ldarg.0
+			IL_02f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_02fd: ldc.r8 1
+			IL_0306: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_030b: stloc.s 11
+			IL_030d: ldloc.s 11
+			IL_030f: box [System.Runtime]System.Double
+			IL_0314: stloc.s 16
+			IL_0316: ldarg.0
+			IL_0317: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_031c: ldc.r8 2
+			IL_0325: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_032a: stloc.s 11
+			IL_032c: ldloc.s 11
+			IL_032e: box [System.Runtime]System.Double
+			IL_0333: stloc.s 12
+			IL_0335: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_033a: ldc.i4.4
+			IL_033b: newarr [System.Runtime]System.Object
+			IL_0340: dup
+			IL_0341: ldc.i4.0
+			IL_0342: ldstr "after"
+			IL_0347: stelem.ref
+			IL_0348: dup
+			IL_0349: ldc.i4.1
+			IL_034a: ldloc.s 13
+			IL_034c: stelem.ref
+			IL_034d: dup
+			IL_034e: ldc.i4.2
+			IL_034f: ldloc.s 16
+			IL_0351: stelem.ref
+			IL_0352: dup
+			IL_0353: ldc.i4.3
+			IL_0354: ldloc.s 12
+			IL_0356: stelem.ref
+			IL_0357: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_035c: pop
+			IL_035d: ldnull
+			IL_035e: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -739,7 +731,7 @@
 			.custom instance void [JavaScriptRuntime]Js2IL.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Js2IL.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28fc
+			// Method begins at RVA 0x28e0
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -805,24 +797,21 @@
 			5a 45 3d 7b 57 4f 52 44 5f 53 49 5a 45 7d 00 00
 		)
 		// Fields
-		.field public object WORD_SIZE
+		.field public float64 WORD_SIZE
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2957
+			// Method begins at RVA 0x293b
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -840,7 +829,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1118 (0x45e)
+		// Code size: 1113 (0x459)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope,
@@ -865,364 +854,363 @@
 		IL_0005: stloc.0
 		IL_0006: ldloc.0
 		IL_0007: ldc.r8 32
-		IL_0010: box [System.Runtime]System.Double
-		IL_0015: stfld object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
-		IL_001a: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_001f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0024: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0029: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_002e: stloc.s 9
-		IL_0030: ldc.i4.1
-		IL_0031: newarr [System.Runtime]System.Object
-		IL_0036: dup
-		IL_0037: ldc.i4.0
-		IL_0038: ldloc.0
-		IL_0039: stelem.ref
-		IL_003a: stloc.s 10
-		IL_003c: ldc.i4.s 10
-		IL_003e: newarr [System.Runtime]System.Object
+		IL_0010: stfld float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
+		IL_0015: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_001a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001f: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_0024: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0029: stloc.s 9
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldloc.0
+		IL_0034: stelem.ref
+		IL_0035: stloc.s 10
+		IL_0037: ldc.i4.s 10
+		IL_0039: newarr [System.Runtime]System.Object
+		IL_003e: dup
+		IL_003f: ldc.i4.0
+		IL_0040: ldloc.s 9
+		IL_0042: stelem.ref
 		IL_0043: dup
-		IL_0044: ldc.i4.0
-		IL_0045: ldloc.s 9
-		IL_0047: stelem.ref
-		IL_0048: dup
-		IL_0049: ldc.i4.1
-		IL_004a: ldstr "setBitTrue"
-		IL_004f: stelem.ref
-		IL_0050: dup
-		IL_0051: ldc.i4.2
-		IL_0052: ldstr "setBitTrue"
-		IL_0057: stelem.ref
-		IL_0058: dup
-		IL_0059: ldc.i4.3
-		IL_005a: ldc.r8 1
-		IL_0063: box [System.Runtime]System.Double
-		IL_0068: stelem.ref
-		IL_0069: dup
-		IL_006a: ldc.i4.4
-		IL_006b: ldstr "setBitTrue"
-		IL_0070: stelem.ref
-		IL_0071: dup
-		IL_0072: ldc.i4.5
-		IL_0073: ldc.i4.0
-		IL_0074: box [System.Runtime]System.Boolean
-		IL_0079: stelem.ref
-		IL_007a: dup
-		IL_007b: ldc.i4.6
-		IL_007c: ldc.i4.0
-		IL_007d: box [System.Runtime]System.Boolean
-		IL_0082: stelem.ref
-		IL_0083: dup
-		IL_0084: ldc.i4.7
-		IL_0085: ldc.i4.0
-		IL_0086: box [System.Runtime]System.Boolean
-		IL_008b: stelem.ref
-		IL_008c: dup
-		IL_008d: ldc.i4.8
-		IL_008e: ldc.i4.0
-		IL_008f: box [System.Runtime]System.Boolean
-		IL_0094: stelem.ref
-		IL_0095: dup
-		IL_0096: ldc.i4.s 9
-		IL_0098: ldloc.s 10
-		IL_009a: stelem.ref
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00a0: pop
-		IL_00a1: ldc.i4.s 10
-		IL_00a3: newarr [System.Runtime]System.Object
+		IL_0044: ldc.i4.1
+		IL_0045: ldstr "setBitTrue"
+		IL_004a: stelem.ref
+		IL_004b: dup
+		IL_004c: ldc.i4.2
+		IL_004d: ldstr "setBitTrue"
+		IL_0052: stelem.ref
+		IL_0053: dup
+		IL_0054: ldc.i4.3
+		IL_0055: ldc.r8 1
+		IL_005e: box [System.Runtime]System.Double
+		IL_0063: stelem.ref
+		IL_0064: dup
+		IL_0065: ldc.i4.4
+		IL_0066: ldstr "setBitTrue"
+		IL_006b: stelem.ref
+		IL_006c: dup
+		IL_006d: ldc.i4.5
+		IL_006e: ldc.i4.0
+		IL_006f: box [System.Runtime]System.Boolean
+		IL_0074: stelem.ref
+		IL_0075: dup
+		IL_0076: ldc.i4.6
+		IL_0077: ldc.i4.0
+		IL_0078: box [System.Runtime]System.Boolean
+		IL_007d: stelem.ref
+		IL_007e: dup
+		IL_007f: ldc.i4.7
+		IL_0080: ldc.i4.0
+		IL_0081: box [System.Runtime]System.Boolean
+		IL_0086: stelem.ref
+		IL_0087: dup
+		IL_0088: ldc.i4.8
+		IL_0089: ldc.i4.0
+		IL_008a: box [System.Runtime]System.Boolean
+		IL_008f: stelem.ref
+		IL_0090: dup
+		IL_0091: ldc.i4.s 9
+		IL_0093: ldloc.s 10
+		IL_0095: stelem.ref
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_009b: pop
+		IL_009c: ldc.i4.s 10
+		IL_009e: newarr [System.Runtime]System.Object
+		IL_00a3: dup
+		IL_00a4: ldc.i4.0
+		IL_00a5: ldloc.s 9
+		IL_00a7: stelem.ref
 		IL_00a8: dup
-		IL_00a9: ldc.i4.0
-		IL_00aa: ldloc.s 9
-		IL_00ac: stelem.ref
-		IL_00ad: dup
-		IL_00ae: ldc.i4.1
-		IL_00af: ldstr "setBitsTrue"
-		IL_00b4: stelem.ref
-		IL_00b5: dup
-		IL_00b6: ldc.i4.2
-		IL_00b7: ldstr "setBitsTrue"
-		IL_00bc: stelem.ref
-		IL_00bd: dup
-		IL_00be: ldc.i4.3
-		IL_00bf: ldc.r8 3
-		IL_00c8: box [System.Runtime]System.Double
-		IL_00cd: stelem.ref
-		IL_00ce: dup
-		IL_00cf: ldc.i4.4
-		IL_00d0: ldstr "setBitsTrue"
-		IL_00d5: stelem.ref
-		IL_00d6: dup
-		IL_00d7: ldc.i4.5
-		IL_00d8: ldc.i4.0
-		IL_00d9: box [System.Runtime]System.Boolean
-		IL_00de: stelem.ref
-		IL_00df: dup
-		IL_00e0: ldc.i4.6
-		IL_00e1: ldc.i4.0
-		IL_00e2: box [System.Runtime]System.Boolean
-		IL_00e7: stelem.ref
-		IL_00e8: dup
-		IL_00e9: ldc.i4.7
-		IL_00ea: ldc.i4.0
-		IL_00eb: box [System.Runtime]System.Boolean
-		IL_00f0: stelem.ref
-		IL_00f1: dup
-		IL_00f2: ldc.i4.8
-		IL_00f3: ldc.i4.0
-		IL_00f4: box [System.Runtime]System.Boolean
-		IL_00f9: stelem.ref
-		IL_00fa: dup
-		IL_00fb: ldc.i4.s 9
-		IL_00fd: ldloc.s 10
-		IL_00ff: stelem.ref
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0105: pop
-		IL_0106: ldc.i4.s 10
-		IL_0108: newarr [System.Runtime]System.Object
+		IL_00a9: ldc.i4.1
+		IL_00aa: ldstr "setBitsTrue"
+		IL_00af: stelem.ref
+		IL_00b0: dup
+		IL_00b1: ldc.i4.2
+		IL_00b2: ldstr "setBitsTrue"
+		IL_00b7: stelem.ref
+		IL_00b8: dup
+		IL_00b9: ldc.i4.3
+		IL_00ba: ldc.r8 3
+		IL_00c3: box [System.Runtime]System.Double
+		IL_00c8: stelem.ref
+		IL_00c9: dup
+		IL_00ca: ldc.i4.4
+		IL_00cb: ldstr "setBitsTrue"
+		IL_00d0: stelem.ref
+		IL_00d1: dup
+		IL_00d2: ldc.i4.5
+		IL_00d3: ldc.i4.0
+		IL_00d4: box [System.Runtime]System.Boolean
+		IL_00d9: stelem.ref
+		IL_00da: dup
+		IL_00db: ldc.i4.6
+		IL_00dc: ldc.i4.0
+		IL_00dd: box [System.Runtime]System.Boolean
+		IL_00e2: stelem.ref
+		IL_00e3: dup
+		IL_00e4: ldc.i4.7
+		IL_00e5: ldc.i4.0
+		IL_00e6: box [System.Runtime]System.Boolean
+		IL_00eb: stelem.ref
+		IL_00ec: dup
+		IL_00ed: ldc.i4.8
+		IL_00ee: ldc.i4.0
+		IL_00ef: box [System.Runtime]System.Boolean
+		IL_00f4: stelem.ref
+		IL_00f5: dup
+		IL_00f6: ldc.i4.s 9
+		IL_00f8: ldloc.s 10
+		IL_00fa: stelem.ref
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0100: pop
+		IL_0101: ldc.i4.s 10
+		IL_0103: newarr [System.Runtime]System.Object
+		IL_0108: dup
+		IL_0109: ldc.i4.0
+		IL_010a: ldloc.s 9
+		IL_010c: stelem.ref
 		IL_010d: dup
-		IL_010e: ldc.i4.0
-		IL_010f: ldloc.s 9
-		IL_0111: stelem.ref
-		IL_0112: dup
-		IL_0113: ldc.i4.1
-		IL_0114: ldstr "testBitTrue"
-		IL_0119: stelem.ref
-		IL_011a: dup
-		IL_011b: ldc.i4.2
-		IL_011c: ldstr "testBitTrue"
-		IL_0121: stelem.ref
-		IL_0122: dup
-		IL_0123: ldc.i4.3
-		IL_0124: ldc.r8 1
-		IL_012d: box [System.Runtime]System.Double
-		IL_0132: stelem.ref
-		IL_0133: dup
-		IL_0134: ldc.i4.4
-		IL_0135: ldstr "testBitTrue"
-		IL_013a: stelem.ref
-		IL_013b: dup
-		IL_013c: ldc.i4.5
-		IL_013d: ldc.i4.0
-		IL_013e: box [System.Runtime]System.Boolean
-		IL_0143: stelem.ref
-		IL_0144: dup
-		IL_0145: ldc.i4.6
-		IL_0146: ldc.i4.0
-		IL_0147: box [System.Runtime]System.Boolean
-		IL_014c: stelem.ref
-		IL_014d: dup
-		IL_014e: ldc.i4.7
-		IL_014f: ldc.i4.0
-		IL_0150: box [System.Runtime]System.Boolean
-		IL_0155: stelem.ref
-		IL_0156: dup
-		IL_0157: ldc.i4.8
-		IL_0158: ldc.i4.0
-		IL_0159: box [System.Runtime]System.Boolean
-		IL_015e: stelem.ref
-		IL_015f: dup
-		IL_0160: ldc.i4.s 9
-		IL_0162: ldloc.s 10
-		IL_0164: stelem.ref
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_016a: pop
-		IL_016b: ldc.i4.1
-		IL_016c: newarr [System.Runtime]System.Object
-		IL_0171: dup
-		IL_0172: ldc.i4.0
-		IL_0173: ldloc.0
-		IL_0174: stelem.ref
-		IL_0175: stloc.s 10
-		IL_0177: ldloc.s 9
-		IL_0179: ldloc.s 10
-		IL_017b: ldc.r8 1
-		IL_0184: box [System.Runtime]System.Double
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_018e: stloc.s 11
-		IL_0190: ldloc.s 11
-		IL_0192: stloc.1
-		IL_0193: ldc.i4.1
-		IL_0194: newarr [System.Runtime]System.Object
-		IL_0199: dup
-		IL_019a: ldc.i4.0
-		IL_019b: ldloc.0
-		IL_019c: stelem.ref
-		IL_019d: stloc.s 10
-		IL_019f: ldloc.s 10
-		IL_01a1: ldc.i4.1
-		IL_01a2: newarr [System.Runtime]System.Object
-		IL_01a7: dup
-		IL_01a8: ldc.i4.0
-		IL_01a9: ldc.r8 64
-		IL_01b2: box [System.Runtime]System.Double
-		IL_01b7: stelem.ref
-		IL_01b8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01bd: ldc.r8 64
-		IL_01c6: box [System.Runtime]System.Double
-		IL_01cb: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], object)
-		IL_01d0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_01d5: stloc.s 12
-		IL_01d7: ldloc.s 12
-		IL_01d9: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_01de: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01e3: ldstr "prototype"
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-		IL_01ed: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01f2: ldloc.s 12
-		IL_01f4: stloc.2
-		IL_01f5: ldc.r8 3
-		IL_01fe: box [System.Runtime]System.Double
-		IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_0208: stloc.s 13
-		IL_020a: ldloc.s 13
-		IL_020c: stloc.3
-		IL_020d: ldc.r8 0.0
-		IL_0216: stloc.s 4
-		IL_0218: ldloc.3
-		IL_0219: ldloc.s 4
-		IL_021b: ldc.r8 16
-		IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-		IL_0229: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_022e: ldstr "varIndexSet"
-		IL_0233: ldloc.3
-		IL_0234: ldc.r8 0.0
-		IL_023d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_0242: box [System.Runtime]System.Double
-		IL_0247: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_024c: pop
-		IL_024d: ldloc.2
-		IL_024e: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0253: ldc.r8 4
-		IL_025c: box [System.Runtime]System.Double
-		IL_0261: ldc.r8 3
-		IL_026a: box [System.Runtime]System.Double
-		IL_026f: ldc.r8 64
-		IL_0278: box [System.Runtime]System.Double
-		IL_027d: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
-		IL_0282: pop
-		IL_0283: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0288: stloc.s 14
-		IL_028a: ldloc.2
-		IL_028b: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0290: ldc.r8 4
-		IL_0299: box [System.Runtime]System.Double
-		IL_029e: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_02a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_02a8: stloc.s 15
-		IL_02aa: ldloc.s 15
-		IL_02ac: brfalse IL_02c6
+		IL_010e: ldc.i4.1
+		IL_010f: ldstr "testBitTrue"
+		IL_0114: stelem.ref
+		IL_0115: dup
+		IL_0116: ldc.i4.2
+		IL_0117: ldstr "testBitTrue"
+		IL_011c: stelem.ref
+		IL_011d: dup
+		IL_011e: ldc.i4.3
+		IL_011f: ldc.r8 1
+		IL_0128: box [System.Runtime]System.Double
+		IL_012d: stelem.ref
+		IL_012e: dup
+		IL_012f: ldc.i4.4
+		IL_0130: ldstr "testBitTrue"
+		IL_0135: stelem.ref
+		IL_0136: dup
+		IL_0137: ldc.i4.5
+		IL_0138: ldc.i4.0
+		IL_0139: box [System.Runtime]System.Boolean
+		IL_013e: stelem.ref
+		IL_013f: dup
+		IL_0140: ldc.i4.6
+		IL_0141: ldc.i4.0
+		IL_0142: box [System.Runtime]System.Boolean
+		IL_0147: stelem.ref
+		IL_0148: dup
+		IL_0149: ldc.i4.7
+		IL_014a: ldc.i4.0
+		IL_014b: box [System.Runtime]System.Boolean
+		IL_0150: stelem.ref
+		IL_0151: dup
+		IL_0152: ldc.i4.8
+		IL_0153: ldc.i4.0
+		IL_0154: box [System.Runtime]System.Boolean
+		IL_0159: stelem.ref
+		IL_015a: dup
+		IL_015b: ldc.i4.s 9
+		IL_015d: ldloc.s 10
+		IL_015f: stelem.ref
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0165: pop
+		IL_0166: ldc.i4.1
+		IL_0167: newarr [System.Runtime]System.Object
+		IL_016c: dup
+		IL_016d: ldc.i4.0
+		IL_016e: ldloc.0
+		IL_016f: stelem.ref
+		IL_0170: stloc.s 10
+		IL_0172: ldloc.s 9
+		IL_0174: ldloc.s 10
+		IL_0176: ldc.r8 1
+		IL_017f: box [System.Runtime]System.Double
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0189: stloc.s 11
+		IL_018b: ldloc.s 11
+		IL_018d: stloc.1
+		IL_018e: ldc.i4.1
+		IL_018f: newarr [System.Runtime]System.Object
+		IL_0194: dup
+		IL_0195: ldc.i4.0
+		IL_0196: ldloc.0
+		IL_0197: stelem.ref
+		IL_0198: stloc.s 10
+		IL_019a: ldloc.s 10
+		IL_019c: ldc.i4.1
+		IL_019d: newarr [System.Runtime]System.Object
+		IL_01a2: dup
+		IL_01a3: ldc.i4.0
+		IL_01a4: ldc.r8 64
+		IL_01ad: box [System.Runtime]System.Double
+		IL_01b2: stelem.ref
+		IL_01b3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01b8: ldc.r8 64
+		IL_01c1: box [System.Runtime]System.Double
+		IL_01c6: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], object)
+		IL_01cb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01d0: stloc.s 12
+		IL_01d2: ldloc.s 12
+		IL_01d4: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_01d9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01de: ldstr "prototype"
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+		IL_01e8: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_01ed: ldloc.s 12
+		IL_01ef: stloc.2
+		IL_01f0: ldc.r8 3
+		IL_01f9: box [System.Runtime]System.Double
+		IL_01fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_0203: stloc.s 13
+		IL_0205: ldloc.s 13
+		IL_0207: stloc.3
+		IL_0208: ldc.r8 0.0
+		IL_0211: stloc.s 4
+		IL_0213: ldloc.3
+		IL_0214: ldloc.s 4
+		IL_0216: ldc.r8 16
+		IL_021f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+		IL_0224: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0229: ldstr "varIndexSet"
+		IL_022e: ldloc.3
+		IL_022f: ldc.r8 0.0
+		IL_0238: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_023d: box [System.Runtime]System.Double
+		IL_0242: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0247: pop
+		IL_0248: ldloc.2
+		IL_0249: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_024e: ldc.r8 4
+		IL_0257: box [System.Runtime]System.Double
+		IL_025c: ldc.r8 3
+		IL_0265: box [System.Runtime]System.Double
+		IL_026a: ldc.r8 64
+		IL_0273: box [System.Runtime]System.Double
+		IL_0278: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
+		IL_027d: pop
+		IL_027e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0283: stloc.s 14
+		IL_0285: ldloc.2
+		IL_0286: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_028b: ldc.r8 4
+		IL_0294: box [System.Runtime]System.Double
+		IL_0299: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_029e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_02a3: stloc.s 15
+		IL_02a5: ldloc.s 15
+		IL_02a7: brfalse IL_02c1
 
-		IL_02b1: ldc.r8 1
-		IL_02ba: box [System.Runtime]System.Double
-		IL_02bf: stloc.s 5
-		IL_02c1: br IL_02d6
+		IL_02ac: ldc.r8 1
+		IL_02b5: box [System.Runtime]System.Double
+		IL_02ba: stloc.s 5
+		IL_02bc: br IL_02d1
 
-		IL_02c6: ldc.r8 0.0
-		IL_02cf: box [System.Runtime]System.Double
-		IL_02d4: stloc.s 5
+		IL_02c1: ldc.r8 0.0
+		IL_02ca: box [System.Runtime]System.Double
+		IL_02cf: stloc.s 5
 
-		IL_02d6: ldloc.s 14
-		IL_02d8: ldstr "bit4"
-		IL_02dd: ldloc.s 5
-		IL_02df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02e4: pop
-		IL_02e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ea: stloc.s 14
-		IL_02ec: ldloc.2
-		IL_02ed: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_02f2: ldc.r8 7
-		IL_02fb: box [System.Runtime]System.Double
-		IL_0300: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0305: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_030a: stloc.s 15
-		IL_030c: ldloc.s 15
-		IL_030e: brfalse IL_0328
+		IL_02d1: ldloc.s 14
+		IL_02d3: ldstr "bit4"
+		IL_02d8: ldloc.s 5
+		IL_02da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02df: pop
+		IL_02e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e5: stloc.s 14
+		IL_02e7: ldloc.2
+		IL_02e8: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_02ed: ldc.r8 7
+		IL_02f6: box [System.Runtime]System.Double
+		IL_02fb: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0300: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0305: stloc.s 15
+		IL_0307: ldloc.s 15
+		IL_0309: brfalse IL_0323
 
-		IL_0313: ldc.r8 1
-		IL_031c: box [System.Runtime]System.Double
-		IL_0321: stloc.s 6
-		IL_0323: br IL_0338
+		IL_030e: ldc.r8 1
+		IL_0317: box [System.Runtime]System.Double
+		IL_031c: stloc.s 6
+		IL_031e: br IL_0333
 
-		IL_0328: ldc.r8 0.0
-		IL_0331: box [System.Runtime]System.Double
-		IL_0336: stloc.s 6
+		IL_0323: ldc.r8 0.0
+		IL_032c: box [System.Runtime]System.Double
+		IL_0331: stloc.s 6
 
-		IL_0338: ldloc.s 14
-		IL_033a: ldstr "bit7"
-		IL_033f: ldloc.s 6
-		IL_0341: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0346: pop
-		IL_0347: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_034c: stloc.s 14
-		IL_034e: ldloc.2
-		IL_034f: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0354: ldc.r8 31
-		IL_035d: box [System.Runtime]System.Double
-		IL_0362: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0367: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_036c: stloc.s 15
-		IL_036e: ldloc.s 15
-		IL_0370: brfalse IL_038a
+		IL_0333: ldloc.s 14
+		IL_0335: ldstr "bit7"
+		IL_033a: ldloc.s 6
+		IL_033c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0341: pop
+		IL_0342: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0347: stloc.s 14
+		IL_0349: ldloc.2
+		IL_034a: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_034f: ldc.r8 31
+		IL_0358: box [System.Runtime]System.Double
+		IL_035d: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0362: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0367: stloc.s 15
+		IL_0369: ldloc.s 15
+		IL_036b: brfalse IL_0385
 
-		IL_0375: ldc.r8 1
-		IL_037e: box [System.Runtime]System.Double
-		IL_0383: stloc.s 7
-		IL_0385: br IL_039a
+		IL_0370: ldc.r8 1
+		IL_0379: box [System.Runtime]System.Double
+		IL_037e: stloc.s 7
+		IL_0380: br IL_0395
 
-		IL_038a: ldc.r8 0.0
-		IL_0393: box [System.Runtime]System.Double
-		IL_0398: stloc.s 7
+		IL_0385: ldc.r8 0.0
+		IL_038e: box [System.Runtime]System.Double
+		IL_0393: stloc.s 7
 
-		IL_039a: ldloc.s 14
-		IL_039c: ldstr "bit31"
-		IL_03a1: ldloc.s 7
-		IL_03a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03a8: pop
-		IL_03a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03ae: stloc.s 14
-		IL_03b0: ldloc.2
-		IL_03b1: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_03b6: ldc.r8 5
-		IL_03bf: box [System.Runtime]System.Double
-		IL_03c4: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_03c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_03ce: stloc.s 15
-		IL_03d0: ldloc.s 15
-		IL_03d2: brfalse IL_03ec
+		IL_0395: ldloc.s 14
+		IL_0397: ldstr "bit31"
+		IL_039c: ldloc.s 7
+		IL_039e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03a3: pop
+		IL_03a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a9: stloc.s 14
+		IL_03ab: ldloc.2
+		IL_03ac: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_03b1: ldc.r8 5
+		IL_03ba: box [System.Runtime]System.Double
+		IL_03bf: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_03c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_03c9: stloc.s 15
+		IL_03cb: ldloc.s 15
+		IL_03cd: brfalse IL_03e7
 
-		IL_03d7: ldc.r8 1
-		IL_03e0: box [System.Runtime]System.Double
-		IL_03e5: stloc.s 8
-		IL_03e7: br IL_03fc
+		IL_03d2: ldc.r8 1
+		IL_03db: box [System.Runtime]System.Double
+		IL_03e0: stloc.s 8
+		IL_03e2: br IL_03f7
 
-		IL_03ec: ldc.r8 0.0
-		IL_03f5: box [System.Runtime]System.Double
-		IL_03fa: stloc.s 8
+		IL_03e7: ldc.r8 0.0
+		IL_03f0: box [System.Runtime]System.Double
+		IL_03f5: stloc.s 8
 
-		IL_03fc: ldloc.s 14
-		IL_03fe: ldstr "bit5"
-		IL_0403: ldloc.s 8
-		IL_0405: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_040a: pop
-		IL_040b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0410: ldstr "word0"
-		IL_0415: ldloc.2
-		IL_0416: ldstr "wordArray"
-		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0420: ldc.r8 0.0
-		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_042e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0433: pop
-		IL_0434: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0439: ldstr "word1"
-		IL_043e: ldloc.2
-		IL_043f: ldstr "wordArray"
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0449: ldc.r8 1
-		IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0457: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_045c: pop
-		IL_045d: ret
+		IL_03f7: ldloc.s 14
+		IL_03f9: ldstr "bit5"
+		IL_03fe: ldloc.s 8
+		IL_0400: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0405: pop
+		IL_0406: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_040b: ldstr "word0"
+		IL_0410: ldloc.2
+		IL_0411: ldstr "wordArray"
+		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_041b: ldc.r8 0.0
+		IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0429: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_042e: pop
+		IL_042f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0434: ldstr "word1"
+		IL_0439: ldloc.2
+		IL_043a: ldstr "wordArray"
+		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0444: ldc.r8 1
+		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0452: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0457: pop
+		IL_0458: ret
 	} // end of method Prime_SetBitsTrue_SmallStep_WordValueOrAssign::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign
@@ -1234,7 +1222,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29bc
+		// Method begins at RVA 0x2995
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
+++ b/tests/Js2IL.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213d
+				// Method begins at RVA 0x2104
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,41 +44,28 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d4
+			// Method begins at RVA 0x20d0
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] bool
+				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Variable_CapturedConst_BoolStringFieldType/Scope::FLAG
-			IL_0006: ldstr "Cannot access 'FLAG' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0017: stloc.2
-			IL_0018: ldloc.2
-			IL_0019: brfalse IL_0036
+			IL_0001: ldfld bool Modules.Variable_CapturedConst_BoolStringFieldType/Scope::FLAG
+			IL_0006: brfalse IL_0017
 
-			IL_001e: ldarg.0
-			IL_001f: ldfld object Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
-			IL_0024: ldstr "Cannot access 'NAME' before initialization"
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_002e: stloc.1
-			IL_002f: ldloc.1
-			IL_0030: stloc.0
-			IL_0031: br IL_003c
+			IL_000b: ldarg.0
+			IL_000c: ldfld string Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
+			IL_0011: stloc.0
+			IL_0012: br IL_001d
 
-			IL_0036: ldstr "untyped"
-			IL_003b: stloc.0
+			IL_0017: ldstr "untyped"
+			IL_001c: stloc.0
 
-			IL_003c: ldloc.0
-			IL_003d: ret
+			IL_001d: ldloc.0
+			IL_001e: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -92,29 +79,23 @@
 			7d 2c 20 72 75 6e 3d 7b 72 75 6e 7d 00 00
 		)
 		// Fields
-		.field public object FLAG
-		.field public object NAME
+		.field public bool FLAG
+		.field public string NAME
 		.field public object run
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211e
+			// Method begins at RVA 0x20fb
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Variable_CapturedConst_BoolStringFieldType/Scope::FLAG
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -132,7 +113,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 120 (0x78)
+		// Code size: 115 (0x73)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_BoolStringFieldType/Scope,
@@ -162,30 +143,29 @@
 		IL_0030: stloc.1
 		IL_0031: ldloc.0
 		IL_0032: ldc.i4.1
-		IL_0033: box [System.Runtime]System.Boolean
-		IL_0038: stfld object Modules.Variable_CapturedConst_BoolStringFieldType/Scope::FLAG
-		IL_003d: ldloc.0
-		IL_003e: ldstr "typed"
-		IL_0043: stfld object Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
-		IL_0048: ldc.i4.1
-		IL_0049: newarr [System.Runtime]System.Object
-		IL_004e: dup
-		IL_004f: ldc.i4.0
-		IL_0050: ldloc.0
-		IL_0051: stelem.ref
-		IL_0052: ldc.i4.0
-		IL_0053: ldelem.ref
-		IL_0054: castclass Modules.Variable_CapturedConst_BoolStringFieldType/Scope
-		IL_0059: ldftn object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
-		IL_005f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0064: ldnull
-		IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_006a: stloc.2
-		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0070: ldloc.2
-		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0076: pop
-		IL_0077: ret
+		IL_0033: stfld bool Modules.Variable_CapturedConst_BoolStringFieldType/Scope::FLAG
+		IL_0038: ldloc.0
+		IL_0039: ldstr "typed"
+		IL_003e: stfld string Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
+		IL_0043: ldc.i4.1
+		IL_0044: newarr [System.Runtime]System.Object
+		IL_0049: dup
+		IL_004a: ldc.i4.0
+		IL_004b: ldloc.0
+		IL_004c: stelem.ref
+		IL_004d: ldc.i4.0
+		IL_004e: ldelem.ref
+		IL_004f: castclass Modules.Variable_CapturedConst_BoolStringFieldType/Scope
+		IL_0054: ldftn object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
+		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_005f: ldnull
+		IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+		IL_0065: stloc.2
+		IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006b: ldloc.2
+		IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0071: pop
+		IL_0072: ret
 	} // end of method Variable_CapturedConst_BoolStringFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_BoolStringFieldType
@@ -197,7 +177,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2146
+		// Method begins at RVA 0x210d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
+++ b/tests/Js2IL.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2117
+				// Method begins at RVA 0x20ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,26 +44,17 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d4
-			// Header size: 12
-			// Code size: 35 (0x23)
+			// Method begins at RVA 0x20cc
+			// Header size: 1
+			// Code size: 22 (0x16)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
-			IL_0006: ldstr "Cannot access 'NOW_UNITS_PER_SECOND' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 23
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0020: stloc.1
-			IL_0021: ldloc.1
-			IL_0022: ret
+			IL_0001: ldfld float64 Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
+			IL_0006: ldc.r8 23
+			IL_000f: add
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -78,25 +69,22 @@
 			4f 4e 44 7d 2c 20 72 75 6e 3d 7b 72 75 6e 7d 00 00
 		)
 		// Fields
-		.field public object NOW_UNITS_PER_SECOND
+		.field public float64 NOW_UNITS_PER_SECOND
 		.field public object run
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2103
+			// Method begins at RVA 0x20e3
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -114,7 +102,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 117 (0x75)
+		// Code size: 112 (0x70)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_NumberFieldType/Scope,
@@ -144,27 +132,26 @@
 		IL_0030: stloc.1
 		IL_0031: ldloc.0
 		IL_0032: ldc.r8 1000
-		IL_003b: box [System.Runtime]System.Double
-		IL_0040: stfld object Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
-		IL_0045: ldc.i4.1
-		IL_0046: newarr [System.Runtime]System.Object
-		IL_004b: dup
-		IL_004c: ldc.i4.0
-		IL_004d: ldloc.0
-		IL_004e: stelem.ref
-		IL_004f: ldc.i4.0
-		IL_0050: ldelem.ref
-		IL_0051: castclass Modules.Variable_CapturedConst_NumberFieldType/Scope
-		IL_0056: ldftn object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
-		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0061: ldnull
-		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0067: stloc.2
-		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006d: ldloc.2
-		IL_006e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0073: pop
-		IL_0074: ret
+		IL_003b: stfld float64 Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
+		IL_0040: ldc.i4.1
+		IL_0041: newarr [System.Runtime]System.Object
+		IL_0046: dup
+		IL_0047: ldc.i4.0
+		IL_0048: ldloc.0
+		IL_0049: stelem.ref
+		IL_004a: ldc.i4.0
+		IL_004b: ldelem.ref
+		IL_004c: castclass Modules.Variable_CapturedConst_NumberFieldType/Scope
+		IL_0051: ldftn object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
+		IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_005c: ldnull
+		IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+		IL_0062: stloc.2
+		IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0068: ldloc.2
+		IL_0069: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006e: pop
+		IL_006f: ret
 	} // end of method Variable_CapturedConst_NumberFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_NumberFieldType
@@ -176,7 +163,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2120
+		// Method begins at RVA 0x20f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
+++ b/tests/Js2IL.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e2
+				// Method begins at RVA 0x2196
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,43 +44,28 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x2160
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 33 (0x21)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] float64,
-				[3] float64,
-				[4] object
+				[1] float64
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::a
-			IL_0006: ldstr "Cannot access 'a' before initialization"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldarg.0
-			IL_0012: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
-			IL_0017: ldstr "Cannot access 'b' before initialization"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0021: stloc.1
-			IL_0022: ldloc.0
-			IL_0023: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0028: stloc.2
-			IL_0029: ldloc.1
-			IL_002a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002f: stloc.3
-			IL_0030: ldloc.2
-			IL_0031: ldloc.3
-			IL_0032: mul
-			IL_0033: stloc.3
-			IL_0034: ldloc.3
-			IL_0035: box [System.Runtime]System.Double
-			IL_003a: stloc.s 4
-			IL_003c: ldloc.s 4
-			IL_003e: ret
+			IL_0001: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::a
+			IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0012: stloc.1
+			IL_0013: ldloc.1
+			IL_0014: ldloc.0
+			IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_001a: mul
+			IL_001b: box [System.Runtime]System.Double
+			IL_0020: ret
 		} // end of method compute::__js_call__
 
 	} // end of class compute
@@ -102,21 +87,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c3
+			// Method begins at RVA 0x218d
 			// Header size: 1
-			// Code size: 30 (0x1e)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.Variable_ObjectDestructuring_Captured/Scope::a
-			IL_0011: ldarg.0
-			IL_0012: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_0017: stfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
-			IL_001c: nop
-			IL_001d: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -134,7 +113,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 283 (0x11b)
+		// Code size: 259 (0x103)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_ObjectDestructuring_Captured/Scope,
@@ -195,46 +174,38 @@
 		IL_0093: ldstr "b"
 		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_009d: stfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
-		IL_00a2: ldloc.0
-		IL_00a3: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::a
-		IL_00a8: ldstr "Cannot access 'a' before initialization"
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00b2: stloc.3
-		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b8: ldstr "a="
-		IL_00bd: ldloc.3
-		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00c3: pop
-		IL_00c4: ldloc.0
-		IL_00c5: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
-		IL_00ca: ldstr "Cannot access 'b' before initialization"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00d4: stloc.3
-		IL_00d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00da: ldstr "b="
-		IL_00df: ldloc.3
-		IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00e5: pop
-		IL_00e6: ldc.i4.1
-		IL_00e7: newarr [System.Runtime]System.Object
-		IL_00ec: dup
-		IL_00ed: ldc.i4.0
-		IL_00ee: ldloc.0
-		IL_00ef: stelem.ref
-		IL_00f0: ldc.i4.0
-		IL_00f1: ldelem.ref
-		IL_00f2: castclass Modules.Variable_ObjectDestructuring_Captured/Scope
-		IL_00f7: ldftn object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
-		IL_00fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0102: ldnull
-		IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0108: stloc.3
-		IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010e: ldstr "compute()="
-		IL_0113: ldloc.3
-		IL_0114: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0119: pop
-		IL_011a: ret
+		IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a7: ldstr "a="
+		IL_00ac: ldloc.0
+		IL_00ad: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::a
+		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b7: pop
+		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bd: ldstr "b="
+		IL_00c2: ldloc.0
+		IL_00c3: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
+		IL_00c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00cd: pop
+		IL_00ce: ldc.i4.1
+		IL_00cf: newarr [System.Runtime]System.Object
+		IL_00d4: dup
+		IL_00d5: ldc.i4.0
+		IL_00d6: ldloc.0
+		IL_00d7: stelem.ref
+		IL_00d8: ldc.i4.0
+		IL_00d9: ldelem.ref
+		IL_00da: castclass Modules.Variable_ObjectDestructuring_Captured/Scope
+		IL_00df: ldftn object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
+		IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ea: ldnull
+		IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+		IL_00f0: stloc.3
+		IL_00f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f6: ldstr "compute()="
+		IL_00fb: ldloc.3
+		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0101: pop
+		IL_0102: ret
 	} // end of method Variable_ObjectDestructuring_Captured::__js_module_init__
 
 } // end of class Modules.Variable_ObjectDestructuring_Captured
@@ -246,7 +217,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21eb
+		// Method begins at RVA 0x219f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Js2IL.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Js2IL.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x22c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x21fc
 			// Header size: 12
 			// Code size: 111 (0x6f)
 			.maxstack 8
@@ -109,7 +109,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2304
+				// Method begins at RVA 0x22e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -135,9 +135,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x2278
 			// Header size: 12
-			// Code size: 69 (0x45)
+			// Code size: 57 (0x39)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -149,27 +149,23 @@
 			IL_0005: pop
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-			IL_000c: ldstr "Cannot access 'ref' before initialization"
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_000c: ldstr "deref"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0016: stloc.0
 			IL_0017: ldloc.0
-			IL_0018: ldstr "deref"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0022: stloc.0
-			IL_0023: ldloc.0
-			IL_0024: ldc.i4.0
-			IL_0025: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
-			IL_0031: box [System.Runtime]System.Boolean
-			IL_0036: stloc.2
-			IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_003c: ldloc.2
-			IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0042: pop
-			IL_0043: ldnull
-			IL_0044: ret
+			IL_0018: ldc.i4.0
+			IL_0019: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_001e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+			IL_0023: stloc.1
+			IL_0024: ldloc.1
+			IL_0025: box [System.Runtime]System.Boolean
+			IL_002a: stloc.2
+			IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0030: ldloc.2
+			IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0036: pop
+			IL_0037: ldnull
+			IL_0038: ret
 		} // end of method ArrowFunction_L23C14::__js_call__
 
 	} // end of class ArrowFunction_L23C14
@@ -191,7 +187,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x22cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -211,7 +207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22fb
+				// Method begins at RVA 0x22d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -233,18 +229,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22d5
+			// Method begins at RVA 0x22bd
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 8 (0x8)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.0
-			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
-			IL_000c: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-			IL_0011: nop
-			IL_0012: ret
+			IL_0006: nop
+			IL_0007: ret
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
@@ -262,7 +255,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 412 (0x19c)
+		// Code size: 398 (0x18e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakRef_Deref_KeptObjects/Scope,
@@ -312,119 +305,115 @@
 		IL_0057: ldloc.0
 		IL_0058: ldloc.s 7
 		IL_005a: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-		IL_005f: ldloc.0
-		IL_0060: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-		IL_0065: ldstr "Cannot access 'ref' before initialization"
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_006f: stloc.s 7
-		IL_0071: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_0076: ldstr "prototype"
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0080: ldstr "toString"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008a: ldstr "call"
+		IL_005f: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0064: ldstr "prototype"
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006e: ldstr "toString"
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0078: ldstr "call"
+		IL_007d: ldloc.0
+		IL_007e: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
+		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0088: stloc.s 7
+		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_008f: ldloc.s 7
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0096: stloc.s 7
-		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009d: ldloc.s 7
-		IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a4: pop
+		IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0096: pop
 		.try
 		{
-			IL_00a5: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L15C4::.ctor()
-			IL_00aa: stloc.2
-			IL_00ab: ldc.r8 123
-			IL_00b4: box [System.Runtime]System.Double
-			IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
-			IL_00be: pop
-			IL_00bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00c4: ldstr "primitive target threw:"
-			IL_00c9: ldc.i4.0
-			IL_00ca: box [System.Runtime]System.Boolean
-			IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00d4: pop
-			IL_00d5: leave IL_014f
+			IL_0097: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L15C4::.ctor()
+			IL_009c: stloc.2
+			IL_009d: ldc.r8 123
+			IL_00a6: box [System.Runtime]System.Double
+			IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
+			IL_00b0: pop
+			IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00b6: ldstr "primitive target threw:"
+			IL_00bb: ldc.i4.0
+			IL_00bc: box [System.Runtime]System.Boolean
+			IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00c6: pop
+			IL_00c7: leave IL_0141
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00da: stloc.3
-			IL_00db: ldloc.3
-			IL_00dc: dup
-			IL_00dd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00e2: dup
-			IL_00e3: brtrue IL_00f9
+			IL_00cc: stloc.3
+			IL_00cd: ldloc.3
+			IL_00ce: dup
+			IL_00cf: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00d4: dup
+			IL_00d5: brtrue IL_00eb
 
+			IL_00da: pop
+			IL_00db: dup
+			IL_00dc: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00e1: dup
+			IL_00e2: brtrue IL_00f8
+
+			IL_00e7: pop
 			IL_00e8: pop
-			IL_00e9: dup
-			IL_00ea: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00ef: dup
-			IL_00f0: brtrue IL_0106
+			IL_00e9: rethrow
 
-			IL_00f5: pop
-			IL_00f6: pop
-			IL_00f7: rethrow
+			IL_00eb: pop
+			IL_00ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00f1: stloc.s 4
+			IL_00f3: br IL_00fb
 
-			IL_00f9: pop
-			IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00ff: stloc.s 4
-			IL_0101: br IL_0109
+			IL_00f8: pop
+			IL_00f9: stloc.s 4
 
-			IL_0106: pop
-			IL_0107: stloc.s 4
-
-			IL_0109: ldloc.s 4
-			IL_010b: stloc.s 7
-			IL_010d: ldloc.s 7
-			IL_010f: stloc.s 5
-			IL_0111: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L18C16::.ctor()
-			IL_0116: stloc.s 6
-			IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_011d: ldstr "primitive target threw:"
-			IL_0122: ldc.i4.1
-			IL_0123: box [System.Runtime]System.Boolean
-			IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_012d: pop
-			IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0133: ldstr "primitive target name:"
-			IL_0138: ldloc.s 5
-			IL_013a: ldstr "name"
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0149: pop
-			IL_014a: leave IL_014f
+			IL_00fb: ldloc.s 4
+			IL_00fd: stloc.s 7
+			IL_00ff: ldloc.s 7
+			IL_0101: stloc.s 5
+			IL_0103: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L18C16::.ctor()
+			IL_0108: stloc.s 6
+			IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_010f: ldstr "primitive target threw:"
+			IL_0114: ldc.i4.1
+			IL_0115: box [System.Runtime]System.Boolean
+			IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_011f: pop
+			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0125: ldstr "primitive target name:"
+			IL_012a: ldloc.s 5
+			IL_012c: ldstr "name"
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_013b: pop
+			IL_013c: leave IL_0141
 		} // end handler
 
-		IL_014f: ldc.i4.1
-		IL_0150: newarr [System.Runtime]System.Object
-		IL_0155: dup
-		IL_0156: ldc.i4.0
-		IL_0157: ldloc.0
-		IL_0158: stelem.ref
-		IL_0159: ldc.i4.0
-		IL_015a: ldelem.ref
-		IL_015b: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_0160: ldftn object Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
-		IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_016b: ldc.i4.1
-		IL_016c: newarr [System.Runtime]System.Object
-		IL_0171: dup
-		IL_0172: ldc.i4.0
-		IL_0173: ldloc.0
-		IL_0174: stelem.ref
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_017f: ldc.i4.0
-		IL_0180: conv.r8
-		IL_0181: ldstr ""
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
-		IL_018b: stloc.s 7
-		IL_018d: ldloc.s 7
-		IL_018f: ldc.i4.0
-		IL_0190: newarr [System.Runtime]System.Object
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_019a: pop
-		IL_019b: ret
+		IL_0141: ldc.i4.1
+		IL_0142: newarr [System.Runtime]System.Object
+		IL_0147: dup
+		IL_0148: ldc.i4.0
+		IL_0149: ldloc.0
+		IL_014a: stelem.ref
+		IL_014b: ldc.i4.0
+		IL_014c: ldelem.ref
+		IL_014d: castclass Modules.WeakRef_Deref_KeptObjects/Scope
+		IL_0152: ldftn object Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
+		IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_015d: ldc.i4.1
+		IL_015e: newarr [System.Runtime]System.Object
+		IL_0163: dup
+		IL_0164: ldc.i4.0
+		IL_0165: ldloc.0
+		IL_0166: stelem.ref
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0171: ldc.i4.0
+		IL_0172: conv.r8
+		IL_0173: ldstr ""
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string)
+		IL_017d: stloc.s 7
+		IL_017f: ldloc.s 7
+		IL_0181: ldc.i4.0
+		IL_0182: newarr [System.Runtime]System.Object
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_018c: pop
+		IL_018d: ret
 	} // end of method WeakRef_Deref_KeptObjects::__js_module_init__
 
 } // end of class Modules.WeakRef_Deref_KeptObjects
@@ -436,7 +425,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x230d
+		// Method begins at RVA 0x22ea
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- restore numeric lowering in PrimeJavaScript hot paths by narrowing self-reference type-inference exclusion to the binding being inferred
- only emit captured-const TDZ runtime guards when a closure can actually be created before initialization
- update affected generator snapshots and add focused symbol table coverage for the TDZ and prime scenarios

## Validation
- focused Js2IL symbol table, TDZ, and generator tests
- test262 const suite including block-local-closure-get-before-initialization
- local PrimeJavaScript IL/perf comparison against v0.9.20