### PR TITLE
fix(test262): unskip issue 1107 built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- compiler/runtime/tests/docs/test262: fix issue #1107 by unskipping Date, Number, and RegExp built-in test262 ports; Date constructor metadata now matches `name`/`length`, `new Date(date)` copies the Date value without user coercion, Number exposes `EPSILON`, `parseFloat`, and `parseInt`, and discarded `Number(value)` calls still perform abrupt `ToNumber` coercion.
 - compiler/runtime/tests/docs/test262: unskip supported non-eval test262 ports covering Date constructor visibility, strict assignment to read-only intrinsic data properties, named function-expression self bindings, and generator method construction/call semantics while keeping eval-dependent cases explicitly skipped.
 
 ## v0.9.24 - 2026-05-22

--- a/docs/ECMA262/21/Section21_1.json
+++ b/docs/ECMA262/21/Section21_1.json
@@ -18,7 +18,7 @@
     {
       "clause": "21.1.1.1",
       "title": "Number ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-number-constructor-number-value"
     },
     {
@@ -30,7 +30,7 @@
     {
       "clause": "21.1.2.1",
       "title": "Number.EPSILON",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-number.epsilon"
     },
     {
@@ -96,13 +96,13 @@
     {
       "clause": "21.1.2.12",
       "title": "Number.parseFloat ( string )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-number.parsefloat"
     },
     {
       "clause": "21.1.2.13",
       "title": "Number.parseInt ( string , radix )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-number.parseint"
     },
     {
@@ -177,5 +177,45 @@
       "status": "Untracked",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-number-instances"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "21.1.1.1",
+        "feature": "Number ( value )",
+        "status": "Supported with Limitations",
+        "test262Paths": [
+          "built-ins/Number/return-abrupt-tonumber-value.js"
+        ],
+        "notes": "Direct calls to the global Number function are lowered to TypeUtilities.ToNumber and preserve observable abrupt completions even when the converted value is discarded. Wrapper construction is supported for the currently modeled Number object surface, but full Number constructor/prototype semantics remain incomplete."
+      },
+      {
+        "clause": "21.1.2.1",
+        "feature": "Number.EPSILON",
+        "status": "Supported",
+        "test262Paths": [
+          "built-ins/Number/EPSILON.js"
+        ],
+        "notes": "Exposed on the Number constructor with non-writable, non-enumerable, non-configurable data-property attributes."
+      },
+      {
+        "clause": "21.1.2.12",
+        "feature": "Number.parseFloat",
+        "status": "Supported",
+        "test262Paths": [
+          "built-ins/Number/parseFloat.js"
+        ],
+        "notes": "Exposed as the same function value as the global parseFloat property with writable, non-enumerable, configurable data-property attributes."
+      },
+      {
+        "clause": "21.1.2.13",
+        "feature": "Number.parseInt",
+        "status": "Supported",
+        "test262Paths": [
+          "built-ins/Number/parseInt.js"
+        ],
+        "notes": "Exposed as the same function value as the global parseInt property with writable, non-enumerable, configurable data-property attributes."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/21/Section21_1.md
+++ b/docs/ECMA262/21/Section21_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section21](Section21.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-05-23T13:44:44Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -15,9 +15,9 @@
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
 | 21.1.1 | The Number Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number-constructor) |
-| 21.1.1.1 | Number ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number-constructor-number-value) |
+| 21.1.1.1 | Number ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-number-constructor-number-value) |
 | 21.1.2 | Properties of the Number Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-number-constructor) |
-| 21.1.2.1 | Number.EPSILON | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.epsilon) |
+| 21.1.2.1 | Number.EPSILON | Supported | [tc39.es](https://tc39.es/ecma262/#sec-number.epsilon) |
 | 21.1.2.2 | Number.isFinite ( number ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.isfinite) |
 | 21.1.2.3 | Number.isInteger ( number ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.isinteger) |
 | 21.1.2.4 | Number.isNaN ( number ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.isnan) |
@@ -28,8 +28,8 @@
 | 21.1.2.9 | Number.MIN_VALUE | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.min_value) |
 | 21.1.2.10 | Number.NaN | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.nan) |
 | 21.1.2.11 | Number.NEGATIVE_INFINITY | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.negative_infinity) |
-| 21.1.2.12 | Number.parseFloat ( string ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.parsefloat) |
-| 21.1.2.13 | Number.parseInt ( string , radix ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.parseint) |
+| 21.1.2.12 | Number.parseFloat ( string ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-number.parsefloat) |
+| 21.1.2.13 | Number.parseInt ( string , radix ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-number.parseint) |
 | 21.1.2.14 | Number.POSITIVE_INFINITY | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.positive_infinity) |
 | 21.1.2.15 | Number.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype) |
 | 21.1.3 | Properties of the Number Prototype Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-number-prototype-object) |
