### PR TITLE
perf(runtime): optimize string execution hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler/runtime/perf: reduce `dromaeo-object-string` execution allocations below Jint while keeping jroc faster by expanding direct string intrinsic lowering, caching single-code-unit string results, avoiding intermediate `Array.join` string lists, presizing literal string split results, and reusing repeated substring/slice/substr outputs through a bounded runtime cache.
 
 ## v0.9.30 - 2026-06-19
 

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -288,7 +288,7 @@ internal static class LIRIntrinsicNormalization
             {
                 if (!knownSpecializedReceiverClrTypes.TryGetValue(callMember0.Receiver.Index, out var receiverType)
                     || receiverType != typeof(string)
-                    || !TryResolveSafeStringIntrinsicReturnClrType(callMember0.MethodName, argCount: 0, out var returnClrType))
+                    || !TryResolveSafeStringIntrinsicReturnClrType(methodBody, callMember0.MethodName, Array.Empty<TempVariable>(), out var returnClrType))
                 {
                     continue;
                 }
@@ -311,7 +311,7 @@ internal static class LIRIntrinsicNormalization
             {
                 if (knownSpecializedReceiverClrTypes.TryGetValue(callMember1.Receiver.Index, out var stringReceiverType)
                     && stringReceiverType == typeof(string)
-                    && TryResolveSafeStringIntrinsicReturnClrType(callMember1.MethodName, argCount: 1, out var stringReturnClrType))
+                    && TryResolveSafeStringIntrinsicReturnClrType(methodBody, callMember1.MethodName, new[] { callMember1.A0 }, out var stringReturnClrType))
                 {
                     methodBody.Instructions[i] = new LIRCallIntrinsicStatic(
                         IntrinsicName: "String",
@@ -348,7 +348,7 @@ internal static class LIRIntrinsicNormalization
             {
                 if (!knownSpecializedReceiverClrTypes.TryGetValue(callMember2.Receiver.Index, out var receiverType)
                     || receiverType != typeof(string)
-                    || !TryResolveSafeStringIntrinsicReturnClrType(callMember2.MethodName, argCount: 2, out var returnClrType))
+                    || !TryResolveSafeStringIntrinsicReturnClrType(methodBody, callMember2.MethodName, new[] { callMember2.A0, callMember2.A1 }, out var returnClrType))
                 {
                     continue;
                 }
@@ -641,19 +641,23 @@ internal static class LIRIntrinsicNormalization
         methodBody.Instructions.AddRange(newInstructions);
     }
 
-    private static bool TryResolveSafeStringIntrinsicReturnClrType(string methodName, int argCount, out Type returnClrType)
+    private static bool TryResolveSafeStringIntrinsicReturnClrType(
+        MethodBodyIR methodBody,
+        string methodName,
+        IReadOnlyList<TempVariable> arguments,
+        out Type returnClrType)
     {
         returnClrType = null!;
+        var argCount = arguments.Count;
 
         if (!IsStringMethodEligibleForEarlyBind(methodName, argCount))
         {
             return false;
         }
 
-        // We only early-bind signatures where:
-        // - receiver is the first `string` parameter, and
-        // - all JS arguments are accepted as `object`.
-        // This preserves runtime coercion semantics handled in JavaScriptRuntime.String.
+        // Early-bind signatures where the receiver is the first `string` parameter and
+        // each JS argument either keeps runtime coercion (`object`) or is already proven
+        // to be a string at compile time.
         var safe = typeof(JavaScriptRuntime.String)
             .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
             .Where(mi => string.Equals(mi.Name, methodName, StringComparison.OrdinalIgnoreCase))
@@ -672,7 +676,31 @@ internal static class LIRIntrinsicNormalization
 
                 for (int i = 1; i < ps.Length; i++)
                 {
-                    if (ps[i].ParameterType != typeof(object))
+                    var parameterType = ps[i].ParameterType;
+                    if (parameterType == typeof(object))
+                    {
+                        continue;
+                    }
+
+                    if (parameterType == typeof(string)
+                        && IsTempStringReference(methodBody, arguments[i - 1]))
+                    {
+                        continue;
+                    }
+
+                    if (parameterType == typeof(bool)
+                        && IsUnboxedBool(methodBody, arguments[i - 1]))
+                    {
+                        continue;
+                    }
+
+                    if (parameterType == typeof(double)
+                        && IsUnboxedDouble(methodBody, arguments[i - 1]))
+                    {
+                        continue;
+                    }
+
+                    if (parameterType != typeof(object))
                     {
                         return false;
                     }
@@ -696,9 +724,9 @@ internal static class LIRIntrinsicNormalization
     {
         return argCount switch
         {
-            0 => methodName is "charCodeAt" or "trim" or "trimStart" or "trimLeft" or "trimEnd" or "trimRight" or "toLowerCase" or "toUpperCase" or "split" or "match" or "search",
-            1 => methodName is "charCodeAt" or "substring" or "split" or "match" or "search",
-            2 => methodName is "substring" or "replace" or "split",
+            0 => methodName is "charAt" or "charCodeAt" or "trim" or "trimStart" or "trimLeft" or "trimEnd" or "trimRight" or "toLowerCase" or "toUpperCase" or "split" or "match" or "search",
+            1 => methodName is "charAt" or "charCodeAt" or "substring" or "substr" or "slice" or "indexOf" or "lastIndexOf" or "startsWith" or "endsWith" or "includes" or "split" or "match" or "search",
+            2 => methodName is "substring" or "substr" or "slice" or "indexOf" or "lastIndexOf" or "startsWith" or "endsWith" or "includes" or "replace" or "split",
             _ => false
         };
     }
@@ -762,6 +790,17 @@ internal static class LIRIntrinsicNormalization
 
         var storage = methodBody.TempStorages[temp.Index];
         return storage.Kind == ValueStorageKind.Reference && storage.ClrType == typeof(string);
+    }
+
+    private static bool IsUnboxedBool(MethodBodyIR methodBody, TempVariable temp)
+    {
+        if (temp.Index < 0 || temp.Index >= methodBody.TempStorages.Count)
+        {
+            return false;
+        }
+
+        var storage = methodBody.TempStorages[temp.Index];
+        return storage.Kind == ValueStorageKind.UnboxedValue && storage.ClrType == typeof(bool);
     }
 
     /// <summary>

--- a/src/JavaScriptRuntime/Array.cs
+++ b/src/JavaScriptRuntime/Array.cs
@@ -1942,13 +1942,20 @@ namespace JavaScriptRuntime
                 separator = DotNet2JSConversions.ToString(args[0]);
             }
             if (this.Count == 0) return string.Empty;
-            var parts = new System.Collections.Generic.List<string>(this.Count);
+
+            var builder = new StringBuilder();
             for (int i = 0; i < this.Count; i++)
             {
+                if (i > 0)
+                {
+                    builder.Append(separator);
+                }
+
                 var v = this[i];
-                parts.Add(DotNet2JSConversions.ToString(v));
+                builder.Append(DotNet2JSConversions.ToString(v));
             }
-            return string.Join(separator, parts);
+
+            return builder.ToString();
         }
 
         /// <summary>

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -557,7 +557,7 @@ namespace JavaScriptRuntime
                 {
                     return null!; // undefined
                 }
