### PR TITLE
ci: fix linux/windows smoke publish wait for reruns

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -48,8 +48,8 @@ jobs:
         with:
           script: |
             const workflowId = 'publish-tool.yml';
-            const targetSha = process.env.GITHUB_SHA;
-            const targetRef = process.env.GITHUB_REF_NAME;
+            const targetVersion = process.env.TOOL_VERSION;
+            const targetTag = `v${targetVersion}`;
             const deadlineMs = 20 * 60 * 1000;
             const pollMs = 15 * 1000;
             const startedAt = Date.now();
@@ -58,37 +58,40 @@ jobs:
               const response = await github.request('GET /repos/{owner}/{repo}/actions/runs', {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                event: 'push',
                 per_page: 50
               });
 
-              const run = response.data.workflow_runs.find(candidate =>
+              const matchingRuns = response.data.workflow_runs.filter(candidate =>
                 candidate.path === '.github/workflows/publish-tool.yml' &&
-                candidate.head_sha === targetSha &&
-                candidate.head_branch === targetRef);
+                (candidate.display_title ?? '').includes(targetTag)
+              );
 
-              if (!run) {
-                core.info(`Waiting for ${workflowId} run for ${targetRef} (${targetSha}) to appear...`);
+              if (matchingRuns.length === 0) {
+                core.info(`Waiting for ${workflowId} run for ${targetTag} to appear...`);
                 await new Promise(resolve => setTimeout(resolve, pollMs));
                 continue;
               }
 
-              core.info(`Found ${workflowId} run ${run.id} with status=${run.status} conclusion=${run.conclusion ?? 'n/a'}`);
+              const successfulRun = matchingRuns.find(candidate =>
+                candidate.status === 'completed' && candidate.conclusion === 'success');
+              if (successfulRun) {
+                core.info(`Found successful ${workflowId} run ${successfulRun.id}; proceeding to tool install.`);
+                return;
+              }
 
-              if (run.status !== 'completed') {
+              const inProgressRun = matchingRuns.find(candidate => candidate.status !== 'completed');
+              if (inProgressRun) {
+                core.info(`Waiting for ${workflowId} run ${inProgressRun.id} to complete for ${targetTag}...`);
                 await new Promise(resolve => setTimeout(resolve, pollMs));
                 continue;
               }
 
-              if (run.conclusion !== 'success') {
-                throw new Error(`${workflowId} run ${run.id} completed with conclusion=${run.conclusion}`);
-              }
-
-              core.info(`${workflowId} completed successfully; proceeding to tool install.`);
-              return;
+              const latestCompleted = matchingRuns[0];
+              core.info(`No successful ${workflowId} run yet for ${targetTag}. Latest completed run ${latestCompleted.id} concluded ${latestCompleted.conclusion ?? 'n/a'}. Retrying...`);
+              await new Promise(resolve => setTimeout(resolve, pollMs));
             }
 
-            throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
+            throw new Error(`Timed out waiting for a successful ${workflowId} run for ${targetTag}.`);
 
       - name: Wait for NuGet package availability
         if: github.event_name == 'release'

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -50,8 +50,8 @@ jobs:
         with:
           script: |
             const workflowId = 'publish-tool.yml';
-            const targetSha = process.env.GITHUB_SHA;
-            const targetRef = process.env.GITHUB_REF_NAME;
+            const targetVersion = process.env.TOOL_VERSION;
+            const targetTag = `v${targetVersion}`;
             const deadlineMs = 20 * 60 * 1000;
             const pollMs = 15 * 1000;
             const startedAt = Date.now();
@@ -60,37 +60,40 @@ jobs:
               const response = await github.request('GET /repos/{owner}/{repo}/actions/runs', {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                event: 'push',
                 per_page: 50
               });
 
-              const run = response.data.workflow_runs.find(candidate =>
+              const matchingRuns = response.data.workflow_runs.filter(candidate =>
                 candidate.path === '.github/workflows/publish-tool.yml' &&
-                candidate.head_sha === targetSha &&
-                candidate.head_branch === targetRef);
+                (candidate.display_title ?? '').includes(targetTag)
+              );
 
-              if (!run) {
-                core.info(`Waiting for ${workflowId} run for ${targetRef} (${targetSha}) to appear...`);
+              if (matchingRuns.length === 0) {
+                core.info(`Waiting for ${workflowId} run for ${targetTag} to appear...`);
                 await new Promise(resolve => setTimeout(resolve, pollMs));
                 continue;
               }
 
-              core.info(`Found ${workflowId} run ${run.id} with status=${run.status} conclusion=${run.conclusion ?? 'n/a'}`);
+              const successfulRun = matchingRuns.find(candidate =>
+                candidate.status === 'completed' && candidate.conclusion === 'success');
+              if (successfulRun) {
+                core.info(`Found successful ${workflowId} run ${successfulRun.id}; proceeding to tool install.`);
+                return;
+              }
 
-              if (run.status !== 'completed') {
+              const inProgressRun = matchingRuns.find(candidate => candidate.status !== 'completed');
+              if (inProgressRun) {
+                core.info(`Waiting for ${workflowId} run ${inProgressRun.id} to complete for ${targetTag}...`);
                 await new Promise(resolve => setTimeout(resolve, pollMs));
                 continue;
               }
 
-              if (run.conclusion !== 'success') {
-                throw new Error(`${workflowId} run ${run.id} completed with conclusion=${run.conclusion}`);
-              }
-
-              core.info(`${workflowId} completed successfully; proceeding to tool install.`);
-              return;
+              const latestCompleted = matchingRuns[0];
+              core.info(`No successful ${workflowId} run yet for ${targetTag}. Latest completed run ${latestCompleted.id} concluded ${latestCompleted.conclusion ?? 'n/a'}. Retrying...`);
+              await new Promise(resolve => setTimeout(resolve, pollMs));
             }
 
-            throw new Error(`Timed out waiting for ${workflowId} to publish packages for ${targetRef}.`);
+            throw new Error(`Timed out waiting for a successful ${workflowId} run for ${targetTag}.`);
 
       - name: Wait for NuGet package availability
         if: github.event_name == 'release'


### PR DESCRIPTION
## Summary
- apply the same rerun-safe publish wait logic to both smoke workflows:
  - .github/workflows/linux-smoke.yml
  - .github/workflows/windows-smoke.yml
- wait for any successful publish-tool.yml run matching the release version tag
- stop hard-failing immediately when the first matching publish run is failed

## Why
Release reruns can fail even after packages are successfully published later (for example via manual workflow dispatch) when the workflow only checks one failed publish run by original tag/sha.