@@ -42,4 +42,32 @@
 | 21.1.3.7 | Number.prototype.valueOf ( ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.prototype.valueof) |
 | 21.1.3.7.1 | ThisNumberValue ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-thisnumbervalue) |
 | 21.1.4 | Properties of Number Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-number-instances) |
+
+## Support
+
+Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 21.1.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-number-constructor-number-value))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Number ( value ) | Supported with Limitations |  | `built-ins/Number/return-abrupt-tonumber-value.js` | Direct calls to the global Number function are lowered to TypeUtilities.ToNumber and preserve observable abrupt completions even when the converted value is discarded. Wrapper construction is supported for the currently modeled Number object surface, but full Number constructor/prototype semantics remain incomplete. |
+
+### 21.1.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-number.epsilon))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Number.EPSILON | Supported |  | `built-ins/Number/EPSILON.js` | Exposed on the Number constructor with non-writable, non-enumerable, non-configurable data-property attributes. |
+
+### 21.1.2.12 ([tc39.es](https://tc39.es/ecma262/#sec-number.parsefloat))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Number.parseFloat | Supported |  | `built-ins/Number/parseFloat.js` | Exposed as the same function value as the global parseFloat property with writable, non-enumerable, configurable data-property attributes. |
+
+### 21.1.2.13 ([tc39.es](https://tc39.es/ecma262/#sec-number.parseint))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Number.parseInt | Supported |  | `built-ins/Number/parseInt.js` | Exposed as the same function value as the global parseInt property with writable, non-enumerable, configurable data-property attributes. |
 

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Arithmetic.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Arithmetic.cs
@@ -150,6 +150,19 @@ internal sealed partial class LIRToILCompiler
                 EmitStoreTemp(convertToNumber.Result, ilEncoder, allocation);
                 break;
 
+            case LIRConvertToNumberDiscard convertToNumberDiscard:
+                EmitLoadTempAsObject(convertToNumberDiscard.Source, ilEncoder, allocation, methodDescriptor);
+                {
+                    var toNumberMref = _memberRefRegistry.GetOrAddMethod(
+                        typeof(JavaScriptRuntime.TypeUtilities),
+                        nameof(JavaScriptRuntime.TypeUtilities.ToNumber),
+                        parameterTypes: new[] { typeof(object) });
+                    ilEncoder.OpCode(ILOpCode.Call);
+                    ilEncoder.Token(toNumberMref);
+                    ilEncoder.OpCode(ILOpCode.Pop);
+                }
+                break;
+
             case LIRConvertToBoolean convertToBoolean:
                 if (!IsMaterialized(convertToBoolean.Result, allocation))
                 {

--- a/src/Compiler/IL/TempLocalAllocator.cs
+++ b/src/Compiler/IL/TempLocalAllocator.cs
@@ -297,6 +297,9 @@ internal static class TempLocalAllocator
             case LIRConvertToNumber convNum:
                 yield return convNum.Source;
                 break;
+            case LIRConvertToNumberDiscard convNumDiscard:
+                yield return convNumDiscard.Source;
+                break;
             case LIRConvertToBoolean convBool:
                 yield return convBool.Source;
                 break;
@@ -887,6 +890,7 @@ internal static class TempLocalAllocator
             case LIRAsyncReject:
             case LIRAsyncStateSwitch:
             case LIRAsyncStoreAwaitedResult:
+            case LIRConvertToNumberDiscard:
                 defined = default;
                 return false;
             case LIRConvertToObject conv:

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
@@ -33,6 +33,24 @@ public sealed partial class HIRToLIRLowerer
             return true;
         }
 
+        if (expression is HIRCallExpression
+            {
+                Callee: HIRVariableExpression { Name.Kind: BindingKind.Global, Name.Name: "Number" }
+            } numberCall)
+        {
+            if (!TryEvaluateCallArguments(numberCall.Arguments, 1, out var args))
+            {
+                return false;
+            }
+
+            if (args.Count > 0)
+            {
+                _methodBodyIR.Instructions.Add(new LIRConvertToNumberDiscard(args[0]));
+            }
+
+            return true;
+        }
+
         return TryLowerExpression(expression, out _);
     }
 