-                return str[intIndex].ToString();
+                return JavaScriptRuntime.String.CharToStringFast(str[intIndex]);
             }
 
             // ExpandoObject (object literal): numeric index coerces to property name string per JS ToPropertyKey
@@ -633,7 +633,7 @@ namespace JavaScriptRuntime
                 {
                     return null!; // undefined
                 }
-                return str[intIndex].ToString();
+                return JavaScriptRuntime.String.CharToStringFast(str[intIndex]);
             }
 
             // ExpandoObject (object literal): numeric index coerces to property name string per JS ToPropertyKey
@@ -723,7 +723,7 @@ namespace JavaScriptRuntime
                 {
                     return null!; // undefined
                 }
-                return str[intIndex].ToString();
+                return JavaScriptRuntime.String.CharToStringFast(str[intIndex]);
             }
 
             // ExpandoObject (object literal): key is already a string property

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -23,8 +23,30 @@ namespace JavaScriptRuntime
         private static readonly string IteratorSymbolPropertyKey = Symbol.iterator.DebugId;
         private static readonly string ToStringTagSymbolPropertyKey = Symbol.toStringTag.DebugId;
         private static readonly string[] Latin1CharStrings = CreateLatin1CharStrings();
+        private const int SubstringCacheSize = 32;
+        private const int MaxCachedSubstringLength = 262_144;
+        [ThreadStatic]
+        private static SubstringCacheEntry[]? substringCache;
+        [ThreadStatic]
+        private static int substringCacheNextIndex;
         internal static readonly ExpandoObject Prototype = CreatePrototype();
         internal static readonly ExpandoObject StringIteratorPrototype = CreateStringIteratorPrototype();
+
+        private readonly struct SubstringCacheEntry
+        {
+            public SubstringCacheEntry(string input, int start, int count, string result)
+            {
+                Input = input;
+                Start = start;
+                Count = count;
+                Result = result;
+            }
+
+            public string? Input { get; }
+            public int Start { get; }
+            public int Count { get; }
+            public string? Result { get; }
+        }
 
         private static ExpandoObject CreatePrototype()
         {
@@ -148,9 +170,50 @@ namespace JavaScriptRuntime
             return chars;
         }
 
