### PR TITLE
feat(runtime): add Promise.try support and enable test262 ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- runtime/tests/docs: add `Promise.try` support, including constructor-aware capability creation, callback invocation with forwarded arguments, and Promise resolve/reject wiring; enable the new non-`eval` test262 `Promise.try` metadata ports and refresh ECMA-262 Promise docs.
 
 ## v0.9.31 - 2026-06-20
 

--- a/docs/ECMA262/27/Section27_2.json
+++ b/docs/ECMA262/27/Section27_2.json
@@ -191,7 +191,7 @@
                        {
                            "clause":  "27.2.4.8",
                            "title":  "Promise.try ( callback , ... args )",
-                           "status":  "Not Yet Supported",
+                           "status":  "Supported",
                            "specUrl":  "https://tc39.es/ecma262/#sec-promise.try"
                        },
                        {
@@ -279,6 +279,19 @@
                                                            "tests/Jroc.Test262.Tests/built-ins/Promise/reject/JavaScript/prop-desc.js"
                                                         ],
                                         "notes":  "Constructor accepts an executor delegate and supports resolving/rejecting, including thenable assimilation in Promise.resolve. The checked-in test262 coverage now also verifies Promise.resolve and Promise.reject name/length/property-descriptor metadata."
+                                    },
+                                    {
+                                        "clause":  "27.2.4.8",
+                                        "feature":  "Promise.try(callback, ...args)",
+                                        "status":  "Supported",
+                                        "specUrl":  "https://tc39.es/ecma262/#sec-promise.try",
+                                        "testScripts":  [
+                                                            "tests/Jroc.Test262.Tests/built-ins/Promise/try/ExecutionTests.cs",
+                                                            "tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/length.js",
+                                                            "tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/name.js",
+                                                            "tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/prop-desc.js"
+                                                        ],
+                                        "notes":  "Adds Promise.try as a constructor-aware static helper that creates a new capability, invokes the callback with forwarded arguments, and resolves or rejects based on the callback completion."
                                     },
                                     {
                                         "clause":  "27.2.4.9",

--- a/docs/ECMA262/27/Section27_2.md
+++ b/docs/ECMA262/27/Section27_2.md
@@ -42,7 +42,7 @@
 | 27.2.4.6 | Promise.reject ( r ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.reject) |
 | 27.2.4.7 | Promise.resolve ( x ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.resolve) |
 | 27.2.4.7.1 | PromiseResolve ( C , x ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-promise-resolve) |
-| 27.2.4.8 | Promise.try ( callback , ... args ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.try) |
+| 27.2.4.8 | Promise.try ( callback , ... args ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.try) |
 | 27.2.4.9 | Promise.withResolvers ( ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-promise.withResolvers) |
 | 27.2.4.10 | get Promise [ %Symbol.species% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-promise-%symbol.species%) |
 | 27.2.5 | Properties of the Promise Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-promise-prototype-object) |
@@ -69,6 +69,12 @@ Feature-level support tracking with test script references.
 | Feature name | Status | Test scripts | Notes |
 |---|---|---|---|
 | Promise.all / allSettled / any / race | Supported | [`Promise_All_AllResolved.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_All_AllResolved.js)<br>[`Promise_All_OneRejected.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_All_OneRejected.js)<br>[`Promise_All_EmptyArray.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_All_EmptyArray.js)<br>[`Promise_AllSettled_MixedResults.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_AllSettled_MixedResults.js)<br>[`Promise_AllSettled_AllResolved.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_AllSettled_AllResolved.js)<br>[`Promise_AllSettled_AllRejected.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_AllSettled_AllRejected.js)<br>[`Promise_Any_FirstResolved.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_Any_FirstResolved.js)<br>[`Promise_Any_AllRejected.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_Any_AllRejected.js)<br>[`Promise_Race_FirstResolved.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_Race_FirstResolved.js)<br>[`Promise_Race_FirstRejected.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_Race_FirstRejected.js)<br>[`length.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/all/JavaScript/length.js)<br>[`name.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/all/JavaScript/name.js)<br>[`prop-desc.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/all/JavaScript/prop-desc.js)<br>[`length.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/race/JavaScript/length.js)<br>[`name.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/race/JavaScript/name.js)<br>[`prop-desc.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/race/JavaScript/prop-desc.js) |  |
