### PR TITLE
docs(changelog): add Unreleased workflow fixes entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- ci/workflows: switch NuGet publishing to trusted publishing (OIDC) and harden release-following benchmark/smoke workflow gating so reruns wait for a successful `publish-tool.yml` run by release version instead of failing on an earlier failed publish attempt.
 
 ## v0.9.28 - 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Modern JavaScript dotnet compiler.
 
 JROC compiles JavaScript source code to native .NET assemblies. It includes runtime support for some Node.js core modules, enabling JavaScript applications and libraries to run on the .NET runtime.
 
+For release notes and unreleased changes, see `CHANGELOG.md`.
+
 ## Usage
 
 Prerequisite: .NET 10 SDK.


### PR DESCRIPTION
## Summary
- add an Unreleased changelog entry documenting recent workflow reliability updates
- note trusted NuGet publishing (OIDC) and rerun-safe publish-wait handling in release-following benchmark/smoke workflows