### PR TITLE
ci: wait for NuGet package availability after release

### DIFF
--- a/.github/workflows/benchmarkdotnet-suite.yml
+++ b/.github/workflows/benchmarkdotnet-suite.yml
@@ -117,6 +117,16 @@ jobs:
 
             throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
 
+      - name: Wait for NuGet package availability
+        if: env.USE_PUBLISHED_JS2IL_PACKAGES == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/waitForNuGetPackageVersions.js \
+            --version "${JS2IL_PACKAGE_VERSION}" \
+            --package Js2IL.Core \
+            --package Js2IL.Runtime
+
       - name: Restore benchmark project
         shell: bash
         run: |

--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Determine js2il tool version
         run: |
           set -euo pipefail
@@ -85,6 +90,16 @@ jobs:
 
             throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
 
+      - name: Wait for NuGet package availability
+        if: github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          node scripts/waitForNuGetPackageVersions.js \
+            --version "$TOOL_VERSION" \
+            --package js2il \
+            --package Js2IL.Runtime \
+            --package Js2IL.SDK
+
       - name: Install js2il tool from NuGet (specific version with retry)
         run: |
           set -euo pipefail
@@ -121,11 +136,6 @@ jobs:
             echo "Smoke test failed: expected output containing 'x is'"
             exit 1
           fi
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
 
       - name: Build Jint and Okojo comparison projects
         run: |

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Determine js2il tool version
         shell: pwsh
         run: |
@@ -87,6 +92,17 @@ jobs:
 
             throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
 
+      - name: Wait for NuGet package availability
+        if: github.event_name == 'release'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          node scripts/waitForNuGetPackageVersions.js `
+            --version $env:TOOL_VERSION `
+            --package js2il `
+            --package Js2IL.Runtime `
+            --package Js2IL.SDK
+
       - name: Install js2il tool from NuGet (specific version with retry)
         shell: pwsh
         run: |
@@ -133,11 +149,6 @@ jobs:
           if ($outputText -notmatch 'x is') {
             throw "Smoke test failed: expected output containing 'x is'"
           }
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
 
       - name: Build Jint and Okojo comparison projects
         shell: pwsh