--- a/src/Compiler/IR/LIR/LIRInstructions.cs
+++ b/src/Compiler/IR/LIR/LIRInstructions.cs
@@ -359,6 +359,11 @@ public record LIRConvertToObject(TempVariable Source, Type SourceType, TempVaria
 public record LIRConvertToNumber(TempVariable Source, TempVariable Result) : LIRInstruction;
 
 /// <summary>
+/// Performs ToNumber for its observable coercion effects when the converted value is discarded.
+/// </summary>
+public record LIRConvertToNumberDiscard(TempVariable Source) : LIRInstruction;
+
+/// <summary>
 /// Converts a value (typically an object) to a JavaScript boolean (truthiness) using runtime coercion.
 /// </summary>
 public record LIRConvertToBoolean(TempVariable Source, TempVariable Result) : LIRInstruction;

--- a/src/JavaScriptRuntime/Date.cs
+++ b/src/JavaScriptRuntime/Date.cs
@@ -38,6 +38,7 @@ namespace JavaScriptRuntime
                 case byte b: return b;
                 case bool bo: return bo ? 1 : 0;
                 case JsNull: return 0; // Number(null) === +0
+                case Date date: return date._msSinceEpoch;
                 case string str:
                     // Try parse as number first, then as date string
                     if (double.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out var nd))

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -85,6 +85,7 @@ namespace JavaScriptRuntime
             return JavaScriptRuntime.Array.from(source, mapFn, thisArg);
         };
         private static readonly Func<object?, object?, double> _parseIntValue = parseInt;
+        private static readonly Func<object?, double> _parseFloatValue = parseFloat;
         private static readonly Func<object?, bool> _isFiniteValue = isFinite;
         private static readonly Func<object?, bool> _isNaNValue = isNaN;
         private static readonly Func<object?, bool> _numberIsIntegerValue = JavaScriptRuntime.Number.isInteger;
@@ -361,12 +362,18 @@ namespace JavaScriptRuntime
             DefineIntrinsicConstantDataProperty(_numberFunctionValue, "NaN", double.NaN);
             DefineIntrinsicConstantDataProperty(_numberFunctionValue, "NEGATIVE_INFINITY", double.NegativeInfinity);
             DefineIntrinsicConstantDataProperty(_numberFunctionValue, "POSITIVE_INFINITY", double.PositiveInfinity);
+            DefineIntrinsicConstantDataProperty(_numberFunctionValue, "EPSILON", 2.220446049250313e-16);
+            DefineIntrinsicDataProperty(_numberFunctionValue, "parseFloat", _parseFloatValue);
+            DefineIntrinsicDataProperty(_numberFunctionValue, "parseInt", _parseIntValue);
+            DefineDateConstructorMetadata();
             ConfigureBuiltinFunctionObject(_stringFunctionValue);
             ConfigureBuiltinFunctionObject(_booleanFunctionValue);
             ConfigureBuiltinFunctionObject(_parseIntValue);
+            ConfigureBuiltinFunctionObject(_parseFloatValue);
             ConfigureBuiltinFunctionObject(_isFiniteValue);
             ConfigureBuiltinFunctionObject(_isNaNValue);
             DefineUndefinedPrototypeProperty(_parseIntValue);
+            DefineUndefinedPrototypeProperty(_parseFloatValue);
             DefineUndefinedPrototypeProperty(_isFiniteValue);
             DefineUndefinedPrototypeProperty(_isNaNValue);
 
@@ -668,6 +675,26 @@ namespace JavaScriptRuntime
             });
         }
 
+        private static void DefineDateConstructorMetadata()
+        {
+            PropertyDescriptorStore.DefineOrUpdate(typeof(JavaScriptRuntime.Date), "name", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = "Date"
+            });
+            PropertyDescriptorStore.DefineOrUpdate(typeof(JavaScriptRuntime.Date), "length", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = 7d
+            });
+        }
+
         private static void DefineIntrinsicDataProperty(object target, string key, object? value)
         {
             PropertyDescriptorStore.DefineOrUpdate(target, key, new JsPropertyDescriptor
@@ -885,7 +912,7 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.parseInt), _parseIntValue);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.parseInt), dict[nameof(GlobalThis.parseInt)]);
 
-            dict.TryAdd(nameof(GlobalThis.parseFloat), (Func<object?, double>)parseFloat);
+            dict.TryAdd(nameof(GlobalThis.parseFloat), _parseFloatValue);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.parseFloat), dict[nameof(GlobalThis.parseFloat)]);
 
             dict.TryAdd(nameof(GlobalThis.isFinite), _isFiniteValue);

--- a/tests/Js2IL.Test262.Tests/built-ins/Date/ExecutionTests.cs
+++ b/tests/Js2IL.Test262.Tests/built-ins/Date/ExecutionTests.cs
@@ -18,15 +18,15 @@ public class ExecutionTests : ExecutionTestsBase
     public Task coercion_errors()
         => ExecutionTest("coercion-errors");
 
