### PR TITLE
ci: skip changelog-only pull request runs

### DIFF
--- a/.github/workflows/canary-smoke.yml
+++ b/.github/workflows/canary-smoke.yml
@@ -4,6 +4,8 @@ run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.r
 on:
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - "CHANGELOG.md"
   push:
     branches: [ "master" ]
   schedule:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - "CHANGELOG.md"
 
 jobs:
   build:

--- a/.github/workflows/test262-mvp.yml
+++ b/.github/workflows/test262-mvp.yml
@@ -4,6 +4,8 @@ run-name: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.event.i
 on:
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - "CHANGELOG.md"
   push:
     branches: [ "master" ]
   schedule:


### PR DESCRIPTION
## Summary
- ignore changelog-only pull requests in the .NET, canary smoke, and test262 MVP workflows
- keep normal push and mixed-change pull request behavior unchanged

## Testing
- not run (workflow trigger change only)