### PR TITLE
test: Fix issue 1048 class test262 execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- tests/test262: close issue #1048 by keeping the class-family test262 ports unskipped and running the duplicate-basename computed-yield class statement ports out-of-process so the full class slice no longer races on generated assembly identity.
 - compiler/runtime/tests/test262: fix issue #1049 by supporting computed object destructuring keys, iterator-protocol array destructuring close ordering, Proxy-aware object rest copy semantics, and with-environment binding probes needed by the related test262 destructuring ports.
 
 ## v0.9.22 - 2026-05-22

--- a/tests/Js2IL.Test262.Tests/language/statements/class/ExecutionTests.cs
+++ b/tests/Js2IL.Test262.Tests/language/statements/class/ExecutionTests.cs
@@ -8,9 +8,9 @@ public class ExecutionTests : ExecutionTestsBase
 
     [Fact(DisplayName = "accessor-name-inst-computed-yield-expr")]
     public Task accessor_name_inst_computed_yield_expr()
-        => ExecutionTest("accessor-name-inst-computed-yield-expr");
+        => ExecutionTest("accessor-name-inst-computed-yield-expr", preferOutOfProc: true);
 
     [Fact(DisplayName = "accessor-name-static-computed-yield-expr")]
     public Task accessor_name_static_computed_yield_expr()
-        => ExecutionTest("accessor-name-static-computed-yield-expr");
+        => ExecutionTest("accessor-name-static-computed-yield-expr", preferOutOfProc: true);
 }


### PR DESCRIPTION
## Summary

Closes #1048.

This keeps the class-family test262 ports unskipped and fixes the combined class slice by running the two duplicate-basename statement-class computed-yield tests out-of-process. Those test names also exist under `language/expressions/class`, and in-proc execution can race on the generated assembly identity when the whole class family runs together.

## Validation

- `dotnet test tests\Js2IL.Test262.Tests\Js2IL.Test262.Tests.csproj --filter "FullyQualifiedName~language.expressions.class_|FullyQualifiedName~language.statements.class_"`