-    [Fact(DisplayName = "construct_with_date", Skip = "Tracked by #1093: built-ins port is sound but JS2IL does not yet match expected runtime behavior.")]
+    [Fact(DisplayName = "construct_with_date")]
     public Task construct_with_date()
         => ExecutionTest("construct_with_date");
 
-    [Fact(DisplayName = "length", Skip = "Tracked by #1093: built-ins port is sound but JS2IL does not yet match expected runtime behavior.")]
+    [Fact(DisplayName = "length")]
     public Task length()
         => ExecutionTest("length");
 
-    [Fact(DisplayName = "name", Skip = "Tracked by #1093: built-ins port is sound but JS2IL does not yet match expected runtime behavior.")]
+    [Fact(DisplayName = "name")]
     public Task name()
         => ExecutionTest("name");
 

--- a/tests/Js2IL.Test262.Tests/built-ins/Number/ExecutionTests.cs
+++ b/tests/Js2IL.Test262.Tests/built-ins/Number/ExecutionTests.cs
@@ -18,7 +18,7 @@ public class ExecutionTests : ExecutionTestsBase
     public Task _15_7_4_1()
         => ExecutionTest("15.7.4-1");
 
-    [Fact(DisplayName = "EPSILON", Skip = "Tracked by #1093: built-ins port is sound but JS2IL does not yet match expected runtime behavior.")]
+    [Fact(DisplayName = "EPSILON")]
     public Task EPSILON()
         => ExecutionTest("EPSILON");
 
@@ -26,15 +26,15 @@ public class ExecutionTests : ExecutionTestsBase
     public Task NaN()
         => ExecutionTest("NaN");
 
-    [Fact(DisplayName = "parseFloat", Skip = "Tracked by #1093: built-ins port is sound but JS2IL does not yet match expected runtime behavior.")]
+    [Fact(DisplayName = "parseFloat")]
     public Task parseFloat()
         => ExecutionTest("parseFloat");
 
-    [Fact(DisplayName = "parseInt", Skip = "Tracked by #1093: built-ins port is sound but JS2IL does not yet match expected runtime behavior.")]
+    [Fact(DisplayName = "parseInt")]
     public Task parseInt()
         => ExecutionTest("parseInt");
 
-    [Fact(DisplayName = "return-abrupt-tonumber-value", Skip = "Tracked by #1093: built-ins port is sound but JS2IL does not yet match expected runtime behavior.")]
+    [Fact(DisplayName = "return-abrupt-tonumber-value")]
     public Task return_abrupt_tonumber_value()
         => ExecutionTest("return-abrupt-tonumber-value");
 

--- a/tests/Js2IL.Test262.Tests/built-ins/RegExp/ExecutionTests.cs
+++ b/tests/Js2IL.Test262.Tests/built-ins/RegExp/ExecutionTests.cs
@@ -30,7 +30,7 @@ public class ExecutionTests : ExecutionTestsBase
     public Task _15_10_4_1_3()
         => ExecutionTest("15.10.4.1-3");
 
-    [Fact(DisplayName = "15.10.4.1-4", Skip = "Tracked by #1093: built-ins port is sound but JS2IL does not yet match expected runtime behavior.")]
+    [Fact(DisplayName = "15.10.4.1-4")]
     public Task _15_10_4_1_4()
         => ExecutionTest("15.10.4.1-4");
 

--- a/tests/Js2IL.Test262.Tests/built-ins/RegExp/Snapshots/ExecutionTests._15_10_4_1_4.verified.txt
+++ b/tests/Js2IL.Test262.Tests/built-ins/RegExp/Snapshots/ExecutionTests._15_10_4_1_4.verified.txt
@@ -1,0 +1,1 @@
+emptyString


### PR DESCRIPTION
## Summary
- Fixes #1107 by unskipping the Date, Number, and RegExp built-ins test262 ports.
- Adds Date constructor metadata and Date-to-Date construction behavior.
- Exposes Number.EPSILON, Number.parseFloat, and Number.parseInt; preserves discarded Number(value) ToNumber abrupt completions.
- Updates ECMA-262 Number docs and changelog.

## Validation
- dotnet test tests\Js2IL.Test262.Tests\Js2IL.Test262.Tests.csproj --filter "FullyQualifiedName~built_ins.Date.ExecutionTests|FullyQualifiedName~built_ins.Number.ExecutionTests|FullyQualifiedName~built_ins.RegExp.ExecutionTests" --no-restore

Closes #1107