+
+### 27.2.4.8 ([tc39.es](https://tc39.es/ecma262/#sec-promise.try))
+
+| Feature name | Status | Test scripts | Notes |
+|---|---|---|---|
+| Promise.try(callback, ...args) | Supported | `tests/Jroc.Test262.Tests/built-ins/Promise/try/ExecutionTests.cs`<br>[`length.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/length.js)<br>[`name.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/name.js)<br>[`prop-desc.js`](../../../tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/prop-desc.js) | Adds Promise.try as a constructor-aware static helper that creates a new capability, invokes the callback with forwarded arguments, and resolves or rejects based on the callback completion. |
 
 ### 27.2.4.9 ([tc39.es](https://tc39.es/ecma262/#sec-promise.withResolvers))
 

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -135,6 +135,26 @@ namespace JavaScriptRuntime
             global::JavaScriptRuntime.Promise.race(iterable);
         private static readonly Func<object[], object?, object?> _promiseRejectValue = static (_, reason) =>
             global::JavaScriptRuntime.Promise.reject(reason);
+        private static readonly Func<object[], object?[]?, object?> _promiseTryValue = static (_, args) =>
+        {
+            args ??= global::System.Array.Empty<object?>();
+            var callback = args.Length > 0 ? args[0] : null;
+            object?[] callbackArgs;
+            if (args.Length <= 1)
+            {
+                callbackArgs = global::System.Array.Empty<object?>();
+            }
+            else
+            {
+                callbackArgs = new object?[args.Length - 1];
+                global::System.Array.Copy(args, 1, callbackArgs, 0, callbackArgs.Length);
+            }
+
+            return global::JavaScriptRuntime.Promise.TryForConstructor(
+                RuntimeServices.GetCurrentThis(),
+                callback,
+                callbackArgs);
+        };
 
         private static readonly JsFuncNoScopes2 _proxyConstructorValue = static (newTarget, target, handler) =>
         {
@@ -387,6 +407,7 @@ namespace JavaScriptRuntime
             DefineBuiltinFunctionProperty(_promiseConstructorValue, "all", _promiseAllValue, 1d);
             DefineBuiltinFunctionProperty(_promiseConstructorValue, "race", _promiseRaceValue, 1d);
             DefineBuiltinFunctionProperty(_promiseConstructorValue, "reject", _promiseRejectValue, 1d);
+            DefineBuiltinFunctionProperty(_promiseConstructorValue, "try", _promiseTryValue, 1d);
             PropertyDescriptorStore.DefineOrUpdate(_booleanFunctionValue, "prototype", new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,

--- a/src/JavaScriptRuntime/Promise.cs
+++ b/src/JavaScriptRuntime/Promise.cs
@@ -190,6 +190,51 @@ public sealed class Promise
         return promise;
     }
 
+    internal static object? TryForConstructor(object? constructor, object? callback, object?[]? args)
+    {
+        if (constructor is null || constructor is JsNull || !Object.IsConstructibleValue(constructor))
+        {
+            throw new TypeError("Promise.try requires a constructor receiver");
+        }
+
+        object? capabilityResolve = null;
+        object? capabilityReject = null;
+        Func<object[], object?, object?, object?> executor = (scopes, resolveArg, rejectArg) =>
+        {
+            if (capabilityResolve is not null || capabilityReject is not null)
+            {
+                throw new TypeError("Promise capability executor already initialized");
+            }
+
+            capabilityResolve = resolveArg;
+            capabilityReject = rejectArg;
+            return null;
+        };
+
+        Function.InitializeFunctionInstance(executor, 2d, string.Empty, requiresInvocationContext: false);
+
+        var promise = Object.ConstructValue(constructor, new object[] { executor });
+        if (capabilityResolve is not Delegate resolveFunction || capabilityReject is not Delegate rejectFunction)
+        {
+            throw new TypeError("Promise constructor did not supply resolving functions");
+        }
+
+        try
+        {
+            var callbackResult = Closure.InvokeFunctionCallWithArgs(
+                callback!,
+                RuntimeServices.EmptyScopes,
+                args ?? System.Array.Empty<object?>());
+            Closure.InvokeWithArgs(resolveFunction, RuntimeServices.EmptyScopes, callbackResult);
+        }
+        catch (Exception ex)
+        {
+            Closure.InvokeWithArgs(rejectFunction, RuntimeServices.EmptyScopes, ex.InnerException ?? ex);
+        }
+
+        return promise;
+    }
+
     /// <summary>
     /// Returns an object containing a new promise and its associated resolve/reject functions.
     /// Equivalent to the TC39 Promise.withResolvers() proposal (now part of ECMA-262).

--- a/tests/Jroc.Test262.Tests/built-ins/Promise/try/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Promise/try/ExecutionTests.cs
@@ -1,0 +1,20 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.Promise.try_;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.Promise.try") { }
+
+    [Fact(DisplayName = "length")]
+    public Task length()
+        => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name")]
+    public Task name()
+        => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "prop-desc")]
+    public Task prop_desc()
+        => ExecutionTestFromFile("prop-desc");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/length.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 Jordan Harband. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Promise.try `length` property
+features: [promise-try]
+---*/
+
+function sameValue(actual, expected) {
+    return Object.is(actual, expected);
+}
+
+function assert(condition, message) {
+    var passed = !!condition;
+    console.log(passed);
+    if (!passed) {
+        throw new Error(message || "Assertion failed");
+    }
+}
+
+function verifyProperty(object, name, desc) {
+    var actual = Object.getOwnPropertyDescriptor(object, name);
+    assert(!!actual, "Property descriptor missing: " + name);
+
+    if (Object.prototype.hasOwnProperty.call(desc, "value")) {
+        assert(sameValue(actual.value, desc.value), "Unexpected value for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "writable")) {
+        assert(actual.writable === desc.writable, "Unexpected writable for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "enumerable")) {
+        assert(actual.enumerable === desc.enumerable, "Unexpected enumerable for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "configurable")) {
+        assert(actual.configurable === desc.configurable, "Unexpected configurable for " + name);
+    }
+}
+
+verifyProperty(Promise.try, "length", {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/name.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 Jordan Harband. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Promise.try `name` property
+features: [promise-try]
+---*/
+
+function sameValue(actual, expected) {
+    return Object.is(actual, expected);
+}
+
+function assert(condition, message) {
+    var passed = !!condition;
+    console.log(passed);
+    if (!passed) {
+        throw new Error(message || "Assertion failed");
+    }
+}
+
+function verifyProperty(object, name, desc) {
+    var actual = Object.getOwnPropertyDescriptor(object, name);
+    assert(!!actual, "Property descriptor missing: " + name);
+
+    if (Object.prototype.hasOwnProperty.call(desc, "value")) {
+        assert(sameValue(actual.value, desc.value), "Unexpected value for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "writable")) {
+        assert(actual.writable === desc.writable, "Unexpected writable for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "enumerable")) {
+        assert(actual.enumerable === desc.enumerable, "Unexpected enumerable for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "configurable")) {
+        assert(actual.configurable === desc.configurable, "Unexpected configurable for " + name);
+    }
+}
+
+verifyProperty(Promise.try, "name", {
+    value: "try",
+    writable: false,
+    enumerable: false,
+    configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Promise/try/JavaScript/prop-desc.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2024 Jordan Harband. All rights reserved.
+// See LICENSE for details.
+/*---
+author: Jordan Harband
+description: Promise.try property descriptor
+features: [promise-try]
+---*/
+
+function sameValue(actual, expected) {
+    return Object.is(actual, expected);
+}
+
+function assert(condition, message) {
+    var passed = !!condition;
+    console.log(passed);
+    if (!passed) {
+        throw new Error(message || "Assertion failed");
+    }
+}
+
+function verifyProperty(object, name, desc) {
+    var actual = Object.getOwnPropertyDescriptor(object, name);
+    assert(!!actual, "Property descriptor missing: " + name);
+
+    if (Object.prototype.hasOwnProperty.call(desc, "value")) {
+        assert(sameValue(actual.value, desc.value), "Unexpected value for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "writable")) {
+        assert(actual.writable === desc.writable, "Unexpected writable for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "enumerable")) {
+        assert(actual.enumerable === desc.enumerable, "Unexpected enumerable for " + name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(desc, "configurable")) {
+        assert(actual.configurable === desc.configurable, "Unexpected configurable for " + name);
+    }
+}
+
+verifyProperty(Promise, "try", {
+    value: Promise.try,
+    writable: true,
+    enumerable: false,
+    configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/Promise/try/Snapshots/ExecutionTests.length.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Promise/try/Snapshots/ExecutionTests.length.verified.txt
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Promise/try/Snapshots/ExecutionTests.name.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Promise/try/Snapshots/ExecutionTests.name.verified.txt
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Promise/try/Snapshots/ExecutionTests.prop_desc.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Promise/try/Snapshots/ExecutionTests.prop_desc.verified.txt
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true


### PR DESCRIPTION
## Summary
- add `Promise.try` support in runtime:
  - expose `Promise.try` on the constructor surface in `GlobalThis`
  - implement constructor-aware capability creation/invocation flow in `Promise.TryForConstructor`
  - forward callback arguments and resolve/reject based on callback completion
- enable the newly added non-`eval` test262 ports under `tests/Jroc.Test262.Tests/built-ins/Promise/try`
- add verified execution snapshots for the enabled `Promise.try` test262 ports
- update `CHANGELOG.md` and ECMA-262 Promise docs (`docs/ECMA262/27/Section27_2.{json,md}`) to mark `Promise.try` as supported

## Notes
- `scripts/ECMA262/generateEcma262SectionMarkdown.js --section 27.2` currently errors in this repo because `reference.specMarkdownPath` (`test_output/ecma262-27.2.md`) is missing, so `Section27_2.md` was updated directly to stay consistent with `Section27_2.json`.