### PR TITLE
ci: fix benchmark suite publish wait for reruns

### DIFF
--- a/.github/workflows/benchmarkdotnet-suite.yml
+++ b/.github/workflows/benchmarkdotnet-suite.yml
@@ -75,8 +75,8 @@ jobs:
         with:
           script: |
             const workflowId = 'publish-tool.yml';
-            const targetSha = process.env.GITHUB_SHA;
-            const targetRef = process.env.GITHUB_REF_NAME;
+            const targetVersion = process.env.JROC_PACKAGE_VERSION;
+            const targetTag = `v${targetVersion}`;
             const deadlineMs = 20 * 60 * 1000;
             const pollMs = 15 * 1000;
             const startedAt = Date.now();
@@ -85,37 +85,40 @@ jobs:
               const response = await github.request('GET /repos/{owner}/{repo}/actions/runs', {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                event: 'push',
                 per_page: 50
               });
 
-              const run = response.data.workflow_runs.find(candidate =>
+              const matchingRuns = response.data.workflow_runs.filter(candidate =>
                 candidate.path === '.github/workflows/publish-tool.yml' &&
-                candidate.head_sha === targetSha &&
-                candidate.head_branch === targetRef);
+                (candidate.display_title ?? '').includes(targetTag)
+              );
 
-              if (!run) {
-                core.info(`Waiting for ${workflowId} run for ${targetRef} (${targetSha}) to appear...`);
+              if (matchingRuns.length === 0) {
+                core.info(`Waiting for ${workflowId} run for ${targetTag} to appear...`);
                 await new Promise(resolve => setTimeout(resolve, pollMs));
                 continue;
               }
 
-              core.info(`Found ${workflowId} run ${run.id} with status=${run.status} conclusion=${run.conclusion ?? 'n/a'}`);
+              const successfulRun = matchingRuns.find(candidate =>
+                candidate.status === 'completed' && candidate.conclusion === 'success');
+              if (successfulRun) {
+                core.info(`Found successful ${workflowId} run ${successfulRun.id}; proceeding to package restore.`);
+                return;
+              }
 
-              if (run.status !== 'completed') {
+              const inProgressRun = matchingRuns.find(candidate => candidate.status !== 'completed');
+              if (inProgressRun) {
+                core.info(`Waiting for ${workflowId} run ${inProgressRun.id} to complete for ${targetTag}...`);
                 await new Promise(resolve => setTimeout(resolve, pollMs));
                 continue;
               }
 
-              if (run.conclusion !== 'success') {
-                throw new Error(`${workflowId} run ${run.id} completed with conclusion=${run.conclusion}`);
-              }
-
-              core.info(`${workflowId} completed successfully; proceeding to package restore.`);
-              return;
+              const latestCompleted = matchingRuns[0];
+              core.info(`No successful ${workflowId} run yet for ${targetTag}. Latest completed run ${latestCompleted.id} concluded ${latestCompleted.conclusion ?? 'n/a'}. Retrying...`);
+              await new Promise(resolve => setTimeout(resolve, pollMs));
             }
 
-            throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
+            throw new Error(`Timed out waiting for a successful ${workflowId} run for ${targetTag}.`);
 
       - name: Wait for NuGet package availability
         if: env.USE_PUBLISHED_JROC_PACKAGES == 'true'


### PR DESCRIPTION
## Summary
- fix BenchmarkDotNet release gating so reruns do not fail solely because an earlier publish-tool.yml run for the tag failed
- wait for any successful publish-tool.yml run matching the release version tag (e.g. 0.9.28), including manual workflow_dispatch publish runs
- keep polling until timeout instead of hard-failing on first failed publish run

## Why
BenchmarkDotNet Performance Suite currently fails reruns when it finds a failed publish run for the release tag/sha, even if packages are later published successfully via another run. This change makes the wait logic resilient and aligned with package availability gating that follows.