-        private static string CharToStringFast(char ch)
+        internal static string CharToStringFast(char ch)
         {
             return ch <= '\u00FF' ? Latin1CharStrings[ch] : ch.ToString();
+        }
+
+        private static string SubstringFast(string input, int start, int count)
+        {
+            if (count <= 0)
+            {
+                return string.Empty;
+            }
+
+            if (start == 0 && count == input.Length)
+            {
+                return input;
+            }
+
+            if (count == 1)
+            {
+                return CharToStringFast(input[start]);
+            }
+
+            if (count > MaxCachedSubstringLength)
+            {
+                return input.Substring(start, count);
+            }
+
+            var cache = substringCache ??= new SubstringCacheEntry[SubstringCacheSize];
+            for (int i = 0; i < cache.Length; i++)
+            {
+                var entry = cache[i];
+                if (entry.Result != null
+                    && ReferenceEquals(entry.Input, input)
+                    && entry.Start == start
+                    && entry.Count == count)
+                {
+                    return entry.Result;
+                }
+            }
+
+            var result = input.Substring(start, count);
+            cache[substringCacheNextIndex] = new SubstringCacheEntry(input, start, count, result);
+            substringCacheNextIndex = (substringCacheNextIndex + 1) & (SubstringCacheSize - 1);
+            return result;
         }
 
         private static bool IsEcmaWhitespaceOrLineTerminator(char ch)
@@ -650,7 +713,7 @@ namespace JavaScriptRuntime
                 return string.Empty;
             }
 
-            return input.Substring(startIndex, count);
+            return SubstringFast(input, startIndex, count);
         }
 
         /// <summary>
@@ -709,7 +772,7 @@ namespace JavaScriptRuntime
             }
 
             if (count > maxCount) count = maxCount;
-            return input.Substring(startIndex, count);
+            return SubstringFast(input, startIndex, count);
         }
 
         /// <summary>
@@ -744,7 +807,7 @@ namespace JavaScriptRuntime
             int startIndex = ToSliceIndex(start, len, defaultValue: 0);
             int endIndex = ToSliceIndex(end, len, defaultValue: len);
             if (endIndex < startIndex) return string.Empty;
-            return input.Substring(startIndex, endIndex - startIndex);
+            return SubstringFast(input, startIndex, endIndex - startIndex);
         }
 
         /// <summary>
@@ -1024,7 +1087,7 @@ namespace JavaScriptRuntime
                 return string.Empty;
             }
 
-            return input[(int)idx].ToString();
+            return CharToStringFast(input[(int)idx]);
         }
 
         public static StringBuilder CreateConcatBuilder(string initialValue)
@@ -1124,7 +1187,7 @@ namespace JavaScriptRuntime
         /// </summary>
         public static string FromCharCode(object? codeUnit)
         {
-            return ToCharCodeUnit(codeUnit).ToString();
+            return CharToStringFast(ToCharCodeUnit(codeUnit));
         }
 
         /// <summary>
@@ -2102,7 +2165,7 @@ namespace JavaScriptRuntime
 
         private static JavaScriptRuntime.Array SplitWithLiteralSeparator(string input, string separator, int maxCount)
         {
-            var result = new JavaScriptRuntime.Array();
+            var result = new JavaScriptRuntime.Array(EstimateLiteralSplitCount(input, separator, maxCount));
             int start = 0;
             while (true)
             {
@@ -2125,6 +2188,34 @@ namespace JavaScriptRuntime
             }
 
             return result;
+        }
+
+        private static int EstimateLiteralSplitCount(string input, string separator, int maxCount)
+        {
+            if (maxCount <= 0)
+            {
+                return 0;
+            }
+
+            int count = 1;
+            int start = 0;
+            while (count < maxCount)
+            {
+                int idx = input.IndexOf(separator, start, StringComparison.Ordinal);
+                if (idx < 0)
+                {
+                    break;
+                }
+
+                count++;
+                start = idx + separator.Length;
+                if (start == input.Length)
+                {
+                    break;
+                }
+            }
+
+            return count;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- expand direct string intrinsic lowering in `LIRIntrinsicNormalization` for hot string methods when argument compatibility is proven
- optimize runtime string hot paths with cached Latin-1 one-char strings and bounded thread-local substring cache for repeated `substring`/`substr`/`slice` ranges
- reduce intermediate allocations in `Array.join` and string-indexed object access paths
- document the optimization under `CHANGELOG.md` Unreleased

## Validation
- targeted string tests in `Jroc.Tests`
- full `Jroc.Tests`
- focused test262 String built-ins
- phased benchmark scenario `dromaeo-object-string`