### PR TITLE
ci: run mitata benchmarks after release

### DIFF
--- a/.github/workflows/mitata-suite.yml
+++ b/.github/workflows/mitata-suite.yml
@@ -1,0 +1,176 @@
+name: Mitata Performance Suite
+run-name: Mitata suite (${{ github.event.release.tag_name || github.ref_name }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      benchmark:
+        description: 'Mitata benchmark suffix (for example string-width)'
+        required: false
+        default: 'string-width'
+      jroc_package_version:
+        description: 'Published jroc package version to benchmark (for example 0.9.31)'
+        required: false
+        default: ''
+  release:
+    types: [published]
+
+jobs:
+  mitata-suite:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Determine jroc benchmark package mode
+        shell: bash
+        env:
+          INPUT_JROC_PACKAGE_VERSION: ${{ github.event.inputs.jroc_package_version || '' }}
+        run: |
+          set -euo pipefail
+
+          package_version=""
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            package_version="${{ github.event.release.tag_name }}"
+          elif [ -n "$INPUT_JROC_PACKAGE_VERSION" ]; then
+            package_version="$INPUT_JROC_PACKAGE_VERSION"
+          elif [ "${GITHUB_REF_TYPE:-}" = "tag" ] && [[ "${GITHUB_REF_NAME}" == v* ]]; then
+            package_version="${GITHUB_REF_NAME}"
+          fi
+
+          package_version="${package_version#v}"
+
+          if [ -n "$package_version" ]; then
+            echo "Using published jroc tool version: $package_version"
+            echo "USE_PUBLISHED_JROC_TOOL=true" >> "$GITHUB_ENV"
+            echo "JROC_PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
+          else
+            echo "Using checked-out source tree for jroc compilation path"
+            echo "USE_PUBLISHED_JROC_TOOL=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Wait for published jroc packages
+        if: env.USE_PUBLISHED_JROC_TOOL == 'true' && github.event_name == 'release'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflowId = 'publish-tool.yml';
+            const targetVersion = process.env.JROC_PACKAGE_VERSION;
+            const targetTag = `v${targetVersion}`;
+            const deadlineMs = 20 * 60 * 1000;
+            const pollMs = 15 * 1000;
+            const startedAt = Date.now();
+
+            while (Date.now() - startedAt < deadlineMs) {
+              const response = await github.request('GET /repos/{owner}/{repo}/actions/runs', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 50
+              });
+
+              const matchingRuns = response.data.workflow_runs.filter(candidate =>
+                candidate.path === '.github/workflows/publish-tool.yml' &&
+                (candidate.display_title ?? '').includes(targetTag)
+              );
+
+              if (matchingRuns.length === 0) {
+                core.info(`Waiting for ${workflowId} run for ${targetTag} to appear...`);
+                await new Promise(resolve => setTimeout(resolve, pollMs));
+                continue;
+              }
+
+              const successfulRun = matchingRuns.find(candidate =>
+                candidate.status === 'completed' && candidate.conclusion === 'success');
+              if (successfulRun) {
+                core.info(`Found successful ${workflowId} run ${successfulRun.id}; proceeding to package restore.`);
+                return;
+              }
+
+              const inProgressRun = matchingRuns.find(candidate => candidate.status !== 'completed');
+              if (inProgressRun) {
+                core.info(`Waiting for ${workflowId} run ${inProgressRun.id} to complete for ${targetTag}...`);
+                await new Promise(resolve => setTimeout(resolve, pollMs));
+                continue;
+              }
+
+              const latestCompleted = matchingRuns[0];
+              core.info(`No successful ${workflowId} run yet for ${targetTag}. Latest completed run ${latestCompleted.id} concluded ${latestCompleted.conclusion ?? 'n/a'}. Retrying...`);
+              await new Promise(resolve => setTimeout(resolve, pollMs));
+            }
+
+            throw new Error(`Timed out waiting for a successful ${workflowId} run for ${targetTag}.`);
+
+      - name: Wait for NuGet package availability
+        if: env.USE_PUBLISHED_JROC_TOOL == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/waitForNuGetPackageVersions.js \
+            --version "${JROC_PACKAGE_VERSION}" \
+            --package jroc
+
+      - name: Install mitata dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd tests/performance/mitata
+          npm ci
+
+      - name: Install jroc tool (release mode)
+        if: env.USE_PUBLISHED_JROC_TOOL == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+          if dotnet tool list --global | awk '{print $1}' | grep -qx "jroc"; then
+            dotnet tool update --global jroc --version "${JROC_PACKAGE_VERSION}"
+          else
+            dotnet tool install --global jroc --version "${JROC_PACKAGE_VERSION}"
+          fi
+
+      - name: Run mitata benchmark suite
+        shell: bash
+        env:
+          BENCHMARK_NAME: ${{ github.event.inputs.benchmark || 'string-width' }}
+        run: |
+          set -euo pipefail
+          cd tests/performance/mitata
+          node scripts/run-release-suite.mjs --bench "${BENCHMARK_NAME}" --output results.json
+          if [ ! -f "results.json" ]; then
+            echo "Mitata runner produced no results.json output; failing workflow."
+            exit 1
+          fi
+
+      - name: Ingest Mitata results to Supabase
+        if: always()
+        continue-on-error: true
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          node tests/performance/ingestPerfToSupabase.js --source mitata --input tests/performance/mitata/results.json
+
+      - name: Upload Mitata artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mitata-results
+          path: |
+            tests/performance/mitata/results.json
+            tests/performance/mitata/.jroc/**/*
+          retention-days: 90

--- a/tests/performance/ingestPerfToSupabase.js
+++ b/tests/performance/ingestPerfToSupabase.js
@@ -358,6 +358,85 @@ function parsePrimeResults(inputPath, base, hostMetadata) {
     return rows;
 }
 
+function parseMitataResults(inputPath, base, hostMetadata) {
+    if (!fs.existsSync(inputPath)) {
+        console.log(`Mitata results file not found: ${inputPath}`);
+        return [];
+    }
+
+    let payload;
+    try {
+        payload = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+    } catch (error) {
+        console.log(`Skipping invalid mitata JSON file: ${inputPath} (${error.message})`);
+        return [];
+    }
+
+    const rows = [];
+    const hostColumns = buildHostColumns(hostMetadata);
+    const runAt = payload.timestamp ?? new Date().toISOString();
+    const benchmark = payload.benchmark ?? null;
+    const runs = Array.isArray(payload.runs) ? payload.runs : [];
+
+    for (const run of runs) {
+        if (!run || typeof run !== 'object') {
+            continue;
+        }
+
+        const runtime = run.runtime ?? 'unknown';
+        const runIterations = getNumber(run.iterations);
+        const script = run.script ?? null;
+        const benchmarks = Array.isArray(run.benchmarks) ? run.benchmarks : [];
+
+        for (const entry of benchmarks) {
+            if (!entry || typeof entry !== 'object') {
+                continue;
+            }
+
+            const scenario = entry.name ?? 'unknown';
+            const avgNs = getNumber(entry.avgNs ?? entry.avg_ns);
+            const totalNs = getNumber(entry.totalNs ?? entry.total_ns);
+            const benchmarkIterations = getNumber(entry.iterations) ?? runIterations;
+            const errorMessage = typeof entry.error === 'string'
+                ? entry.error
+                : (entry.error && typeof entry.error === 'object' ? entry.error.message ?? null : null);
+
+            const meta = {
+                benchmark,
+                script,
+                runner_iterations: runIterations,
+                host: hostMetadata
+            };
+
+            if (avgNs !== null) {
+                rows.push(createRow(base, 'mitata', scenario, runtime, 'avg_ns', avgNs, 'ns', runAt, meta, hostColumns));
+            }
+            if (totalNs !== null) {
+                rows.push(createRow(base, 'mitata', scenario, runtime, 'total_ns', totalNs, 'ns', runAt, meta, hostColumns));
+            }
+            if (benchmarkIterations !== null) {
+                rows.push(createRow(base, 'mitata', scenario, runtime, 'iterations', benchmarkIterations, 'count', runAt, meta, hostColumns));
+            }
+            if (errorMessage) {
+                rows.push(createRow(
+                    base,
+                    'mitata',
+                    scenario,
+                    runtime,
+                    'error',
+                    1,
+                    'flag',
+                    runAt,
+                    { ...meta, error: errorMessage },
+                    hostColumns
+                ));
+            }
+        }
+    }
+
+    return rows;
+}
+
 function extractBenchmarksFromJson(data) {
     if (!data) return [];
     if (Array.isArray(data)) {
@@ -710,6 +789,8 @@ async function main() {
         rows = parseBenchmarkDotNetResults(input || path.join('tests', 'performance', 'Benchmarks', 'BenchmarkDotNet.Artifacts', 'results'), base, hostMetadata);
     } else if (source === 'prime-script') {
         rows = parsePrimeResults(input || path.join('tests', 'performance', 'results.json'), base, hostMetadata);
+    } else if (source === 'mitata') {
+        rows = parseMitataResults(input || path.join('tests', 'performance', 'mitata', 'results.json'), base, hostMetadata);
     } else {
         console.error(`Unsupported source: ${source}`);
         process.exit(1);

--- a/tests/performance/mitata/package.json
+++ b/tests/performance/mitata/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "bench": "npm run bench:string-width",
     "bench:jroc": "npm run bench:string-width:jroc",
+    "bench:release": "node scripts/run-release-suite.mjs",
     "bench:string-width": "node snippets/string-width.mjs",
     "bench:string-width:jroc": "node scripts/run-jroc-string-width.mjs"
   }

--- a/tests/performance/mitata/runner.mjs
+++ b/tests/performance/mitata/runner.mjs
@@ -58,6 +58,7 @@ function formatDurationNs(ns) {
 }
 
 async function simpleRun() {
+  const runtimeLabel = process?.env?.BENCHMARK_RUNTIME || "jroc";
   const now = globalThis.performance?.now
     ? () => globalThis.performance.now() * 1e6
     : () => Date.now() * 1e6;
@@ -96,7 +97,7 @@ async function simpleRun() {
 
   if (process?.env?.BENCHMARK_RUNNER) {
     console.log(JSON.stringify({
-      runtime: "jroc",
+      runtime: runtimeLabel,
       iterations: runsPerBenchmark,
       benchmarks: results.map(result => ({
         ...result,

--- a/tests/performance/mitata/scripts/run-release-suite.mjs
+++ b/tests/performance/mitata/scripts/run-release-suite.mjs
@@ -1,0 +1,162 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const benchmarkDirectory = path.resolve(scriptDirectory, "..");
+
+function parseArgs(argv) {
+  const parsed = {
+    bench: "string-width",
+    runtimes: [],
+    output: "results.json",
+  };
+  const positional = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--bench") {
+      parsed.bench = argv[++i] ?? parsed.bench;
+      continue;
+    }
+    if (token === "--runtime") {
+      parsed.runtimes.push(argv[++i] ?? "");
+      continue;
+    }
+    if (token === "--output") {
+      parsed.output = argv[++i] ?? parsed.output;
+      continue;
+    }
+    if (token.startsWith("--")) {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+
+    positional.push(token);
+  }
+
+  if (positional.length > 3) {
+    throw new Error(`Unknown argument: ${positional[3]}`);
+  }
+
+  if (positional[0] && parsed.bench === "string-width") {
+    parsed.bench = positional[0];
+  }
+  if (positional[1] && parsed.runtimes.length === 0) {
+    parsed.runtimes.push(positional[1]);
+  }
+  if (positional[2] && parsed.output === "results.json") {
+    parsed.output = positional[2];
+  }
+
+  return parsed;
+}
+
+function extractRunnerJson(stdout, stderr) {
+  const lines = `${stdout ?? ""}\n${stderr ?? ""}`
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const candidate = lines[i];
+    if (!candidate.startsWith("{") || !candidate.includes("\"benchmarks\"")) {
+      continue;
+    }
+
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // Keep scanning if there are non-JSON lines that start with '{'.
+    }
+  }
+
+  throw new Error("Could not find mitata JSON output in command logs.");
+}
+
+function runNpmScript(scriptName, runtimeLabel) {
+  console.log(`Running ${scriptName} (${runtimeLabel})...`);
+  const isWindows = process.platform === "win32";
+  const command = isWindows ? (process.env.ComSpec || "cmd.exe") : "npm";
+  const commandArgs = isWindows
+    ? ["/d", "/s", "/c", `npm run ${scriptName}`]
+    : ["run", scriptName];
+
+  const env = {
+    ...process.env,
+    BENCHMARK_RUNNER: "1",
+    JROC_SIMPLE_BENCH_RUNNER: "1",
+    BENCHMARK_RUNTIME: runtimeLabel,
+  };
+
+  if (
+    runtimeLabel === "jroc" &&
+    !env.JROC &&
+    String(env.USE_PUBLISHED_JROC_TOOL || "").toLowerCase() === "true"
+  ) {
+    // In release mode, prefer the globally installed jroc tool.
+    env.JROC = "jroc";
+  }
+
+  const result = spawnSync(command, commandArgs, {
+    cwd: benchmarkDirectory,
+    env,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`npm run ${scriptName} failed with exit code ${result.status ?? "unknown"}.`);
+  }
+
+  const payload = extractRunnerJson(result.stdout, result.stderr);
+  payload.runtime = runtimeLabel;
+  payload.script = scriptName;
+  return payload;
+}
+
+function resolveScriptName(benchName, runtimeLabel) {
+  if (runtimeLabel === "node") {
+    return `bench:${benchName}`;
+  }
+  if (runtimeLabel === "jroc") {
+    return `bench:${benchName}:jroc`;
+  }
+
+  throw new Error(`Unsupported runtime '${runtimeLabel}'. Supported runtimes: node, jroc.`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const runtimes = args.runtimes.length > 0 ? args.runtimes : ["node", "jroc"];
+  const outputPath = path.resolve(benchmarkDirectory, args.output);
+  const runAt = new Date().toISOString();
+
+  const runs = runtimes.map(runtimeLabel => {
+    const scriptName = resolveScriptName(args.bench, runtimeLabel);
+    return runNpmScript(scriptName, runtimeLabel);
+  });
+
+  const payload = {
+    timestamp: runAt,
+    benchmark: args.bench,
+    runs,
+  };
+
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  console.log(`Mitata results written to ${outputPath}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a new Mitata release workflow that triggers on release publication and optional workflow_dispatch
- add `tests/performance/mitata/scripts/run-release-suite.mjs` to run node+jroc Mitata scripts and emit `results.json` payloads
- extend perf ingestion to support `--source mitata` and map Mitata output into Supabase perf rows
- update Mitata runner/runtime labeling and package scripts for release-mode execution

## Validation
- `node tests/performance/mitata/scripts/run-release-suite.mjs --bench string-width --runtime node --output results.json`
- `npm run bench:release -- --bench string-width --runtime node --output results.json` (from `tests/performance/mitata`)
- `node tests/performance/ingestPerfToSupabase.js --source mitata --input tests/performance/mitata/results.json`