--- a/scripts/waitForNuGetPackageVersions.js
+++ b/scripts/waitForNuGetPackageVersions.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+"use strict";
+
+const DEFAULT_TIMEOUT_SECONDS = 45 * 60;
+const DEFAULT_POLL_SECONDS = 30;
+const DEFAULT_SOURCE = "https://api.nuget.org/v3-flatcontainer";
+
+function parseArgs(argv) {
+  const args = {
+    packages: [],
+    source: DEFAULT_SOURCE,
+    timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+    pollSeconds: DEFAULT_POLL_SECONDS,
+    help: false,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const current = argv[i];
+    switch (current) {
+      case "--version":
+      case "-v":
+        args.version = argv[++i];
+        break;
+      case "--package":
+      case "-p":
+        args.packages.push(argv[++i]);
+        break;
+      case "--source":
+        args.source = argv[++i] || args.source;
+        break;
+      case "--timeout-seconds":
+        args.timeoutSeconds = Number.parseInt(argv[++i], 10);
+        break;
+      case "--poll-seconds":
+        args.pollSeconds = Number.parseInt(argv[++i], 10);
+        break;
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${current}`);
+    }
+  }
+
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/waitForNuGetPackageVersions.js --version <version> --package <id> [--package <id> ...]
+
+Options:
+  --version, -v <version>        Required package version to wait for
+  --package, -p <id>             Required package id (repeatable)
+  --source <url>                 Flat-container base URL (default: ${DEFAULT_SOURCE})
+  --timeout-seconds <seconds>    Overall timeout (default: ${DEFAULT_TIMEOUT_SECONDS})
+  --poll-seconds <seconds>       Poll interval (default: ${DEFAULT_POLL_SECONDS})
+  --help, -h                     Show help
+`);
+}
+
+function validateArgs(args) {
+  if (!args.version) {
+    throw new Error("Missing required --version.");
+  }
+
+  if (args.packages.length === 0) {
+    throw new Error("Specify at least one --package.");
+  }
+
+  if (!Number.isInteger(args.timeoutSeconds) || args.timeoutSeconds <= 0) {
+    throw new Error("--timeout-seconds must be a positive integer.");
+  }
+
+  if (!Number.isInteger(args.pollSeconds) || args.pollSeconds <= 0) {
+    throw new Error("--poll-seconds must be a positive integer.");
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizePackageId(packageId) {
+  return packageId.trim().toLowerCase();
+}
+
+async function isVersionAvailable(source, packageId, version) {
+  const normalizedPackageId = normalizePackageId(packageId);
+  const url = `${source.replace(/\/$/, "")}/${encodeURIComponent(normalizedPackageId)}/index.json`;
+
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        "User-Agent": "js2il-release-workflow/1.0",
+      },
+    });
+  } catch (error) {
+    return {
+      available: false,
+      message: `${packageId}: request failed (${error.message})`,
+    };
+  }
+
+  if (response.status === 404) {
+    return {
+      available: false,
+      message: `${packageId}: package index not published yet`,
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      available: false,
+      message: `${packageId}: package index returned HTTP ${response.status}`,
+    };
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    return {
+      available: false,
+      message: `${packageId}: invalid JSON (${error.message})`,
+    };
+  }
+
+  const versions = Array.isArray(payload?.versions) ? payload.versions : [];
+  return versions.includes(version)
+    ? { available: true, message: `${packageId}: ${version} available` }
+    : { available: false, message: `${packageId}: ${version} not indexed yet` };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+
+  validateArgs(args);
+
+  const deadline = Date.now() + (args.timeoutSeconds * 1000);
+  const packageIds = [...new Set(args.packages)];
+  const unavailable = new Set(packageIds);
+
+  process.stdout.write(
+    `Waiting for NuGet version ${args.version} across ${packageIds.join(", ")} ` +
+      `(timeout ${args.timeoutSeconds}s, poll ${args.pollSeconds}s)\n`
+  );
+
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    attempt++;
+    process.stdout.write(`Attempt ${attempt}: checking ${unavailable.size} package(s)\n`);
+
+    const checks = await Promise.all(
+      [...unavailable].map(async (packageId) => ({
+        packageId,
+        result: await isVersionAvailable(args.source, packageId, args.version),
+      }))
+    );
+
+    for (const check of checks) {
+      process.stdout.write(`- ${check.result.message}\n`);
+      if (check.result.available) {
+        unavailable.delete(check.packageId);
+      }
+    }
+
+    if (unavailable.size === 0) {
+      process.stdout.write(`All packages are available for version ${args.version}.\n`);
+      return 0;
+    }
+
+    if (Date.now() + (args.pollSeconds * 1000) >= deadline) {
+      break;
+    }
+
+    await delay(args.pollSeconds * 1000);
+  }
+
+  process.stderr.write(
+    `Timed out waiting for version ${args.version}. Missing packages: ${[...unavailable].join(", ")}\n`
+  );
+  return 1;
+}
+
+main()
+  .then((exitCode) => {
+    if (exitCode !== 0) {
+      process.exit(exitCode);
+    }
+  })
+  .catch((error) => {
+    process.stderr.write(`${error?.stack || String(error)}\n`);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- wait for published release workflows to block on actual NuGet package availability
- cover the full released package set needed by smoke and benchmark jobs
- keep the existing install/restore retry loops as a secondary safeguard

## Validation
- node scripts/waitForNuGetPackageVersions.js --version 0.9.24 --package js2il --package Js2IL.Runtime --package Js2IL.SDK --timeout-seconds 10 --poll-seconds 1
- node scripts/waitForNuGetPackageVersions.js --version 0.9.24 --package Js2IL.Core --package Js2IL.Runtime --timeout-seconds 10 --poll-seconds 1
- dotnet tool install --tool-path .tmp-js2il-tool js2il --version 0.9.24
- dotnet restore tests/performance/Benchmarks/Benchmarks.csproj --no-cache -p:UsePublishedJs2ILPackages=true -p:Js2ILPackageVersion=0.9.24
- dotnet restore samples/Hosting.Basic/host/Hosting.Basic.csproj -p:Js2ILRuntimePackageVersion=0.9.24